### PR TITLE
fix(customers): pre-check creates customers via the shared PII+Contact pipeline (no dup identities)

### DIFF
--- a/apps/api/src/modules/customers/customer-precheck.service.spec.ts
+++ b/apps/api/src/modules/customers/customer-precheck.service.spec.ts
@@ -2,8 +2,17 @@ import { Test } from '@nestjs/testing';
 import { CustomerPreCheckService } from './customer-precheck.service';
 import { PrismaService } from '../../prisma/prisma.service';
 import { CustomerTierService } from './customer-tier.service';
+import { CustomersService } from './customers.service';
 import { TestModeService } from '../test-mode/test-mode.service';
 import { AuditService } from '../audit/audit.service';
+
+// Shared placeholder-customer helper mock. The lookup/create/revive logic now
+// lives in CustomersService.findOrCreatePrecheckCustomer (so the pre-check path
+// shares create()'s nationalIdHash + Contact dedup — see that helper's spec for
+// the dedup behavior). Here we only assert pre-check DELEGATES to it.
+function customersServiceMock(ret: { id: string; isNew: boolean } = { id: 'cust-default', isNew: false }) {
+  return { findOrCreatePrecheckCustomer: jest.fn().mockResolvedValue(ret) };
+}
 
 describe('CustomerPreCheckService — decideOutcome (pure)', () => {
   let service: CustomerPreCheckService;
@@ -14,6 +23,7 @@ describe('CustomerPreCheckService — decideOutcome (pure)', () => {
         CustomerPreCheckService,
         { provide: PrismaService, useValue: {} },
         { provide: CustomerTierService, useValue: {} },
+        { provide: CustomersService, useValue: customersServiceMock() },
         { provide: TestModeService, useValue: { isEnabled: jest.fn().mockResolvedValue(false) } },
         { provide: AuditService, useValue: { log: jest.fn() } },
       ],
@@ -65,15 +75,32 @@ describe('CustomerPreCheckService — decideOutcome (pure)', () => {
     expect(result.decision).toBe('REVIEW');
     expect(result.reasons[0].code).toBe('NEW_PENDING_REVIEW');
     expect(result.reasons[0].message).toContain('แนบ statement แล้ว');
-    // Must NOT claim "no statement" when one was uploaded.
     expect(result.reasons[0].message).not.toContain('ยังไม่มี statement');
   });
 });
 
-describe('CustomerPreCheckService — runPreCheck soft-delete revival', () => {
+describe('CustomerPreCheckService — runPreCheck placeholder + credit-check', () => {
   let service: CustomerPreCheckService;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let prisma: any;
+  let customersService: ReturnType<typeof customersServiceMock>;
+
+  async function build() {
+    const mod = await Test.createTestingModule({
+      providers: [
+        CustomerPreCheckService,
+        { provide: PrismaService, useValue: prisma },
+        {
+          provide: CustomerTierService,
+          useValue: { getCustomerTier: jest.fn().mockResolvedValue({ tier: 'NEW', reasons: [] }) },
+        },
+        { provide: CustomersService, useValue: customersService },
+        { provide: TestModeService, useValue: { isEnabled: jest.fn().mockResolvedValue(false) } },
+        { provide: AuditService, useValue: { log: jest.fn() } },
+      ],
+    }).compile();
+    return mod.get(CustomerPreCheckService);
+  }
 
   beforeEach(async () => {
     prisma = {
@@ -86,107 +113,49 @@ describe('CustomerPreCheckService — runPreCheck soft-delete revival', () => {
         findFirst: jest.fn().mockResolvedValue(null),
         create: jest.fn(),
       },
-      // Pass-through transaction so tests exercise the same prisma mocks.
       $transaction: jest.fn((fn: (tx: unknown) => Promise<unknown>) => fn(prisma)),
     };
-    const tierService = {
-      getCustomerTier: jest.fn().mockResolvedValue({ tier: 'NEW', reasons: [] }),
-    };
-    const mod = await Test.createTestingModule({
-      providers: [
-        CustomerPreCheckService,
-        { provide: PrismaService, useValue: prisma },
-        { provide: CustomerTierService, useValue: tierService },
-        { provide: TestModeService, useValue: { isEnabled: jest.fn().mockResolvedValue(false) } },
-        { provide: AuditService, useValue: { log: jest.fn() } },
-      ],
-    }).compile();
-    service = mod.get(CustomerPreCheckService);
+    customersService = customersServiceMock({ id: 'cust-default', isNew: false });
+    service = await build();
   });
 
-  it('revives a soft-deleted customer with the same nationalId instead of throwing P2002', async () => {
-    prisma.customer.findFirst.mockResolvedValue({
-      id: 'cust-dead',
-      deletedAt: new Date('2026-04-22'),
-    });
+  it('delegates placeholder creation to CustomersService.findOrCreatePrecheckCustomer (shared dedup pipeline)', async () => {
+    customersService.findOrCreatePrecheckCustomer.mockResolvedValue({ id: 'cust-new', isNew: true });
 
-    const result = await service.runPreCheck({
-      nationalId: '1234567890123',
-      phone: '0812345678',
-    });
+    const result = await service.runPreCheck({ nationalId: '2222222222222', phone: '0898765432' });
 
-    // Must NOT call create() — that's the line that blows up with P2002
-    expect(prisma.customer.create).not.toHaveBeenCalled();
-    // Must clear deletedAt so the customer is usable again
-    expect(prisma.customer.update).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: { id: 'cust-dead' },
-        data: expect.objectContaining({ deletedAt: null }),
-      }),
-    );
-    expect(result.customerId).toBe('cust-dead');
-    expect(result.isNewCustomer).toBe(false);
-  });
-
-  it('creates a fresh customer when no row exists at all', async () => {
-    prisma.customer.findFirst.mockResolvedValue(null);
-    prisma.customer.create.mockResolvedValue({ id: 'cust-new' });
-
-    const result = await service.runPreCheck({
+    expect(customersService.findOrCreatePrecheckCustomer).toHaveBeenCalledWith({
       nationalId: '2222222222222',
       phone: '0898765432',
     });
-
-    expect(prisma.customer.create).toHaveBeenCalled();
+    // It must NOT do its own plaintext create/lookup anymore (that was the bug).
+    expect(prisma.customer.create).not.toHaveBeenCalled();
+    expect(prisma.customer.findFirst).not.toHaveBeenCalled();
     expect(result.customerId).toBe('cust-new');
     expect(result.isNewCustomer).toBe(true);
   });
 
-  it('uses the active customer without touching update() when one already exists', async () => {
-    prisma.customer.findFirst.mockResolvedValue({
-      id: 'cust-live',
-      deletedAt: null,
-    });
+  it('returns an existing (non-new) customer from the helper', async () => {
+    customersService.findOrCreatePrecheckCustomer.mockResolvedValue({ id: 'cust-live', isNew: false });
 
-    const result = await service.runPreCheck({
-      nationalId: '3333333333333',
-      phone: '0811111111',
-    });
+    const result = await service.runPreCheck({ nationalId: '3333333333333', phone: '0811111111' });
 
-    expect(prisma.customer.create).not.toHaveBeenCalled();
-    // update() is still called at the end of runPreCheck to set creditCheckStatus,
-    // so assert we did NOT try to clear deletedAt (the revive-only path).
+    expect(result.customerId).toBe('cust-live');
+    expect(result.isNewCustomer).toBe(false);
+    // The only customer.update is the final creditCheckStatus write — never a
+    // deletedAt clear here (revive lives inside the helper now).
     const updateCalls = prisma.customer.update.mock.calls;
     expect(
       updateCalls.every((call: [unknown]) => !('deletedAt' in (call[0] as { data: object }).data)),
     ).toBe(true);
-    expect(result.customerId).toBe('cust-live');
-    expect(result.isNewCustomer).toBe(false);
   });
 
-  // ─── PRE-check idempotency (covers cross-instance / cache-miss races) ────
   it('reuses a recent PRE credit check instead of creating a duplicate', async () => {
-    prisma.customer.findFirst.mockResolvedValue({ id: 'cust-x', deletedAt: null });
+    customersService.findOrCreatePrecheckCustomer.mockResolvedValue({ id: 'cust-x', isNew: false });
     prisma.creditCheck.findFirst.mockResolvedValue({ id: 'cc-recent', aiScore: null });
+    service = await build(); // fresh instance — empty in-memory cache
 
-    // Fresh instance so the in-memory cache is empty — forces DB check path.
-    const fresh = await Test.createTestingModule({
-      providers: [
-        CustomerPreCheckService,
-        { provide: PrismaService, useValue: prisma },
-        {
-          provide: CustomerTierService,
-          useValue: {
-            getCustomerTier: jest.fn().mockResolvedValue({ tier: 'NEW', reasons: [] }),
-          },
-        },
-        { provide: TestModeService, useValue: { isEnabled: jest.fn().mockResolvedValue(false) } },
-        { provide: AuditService, useValue: { log: jest.fn() } },
-      ],
-    }).compile();
-    const svc = fresh.get(CustomerPreCheckService);
-
-    const result = await svc.runPreCheck({
+    const result = await service.runPreCheck({
       nationalId: '4444444444444',
       phone: '0820000000',
       bankName: 'KBANK',
@@ -198,27 +167,12 @@ describe('CustomerPreCheckService — runPreCheck soft-delete revival', () => {
   });
 
   it('creates a new PRE credit check when no recent duplicate exists', async () => {
-    prisma.customer.findFirst.mockResolvedValue({ id: 'cust-y', deletedAt: null });
+    customersService.findOrCreatePrecheckCustomer.mockResolvedValue({ id: 'cust-y', isNew: false });
     prisma.creditCheck.findFirst.mockResolvedValue(null);
     prisma.creditCheck.create.mockResolvedValue({ id: 'cc-new', aiScore: null });
+    service = await build();
 
-    const fresh = await Test.createTestingModule({
-      providers: [
-        CustomerPreCheckService,
-        { provide: PrismaService, useValue: prisma },
-        {
-          provide: CustomerTierService,
-          useValue: {
-            getCustomerTier: jest.fn().mockResolvedValue({ tier: 'NEW', reasons: [] }),
-          },
-        },
-        { provide: TestModeService, useValue: { isEnabled: jest.fn().mockResolvedValue(false) } },
-        { provide: AuditService, useValue: { log: jest.fn() } },
-      ],
-    }).compile();
-    const svc = fresh.get(CustomerPreCheckService);
-
-    const result = await svc.runPreCheck({
+    const result = await service.runPreCheck({
       nationalId: '5555555555555',
       phone: '0833333333',
       bankName: 'SCB',
@@ -231,6 +185,26 @@ describe('CustomerPreCheckService — runPreCheck soft-delete revival', () => {
     expect(findFirstCall.where.checkType).toBe('PRE');
     expect(findFirstCall.where.bankName).toBe('SCB');
     expect(findFirstCall.where.deletedAt).toBeNull();
+  });
+
+  it('wraps creditCheck create + customer.creditCheckStatus update in one $transaction (no drift on failure)', async () => {
+    customersService.findOrCreatePrecheckCustomer.mockResolvedValue({ id: 'cust-tx', isNew: false });
+    prisma.creditCheck.create.mockResolvedValue({ id: 'cc-tx', aiScore: null });
+    service = await build();
+
+    await service.runPreCheck({
+      nationalId: '6666666666666',
+      phone: '0844444444',
+      bankName: 'BBL',
+      statementFiles: ['data:image/png;base64,zzz'],
+    });
+
+    expect(prisma.$transaction).toHaveBeenCalledTimes(1);
+    expect(prisma.creditCheck.create).toHaveBeenCalledTimes(1);
+    const statusUpdateCall = prisma.customer.update.mock.calls.find(
+      (call: [{ data: { creditCheckStatus?: string } }]) => call[0].data.creditCheckStatus !== undefined,
+    );
+    expect(statusUpdateCall).toBeDefined();
   });
 
   // ─── abandonPreCheck — refuse to delete real customer rows ──────────────
@@ -260,9 +234,7 @@ describe('CustomerPreCheckService — runPreCheck soft-delete revival', () => {
       creditCheckStatus: 'UNDER_REVIEW',
       _count: { contracts: 0 },
     });
-
     const result = await service.abandonPreCheck('cust-real');
-
     expect(result.deleted).toBe(false);
     expect(prisma.customer.update).not.toHaveBeenCalled();
   });
@@ -274,9 +246,7 @@ describe('CustomerPreCheckService — runPreCheck soft-delete revival', () => {
       creditCheckStatus: 'UNDER_REVIEW',
       _count: { contracts: 1 },
     });
-
     const result = await service.abandonPreCheck('cust-with-contract');
-
     expect(result.deleted).toBe(false);
     expect(prisma.customer.update).not.toHaveBeenCalled();
   });
@@ -288,58 +258,16 @@ describe('CustomerPreCheckService — runPreCheck soft-delete revival', () => {
       creditCheckStatus: 'APPROVED',
       _count: { contracts: 0 },
     });
-
     const result = await service.abandonPreCheck('cust-approved');
-
     expect(result.deleted).toBe(false);
     expect(prisma.customer.update).not.toHaveBeenCalled();
   });
 
   it('returns {deleted:false} silently if customer does not exist (already removed)', async () => {
     prisma.customer.findFirst.mockResolvedValue(null);
-
     const result = await service.abandonPreCheck('cust-gone');
-
     expect(result.deleted).toBe(false);
     expect(prisma.customer.update).not.toHaveBeenCalled();
-  });
-
-  it('wraps creditCheck create + customer.creditCheckStatus update in one $transaction (no drift on failure)', async () => {
-    prisma.customer.findFirst.mockResolvedValue({ id: 'cust-tx', deletedAt: null });
-    prisma.creditCheck.create.mockResolvedValue({ id: 'cc-tx', aiScore: null });
-
-    const fresh = await Test.createTestingModule({
-      providers: [
-        CustomerPreCheckService,
-        { provide: PrismaService, useValue: prisma },
-        {
-          provide: CustomerTierService,
-          useValue: {
-            getCustomerTier: jest.fn().mockResolvedValue({ tier: 'NEW', reasons: [] }),
-          },
-        },
-        { provide: TestModeService, useValue: { isEnabled: jest.fn().mockResolvedValue(false) } },
-        { provide: AuditService, useValue: { log: jest.fn() } },
-      ],
-    }).compile();
-    const svc = fresh.get(CustomerPreCheckService);
-
-    await svc.runPreCheck({
-      nationalId: '6666666666666',
-      phone: '0844444444',
-      bankName: 'BBL',
-      statementFiles: ['data:image/png;base64,zzz'],
-    });
-
-    // The transaction should have been invoked once covering both writes.
-    expect(prisma.$transaction).toHaveBeenCalledTimes(1);
-    expect(prisma.creditCheck.create).toHaveBeenCalledTimes(1);
-    // customer.update was called via the pass-through tx proxy — verifies the
-    // creditCheckStatus write is inside the same transactional boundary.
-    const statusUpdateCall = prisma.customer.update.mock.calls.find(
-      (call: [{ data: { creditCheckStatus?: string } }]) => call[0].data.creditCheckStatus !== undefined,
-    );
-    expect(statusUpdateCall).toBeDefined();
   });
 });
 
@@ -350,6 +278,7 @@ describe('CustomerPreCheckService — test-mode bypass', () => {
   let prisma: any;
   let testMode: { isEnabled: jest.Mock };
   let audit: { log: jest.Mock };
+  let customersService: ReturnType<typeof customersServiceMock>;
 
   beforeEach(async () => {
     prisma = {
@@ -359,20 +288,20 @@ describe('CustomerPreCheckService — test-mode bypass', () => {
     };
     testMode = { isEnabled: jest.fn() };
     audit = { log: jest.fn() };
+    customersService = customersServiceMock({ id: 'cust-real', isNew: false });
     const mod = await Test.createTestingModule({
       providers: [
         CustomerPreCheckService,
         { provide: PrismaService, useValue: prisma },
         {
           provide: CustomerTierService,
-          // If the bypass ever falls through to the real logic, this throws
-          // loudly so the test can't accidentally pass via real checks.
           useValue: {
             getCustomerTier: jest.fn(() => {
               throw new Error('real precheck must NOT run when test-mode is ON');
             }),
           },
         },
+        { provide: CustomersService, useValue: customersService },
         { provide: TestModeService, useValue: testMode },
         { provide: AuditService, useValue: audit },
       ],
@@ -383,27 +312,20 @@ describe('CustomerPreCheckService — test-mode bypass', () => {
   it('returns PASS + TEST_MODE_BYPASS reason WITHOUT running real checks when test-mode is ON', async () => {
     testMode.isEnabled.mockResolvedValue(true);
 
-    const result = await service.runPreCheck({
-      nationalId: '1111111111111',
-      phone: '0810000000',
-    });
+    const result = await service.runPreCheck({ nationalId: '1111111111111', phone: '0810000000' });
 
     expect(result.decision).toBe('PASS');
     expect(result.reasons.map((r) => r.code)).toContain('TEST_MODE_BYPASS');
-    // No real-check side effects — no DB reads/writes, no tier lookup.
-    expect(prisma.customer.findFirst).not.toHaveBeenCalled();
-    expect(prisma.customer.create).not.toHaveBeenCalled();
+    expect(customersService.findOrCreatePrecheckCustomer).not.toHaveBeenCalled();
     expect(prisma.$transaction).not.toHaveBeenCalled();
   });
 
   it('writes a CREDIT_PRECHECK_BYPASSED_TEST_MODE audit marker when bypassing', async () => {
     testMode.isEnabled.mockResolvedValue(true);
-
     await service.runPreCheck(
       { nationalId: '2222222222222', phone: '0820000000' },
       { userId: 'user-1', ipAddress: '127.0.0.1' },
     );
-
     expect(audit.log).toHaveBeenCalledWith(
       expect.objectContaining({
         action: 'CREDIT_PRECHECK_BYPASSED_TEST_MODE',
@@ -415,13 +337,12 @@ describe('CustomerPreCheckService — test-mode bypass', () => {
 
   it('falls through to real logic when test-mode is OFF', async () => {
     testMode.isEnabled.mockResolvedValue(false);
-    // Let the real path reach the tier lookup, where the throwing mock proves
-    // the bypass did NOT short-circuit.
-    prisma.customer.findFirst.mockResolvedValue({ id: 'cust-real', deletedAt: null });
+    // Reaches the placeholder helper, then the throwing tier mock proves the
+    // bypass did NOT short-circuit.
     await expect(
       service.runPreCheck({ nationalId: '3333333333333', phone: '0830000000' }),
     ).rejects.toThrow('real precheck must NOT run when test-mode is ON');
-    expect(prisma.customer.findFirst).toHaveBeenCalled();
+    expect(customersService.findOrCreatePrecheckCustomer).toHaveBeenCalled();
     expect(audit.log).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/modules/customers/customer-precheck.service.ts
+++ b/apps/api/src/modules/customers/customer-precheck.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { createHash } from 'node:crypto';
 import { PrismaService } from '../../prisma/prisma.service';
 import { CustomerTierService } from './customer-tier.service';
+import { CustomersService } from './customers.service';
 import { TestModeService } from '../test-mode/test-mode.service';
 import { AuditService } from '../audit/audit.service';
 import type { CustomerTier } from './dto/tier.dto';
@@ -31,6 +32,7 @@ export class CustomerPreCheckService {
   constructor(
     private readonly prisma: PrismaService,
     private readonly tierService: CustomerTierService,
+    private readonly customersService: CustomersService,
     private readonly testMode: TestModeService,
     private readonly audit: AuditService,
   ) {}
@@ -159,43 +161,21 @@ export class CustomerPreCheckService {
       return cached.result;
     }
 
-    // Look up INCLUDING soft-deleted rows. `nationalId` has a @unique
-    // constraint (encrypted AES-256), so a soft-deleted ghost will block
-    // any create() with the same nationalId (P2002). Revive instead of
-    // crashing — the person behind the national ID is the same person.
-    const existing = await this.prisma.customer.findFirst({
-      where: { nationalId: input.nationalId },
-      select: { id: true, deletedAt: true },
+    // Find-or-create the placeholder customer via CustomersService — the SAME
+    // PII pipeline (nationalIdHash + encrypted columns) + party-master Contact
+    // link as the canonical create(). Previously this looked up + created on
+    // PLAINTEXT nationalId only (no hash/encrypted/Contact), so create()'s
+    // nationalIdHash + contactId dedup MISSED the pre-check row and the same
+    // person got a SECOND duplicate Customer when they completed registration
+    // (splitting contracts/payments across two identities). It also no longer
+    // depends on the plaintext national_id column (dropped in Phase 6). The
+    // helper revives a soft-deleted ghost and upgrades an ensureRole stub.
+    const placeholder = await this.customersService.findOrCreatePrecheckCustomer({
+      nationalId: input.nationalId,
+      phone: input.phone,
     });
-
-    let customer: { id: string };
-    let isNewCustomer = false;
-
-    if (existing?.deletedAt) {
-      await this.prisma.customer.update({
-        where: { id: existing.id },
-        data: {
-          deletedAt: null,
-          phone: input.phone,
-          creditCheckStatus: 'UNDER_REVIEW',
-        },
-      });
-      customer = { id: existing.id };
-      this.logger.log(`[pre-check] revived soft-deleted customer ${existing.id}`);
-    } else if (existing) {
-      customer = { id: existing.id };
-    } else {
-      customer = await this.prisma.customer.create({
-        data: {
-          nationalId: input.nationalId,
-          name: 'ลูกค้าใหม่ (Pre-check)',
-          phone: input.phone,
-          creditCheckStatus: 'UNDER_REVIEW',
-        },
-        select: { id: true },
-      });
-      isNewCustomer = true;
-    }
+    const customer = { id: placeholder.id };
+    const isNewCustomer = placeholder.isNew;
 
     const tierResp = await this.tierService.getCustomerTier(customer.id);
 

--- a/apps/api/src/modules/customers/customers.service.precheck-customer.spec.ts
+++ b/apps/api/src/modules/customers/customers.service.precheck-customer.spec.ts
@@ -1,0 +1,124 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CustomersService } from './customers.service';
+import { CustomerTierService } from './customer-tier.service';
+import { ContactResolverService } from '../contacts/contact-resolver.service';
+import { PrismaService } from '../../prisma/prisma.service';
+
+/**
+ * findOrCreatePrecheckCustomer — the shared placeholder-customer helper that the
+ * credit pre-check intake now uses. The bug it fixes: pre-check used to create a
+ * Customer with ONLY plaintext nationalId (no nationalIdHash, no Contact), so
+ * create() — which dedups on nationalIdHash + contactId — would later make a
+ * SECOND duplicate identity for the same person. These tests pin that the helper
+ * writes nationalIdHash + links a Contact (the keys that make create() dedup
+ * find it), and revives/upgrades instead of duplicating.
+ */
+describe('CustomersService.findOrCreatePrecheckCustomer', () => {
+  let service: CustomersService;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+  let contactResolver: { findOrCreateByNaturalKey: jest.Mock };
+
+  beforeEach(async () => {
+    process.env.PII_HASH_SALT = 'b'.repeat(32); // enables nationalIdHash computation
+    prisma = {
+      customer: {
+        findUnique: jest.fn().mockResolvedValue(null),
+        findFirst: jest.fn().mockResolvedValue(null), // stub-upgrade check (inside tx)
+        update: jest.fn((args: { where: { id: string }; data: object }) =>
+          Promise.resolve({ id: args.where.id, ...args.data }),
+        ),
+        create: jest.fn((args: { data: object }) => Promise.resolve({ id: 'cust-new', ...args.data })),
+      },
+      $transaction: jest.fn(async (cb: (tx: unknown) => unknown) => cb(prisma)),
+    };
+    contactResolver = {
+      findOrCreateByNaturalKey: jest.fn().mockResolvedValue({ id: 'contact-1' }),
+    };
+    const mod: TestingModule = await Test.createTestingModule({
+      providers: [
+        CustomersService,
+        { provide: PrismaService, useValue: prisma },
+        { provide: CustomerTierService, useValue: { getCustomerTier: jest.fn() } },
+        { provide: ContactResolverService, useValue: contactResolver },
+      ],
+    }).compile();
+    service = mod.get(CustomersService);
+  });
+
+  afterEach(() => {
+    delete process.env.PII_HASH_SALT;
+  });
+
+  it('returns an existing non-deleted customer (dedup by nationalIdHash) without creating a second row', async () => {
+    prisma.customer.findUnique.mockResolvedValue({ id: 'cust-existing', deletedAt: null });
+
+    const res = await service.findOrCreatePrecheckCustomer({
+      nationalId: '1234567890123',
+      phone: '0812345678',
+    });
+
+    expect(res).toEqual({ id: 'cust-existing', isNew: false });
+    // Looked up by the HASH column (not plaintext) — the same key create() uses.
+    expect(prisma.customer.findUnique).toHaveBeenCalledWith(
+      expect.objectContaining({ where: expect.objectContaining({ nationalIdHash: expect.any(String) }) }),
+    );
+    expect(prisma.customer.create).not.toHaveBeenCalled();
+    expect(contactResolver.findOrCreateByNaturalKey).not.toHaveBeenCalled();
+  });
+
+  it('creates a new placeholder WITH nationalIdHash + a linked Contact (so create() can later dedup it)', async () => {
+    prisma.customer.findUnique.mockResolvedValue(null);
+
+    const res = await service.findOrCreatePrecheckCustomer({
+      nationalId: '2222222222222',
+      phone: '0898765432',
+    });
+
+    expect(res).toEqual({ id: 'cust-new', isNew: true });
+    // Contact resolved with the nationalIdHash (party-master link).
+    expect(contactResolver.findOrCreateByNaturalKey).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ nationalIdHash: expect.any(String), role: 'CUSTOMER' }),
+    );
+    // The created Customer carries the hash + the Contact connect — the two keys
+    // create() dedups on. (Previously precheck wrote neither → duplicate.)
+    const createArg = prisma.customer.create.mock.calls[0][0];
+    expect(createArg.data.nationalIdHash).toEqual(expect.any(String));
+    expect(createArg.data.contact).toEqual({ connect: { id: 'contact-1' } });
+  });
+
+  it('revives a soft-deleted ghost (same person) instead of creating a duplicate', async () => {
+    prisma.customer.findUnique.mockResolvedValue({ id: 'cust-ghost', deletedAt: new Date('2026-01-01') });
+
+    const res = await service.findOrCreatePrecheckCustomer({
+      nationalId: '3333333333333',
+      phone: '0811111111',
+    });
+
+    expect(res).toEqual({ id: 'cust-ghost', isNew: false });
+    expect(prisma.customer.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'cust-ghost' },
+        data: expect.objectContaining({ deletedAt: null, nationalIdHash: expect.any(String) }),
+      }),
+    );
+    expect(prisma.customer.create).not.toHaveBeenCalled();
+  });
+
+  it('upgrades an existing ensureRole stub on the same Contact instead of creating a second row', async () => {
+    prisma.customer.findUnique.mockResolvedValue(null);
+    prisma.customer.findFirst.mockResolvedValue({ id: 'stub-1' }); // stub on contact-1
+
+    const res = await service.findOrCreatePrecheckCustomer({
+      nationalId: '4444444444444',
+      phone: '0820000000',
+    });
+
+    expect(res).toEqual({ id: 'stub-1', isNew: false });
+    expect(prisma.customer.update).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: 'stub-1' } }),
+    );
+    expect(prisma.customer.create).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/modules/customers/customers.service.ts
+++ b/apps/api/src/modules/customers/customers.service.ts
@@ -654,6 +654,104 @@ export class CustomersService {
     });
   }
 
+  /**
+   * Find-or-create the lightweight "pre-check" placeholder Customer, keyed on
+   * national ID, using the SAME PII pipeline + Contact resolution as create().
+   *
+   * Why this exists: the credit pre-check intake (CustomerPreCheckService) used
+   * to look up + create on PLAINTEXT nationalId only — no nationalIdHash, no
+   * encrypted columns, no party-master Contact. create() dedups exclusively on
+   * nationalIdHash + contactId, so a pre-check customer was invisible to it and
+   * the same person got a SECOND duplicate Customer row when they later
+   * completed registration (splitting contracts/payments across two identities).
+   * Routing both paths through this one helper keeps them from drifting, and is
+   * required anyway once Phase 6 drops the plaintext national_id column.
+   *
+   * Returns the customer id + whether a new row was created. A non-deleted
+   * existing customer is returned as-is; a soft-deleted ghost is revived.
+   */
+  async findOrCreatePrecheckCustomer(input: {
+    nationalId: string;
+    phone: string;
+  }): Promise<{ id: string; isNew: boolean }> {
+    const PLACEHOLDER_NAME = 'ลูกค้าใหม่ (Pre-check)';
+    const normalizedNid = this.normalizeNationalId(input.nationalId);
+    const normalizedPhone = this.normalizePhone(input.phone) ?? input.phone;
+    const nidHash = hashPII(normalizedNid, this.hashSalt);
+
+    // Dedup on nationalIdHash (the @unique column create() uses) — finds the row
+    // even if soft-deleted, so we revive rather than hit a P2002.
+    const existing = await this.prisma.customer.findUnique({
+      where: { nationalIdHash: nidHash },
+      select: { id: true, deletedAt: true },
+    });
+    if (existing && !existing.deletedAt) {
+      return { id: existing.id, isNew: false };
+    }
+
+    const piiEncrypted = this.buildPiiEncryptedFields({
+      nationalId: normalizedNid,
+      phone: normalizedPhone,
+    });
+    const nationalIdHash = (piiEncrypted.nationalIdHash as string | null | undefined) ?? null;
+
+    if (existing?.deletedAt) {
+      // Same person re-entering — revive the ghost + refresh PII/phone/status.
+      await this.prisma.customer.update({
+        where: { id: existing.id },
+        data: {
+          deletedAt: null,
+          nationalId: normalizedNid,
+          phone: normalizedPhone,
+          ...(piiEncrypted as Partial<Prisma.CustomerUpdateInput>),
+          creditCheckStatus: 'UNDER_REVIEW',
+        },
+      });
+      return { id: existing.id, isNew: false };
+    }
+
+    return this.prisma.$transaction(async (tx) => {
+      const contact = await this.contactResolver.findOrCreateByNaturalKey(tx, {
+        name: PLACEHOLDER_NAME,
+        taxId: null,
+        nationalIdHash,
+        phone: normalizedPhone,
+        role: 'CUSTOMER',
+      });
+      const data = {
+        nationalId: normalizedNid,
+        name: PLACEHOLDER_NAME,
+        phone: normalizedPhone,
+        ...(piiEncrypted as Partial<Prisma.CustomerCreateInput>),
+        creditCheckStatus: 'UNDER_REVIEW' as const,
+      };
+      // Stub-upgrade guard (mirrors create()): a prior ensureRole stub on this
+      // contact must be UPGRADED, not duplicated (Customer.contactId not @unique).
+      const existingStub = await tx.customer.findFirst({
+        where: { contactId: contact.id, deletedAt: null },
+        select: { id: true },
+      });
+      if (existingStub) {
+        await tx.customer.update({
+          where: { id: existingStub.id },
+          data: {
+            ...(data as Prisma.CustomerUpdateInput),
+            contact: { connect: { id: contact.id } },
+          },
+        });
+        return { id: existingStub.id, isNew: false };
+      }
+      const created = await tx.customer.create({
+        data: {
+          ...(data as Prisma.CustomerCreateInput),
+          contact: { connect: { id: contact.id } },
+        },
+        select: { id: true },
+      });
+      return { id: created.id, isNew: true };
+    });
+  }
+
   async update(id: string, dto: UpdateCustomerDto) {
     await this.findOne(id);
     // NID is intentionally not in UpdateCustomerDto — customers can't change


### PR DESCRIPTION
**Finding (Wave-2 triage, D1 — REAL/LIVE, highest data-integrity blast):** `CustomerPreCheckService.runPreCheck` created a Customer writing ONLY plaintext `nationalId` (no `nationalIdHash`, no encrypted columns, no Contact). `create()` dedups EXCLUSIVELY on `nationalIdHash` + `contactId`, so a pre-check customer was invisible to it → the same person completing registration got a **SECOND duplicate identity** (split contracts/payments). Plaintext lookup also breaks once Phase 6 drops the column.

**Fix:** extract `CustomersService.findOrCreatePrecheckCustomer()` reusing `create()`'s pipeline — `normalizeNationalId` + `hashPII` dedup on the @unique `nationalIdHash` (finds soft-deleted ghosts → revive), `buildPiiEncryptedFields`, `contactResolver.findOrCreateByNaturalKey` in one `$transaction`, same stub-upgrade guard. `runPreCheck` delegates (no more plaintext create).

**Verify:** adversarial pass → SOLID/SHIP. Dedup keys byte-for-byte match `create()`; no DI cycle; new constructor dep wired into all precheck specs; no HTTP in tx. 96 customers-module tests pass (4 new helper specs: dedup-by-hash, create-writes-hash+Contact, revive-ghost, stub-upgrade); tsc clean.

⚠️ **OWNER-AWARE + one-time backfill needed:** legacy plaintext-only pre-check rows (no `nationalIdHash`) aren't matched by the hash lookup — pre-backfill they **fail loud (P2002 ConflictException), not silent-dup**. Run the existing `backfill:encrypt-pii` (populates `nationalIdHash`) + `backfill:contacts` to retroactively dedup them. This stops NEW dups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)