### PR TITLE
fix(api): Wave-2 small guards + customer-facing accuracy (bad-debt alarm, batch-approve + early-payoff flex)

### DIFF
--- a/apps/api/src/modules/accounting/bad-debt.service.spec.ts
+++ b/apps/api/src/modules/accounting/bad-debt.service.spec.ts
@@ -7,6 +7,12 @@ import { JournalAutoService } from '../journal/journal-auto.service';
 import { BadDebtProvisionTemplate } from '../journal/cpa-templates/bad-debt-provision.template';
 import { BadDebtWriteOffTemplate } from '../journal/cpa-templates/bad-debt-writeoff.template';
 import { EclStageReverseTemplate } from '../journal/cpa-templates/ecl-stage-reverse.template';
+import * as Sentry from '@sentry/nestjs';
+
+jest.mock('@sentry/nestjs', () => ({
+  captureException: jest.fn(),
+  captureMessage: jest.fn(),
+}));
 
 /**
  * BadDebtService is the financial provisioning engine. It maps overdue
@@ -401,6 +407,7 @@ describe('BadDebtService', () => {
     });
 
     it('falls back to defaults when systemConfig has malformed JSON', async () => {
+      (Sentry.captureException as jest.Mock).mockClear();
       prisma.systemConfig.findUnique.mockResolvedValue({ value: 'not-json{{' });
       prisma.payment.findMany.mockResolvedValue([
         {
@@ -418,6 +425,8 @@ describe('BadDebtService', () => {
       ]);
       const result = await service.calculateProvisions('user-1');
       expect(result.byBucket['1-30'].amount).toBeCloseTo(20, 4); // back to defaults
+      // ...but the corrupt regulated-rate config is NOT silently swallowed.
+      expect(Sentry.captureException as jest.Mock).toHaveBeenCalled();
     });
   });
 

--- a/apps/api/src/modules/accounting/bad-debt.service.ts
+++ b/apps/api/src/modules/accounting/bad-debt.service.ts
@@ -48,8 +48,21 @@ export class BadDebtService {
     if (config) {
       try {
         return JSON.parse(config.value);
-      } catch {
-        /* fall through to defaults */
+      } catch (err) {
+        // Corrupt/edited provision-rate JSON must NOT silently revert to
+        // defaults — these rates drive the TFRS-9 ECL allowance JE (Cr 11-2102),
+        // so a stale basis would post with zero signal. Alarm, THEN fall back to
+        // defaults (safe) so the provisioning cron keeps running. Silent drift
+        // on a regulated provision is the failure we refuse.
+        Sentry.captureException(err, {
+          level: 'error',
+          tags: { subsystem: 'bad-debt', key: 'bad_debt_provision_rates' },
+        });
+        this.logger.error(
+          `Corrupt bad_debt_provision_rates SystemConfig JSON — using DEFAULT_PROVISION_RATES: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
       }
     }
     return DEFAULT_PROVISION_RATES;

--- a/apps/api/src/modules/line-oa/flex-messages/early-payoff-success.flex.spec.ts
+++ b/apps/api/src/modules/line-oa/flex-messages/early-payoff-success.flex.spec.ts
@@ -1,0 +1,24 @@
+import { buildEarlyPayoffSuccessFlex } from './early-payoff-success.flex';
+
+describe('buildEarlyPayoffSuccessFlex — discount badge', () => {
+  const base = {
+    customerName: 'บีม',
+    contractNumber: 'CT-2026-0001',
+    amountPaid: 18450,
+    originalAmount: 22030,
+    savings: 3580,
+    payoffDate: '15 เม.ย. 2568',
+  };
+
+  it('omits the discount badge when no discountPercent is given (no false "50%")', () => {
+    const json = JSON.stringify(buildEarlyPayoffSuccessFlex(base));
+    expect(json).not.toContain('ส่วนลดพิเศษ');
+    expect(json).not.toContain('50%');
+  });
+
+  it('renders the ACTUAL discount percent when provided', () => {
+    const json = JSON.stringify(buildEarlyPayoffSuccessFlex({ ...base, discountPercent: 30 }));
+    expect(json).toContain('ส่วนลดพิเศษ 30%');
+    expect(json).not.toContain('50%');
+  });
+});

--- a/apps/api/src/modules/line-oa/flex-messages/early-payoff-success.flex.ts
+++ b/apps/api/src/modules/line-oa/flex-messages/early-payoff-success.flex.ts
@@ -14,6 +14,9 @@ export interface EarlyPayoffSuccessFlexData {
   originalAmount: number;
   savings: number;
   payoffDate: string;
+  /** Actual early-payoff interest-discount percent (0..50). When omitted, the
+   *  "ส่วนลดพิเศษ X%" badge is hidden — never claim a fixed 50%. */
+  discountPercent?: number;
   receiptUrl?: string;
   branchPickupHint?: string;
 }
@@ -34,7 +37,11 @@ export function buildEarlyPayoffSuccessFlex(data: EarlyPayoffSuccessFlexData): F
     body: [
       createHeroAmount('success', formatBaht(data.savings), {
         cap: 'ประหยัดไปทั้งหมด',
-        savingsBadge: 'ส่วนลดพิเศษ 50%',
+        // Only show the discount badge when the real percent is known — the
+        // early-payoff discount is configurable (0..50), so a hardcoded "50%"
+        // lied to customers who got a different rate.
+        savingsBadge:
+          data.discountPercent != null ? `ส่วนลดพิเศษ ${data.discountPercent}%` : undefined,
       }),
       createRowsBlock([
         createRow('ยอดที่ชำระ', formatBaht(data.amountPaid)),

--- a/apps/api/src/modules/line-oa/line-oa-payment.controller.ts
+++ b/apps/api/src/modules/line-oa/line-oa-payment.controller.ts
@@ -181,6 +181,7 @@ export class LineOaPaymentController {
         const evidence = await this.prisma.paymentEvidence.findUnique({
           where: { id },
           include: {
+            payment: { select: { installmentNo: true } },
             contract: {
               include: {
                 customer: true,
@@ -212,12 +213,20 @@ export class LineOaPaymentController {
           const contract = evidence.contract;
           const totalInstallments = contract.payments.length;
           const paidCount = contract.payments.filter((p) => p.status === 'PAID').length;
+          // Derive the installment this evidence pays — the linked Payment if
+          // present, else the next unpaid installment. (Was hardcoded to 1, so a
+          // customer paying installment 5/12 was told "1/12" over LINE.)
+          const nextUnpaid = contract.payments.find((p) => p.status !== 'PAID');
+          const installmentNo =
+            evidence.payment?.installmentNo ??
+            nextUnpaid?.installmentNo ??
+            Math.min(paidCount + 1, totalInstallments);
 
           try {
             const flex = this.lineOaService.buildPaymentSuccess({
               customerName: customer.name,
               contractNumber: contract.contractNumber,
-              installmentNo: 1,
+              installmentNo,
               totalInstallments,
               amountPaid: evidence.amount ? d(evidence.amount) : 0,
               paymentMethod: body.paymentMethod,


### PR DESCRIPTION
Three small Wave-2 correctness fixes (alarm + display only — no ledger change):

- **bad-debt.getProvisionRates**: empty catch on corrupt `bad_debt_provision_rates` JSON silently reverted to defaults (those rates drive the TFRS-9 ECL allowance JE). Now `Sentry.captureException` + `logger.error` before falling back (cron keeps running; drift no longer silent).
- **line-oa batch-approve**: payment-success LINE flex was hardcoded `installmentNo: 1` → customer paying 5/12 told "1/12". Now derives the real installment (evidence's linked Payment, else next unpaid).
- **early-payoff-success flex**: removed the hardcoded "ส่วนลดพิเศษ 50%" badge (discount is configurable 0..50) → optional `discountPercent`, badge shown only when the real % is known (omitted otherwise — never a false 50%).

**Verify:** adversarial pass → SOLID/SHIP. No ledger/Decimal/$transaction/schema changes; callers compile. 45 tests pass; tsc + eslint clean.

Note: the live early-payoff caller doesn't currently have the discount % in scope, so the badge is now **hidden** in prod (strictly better than the false 50%); threading the real % is an optional follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)