### PR TITLE
fix(chatbot-finance): cap the LIFF late-fee quote to match what is actually charged

### DIFF
--- a/apps/api/src/modules/chatbot-finance/services/finance-tools.service.spec.ts
+++ b/apps/api/src/modules/chatbot-finance/services/finance-tools.service.spec.ts
@@ -1,0 +1,92 @@
+import { Prisma } from '@prisma/client';
+import { FinanceToolsService } from './finance-tools.service';
+
+/**
+ * The LIFF chatbot late-fee quote MUST match what the collection path actually
+ * charges (payments.service.recordPayment): min(perDay×days, flatCap, amountDue×5%).
+ * Previously finance-tools quoted an UNCAPPED daysOverdue×rate, over-stating the
+ * fine (e.g. 3,000 quoted vs 100 charged on a 2,000฿ / 60-day installment).
+ */
+describe('FinanceToolsService — capped late-fee quote', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+  let service: FinanceToolsService;
+
+  beforeEach(() => {
+    jest.useFakeTimers().setSystemTime(new Date('2026-06-08T12:00:00Z'));
+    prisma = {
+      contract: {
+        findMany: jest.fn().mockResolvedValue([
+          { id: 'ct-1', contractNumber: 'CT-001', product: { model: 'X', color: 'Y' } },
+        ]),
+      },
+      payment: { findFirst: jest.fn() },
+      // default: no config rows → defaults perDay 50, flatCap 1500 (match payments.service)
+      systemConfig: { findUnique: jest.fn().mockResolvedValue(null) },
+    };
+    const financeConfig = { bankInfoBlock: 'BANK' } as unknown as ConstructorParameters<
+      typeof FinanceToolsService
+    >[1];
+    service = new FinanceToolsService(prisma, financeConfig);
+  });
+
+  afterEach(() => jest.useRealTimers());
+
+  function overdue(opts: { amountDue: number; daysOverdue: number; lateFeeWaived?: boolean }) {
+    return {
+      installmentNo: 3,
+      amountDue: new Prisma.Decimal(opts.amountDue),
+      amountPaid: new Prisma.Decimal(0),
+      dueDate: new Date(Date.now() - opts.daysOverdue * 86400000),
+      lateFeeWaived: opts.lateFeeWaived ?? false,
+      status: 'OVERDUE',
+    };
+  }
+
+  it('getCurrentBalance: 2000฿ / 60 days → lateFee capped at 5% = 100 (NOT uncapped 3000)', async () => {
+    prisma.payment.findFirst.mockResolvedValue(overdue({ amountDue: 2000, daysOverdue: 60 }));
+    const res = await service.getCurrentBalance('cust-1');
+    expect(res.lateFee).toBe(100); // min(50×60=3000, 1500, 2000×0.05=100) = 100
+    expect(res.totalAmount).toBe(2100); // remainingBase 2000 + 100
+    expect(res.daysOverdue).toBe(60);
+  });
+
+  it('getCurrentBalance: honors lateFeeWaived → lateFee 0', async () => {
+    prisma.payment.findFirst.mockResolvedValue(overdue({ amountDue: 2000, daysOverdue: 60, lateFeeWaived: true }));
+    const res = await service.getCurrentBalance('cust-1');
+    expect(res.lateFee).toBe(0);
+  });
+
+  it('getCurrentBalance: uses the configured per-day rate when set', async () => {
+    prisma.systemConfig.findUnique.mockImplementation(({ where }: { where: { key: string } }) =>
+      Promise.resolve(where.key === 'late_fee_per_day' ? { value: '100' } : null),
+    );
+    // 1 day × 100 = 100; 5% of 5000 = 250; flat 1500 → min = 100
+    prisma.payment.findFirst.mockResolvedValue(overdue({ amountDue: 5000, daysOverdue: 1 }));
+    const res = await service.getCurrentBalance('cust-1');
+    expect(res.lateFee).toBe(100);
+  });
+
+  it('getCurrentBalance: found=false when no active contract', async () => {
+    prisma.contract.findMany.mockResolvedValue([]);
+    const res = await service.getCurrentBalance('cust-1');
+    expect(res.found).toBe(false);
+  });
+
+  it('calculateFine(60): no installment context → bounded by the flat cap (1500), not uncapped 3000; notes the 5% cap', async () => {
+    const res = await service.calculateFine(60);
+    expect(res.totalFine).toBe(1500); // min(50×60, 1500) — no amountDue so no % cap
+    expect(res.ratePerDay).toBe(50);
+    expect(res.explanation).toContain('5%');
+  });
+
+  it('calculateFine(2): under the flat cap → 100', async () => {
+    const res = await service.calculateFine(2);
+    expect(res.totalFine).toBe(100);
+  });
+
+  it('calculateFine(0): no fine', async () => {
+    const res = await service.calculateFine(0);
+    expect(res.totalFine).toBe(0);
+  });
+});

--- a/apps/api/src/modules/chatbot-finance/services/finance-tools.service.ts
+++ b/apps/api/src/modules/chatbot-finance/services/finance-tools.service.ts
@@ -3,6 +3,8 @@ import { PrismaService } from '../../../prisma/prisma.service';
 import { LATE_FEE_PER_DAY } from '../constants/finance-rules';
 import { FinanceConfigService } from './finance-config.service';
 import { formatThaiDateText as formatThaiDate } from '../../../utils/thai-date.util';
+import { computeCappedLateFee } from '../../../utils/late-fee.util';
+import { BUSINESS_RULES } from '../../../utils/config.util';
 
 /**
  * Finance Tools — wrap DB queries สำหรับ Claude tool use
@@ -60,7 +62,22 @@ export class FinanceToolsService {
       0,
       Math.floor((now.getTime() - nextPayment.dueDate.getTime()) / (1000 * 60 * 60 * 24)),
     );
-    const lateFee = nextPayment.lateFeeWaived ? 0 : daysOverdue * LATE_FEE_PER_DAY;
+    // Late fee MUST match what the collection path actually charges
+    // (payments.service.recordPayment): capped at
+    // min(perDay×days, flatCap, amountDue×5%). The bot used to quote an
+    // UNCAPPED daysOverdue×rate, over-stating the fine (e.g. 3,000 vs 100).
+    const { feePerDay, flatCap } = await this.getLateFeeConfig();
+    const lateFee = nextPayment.lateFeeWaived
+      ? 0
+      : Number(
+          computeCappedLateFee({
+            daysOverdue,
+            feePerDay,
+            flatCap,
+            capPct: BUSINESS_RULES.LATE_FEE_CAP_PCT,
+            amountDue: nextPayment.amountDue,
+          }),
+        );
     const totalAmount = remainingBase + lateFee;
 
     return {
@@ -128,18 +145,41 @@ export class FinanceToolsService {
     };
   }
 
+  /**
+   * Late-fee config — reads the SAME SystemConfig keys + defaults as the
+   * collection path (payments.service.recordPayment), so the chatbot quote
+   * matches what the customer is actually charged.
+   */
+  private async getLateFeeConfig(): Promise<{ feePerDay: number; flatCap: number }> {
+    const [perDayCfg, capCfg] = await Promise.all([
+      this.prisma.systemConfig.findUnique({ where: { key: 'late_fee_per_day' } }),
+      this.prisma.systemConfig.findUnique({ where: { key: 'late_fee_cap' } }),
+    ]);
+    return {
+      feePerDay: perDayCfg ? Number(perDayCfg.value) : LATE_FEE_PER_DAY,
+      flatCap: capCfg ? Number(capCfg.value) : 1500,
+    };
+  }
+
   // ─── Tool 3: calculate_fine ──────────────────────────────
 
   /**
-   * คำนวณค่าปรับสำหรับวันที่เลยกำหนด (rule-based, ไม่ต้องดึง DB)
+   * คำนวณค่าปรับโดยประมาณสำหรับจำนวนวันที่เลยกำหนด. ไม่มีบริบทงวด → cap 5%
+   * ของยอดงวดคิดไม่ได้ จึงใช้ feePerDay×days กับ flatCap เป็นเพดานบน (เป็น
+   * "ค่าประมาณสูงสุด"). ยอดจริงดูจาก get_current_balance ที่ cap ครบ.
    */
-  calculateFine(daysOverdue: number) {
+  async calculateFine(daysOverdue: number) {
     const days = Math.max(0, Math.floor(daysOverdue));
+    const { feePerDay, flatCap } = await this.getLateFeeConfig();
+    const totalFine = Number(computeCappedLateFee({ daysOverdue: days, feePerDay, flatCap }));
     return {
       daysOverdue: days,
-      ratePerDay: LATE_FEE_PER_DAY,
-      totalFine: days * LATE_FEE_PER_DAY,
-      explanation: `ค่าปรับ ${LATE_FEE_PER_DAY} บาท/วัน × ${days} วัน = ${days * LATE_FEE_PER_DAY} บาท`,
+      ratePerDay: feePerDay,
+      totalFine,
+      explanation:
+        `ค่าปรับ ${feePerDay} บาท/วัน × ${days} วัน` +
+        ` (สูงสุดไม่เกิน ${flatCap} บาท และไม่เกิน 5% ของยอดงวด)` +
+        ` ≈ ${totalFine} บาท — ยอดจริงตรวจได้จากยอดค้างชำระ`,
     };
   }
 

--- a/apps/api/src/modules/chatbot-finance/tools/tool-executor.ts
+++ b/apps/api/src/modules/chatbot-finance/tools/tool-executor.ts
@@ -76,7 +76,7 @@ export class FinanceToolExecutor {
 
         case 'calculate_fine': {
           const days = input.daysOverdue as number;
-          return { ok: true, data: this.tools.calculateFine(days) };
+          return { ok: true, data: await this.tools.calculateFine(days) };
         }
 
         case 'list_recent_receipts': {

--- a/apps/api/src/utils/late-fee.util.spec.ts
+++ b/apps/api/src/utils/late-fee.util.spec.ts
@@ -1,0 +1,48 @@
+import { Prisma } from '@prisma/client';
+import { computeCappedLateFee } from './late-fee.util';
+
+describe('computeCappedLateFee', () => {
+  const s = (d: Prisma.Decimal) => d.toString();
+
+  it('the headline bug case: 2000฿ installment, 60 days, 50/day → capped at 5% = 100 (NOT 3000)', () => {
+    const fee = computeCappedLateFee({
+      daysOverdue: 60,
+      feePerDay: 50,
+      flatCap: 1500,
+      capPct: 0.05,
+      amountDue: 2000,
+    });
+    expect(s(fee)).toBe('100'); // min(3000, 1500, 100) = 100
+  });
+
+  it('per-day wins when it is the smallest (early overdue)', () => {
+    // 2 days × 50 = 100; 5% of 2000 = 100; flat 1500 → min = 100
+    expect(s(computeCappedLateFee({ daysOverdue: 2, feePerDay: 50, flatCap: 1500, capPct: 0.05, amountDue: 2000 }))).toBe('100');
+    // 1 day × 50 = 50 → min(50, 1500, 100) = 50
+    expect(s(computeCappedLateFee({ daysOverdue: 1, feePerDay: 50, flatCap: 1500, capPct: 0.05, amountDue: 2000 }))).toBe('50');
+  });
+
+  it('flat cap binds when amountDue is large and many days overdue', () => {
+    // 100 days × 50 = 5000; 5% of 50000 = 2500; flat 1500 → min = 1500
+    expect(s(computeCappedLateFee({ daysOverdue: 100, feePerDay: 50, flatCap: 1500, capPct: 0.05, amountDue: 50000 }))).toBe('1500');
+  });
+
+  it('without amountDue: only feePerDay×days and flatCap bound it (no % cap)', () => {
+    // 60 × 50 = 3000, flat 1500 → 1500 (no 5% cap because amountDue omitted)
+    expect(s(computeCappedLateFee({ daysOverdue: 60, feePerDay: 50, flatCap: 1500 }))).toBe('1500');
+    // 5 × 50 = 250, flat 1500 → 250
+    expect(s(computeCappedLateFee({ daysOverdue: 5, feePerDay: 50, flatCap: 1500 }))).toBe('250');
+  });
+
+  it('returns 0 for non-positive days (and floors fractional days)', () => {
+    expect(s(computeCappedLateFee({ daysOverdue: 0, feePerDay: 50, flatCap: 1500, capPct: 0.05, amountDue: 2000 }))).toBe('0');
+    expect(s(computeCappedLateFee({ daysOverdue: -3, feePerDay: 50, flatCap: 1500 }))).toBe('0');
+    // 3.9 days floors to 3 → 150
+    expect(s(computeCappedLateFee({ daysOverdue: 3.9, feePerDay: 50, flatCap: 1500 }))).toBe('150');
+  });
+
+  it('rounds HALF_UP to 2dp', () => {
+    // 5% of 100.50 = 5.025 → 5.03 (and < 1×day fee of 50 / flat 1500)
+    expect(s(computeCappedLateFee({ daysOverdue: 1, feePerDay: 50, flatCap: 1500, capPct: 0.05, amountDue: 100.5 }))).toBe('5.03');
+  });
+});

--- a/apps/api/src/utils/late-fee.util.ts
+++ b/apps/api/src/utils/late-fee.util.ts
@@ -1,0 +1,45 @@
+import { Prisma } from '@prisma/client';
+
+export interface CappedLateFeeInput {
+  /** Days past due (floored, clamped to >= 0 internally). */
+  daysOverdue: number;
+  /** Per-day late fee (config `late_fee_per_day`). */
+  feePerDay: Prisma.Decimal | number | string;
+  /** Flat per-installment ceiling (config `late_fee_cap`). */
+  flatCap: Prisma.Decimal | number | string;
+  /** Per-installment percentage cap, e.g. 0.05 = 5% (BUSINESS_RULES.LATE_FEE_CAP_PCT).
+   *  Applied ONLY when amountDue is provided. */
+  capPct?: number;
+  /** The installment's amountDue — enables the percentage cap. Omit for a generic
+   *  estimate with no installment context (then only feePerDay×days + flatCap bound it). */
+  amountDue?: Prisma.Decimal | number | string | null;
+}
+
+/**
+ * Canonical real-time late fee:
+ *   round2( min( feePerDay × daysOverdue, flatCap, amountDue × capPct ) )
+ *
+ * Single source of truth for the per-installment late-fee ceiling. Mirrors the
+ * collection path in payments.service.recordPayment (and the overdue.service
+ * `calculateLateFees` raw-SQL). The LIFF chatbot (finance-tools) MUST use this so
+ * its quote matches what the customer is actually charged — previously the bot
+ * quoted an UNCAPPED daysOverdue×rate, over-stating the fine (e.g. 3,000 quoted
+ * vs 100 charged on a 2,000฿ / 60-day installment).
+ *
+ * When amountDue is omitted (a hypothetical "X days overdue" estimate with no
+ * installment), the percentage cap can't apply, so only feePerDay×days + flatCap
+ * bound the result — callers should make clear it's an upper-bound estimate.
+ */
+export function computeCappedLateFee(input: CappedLateFeeInput): Prisma.Decimal {
+  const days = Math.max(0, Math.floor(input.daysOverdue));
+  if (days <= 0) return new Prisma.Decimal(0);
+
+  const perDayTotal = new Prisma.Decimal(input.feePerDay.toString()).mul(days);
+  const caps: Prisma.Decimal[] = [perDayTotal, new Prisma.Decimal(input.flatCap.toString())];
+
+  if (input.amountDue != null && input.capPct != null) {
+    caps.push(new Prisma.Decimal(input.amountDue.toString()).mul(input.capPct));
+  }
+
+  return Prisma.Decimal.min(...caps).toDecimalPlaces(2, Prisma.Decimal.ROUND_HALF_UP);
+}


### PR DESCRIPTION
**Finding (surfaced by the #1181 characterization):** `FinanceToolsService` (LIFF chatbot) quoted an **uncapped** late fee (`daysOverdue × 50`), while the collection path (`payments.service.recordPayment`) caps at `min(perDay×days, late_fee_cap, amountDue×5%)`. The bot told customers a far larger fine than they're charged — **3,000฿ quoted vs 100฿ charged** on a 2,000฿ / 60-day installment. Also a stale hardcoded 50/day (vs the configurable rate) and `amountDue` actually holding `remainingBase`.

**Fix:**
- New shared pure helper `utils/late-fee.util.computeCappedLateFee` = canonical `round2(min(perDay×days, flatCap, amountDue×capPct))`, golden-tested (incl. the 3000→100 case). Single source of truth mirroring the collection path.
- `getCurrentBalance` reads the **same** SystemConfig keys (`late_fee_per_day`/`late_fee_cap`, defaults 50/1500) + `BUSINESS_RULES.LATE_FEE_CAP_PCT` and applies the full cap → quote == charge.
- `calculateFine` now async, config rate + flat cap; with no installment context the 5% cap can't apply, so its explanation says so and points to the real balance. Executor awaits it.

**No ledger / collection code changed — quote/display only.** 25 tests green (util 6 + finance-tools 8 + tool-executor 11); tsc + eslint clean.

Note: the #1181 finance-tools characterization spec was moved here with corrected (capped) assertions, so that test-only PR stays clean.
Follow-up (out of scope): adopt the helper in payments.service + overdue.service to retire the inline copies; rename the `amountDue` response field (it's `remainingBase`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)