### PR TITLE
refactor(accounting): unify period-lock to AccountingPeriod + test backfill

### DIFF
--- a/apps/api/src/modules/accounting/accounting.controller.ts
+++ b/apps/api/src/modules/accounting/accounting.controller.ts
@@ -233,22 +233,6 @@ export class AccountingController {
   }
 
   // ============================================================
-  // W-013: Period Closing Lock
-  // ============================================================
-
-  @Get('period-status')
-  @Roles('OWNER', 'VIEWER')
-  getPeriodStatus() {
-    return this.service.getAccountingPeriodStatus();
-  }
-
-  @Post('close-period')
-  @Roles('OWNER')
-  closePeriod(@Body('closedUntil') closedUntil: string) {
-    return this.service.closeAccountingPeriod(closedUntil);
-  }
-
-  // ============================================================
   // Bad Debt Provisioning (ค่าเผื่อหนี้สงสัยจะสูญ)
   // ============================================================
 

--- a/apps/api/src/modules/accounting/accounting.service.spec.ts
+++ b/apps/api/src/modules/accounting/accounting.service.spec.ts
@@ -1644,4 +1644,138 @@ describe('AccountingService', () => {
       expect(result.data[0].lines[0].accountCode).toBe('11-2101');
     });
   });
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // getMonthlyPLSummary
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  describe('getMonthlyPLSummary', () => {
+    const YEAR = 2026;
+    // local Date on the 15th so getMonth() lands squarely in `monthIdx`
+    const inMonth = (monthIdx: number) => new Date(YEAR, monthIdx, 15);
+
+    it('returns 12 month rows with Thai labels and zeroed totals on empty data', async () => {
+      const result = await service.getMonthlyPLSummary(YEAR);
+      expect(result.year).toBe(YEAR);
+      expect(result.months).toHaveLength(12);
+      expect(result.months[0]).toMatchObject({
+        month: 1,
+        label: 'ม.ค.',
+        revenue: 0,
+        expenses: 0,
+        netProfit: 0,
+      });
+      expect(result.months[11]).toMatchObject({ month: 12, label: 'ธ.ค.' });
+      expect(result.months.every((m) => m.revenue === 0 && m.expenses === 0)).toBe(true);
+    });
+
+    it('books a CASH sale netAmount as revenue in its createdAt month', async () => {
+      prisma.sale.findMany.mockResolvedValueOnce([
+        { saleType: 'CASH', netAmount: 1000, downPaymentAmount: 0, createdAt: inMonth(2) },
+      ]);
+      const result = await service.getMonthlyPLSummary(YEAR);
+      expect(result.months[2].revenue).toBeCloseTo(1000, 2); // March
+      expect(result.months[0].revenue).toBe(0);
+    });
+
+    it('books only the down payment (not netAmount) for an INSTALLMENT sale', async () => {
+      prisma.sale.findMany.mockResolvedValueOnce([
+        { saleType: 'INSTALLMENT', netAmount: 9999, downPaymentAmount: 500, createdAt: inMonth(3) },
+      ]);
+      const result = await service.getMonthlyPLSummary(YEAR);
+      expect(result.months[3].revenue).toBeCloseTo(500, 2); // April
+    });
+
+    it('uses the stored breakdown (principal+commission+interest+lateFee) when monthlyPrincipal is set', async () => {
+      prisma.payment.findMany.mockResolvedValueOnce([
+        {
+          monthlyPrincipal: 100,
+          monthlyCommission: 20,
+          monthlyInterest: 30,
+          lateFee: 10,
+          lateFeeWaived: false,
+          amountPaid: 9999,
+          paidDate: inMonth(4),
+        },
+      ]);
+      const result = await service.getMonthlyPLSummary(YEAR);
+      expect(result.months[4].revenue).toBeCloseTo(160, 2); // 100+20+30+10
+    });
+
+    it('excludes a waived late fee from the breakdown revenue', async () => {
+      prisma.payment.findMany.mockResolvedValueOnce([
+        {
+          monthlyPrincipal: 100,
+          monthlyCommission: 0,
+          monthlyInterest: 0,
+          lateFee: 50,
+          lateFeeWaived: true,
+          amountPaid: 9999,
+          paidDate: inMonth(6),
+        },
+      ]);
+      const result = await service.getMonthlyPLSummary(YEAR);
+      expect(result.months[6].revenue).toBeCloseTo(100, 2); // lateFee 50 excluded
+    });
+
+    it('falls back to amountPaid when monthlyPrincipal is null (legacy payments)', async () => {
+      prisma.payment.findMany.mockResolvedValueOnce([
+        {
+          monthlyPrincipal: null,
+          amountPaid: 250,
+          lateFee: 0,
+          lateFeeWaived: false,
+          paidDate: inMonth(5),
+        },
+      ]);
+      const result = await service.getMonthlyPLSummary(YEAR);
+      expect(result.months[5].revenue).toBeCloseTo(250, 2);
+    });
+
+    it('books a RECEIVED financeReceivable as revenue in its receivedDate month', async () => {
+      prisma.financeReceivable.findMany.mockResolvedValueOnce([
+        { receivedAmount: 700, receivedDate: inMonth(7) },
+      ]);
+      const result = await service.getMonthlyPLSummary(YEAR);
+      expect(result.months[7].revenue).toBeCloseTo(700, 2);
+    });
+
+    it('books product costPrice as COGS (expenses) reducing netProfit', async () => {
+      // 1st sale.findMany call = sales (empty), 2nd = productSales
+      prisma.sale.findMany
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([{ createdAt: inMonth(8), product: { costPrice: 300 } }]);
+      const result = await service.getMonthlyPLSummary(YEAR);
+      expect(result.months[8].expenses).toBeCloseTo(300, 2);
+      expect(result.months[8].netProfit).toBeCloseTo(-300, 2);
+    });
+
+    it('does not query FINANCE journal expenses when includeFinanceExpenses is false (default)', async () => {
+      await service.getMonthlyPLSummary(YEAR);
+      expect(prisma.journalLine.findMany).not.toHaveBeenCalled();
+    });
+
+    it('adds FINANCE 51-54 journal expenses (debit-credit) when includeFinanceExpenses is true', async () => {
+      prisma.journalLine.findMany.mockResolvedValueOnce([
+        { debit: 400, credit: 0, journalEntry: { entryDate: inMonth(9) } },
+      ]);
+      const result = await service.getMonthlyPLSummary(YEAR, undefined, undefined, true);
+      expect(result.months[9].expenses).toBeCloseTo(400, 2);
+      expect(result.months[9].netProfit).toBeCloseTo(-400, 2);
+      const call = prisma.journalLine.findMany.mock.calls.at(-1)[0];
+      expect(call.where.journalEntry.companyId).toBe('finance-co-id');
+      expect(call.where.OR).toEqual([
+        { accountCode: { startsWith: '51-' } },
+        { accountCode: { startsWith: '52-' } },
+        { accountCode: { startsWith: '53-' } },
+        { accountCode: { startsWith: '54-' } },
+      ]);
+    });
+
+    it('prefers branchIds over branchId in the query filter', async () => {
+      await service.getMonthlyPLSummary(YEAR, 'b1', ['b2', 'b3']);
+      const call = prisma.sale.findMany.mock.calls[0][0];
+      expect(call.where.branchId).toEqual({ in: ['b2', 'b3'] });
+    });
+  });
 });

--- a/apps/api/src/modules/accounting/accounting.service.spec.ts
+++ b/apps/api/src/modules/accounting/accounting.service.spec.ts
@@ -17,7 +17,6 @@ import { CompanyResolverService } from '../journal/company-resolver.service';
  *  - getComparativePL: month-boundary wrapping (Jan → Dec prev year), pctChange arithmetic
  *  - getBalanceSheet: asset/liability/equity structure, derived retainedEarnings = A - L
  *  - getCashFlowStatement: operating cash flow components, sign conventions
- *  - closeAccountingPeriod / getAccountingPeriodStatus: SystemConfig upsert
  *  - getTrialBalance / getProfitLossFromJournal / getBalanceSheetFromJournal:
  *    journal-line-based reports
  *  - getBranchIdsForCompany
@@ -432,45 +431,6 @@ describe('AccountingService', () => {
 
       const result = await service.getCashFlowStatement('2026-01-01', '2026-01-31');
       expect(result.operatingActivities.cashFromCustomers).toBeCloseTo(26000, 4);
-    });
-  });
-
-  // ═══════════════════════════════════════════════════════════════════════════
-  // closeAccountingPeriod & getAccountingPeriodStatus
-  // ═══════════════════════════════════════════════════════════════════════════
-
-  describe('closeAccountingPeriod', () => {
-    it('upserts the accounting_period_closed_until config key', async () => {
-      await service.closeAccountingPeriod('2026-03-31');
-      expect(prisma.systemConfig.upsert).toHaveBeenCalledWith(
-        expect.objectContaining({
-          where: { key: 'accounting_period_closed_until' },
-          update: { value: '2026-03-31' },
-          create: { key: 'accounting_period_closed_until', value: '2026-03-31' },
-        }),
-      );
-    });
-
-    it('returns the closedUntil value in the response', async () => {
-      const result = await service.closeAccountingPeriod('2026-03-31');
-      expect(result.closedUntil).toBe('2026-03-31');
-    });
-  });
-
-  describe('getAccountingPeriodStatus', () => {
-    it('returns null closedUntil when no period lock is set', async () => {
-      prisma.systemConfig.findUnique.mockResolvedValue(null);
-      const result = await service.getAccountingPeriodStatus();
-      expect(result.closedUntil).toBeNull();
-    });
-
-    it('returns the current closedUntil value when set', async () => {
-      prisma.systemConfig.findUnique.mockResolvedValue({
-        key: 'accounting_period_closed_until',
-        value: '2026-03-31',
-      });
-      const result = await service.getAccountingPeriodStatus();
-      expect(result.closedUntil).toBe('2026-03-31');
     });
   });
 
@@ -1327,6 +1287,105 @@ describe('AccountingService', () => {
       const result = await service.getAgingReport(asOf);
       expect(result.asOf).toEqual(asOf);
     });
+
+    // ─── coverage gap-fill: every bucket, boundaries, partial pay, per-customer merge ──
+
+    const agingAsOf = new Date('2026-05-19T00:00:00.000Z');
+    const daysAgo = (n: number) => new Date(agingAsOf.getTime() - n * 86_400_000);
+    const mkOverdue = (
+      id: string,
+      dueDate: Date,
+      amountDue: number,
+      amountPaid: number | null,
+      customer: { id: string; name: string; phone?: string | null },
+    ) => ({
+      id,
+      dueDate,
+      amountDue: new Prisma.Decimal(amountDue),
+      amountPaid: amountPaid == null ? null : new Prisma.Decimal(amountPaid),
+      status: 'OVERDUE',
+      contract: {
+        customer: { id: customer.id, name: customer.name, phone: customer.phone ?? null },
+      },
+    });
+
+    it('buckets a 10-day-overdue payment into bucket_0_30', async () => {
+      prisma.payment.findMany.mockResolvedValueOnce([
+        mkOverdue('p', daysAgo(10), 1000, 0, { id: 'c1', name: 'A' }),
+      ]);
+      const r = await service.getAgingReport(agingAsOf);
+      expect(r.summary.bucket_0_30).toBeCloseTo(1000, 2);
+      expect(r.customers[0].bucket).toBe('bucket_0_30');
+    });
+
+    it('buckets a 75-day-overdue payment into bucket_61_90', async () => {
+      prisma.payment.findMany.mockResolvedValueOnce([
+        mkOverdue('p', daysAgo(75), 1000, 0, { id: 'c1', name: 'A' }),
+      ]);
+      const r = await service.getAgingReport(agingAsOf);
+      expect(r.summary.bucket_61_90).toBeCloseTo(1000, 2);
+      expect(r.customers[0].bucket).toBe('bucket_61_90');
+    });
+
+    it('buckets a 120-day-overdue payment into bucket_90_plus', async () => {
+      prisma.payment.findMany.mockResolvedValueOnce([
+        mkOverdue('p', daysAgo(120), 1000, 0, { id: 'c1', name: 'A' }),
+      ]);
+      const r = await service.getAgingReport(agingAsOf);
+      expect(r.summary.bucket_90_plus).toBeCloseTo(1000, 2);
+      expect(r.customers[0].bucket).toBe('bucket_90_plus');
+    });
+
+    it('treats exactly-30-days as bucket_0_30 and exactly-31-days as bucket_31_60 (boundary)', async () => {
+      prisma.payment.findMany.mockResolvedValueOnce([
+        mkOverdue('p30', daysAgo(30), 100, 0, { id: 'c30', name: '30d' }),
+        mkOverdue('p31', daysAgo(31), 200, 0, { id: 'c31', name: '31d' }),
+      ]);
+      const r = await service.getAgingReport(agingAsOf);
+      expect(r.summary.bucket_0_30).toBeCloseTo(100, 2);
+      expect(r.summary.bucket_31_60).toBeCloseTo(200, 2);
+    });
+
+    it('counts only the remaining balance (amountDue - amountPaid) for a partial payment', async () => {
+      prisma.payment.findMany.mockResolvedValueOnce([
+        mkOverdue('p', daysAgo(45), 1500, 500, { id: 'c1', name: 'A' }),
+      ]);
+      const r = await service.getAgingReport(agingAsOf);
+      expect(r.summary.bucket_31_60).toBeCloseTo(1000, 2);
+      expect(r.customers[0].totalOverdue).toBeCloseTo(1000, 2);
+    });
+
+    it('treats null amountPaid as zero paid', async () => {
+      prisma.payment.findMany.mockResolvedValueOnce([
+        mkOverdue('p', daysAgo(45), 1500, null, { id: 'c1', name: 'A' }),
+      ]);
+      const r = await service.getAgingReport(agingAsOf);
+      expect(r.customers[0].totalOverdue).toBeCloseTo(1500, 2);
+    });
+
+    it('aggregates multiple overdue payments per customer: sums total, keeps max daysOverdue, summary splits per-payment bucket', async () => {
+      prisma.payment.findMany.mockResolvedValueOnce([
+        mkOverdue('old', daysAgo(100), 1000, 0, { id: 'cm', name: 'Merge' }),
+        mkOverdue('new', daysAgo(10), 500, 0, { id: 'cm', name: 'Merge' }),
+      ]);
+      const r = await service.getAgingReport(agingAsOf);
+      expect(r.customers).toHaveLength(1);
+      expect(r.customers[0].totalOverdue).toBeCloseTo(1500, 2);
+      expect(r.customers[0].daysOverdue).toBe(100);
+      expect(r.customers[0].bucket).toBe('bucket_90_plus');
+      // summary tracks each payment in its OWN bucket (can diverge from the customer's max bucket)
+      expect(r.summary.bucket_90_plus).toBeCloseTo(1000, 2);
+      expect(r.summary.bucket_0_30).toBeCloseTo(500, 2);
+    });
+
+    it('sorts customers by daysOverdue descending', async () => {
+      prisma.payment.findMany.mockResolvedValueOnce([
+        mkOverdue('x', daysAgo(20), 100, 0, { id: 'cx', name: 'X' }),
+        mkOverdue('y', daysAgo(80), 200, 0, { id: 'cy', name: 'Y' }),
+      ]);
+      const r = await service.getAgingReport(agingAsOf);
+      expect(r.customers.map((c) => c.customerId)).toEqual(['cy', 'cx']);
+    });
   });
 
   // ═══════════════════════════════════════════════════════════════════════════
@@ -1438,6 +1497,36 @@ describe('AccountingService', () => {
       const result = await service.getBadDebtReport(periodStart, periodEnd);
       expect(result.entries[0].description).toBe('entry-level description');
     });
+
+    // ─── coverage gap-fill ──────────────────────────────────────────────────────
+
+    it('orders results by journalEntry.postedAt desc', async () => {
+      await service.getBadDebtReport(periodStart, periodEnd);
+      const call = prisma.journalLine.findMany.mock.calls.at(-1)[0];
+      expect(call.orderBy).toEqual({ journalEntry: { postedAt: 'desc' } });
+    });
+
+    it('treats a null debit as zero in both total and entry amount', async () => {
+      prisma.journalLine.findMany.mockResolvedValueOnce([
+        {
+          accountCode: '51-1102',
+          debit: null,
+          credit: new Prisma.Decimal(0),
+          description: 'no-amount',
+          journalEntry: {
+            id: 'je-null',
+            entryNumber: 'JP5-20260118-0001',
+            description: 'x',
+            postedAt: new Date('2026-01-18'),
+            referenceType: 'REPOSSESSION',
+            referenceId: 'repo-null',
+          },
+        },
+      ]);
+      const result = await service.getBadDebtReport(periodStart, periodEnd);
+      expect(result.totalBadDebt).toBe(0);
+      expect(result.entries[0].amount).toBe(0);
+    });
   });
 
   // ═══════════════════════════════════════════════════════════════════════════
@@ -1489,6 +1578,70 @@ describe('AccountingService', () => {
       await service.getGeneralJournal(start, end);
       const call = prisma.journalEntry.findMany.mock.calls.at(-1)[0];
       expect(call.where.deletedAt).toBeNull();
+    });
+
+    // ─── coverage gap-fill: paging math, range, lines include, data/total passthrough ──
+
+    it('defaults to page 1 / limit 50 (skip 0 / take 50) when opts omitted', async () => {
+      const start = new Date('2026-05-01');
+      const end = new Date('2026-05-31');
+      const result = await service.getGeneralJournal(start, end);
+      expect(result.page).toBe(1);
+      expect(result.limit).toBe(50);
+      const call = prisma.journalEntry.findMany.mock.calls.at(-1)[0];
+      expect(call.skip).toBe(0);
+      expect(call.take).toBe(50);
+    });
+
+    it('computes skip/take from page and limit', async () => {
+      const start = new Date('2026-05-01');
+      const end = new Date('2026-05-31');
+      await service.getGeneralJournal(start, end, { page: 3, limit: 20 });
+      const call = prisma.journalEntry.findMany.mock.calls.at(-1)[0];
+      expect(call.skip).toBe(40);
+      expect(call.take).toBe(20);
+    });
+
+    it('filters by postedAt range, includes lines ordered by id asc, entries by postedAt desc', async () => {
+      const start = new Date('2026-05-01');
+      const end = new Date('2026-05-31');
+      await service.getGeneralJournal(start, end);
+      const call = prisma.journalEntry.findMany.mock.calls.at(-1)[0];
+      expect(call.where.postedAt.gte).toEqual(start);
+      expect(call.where.postedAt.lte).toEqual(end);
+      expect(call.orderBy).toEqual({ postedAt: 'desc' });
+      expect(call.include.lines.orderBy).toEqual({ id: 'asc' });
+      expect(call.include.lines.select).toMatchObject({
+        accountCode: true,
+        debit: true,
+        credit: true,
+        description: true,
+      });
+    });
+
+    it('returns data with lines and total from the count query', async () => {
+      const start = new Date('2026-05-01');
+      const end = new Date('2026-05-31');
+      prisma.journalEntry.findMany.mockResolvedValueOnce([
+        {
+          id: 'je1',
+          postedAt: new Date('2026-05-10'),
+          lines: [
+            {
+              accountCode: '11-2101',
+              debit: new Prisma.Decimal(100),
+              credit: new Prisma.Decimal(0),
+              description: 'x',
+            },
+          ],
+        },
+      ]);
+      prisma.journalEntry.count.mockResolvedValueOnce(7);
+      const result = await service.getGeneralJournal(start, end, { page: 1, limit: 50 });
+      expect(result.total).toBe(7);
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0].lines).toHaveLength(1);
+      expect(result.data[0].lines[0].accountCode).toBe('11-2101');
     });
   });
 });

--- a/apps/api/src/modules/accounting/accounting.service.ts
+++ b/apps/api/src/modules/accounting/accounting.service.ts
@@ -6,7 +6,6 @@ import {
   OnModuleInit,
 } from '@nestjs/common';
 import { PrismaService } from '../../prisma/prisma.service';
-import { StructuredLoggerService } from '../../common/logger';
 import { Prisma } from '@prisma/client';
 import { JournalAutoService } from '../journal/journal-auto.service';
 import { CompanyResolverService } from '../journal/company-resolver.service';
@@ -59,7 +58,6 @@ type ReportExpenseCategory =
 @Injectable()
 export class AccountingService implements OnModuleInit {
   private readonly logger = new Logger(AccountingService.name);
-  private readonly structuredLogger = new StructuredLoggerService(AccountingService.name);
   constructor(
     private prisma: PrismaService,
     private journalAutoService: JournalAutoService,
@@ -637,25 +635,6 @@ export class AccountingService implements OnModuleInit {
         netProfit: pctChange(current.netProfit, lastYear.netProfit),
       },
     };
-  }
-
-  // ─── W-013: Period Closing Lock ───────────────────────────────────────────────
-
-  async closeAccountingPeriod(closedUntil: string) {
-    await this.prisma.systemConfig.upsert({
-      where: { key: 'accounting_period_closed_until' },
-      update: { value: closedUntil },
-      create: { key: 'accounting_period_closed_until', value: closedUntil },
-    });
-    this.structuredLogger.log('accounting.period.closed', { closedUntil });
-    return { closedUntil };
-  }
-
-  async getAccountingPeriodStatus() {
-    const config = await this.prisma.systemConfig.findUnique({
-      where: { key: 'accounting_period_closed_until' },
-    });
-    return { closedUntil: config?.value || null };
   }
 
   // ─── Balance Sheet (derived from existing data, no general ledger) ────────────

--- a/apps/api/src/modules/contracts/contract-payment.service.ts
+++ b/apps/api/src/modules/contracts/contract-payment.service.ts
@@ -251,16 +251,16 @@ export class ContractPaymentService {
       throw new BadRequestException('กรุณาระบุเลขที่อ้างอิงหรือแนบสลิปสำหรับการชำระแบบโอน/QR');
     }
 
-    // Period-lock guard (audit finding J3): cannot back-date an early payoff
-    // into a closed accounting period.
-    await validatePeriodOpen(this.prisma, paidDate);
-
     // F-3-027 part 2/3 follow-up + Phase A.1b: resolve FINANCE + SHOP
     // companyIds once BEFORE the transaction (and BEFORE the per-installment
     // loop) so the early-payoff JE callers pass both explicitly to
     // JournalAutoService.
     const financeCompanyId = await this.resolveFinanceCompanyId();
     const shopCompanyId = await this.resolveShopCompanyId();
+
+    // Period-lock guard (audit finding J3): cannot back-date an early payoff
+    // into a closed (FINANCE) accounting period.
+    await validatePeriodOpen(this.prisma, paidDate, financeCompanyId);
 
     await this.prisma.$transaction(
       async (tx) => {

--- a/apps/api/src/modules/journal/journal.service.spec.ts
+++ b/apps/api/src/modules/journal/journal.service.spec.ts
@@ -93,33 +93,9 @@ describe('JournalService.create — period lock enforcement', () => {
     expect(prisma.$transaction).toHaveBeenCalled();
   });
 
-  it('also rejects when legacy SystemConfig `accounting_period_closed_until` blocks the date', async () => {
-    prisma.accountingPeriod.findUnique.mockResolvedValue(null);
-    // D1.2.6.2 — validatePeriodOpen now requires today > closedUntil + grace
-    // to throw. Use a `closedUntil` well in the past + grace=0 so the legacy
-    // rejection path still fires deterministically regardless of when this
-    // test runs. (The DTO's entryDate '2026-04-10' is on/before closedUntil
-    // '2026-04-30', so date <= closedUntil holds.)
-    prisma.systemConfig.findUnique.mockImplementation(
-      ({ where }: { where: { key: string } }) => {
-        if (where.key === 'period_grace_days') {
-          return Promise.resolve({ key: 'period_grace_days', value: '0' });
-        }
-        if (where.key === 'accounting_period_closed_until') {
-          return Promise.resolve({
-            key: 'accounting_period_closed_until',
-            value: '2020-12-31',
-          });
-        }
-        return Promise.resolve(null);
-      },
-    );
-
-    await expect(
-      service.create({ ...balancedDto(), entryDate: '2020-04-10' }, 'user-1'),
-    ).rejects.toThrow(BadRequestException);
-    expect(prisma.$transaction).not.toHaveBeenCalled();
-  });
+  // (2026-06 unify) The legacy `accounting_period_closed_until` Tier-2 fallback
+  // was removed — AccountingPeriod is now the single source of truth, so the
+  // former "legacy SystemConfig blocks the date" case no longer applies.
 
   // ─── Wave-1 #10: exact-Decimal balance validation (was float + 0.001 epsilon) ───
 

--- a/apps/api/src/modules/payments/payments.service.ts
+++ b/apps/api/src/modules/payments/payments.service.ts
@@ -183,8 +183,8 @@ export class PaymentsService {
       throw new BadRequestException('ต้อง upload หลักฐานการชำระเงิน (สลิปโอนเงิน) หรือระบุเลขอ้างอิงธุรกรรม');
     }
 
-    // CR-7: Validate payment date is not in a closed accounting period
-    await validatePeriodOpen(this.prisma, new Date());
+    // CR-7: Validate payment date is not in a closed (FINANCE) accounting period.
+    await validatePeriodOpen(this.prisma, new Date(), await this.resolveFinanceCompanyId());
 
     // T16: Tolerance approver role validation.
     // If toleranceApproverId is supplied, verify the named user has an approved role.

--- a/apps/api/src/modules/receipts/receipts.service.spec.ts
+++ b/apps/api/src/modules/receipts/receipts.service.spec.ts
@@ -5,6 +5,7 @@ import { PrismaService } from '../../prisma/prisma.service';
 import { JournalAutoService } from '../journal/journal-auto.service';
 import { LineOaService } from '../line-oa/line-oa.service';
 import { ReceiptVoidReversalTemplate } from '../journal/cpa-templates/receipt-void-reversal.template';
+import { validatePeriodOpen } from '../../utils/period-lock.util';
 
 // Mock the period-lock util so the test isn't blocked by closed-period validation.
 jest.mock('../../utils/period-lock.util', () => ({
@@ -42,6 +43,9 @@ describe('ReceiptsService', () => {
       receipt: {
         findUnique: jest.fn(),
         update: jest.fn(),
+      },
+      companyInfo: {
+        findFirst: jest.fn().mockResolvedValue({ id: 'co-FINANCE' }),
       },
       $transaction: jest.fn().mockImplementation(async (cb: any) => cb(txMock)),
       __tx: txMock,
@@ -106,6 +110,10 @@ describe('ReceiptsService', () => {
 
       expect(result.voidedReceipt).toBeDefined();
       expect(result.creditNote).toBeDefined();
+
+      // Period-lock guard runs with the resolved FINANCE companyId (unify 2026-06):
+      // voids must obey the FINANCE AccountingPeriod, not the removed legacy cutoff.
+      expect(validatePeriodOpen).toHaveBeenCalledWith(prisma, expect.any(Date), 'co-FINANCE');
 
       // Phase A.5a: reversal JE posted via ReceiptVoidReversalTemplate
       // (PR #780 Wave 1 P0: tx is forwarded so JE post + receipt void roll back together)

--- a/apps/api/src/modules/receipts/receipts.service.ts
+++ b/apps/api/src/modules/receipts/receipts.service.ts
@@ -27,6 +27,20 @@ export class ReceiptsService {
   ) {}
 
   /**
+   * Resolve the FINANCE companyId for the period-lock guard. Receipts are a
+   * FINANCE-side artifact (their void posts a FINANCE reversal JE). Returns
+   * undefined when FINANCE is not configured so a void never crashes on
+   * misconfig — FINANCE is always configured in production.
+   */
+  private async resolveFinanceCompanyId(): Promise<string | undefined> {
+    const finance = await this.prisma.companyInfo.findFirst({
+      where: { companyCode: 'FINANCE', deletedAt: null },
+      select: { id: true },
+    });
+    return finance?.id;
+  }
+
+  /**
    * Generate receipt number: RT-YYYYMM-NNNNN (CPA Policy A spec).
    *
    * Per-month sequence guarded by pg_advisory_xact_lock so concurrent generation
@@ -456,8 +470,8 @@ export class ReceiptsService {
       );
     }
 
-    // CR-7: Validate void date is not in a closed accounting period
-    await validatePeriodOpen(this.prisma, new Date());
+    // CR-7: Validate void date is not in a closed (FINANCE) accounting period.
+    await validatePeriodOpen(this.prisma, new Date(), await this.resolveFinanceCompanyId());
     return this.prisma.$transaction(async (tx) => {
       const receipt = await tx.receipt.findUnique({ where: { id } });
       if (!receipt || receipt.deletedAt) throw new NotFoundException('ไม่พบใบเสร็จ');

--- a/apps/api/src/utils/period-lock.util.spec.ts
+++ b/apps/api/src/utils/period-lock.util.spec.ts
@@ -2,15 +2,21 @@ import { BadRequestException } from '@nestjs/common';
 import { validatePeriodOpen } from './period-lock.util';
 
 /**
- * Tests for D1.2.6.2 — `period_grace_days` SystemConfig knob. The default 5d
- * grace window lets owners post invoices into the just-closed period for a
- * few days after the period's last calendar day.
+ * Period-lock enforcement — single source of truth = AccountingPeriod.
  *
- * Note: validatePeriodOpen reads `new Date()` to compare against `today` —
- * we use Jest's fake timers so the grace-window math is deterministic.
+ * (2026-06 unify) The legacy SystemConfig key `accounting_period_closed_until`
+ * was removed as an enforcement mechanism. AccountingPeriod (per-company,
+ * per-month status) is now the ONLY source of truth; `period_grace_days` still
+ * tunes the post-close grace window (D1.2.6.2).
+ *
+ * Enforcement requires a companyId — every accounting write path resolves the
+ * FINANCE/SHOP companyId before calling the guard. A call with no companyId is
+ * intentionally a no-op (see the "no companyId" test below).
+ *
+ * validatePeriodOpen reads `new Date()` for the grace-window comparison — we use
+ * Jest fake timers so the math is deterministic.
  */
-
-describe('validatePeriodOpen — D1.2.6.2 period_grace_days', () => {
+describe('validatePeriodOpen — AccountingPeriod single source of truth', () => {
   beforeEach(() => {
     jest.useFakeTimers();
   });
@@ -22,7 +28,7 @@ describe('validatePeriodOpen — D1.2.6.2 period_grace_days', () => {
   function mockPrisma(opts: {
     period?: { status: string } | null;
     graceDays?: string | null; // raw string as stored in SystemConfig
-    closedUntil?: string | null;
+    legacyClosedUntil?: string | null; // only used to PROVE the legacy key is ignored
   }) {
     return {
       systemConfig: {
@@ -31,7 +37,7 @@ describe('validatePeriodOpen — D1.2.6.2 period_grace_days', () => {
             return Promise.resolve(opts.graceDays ? { value: opts.graceDays } : null);
           }
           if (args.where.key === 'accounting_period_closed_until') {
-            return Promise.resolve(opts.closedUntil ? { value: opts.closedUntil } : null);
+            return Promise.resolve(opts.legacyClosedUntil ? { value: opts.legacyClosedUntil } : null);
           }
           return Promise.resolve(null);
         }),
@@ -42,7 +48,7 @@ describe('validatePeriodOpen — D1.2.6.2 period_grace_days', () => {
     };
   }
 
-  // ── Tier 1: AccountingPeriod (companyId provided) ──────────────────────
+  // ── AccountingPeriod status semantics ──────────────────────────────────
 
   it('CLOSED period: rejects when today is BEYOND grace window (default 5d)', async () => {
     jest.setSystemTime(new Date('2026-06-10T00:00:00Z')); // 10d past May 31
@@ -76,14 +82,6 @@ describe('validatePeriodOpen — D1.2.6.2 period_grace_days', () => {
     ).resolves.toBeUndefined();
   });
 
-  it('OPEN period: never throws regardless of grace window', async () => {
-    jest.setSystemTime(new Date('2027-01-01T00:00:00Z'));
-    const prisma = mockPrisma({ period: { status: 'OPEN' } });
-    await expect(
-      validatePeriodOpen(prisma, new Date('2026-05-31'), 'co-1'),
-    ).resolves.toBeUndefined();
-  });
-
   it('SYNCED period: treated same as CLOSED for grace purposes', async () => {
     jest.setSystemTime(new Date('2026-06-10T00:00:00Z')); // beyond default grace
     const prisma = mockPrisma({ period: { status: 'SYNCED' } });
@@ -92,27 +90,50 @@ describe('validatePeriodOpen — D1.2.6.2 period_grace_days', () => {
     ).rejects.toThrow(BadRequestException);
   });
 
-  // ── Tier 2: legacy `accounting_period_closed_until` ────────────────────
-
-  it('legacy closedUntil: rejects when today is BEYOND grace', async () => {
-    jest.setSystemTime(new Date('2026-06-15T00:00:00Z'));
-    const prisma = mockPrisma({ closedUntil: '2026-05-31' });
+  it('OPEN period: never throws regardless of grace window', async () => {
+    jest.setSystemTime(new Date('2027-01-01T00:00:00Z'));
+    const prisma = mockPrisma({ period: { status: 'OPEN' } });
     await expect(
-      validatePeriodOpen(prisma, new Date('2026-05-30')),
-    ).rejects.toThrow(BadRequestException);
-  });
-
-  it('legacy closedUntil: ALLOWS when today is WITHIN grace', async () => {
-    jest.setSystemTime(new Date('2026-06-03T00:00:00Z'));
-    const prisma = mockPrisma({ closedUntil: '2026-05-31' });
-    await expect(
-      validatePeriodOpen(prisma, new Date('2026-05-30')),
+      validatePeriodOpen(prisma, new Date('2026-05-31'), 'co-1'),
     ).resolves.toBeUndefined();
   });
 
-  // ── Edge: malformed/missing grace config falls back to default 5 ───────
+  it('REVIEW period: not yet closed → never throws', async () => {
+    jest.setSystemTime(new Date('2027-01-01T00:00:00Z'));
+    const prisma = mockPrisma({ period: { status: 'REVIEW' } });
+    await expect(
+      validatePeriodOpen(prisma, new Date('2026-05-31'), 'co-1'),
+    ).resolves.toBeUndefined();
+  });
 
-  it('grace_days unparseable: falls back to default 5', async () => {
+  it('no AccountingPeriod row for the month → never throws', async () => {
+    jest.setSystemTime(new Date('2027-01-01T00:00:00Z'));
+    const prisma = mockPrisma({ period: null });
+    await expect(
+      validatePeriodOpen(prisma, new Date('2026-05-31'), 'co-1'),
+    ).resolves.toBeUndefined();
+  });
+
+  // ── single source of truth: no companyId + legacy key both = NOT guarded ──
+
+  it('no companyId provided → not guarded (resolves) even when the month is CLOSED', async () => {
+    jest.setSystemTime(new Date('2026-06-10T00:00:00Z'));
+    const prisma = mockPrisma({ period: { status: 'CLOSED' } });
+    await expect(validatePeriodOpen(prisma, new Date('2026-05-31'))).resolves.toBeUndefined();
+  });
+
+  it('ignores the legacy accounting_period_closed_until key (removed as a source of truth)', async () => {
+    jest.setSystemTime(new Date('2026-06-15T00:00:00Z')); // well past the legacy cutoff
+    const prisma = mockPrisma({ legacyClosedUntil: '2026-05-31' });
+    await expect(validatePeriodOpen(prisma, new Date('2026-05-30'))).resolves.toBeUndefined();
+    expect(prisma.systemConfig.findUnique).not.toHaveBeenCalledWith({
+      where: { key: 'accounting_period_closed_until' },
+    });
+  });
+
+  // ── grace config edge cases fall back to default 5 ──────────────────────
+
+  it('grace_days unparseable: falls back to default 5 (within window → allows)', async () => {
     jest.setSystemTime(new Date('2026-06-03T00:00:00Z'));
     const prisma = mockPrisma({ period: { status: 'CLOSED' }, graceDays: 'soon' });
     await expect(
@@ -120,7 +141,7 @@ describe('validatePeriodOpen — D1.2.6.2 period_grace_days', () => {
     ).resolves.toBeUndefined();
   });
 
-  it('grace_days negative: falls back to default 5', async () => {
+  it('grace_days negative: falls back to default 5 (beyond window → rejects)', async () => {
     jest.setSystemTime(new Date('2026-06-10T00:00:00Z'));
     const prisma = mockPrisma({ period: { status: 'CLOSED' }, graceDays: '-2' });
     await expect(

--- a/apps/api/src/utils/period-lock.util.ts
+++ b/apps/api/src/utils/period-lock.util.ts
@@ -1,17 +1,25 @@
 /**
  * Accounting period lock utility
- * Shared validation to prevent transactions in closed accounting periods.
- * Used by: AccountingService, PaymentsService, ReceiptsService
+ *
+ * Single source of truth = `AccountingPeriod` (per-company, per-month status).
+ * Prevents posting/voiding accounting transactions into a CLOSED or SYNCED
+ * period — UNLESS today is still inside the `period_grace_days` window.
+ *
+ * (2026-06 unify) The legacy global SystemConfig cutoff
+ * `accounting_period_closed_until` was removed; AccountingPeriod is now the only
+ * mechanism. Every accounting write path resolves the FINANCE/SHOP companyId and
+ * passes it here. A call without companyId is intentionally a no-op.
+ *
+ * Used by: JournalService, PaymentsService, ReceiptsService, ContractPaymentService,
+ *          AssetService, DepreciationService, OtherIncomeService,
+ *          ExpenseDocumentsService, IntercompanyService, RefundsService,
+ *          installment-accrual.cron
  */
 import { BadRequestException } from '@nestjs/common';
 
 interface PrismaLike {
   systemConfig: {
     findUnique(args: { where: { key: string } }): Promise<{ value: string } | null>;
-    findFirst?(args: {
-      where: { key: string; deletedAt?: null };
-      select?: { value: true };
-    }): Promise<{ value: string } | null>;
   };
   accountingPeriod?: {
     findUnique(args: {
@@ -54,60 +62,36 @@ function addDays(base: Date, days: number): Date {
 /**
  * Validate that a transaction date is not in a closed accounting period.
  *
- * Two-tier check:
- * 1. If companyId is provided: look up AccountingPeriod for the date's year+month.
- *    Throws if status is CLOSED or SYNCED — UNLESS today is within
- *    `period_grace_days` after the period's last calendar day (D1.2.6.2).
- * 2. Fallback: check legacy SystemConfig key `accounting_period_closed_until`.
- *    Throws if `date <= closedUntil` — UNLESS today is within
- *    `period_grace_days` after `closedUntil`.
+ * Looks up the AccountingPeriod for the date's (companyId, year, month). Throws
+ * if its status is CLOSED or SYNCED — UNLESS today is within `period_grace_days`
+ * after the period's last calendar day (D1.2.6.2).
  *
- * Both checks are run when companyId is provided (belt-and-suspenders).
+ * Enforcement REQUIRES companyId: callers that do not pass one are not guarded.
  */
 export async function validatePeriodOpen(
   prisma: PrismaLike,
   date: Date,
   companyId?: string,
 ): Promise<void> {
-  const graceDays = await getGraceDays(prisma);
-  const today = new Date();
+  if (!companyId || !prisma.accountingPeriod) return;
 
-  // ── Tier 1: AccountingPeriod model check (when companyId is available) ────
-  if (companyId && prisma.accountingPeriod) {
-    const year = date.getFullYear();
-    const month = date.getMonth() + 1; // JS months are 0-indexed
-    const period = await prisma.accountingPeriod.findUnique({
-      where: { companyId_year_month: { companyId, year, month } },
-      select: { status: true },
-    });
-    if (period && (period.status === 'CLOSED' || period.status === 'SYNCED')) {
-      // D1.2.6.2 — grace window. Allow posting INTO a closed period for
-      // `graceDays` after the period's last calendar day.
-      const periodLastDay = lastDayOfMonth(year, month);
-      const graceEnd = addDays(periodLastDay, graceDays);
-      if (today > graceEnd) {
-        throw new BadRequestException(
-          `ไม่สามารถบันทึกรายการในงวดที่ปิดแล้ว (${year}/${String(month).padStart(2, '0')} สถานะ: ${period.status})`,
-        );
-      }
-      // else: within grace window → fall through (allowed)
-    }
+  const year = date.getFullYear();
+  const month = date.getMonth() + 1; // JS months are 0-indexed
+  const period = await prisma.accountingPeriod.findUnique({
+    where: { companyId_year_month: { companyId, year, month } },
+    select: { status: true },
+  });
+  if (!period || (period.status !== 'CLOSED' && period.status !== 'SYNCED')) {
+    return; // OPEN / REVIEW / no row → not locked
   }
 
-  // ── Tier 2: Legacy SystemConfig check (backward compatibility) ────────────
-  const config = await prisma.systemConfig.findUnique({
-    where: { key: 'accounting_period_closed_until' },
-  });
-  if (config) {
-    const closedUntil = new Date(config.value);
-    if (date <= closedUntil) {
-      // D1.2.6.2 — same grace window applied to the legacy cutoff.
-      const graceEnd = addDays(closedUntil, graceDays);
-      if (today > graceEnd) {
-        throw new BadRequestException(
-          `ไม่สามารถบันทึกรายการในงวดที่ปิดแล้ว (ปิดถึง ${closedUntil.toISOString().split('T')[0]})`,
-        );
-      }
-    }
+  // D1.2.6.2 — grace window. Allow posting INTO a closed period for
+  // `graceDays` after the period's last calendar day.
+  const graceDays = await getGraceDays(prisma);
+  const graceEnd = addDays(lastDayOfMonth(year, month), graceDays);
+  if (new Date() > graceEnd) {
+    throw new BadRequestException(
+      `ไม่สามารถบันทึกรายการในงวดที่ปิดแล้ว (${year}/${String(month).padStart(2, '0')} สถานะ: ${period.status})`,
+    );
   }
 }


### PR DESCRIPTION
## Summary
Two related accounting changes (see commits `3d96b661`, `b22a9988`).

### Period-lock unify (single source of truth = AccountingPeriod)
- `period-lock.util` now enforces ONLY via `AccountingPeriod.status` (CLOSED/SYNCED) + the `period_grace_days` grace window. The legacy global `accounting_period_closed_until` SystemConfig cutoff (Tier 2) is removed.
- `payments` / `receipts` / `contract-payment` now resolve and pass the FINANCE companyId — closing a real enforcement gap (they previously passed no companyId, so they relied on the now-dead Tier-2 path and were effectively **unguarded**).
- Removed dead `AccountingService.closeAccountingPeriod` / `getAccountingPeriodStatus` + the `/accounting/close-period` and `/accounting/period-status` endpoints (no web/e2e caller) and the now-unused `structuredLogger` field.
- **No data migration** — owner confirmed the legacy key was never set in prod.

### Test backfill (characterization)
- +14 cases for the P4-SP1 report methods (`getAgingReport` / `getGeneralJournal` / `getBadDebtReport`): all aging buckets, day boundaries, partial pay, per-customer merge, paging math, data/total passthrough.
- +11 cases for `getMonthlyPLSummary` — previously the only public `AccountingService` method with **zero** coverage.

## Verification
- `period-lock.util.spec` 12/12, `accounting.service.spec` 89/89, all affected specs (payments/receipts/contract-payment/journal/asset/...) 222+ green.
- `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)