### PR TITLE
ci(deploy-gcp): concurrency group + lint-and-test timeout

### DIFF
--- a/.github/workflows/deploy-gcp.yml
+++ b/.github/workflows/deploy-gcp.yml
@@ -22,6 +22,12 @@ env:
   GAR_LOCATION: asia-southeast1
   API_IMAGE: asia-southeast1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/bestchoice/api
 
+# Serialise runs per ref so rapid pushes to main can't overlap a migrate/deploy.
+# cancel-in-progress:false → queue, never abort a run mid-migration/deploy.
+concurrency:
+  group: deploy-gcp-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   # ============================================
   # Job 1: Lint, Test, Build (same as deploy.yml)
@@ -34,6 +40,9 @@ jobs:
   lint-and-test:
     name: Lint & Test
     runs-on: ubuntu-latest
+    # Fail fast if a DB-backed spec hangs (the suite normally finishes in
+    # ~5 min) instead of burning the default 6h job limit then auto-cancelling.
+    timeout-minutes: 25
     if: github.event_name == 'pull_request'
 
     services:


### PR DESCRIPTION
## What
Two CI hardenings for `deploy-gcp.yml`:
1. **`concurrency` group** per ref (`cancel-in-progress: false`) — rapid pushes to `main` can no longer overlap a migrate/deploy run; they queue instead of racing.
2. **`timeout-minutes: 25`** on `lint-and-test` — a hung DB-backed spec now fails fast instead of running to the default 6h limit then auto-cancelling (the symptom seen on PR #1153). The suite normally finishes in ~5 min.

## Why (correcting a stale assumption)
A prior note suspected the "Test API" step ran jest **in parallel** and hit the parallel-DB hang. That's **not the case** — `Test API` runs `npm run test --workspace=apps/api` = `jest --runInBand --forceExit`, and has since the first CI commit (#397). So there was no parallel-config to "fix". The real gaps were the missing concurrency guard and the missing job timeout; this PR addresses those.

## Risk
- Workflow-only change, no app code. Validated: YAML parses; `concurrency` + `timeout-minutes` resolve correctly.
- `cancel-in-progress: false` is the safe choice for a deploy pipeline (never abort a run mid-migration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)