### PR TITLE
refactor(notifications): dedup reminder/overdue dunning guards (Wave-4)

### DIFF
--- a/apps/api/src/modules/notifications/notifications.service.reminders.spec.ts
+++ b/apps/api/src/modules/notifications/notifications.service.reminders.spec.ts
@@ -1,0 +1,221 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotificationsService } from './notifications.service';
+import { PrismaService } from '../../prisma/prisma.service';
+import { ConfigService } from '@nestjs/config';
+import { FlexTemplatesService } from '../line-oa/flex-templates.service';
+import { QuickReplyService } from '../line-oa/quick-reply.service';
+import { IntegrationConfigService } from '../integrations/integration-config.service';
+import { ComplianceService } from './compliance.service';
+import { NotificationTemplateService } from './notification-template.service';
+
+/**
+ * Characterization tests for the two customer-facing dunning cron methods
+ * `sendPaymentReminders` (upcoming) and `sendOverdueNotices` (past-due).
+ *
+ * These had ZERO coverage. They share an identical per-payment guard pair —
+ * the "already notified today" dedup check and the PDPA-consent gate (skip +
+ * IN_APP SKIPPED log) — extracted into shared helpers in this PR (Wave-4
+ * dedup). These tests lock that guard behavior + the happy LINE path so the
+ * extraction is verifiably behaviour-preserving.
+ */
+describe('NotificationsService — reminder / overdue dunning', () => {
+  let service: NotificationsService;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+
+  const customer = (over: Record<string, unknown> = {}) => ({
+    id: 'cust-1',
+    name: 'สมชาย',
+    phone: '0812345678',
+    lineIdFinance: null,
+    ...over,
+  });
+
+  const payment = (over: Record<string, unknown> = {}) => ({
+    id: 'pay-1',
+    installmentNo: 2,
+    amountDue: 1500,
+    amountPaid: 0,
+    lateFee: 0,
+    dueDate: new Date(),
+    contract: { contractNumber: 'CT-001', customer: customer(), _count: { payments: 6 } },
+    ...over,
+  });
+
+  const withLine = () =>
+    payment({
+      contract: {
+        contractNumber: 'CT-001',
+        customer: customer({ lineIdFinance: 'U-line' }),
+        _count: { payments: 6 },
+      },
+    });
+
+  beforeEach(async () => {
+    prisma = {
+      payment: { findMany: jest.fn().mockResolvedValue([]) },
+      notificationLog: {
+        findFirst: jest.fn().mockResolvedValue(null), // not a duplicate
+        create: jest.fn().mockResolvedValue({ id: 'log-1' }),
+      },
+      pDPAConsent: { findFirst: jest.fn().mockResolvedValue({ id: 'consent-1' }) }, // granted
+      systemConfig: { findFirst: jest.fn().mockResolvedValue(null) },
+    };
+
+    const mod: TestingModule = await Test.createTestingModule({
+      providers: [
+        NotificationsService,
+        { provide: PrismaService, useValue: prisma },
+        { provide: ConfigService, useValue: { get: jest.fn() } },
+        {
+          provide: FlexTemplatesService,
+          useValue: {
+            paymentReminder: jest.fn().mockReturnValue({}),
+            overdueNotice: jest.fn().mockReturnValue({}),
+          },
+        },
+        { provide: QuickReplyService, useValue: { afterPayment: jest.fn().mockReturnValue([]) } },
+        {
+          provide: IntegrationConfigService,
+          useValue: { getValue: jest.fn().mockResolvedValue('') },
+        },
+        {
+          provide: ComplianceService,
+          useValue: { canSend: jest.fn().mockResolvedValue({ allowed: true }) },
+        },
+        { provide: NotificationTemplateService, useValue: { findByEventType: jest.fn() } },
+      ],
+    }).compile();
+
+    service = mod.get(NotificationsService);
+    // Stub actual delivery so tests assert branch decisions, not real I/O.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    jest.spyOn(service as any, 'sendLineFlexMessage').mockResolvedValue(undefined);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    jest.spyOn(service as any, 'send').mockResolvedValue(undefined);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    jest.spyOn(service as any, 'sendFromTemplate').mockResolvedValue(undefined);
+  });
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const spyOf = (name: string) => (service as any)[name] as jest.Mock;
+
+  describe('sendPaymentReminders', () => {
+    const SUBJECT = 'แจ้งเตือนค่างวด';
+
+    it('logs an IN_APP SKIPPED row and sends nothing when the customer has no PDPA consent', async () => {
+      prisma.payment.findMany.mockResolvedValue([payment()]);
+      prisma.pDPAConsent.findFirst.mockResolvedValue(null);
+
+      const result = await service.sendPaymentReminders();
+
+      expect(prisma.notificationLog.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            channel: 'IN_APP',
+            status: 'SKIPPED',
+            subject: SUBJECT,
+            relatedId: 'pay-1',
+          }),
+        }),
+      );
+      expect(spyOf('sendLineFlexMessage')).not.toHaveBeenCalled();
+      expect(spyOf('send')).not.toHaveBeenCalled();
+      expect(result.sent).toBe(0);
+    });
+
+    it('skips a payment already reminded today (dedup) without checking consent or sending', async () => {
+      prisma.payment.findMany.mockResolvedValue([payment()]);
+      prisma.notificationLog.findFirst.mockResolvedValue({ id: 'prev-log' });
+
+      const result = await service.sendPaymentReminders();
+
+      expect(prisma.pDPAConsent.findFirst).not.toHaveBeenCalled();
+      expect(spyOf('sendLineFlexMessage')).not.toHaveBeenCalled();
+      expect(prisma.notificationLog.create).not.toHaveBeenCalled();
+      expect(result.sent).toBe(0);
+    });
+
+    it('sends a LINE flex reminder and logs SENT when the customer has lineIdFinance + consent', async () => {
+      prisma.payment.findMany.mockResolvedValue([withLine()]);
+
+      const result = await service.sendPaymentReminders();
+
+      expect(spyOf('sendLineFlexMessage')).toHaveBeenCalledWith(
+        'U-line',
+        expect.anything(),
+        'line-finance',
+      );
+      expect(prisma.notificationLog.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ channel: 'LINE', status: 'SENT', subject: SUBJECT }),
+        }),
+      );
+      expect(result.sent).toBe(1);
+    });
+
+    it('dedup query filters by relatedId + subject', async () => {
+      prisma.payment.findMany.mockResolvedValue([payment()]);
+      await service.sendPaymentReminders();
+      expect(prisma.notificationLog.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ relatedId: 'pay-1', subject: SUBJECT }),
+        }),
+      );
+    });
+  });
+
+  describe('sendOverdueNotices', () => {
+    const SUBJECT = 'แจ้งค้างชำระ';
+
+    it('logs an IN_APP SKIPPED row and sends nothing when the customer has no PDPA consent', async () => {
+      prisma.payment.findMany.mockResolvedValue([payment()]);
+      prisma.pDPAConsent.findFirst.mockResolvedValue(null);
+
+      const result = await service.sendOverdueNotices();
+
+      expect(prisma.notificationLog.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            channel: 'IN_APP',
+            status: 'SKIPPED',
+            subject: SUBJECT,
+            relatedId: 'pay-1',
+          }),
+        }),
+      );
+      expect(spyOf('sendLineFlexMessage')).not.toHaveBeenCalled();
+      expect(result.sent).toBe(0);
+    });
+
+    it('skips a payment already noticed today (dedup) without checking consent or sending', async () => {
+      prisma.payment.findMany.mockResolvedValue([payment()]);
+      prisma.notificationLog.findFirst.mockResolvedValue({ id: 'prev-log' });
+
+      const result = await service.sendOverdueNotices();
+
+      expect(prisma.pDPAConsent.findFirst).not.toHaveBeenCalled();
+      expect(spyOf('sendLineFlexMessage')).not.toHaveBeenCalled();
+      expect(prisma.notificationLog.create).not.toHaveBeenCalled();
+      expect(result.sent).toBe(0);
+    });
+
+    it('sends a LINE flex overdue notice and logs SENT when the customer has lineIdFinance + consent', async () => {
+      prisma.payment.findMany.mockResolvedValue([withLine()]);
+
+      const result = await service.sendOverdueNotices();
+
+      expect(spyOf('sendLineFlexMessage')).toHaveBeenCalledWith(
+        'U-line',
+        expect.anything(),
+        'line-finance',
+      );
+      expect(prisma.notificationLog.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ channel: 'LINE', status: 'SENT', subject: SUBJECT }),
+        }),
+      );
+      expect(result.sent).toBe(1);
+    });
+  });
+});

--- a/apps/api/src/modules/notifications/notifications.service.ts
+++ b/apps/api/src/modules/notifications/notifications.service.ts
@@ -977,6 +977,49 @@ export class NotificationsService {
    * Send payment reminders for upcoming due dates (run daily)
    * Sends reminders exactly 3 days and 1 day before due date
    */
+  /**
+   * True when a notice with this subject was already logged for this payment
+   * today — the per-payment dedup guard shared by the reminder + overdue crons.
+   */
+  private async alreadyNotifiedToday(
+    paymentId: string,
+    subject: string,
+    today: Date,
+  ): Promise<boolean> {
+    const prev = await this.prisma.notificationLog.findFirst({
+      where: { relatedId: paymentId, subject, sentAt: { gte: today } },
+    });
+    return !!prev;
+  }
+
+  /**
+   * PDPA gate shared by the reminder + overdue crons: returns true when the
+   * customer has GRANTED consent. Otherwise logs an IN_APP SKIPPED row (so the
+   * skip stays auditable) and returns false.
+   */
+  private async ensurePdpaConsentOrLogSkip(
+    customerId: string,
+    paymentId: string,
+    subject: string,
+  ): Promise<boolean> {
+    const consent = await this.prisma.pDPAConsent.findFirst({
+      where: { customerId, status: 'GRANTED', deletedAt: null },
+      select: { id: true },
+    });
+    if (consent) return true;
+    await this.prisma.notificationLog.create({
+      data: {
+        channel: 'IN_APP',
+        recipient: customerId,
+        subject,
+        message: `ข้ามการแจ้งเตือน — ลูกค้าไม่มี PDPA consent`,
+        status: 'SKIPPED',
+        relatedId: paymentId,
+      },
+    });
+    return false;
+  }
+
   async sendPaymentReminders() {
     const now = new Date();
     const today = new Date(now.toISOString().split('T')[0]);
@@ -1016,37 +1059,9 @@ export class NotificationsService {
         Math.round((new Date(payment.dueDate).getTime() - today.getTime()) / (1000 * 60 * 60 * 24)),
       );
 
-      // Dedup: skip if already sent a reminder for this payment today
-      const alreadySent = await this.prisma.notificationLog.findFirst({
-        where: {
-          relatedId: payment.id,
-          subject: 'แจ้งเตือนค่างวด',
-          sentAt: { gte: today },
-        },
-      });
-      if (alreadySent) continue;
-
-      // Check PDPA consent before sending notification
-      const consent = await this.prisma.pDPAConsent.findFirst({
-        where: {
-          customerId: customer.id,
-          status: 'GRANTED',
-          deletedAt: null,
-        },
-        select: { id: true },
-      });
-
-      if (!consent) {
-        await this.prisma.notificationLog.create({
-          data: {
-            channel: 'IN_APP',
-            recipient: customer.id,
-            subject: 'แจ้งเตือนค่างวด',
-            message: `ข้ามการแจ้งเตือน — ลูกค้าไม่มี PDPA consent`,
-            status: 'SKIPPED',
-            relatedId: payment.id,
-          },
-        });
+      // Dedup + PDPA guards (shared with sendOverdueNotices)
+      if (await this.alreadyNotifiedToday(payment.id, 'แจ้งเตือนค่างวด', today)) continue;
+      if (!(await this.ensurePdpaConsentOrLogSkip(customer.id, payment.id, 'แจ้งเตือนค่างวด'))) {
         continue;
       }
 
@@ -1178,37 +1193,9 @@ export class NotificationsService {
         (now.getTime() - new Date(payment.dueDate).getTime()) / (1000 * 60 * 60 * 24),
       );
 
-      // Dedup: skip if already sent an overdue notice for this payment today
-      const alreadySent = await this.prisma.notificationLog.findFirst({
-        where: {
-          relatedId: payment.id,
-          subject: 'แจ้งค้างชำระ',
-          sentAt: { gte: today },
-        },
-      });
-      if (alreadySent) continue;
-
-      // Check PDPA consent before sending notification
-      const consent = await this.prisma.pDPAConsent.findFirst({
-        where: {
-          customerId: customer.id,
-          status: 'GRANTED',
-          deletedAt: null,
-        },
-        select: { id: true },
-      });
-
-      if (!consent) {
-        await this.prisma.notificationLog.create({
-          data: {
-            channel: 'IN_APP',
-            recipient: customer.id,
-            subject: 'แจ้งค้างชำระ',
-            message: `ข้ามการแจ้งเตือน — ลูกค้าไม่มี PDPA consent`,
-            status: 'SKIPPED',
-            relatedId: payment.id,
-          },
-        });
+      // Dedup + PDPA guards (shared with sendPaymentReminders)
+      if (await this.alreadyNotifiedToday(payment.id, 'แจ้งค้างชำระ', today)) continue;
+      if (!(await this.ensurePdpaConsentOrLogSkip(customer.id, payment.id, 'แจ้งค้างชำระ'))) {
         continue;
       }
 


### PR DESCRIPTION
## Wave-4 dedup (one of the plan's "merge sendPaymentReminders/sendOverdueNotices" items)

`sendPaymentReminders` (upcoming) and `sendOverdueNotices` (past-due) carried **byte-identical** per-payment guards:
- the **"already notified today"** dedup check, and
- the **PDPA-consent gate** (skip + log an `IN_APP` `SKIPPED` row).

Extracted both into shared private helpers `alreadyNotifiedToday()` + `ensurePdpaConsentOrLogSkip()`, removing ~58 lines of duplication. The divergent delivery logic (different flex template / message / event-type mapping / category) is intentionally left per-method — a fuller merge can follow.

## Test-first (Wave-3 safety net)
These two customer-facing dunning crons had **zero** coverage. This PR adds **7 characterization tests first** (PDPA-skip, dedup-skip, happy LINE-flex path for each method), so the extraction is verifiably **behaviour-preserving** — exactly the order the remediation plan prescribes ("Wave-3 tests are the safety net for Wave-4 refactors").

## Verification
- `notifications.service.{reminders,routing,in-app-toggle}` — **13/13** green.
- `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)