### PR TITLE
refactor(shop): fold shop-buyback ≈ shop-trade-in into TradeInIntakeService (Wave-4)

### DIFF
--- a/apps/api/src/modules/shop-buyback/shop-buyback.module.ts
+++ b/apps/api/src/modules/shop-buyback/shop-buyback.module.ts
@@ -1,13 +1,12 @@
 import { Module } from '@nestjs/common';
 import { ShopBuybackController } from './shop-buyback.controller';
 import { ShopBuybackService } from './shop-buyback.service';
-import { PrismaModule } from '../../prisma/prisma.module';
-import { LineOaModule } from '../line-oa/line-oa.module';
+import { TradeInIntakeModule } from '../shop-trade-in/trade-in-intake.module';
 
 // ShopBotDefenseModule is @Global — guard is available without importing.
 
 @Module({
-  imports: [PrismaModule, LineOaModule],
+  imports: [TradeInIntakeModule],
   controllers: [ShopBuybackController],
   providers: [ShopBuybackService],
   exports: [ShopBuybackService],

--- a/apps/api/src/modules/shop-buyback/shop-buyback.service.spec.ts
+++ b/apps/api/src/modules/shop-buyback/shop-buyback.service.spec.ts
@@ -1,0 +1,124 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { ShopBuybackService } from './shop-buyback.service';
+import { TradeInIntakeService } from '../shop-trade-in/trade-in-intake.service';
+import { PrismaService } from '../../prisma/prisma.service';
+import { LineOaService } from '../line-oa/line-oa.service';
+
+/**
+ * Characterization tests — ShopBuybackService had ZERO coverage. Locks the
+ * buyback margin (0.80/0.95), the BUYBACK intake flow, dedup/valuation guards,
+ * non-fatal LINE flex, and getStatus — before the shared TradeInIntakeService
+ * extraction (Wave-4 fold of shop-buyback ≈ shop-trade-in).
+ */
+describe('ShopBuybackService', () => {
+  let service: ShopBuybackService;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let line: any;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const valuation = (over: any = {}) => ({ basePrice: 10000, deletedAt: null, ...over });
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const dto = (over: any = {}): any => ({
+    brand: 'Apple',
+    model: 'iPhone 13',
+    storage: '128',
+    condition: 'A',
+    batteryHealth: 90,
+    imei: '111',
+    photoUrls: ['u'],
+    notes: 'n',
+    lineUserId: 'L1',
+    sellerName: 'S',
+    sellerPhone: '0800000000',
+    ...over,
+  });
+
+  beforeEach(async () => {
+    prisma = {
+      tradeInValuation: { findUnique: jest.fn().mockResolvedValue(valuation()) },
+      tradeIn: {
+        findFirst: jest.fn().mockResolvedValue(null),
+        create: jest.fn().mockResolvedValue({ id: 'ti-1', status: 'PENDING_APPRAISAL' }),
+        findUnique: jest.fn(),
+      },
+    };
+    line = { sendFlexMessage: jest.fn().mockResolvedValue(undefined) };
+
+    const mod: TestingModule = await Test.createTestingModule({
+      providers: [
+        ShopBuybackService,
+        TradeInIntakeService,
+        { provide: PrismaService, useValue: prisma },
+        { provide: LineOaService, useValue: line },
+      ],
+    }).compile();
+    service = mod.get(ShopBuybackService);
+  });
+
+  describe('quickQuote', () => {
+    it('applies the buyback margin floor(base*0.80) / ceil(base*0.95)', async () => {
+      const r = await service.quickQuote(dto());
+      expect(r).toEqual({ min: 8000, max: 9500, available: true, basePrice: 10000 });
+    });
+
+    it('returns unavailable when no valuation row exists', async () => {
+      prisma.tradeInValuation.findUnique.mockResolvedValue(null);
+      const r = await service.quickQuote(dto());
+      expect(r).toEqual({ min: 0, max: 0, available: false });
+    });
+  });
+
+  describe('submit', () => {
+    it('creates a TradeIn with flow=BUYBACK and returns id/status/etaHours', async () => {
+      const r = await service.submit(dto(), 'cust-1');
+      expect(prisma.tradeIn.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            flow: 'BUYBACK',
+            status: 'PENDING_APPRAISAL',
+            basePriceAtAppraisal: 10000,
+            customerId: 'cust-1',
+          }),
+        }),
+      );
+      expect(r).toEqual({ id: 'ti-1', status: 'PENDING_APPRAISAL', etaHours: 24 });
+    });
+
+    it('rejects a duplicate (same imei+phone within 24h)', async () => {
+      prisma.tradeIn.findFirst.mockResolvedValue({ id: 'dup' });
+      await expect(service.submit(dto(), 'c')).rejects.toThrow(BadRequestException);
+      expect(prisma.tradeIn.create).not.toHaveBeenCalled();
+    });
+
+    it('throws when no valuation exists for the model', async () => {
+      prisma.tradeInValuation.findUnique.mockResolvedValue(null);
+      await expect(service.submit(dto(), 'c')).rejects.toThrow(NotFoundException);
+    });
+
+    it('still succeeds when the LINE flex notification fails (non-fatal)', async () => {
+      line.sendFlexMessage.mockRejectedValue(new Error('LINE down'));
+      const r = await service.submit(dto(), 'c');
+      expect(r.id).toBe('ti-1');
+    });
+  });
+
+  describe('getStatus', () => {
+    it('returns the record when found', async () => {
+      prisma.tradeIn.findUnique.mockResolvedValue({
+        id: 'ti-1',
+        status: 'PENDING_APPRAISAL',
+        flow: 'BUYBACK',
+      });
+      const r = await service.getStatus('ti-1');
+      expect(r.id).toBe('ti-1');
+    });
+
+    it('throws NotFoundException when missing', async () => {
+      prisma.tradeIn.findUnique.mockResolvedValue(null);
+      await expect(service.getStatus('x')).rejects.toThrow(NotFoundException);
+    });
+  });
+});

--- a/apps/api/src/modules/shop-buyback/shop-buyback.service.ts
+++ b/apps/api/src/modules/shop-buyback/shop-buyback.service.ts
@@ -1,157 +1,30 @@
-import { BadRequestException, Injectable, Logger, NotFoundException } from '@nestjs/common';
-import { PrismaService } from '../../prisma/prisma.service';
-import { LineOaService } from '../line-oa/line-oa.service';
-import type { FlexMessagePayload } from '../line-oa/flex-messages/base-template';
+import { Injectable } from '@nestjs/common';
 import { QuickQuoteDto } from './dto/quick-quote.dto';
 import { SubmitBuybackDto } from './dto/submit.dto';
+import { TradeInIntakeService } from '../shop-trade-in/trade-in-intake.service';
 
+/**
+ * Buyback (pure cash-out) — pays less than trade-in because there is no
+ * downstream sale margin to offset (margin floor 0.80 / ceil 0.95). The
+ * online-intake flow itself is shared with trade-in via TradeInIntakeService;
+ * only the margin, the BUYBACK flow tag, and the confirmation-flex copy differ.
+ */
 @Injectable()
 export class ShopBuybackService {
-  private readonly logger = new Logger(ShopBuybackService.name);
+  constructor(private readonly intake: TradeInIntakeService) {}
 
-  constructor(
-    private prisma: PrismaService,
-    private line: LineOaService,
-  ) {}
-
-  /**
-   * Quick-quote — buyback (pure cash-out) pays less than exchange because
-   * there is no downstream sale margin to offset. Margin: min=floor(base*0.80),
-   * max=ceil(base*0.95).
-   */
   async quickQuote(dto: QuickQuoteDto) {
-    const v = await this.prisma.tradeInValuation.findUnique({
-      where: {
-        brand_model_storage_condition: {
-          brand: dto.brand,
-          model: dto.model,
-          storage: dto.storage,
-          condition: dto.condition,
-        },
-      },
-    });
-    if (!v || v.deletedAt) {
-      return { min: 0, max: 0, available: false };
-    }
-    const base = Number(v.basePrice);
-    return {
-      min: Math.floor(base * 0.8),
-      max: Math.ceil(base * 0.95),
-      available: true,
-      basePrice: base,
-    };
+    return this.intake.quote(dto, { minMult: 0.8, maxMult: 0.95 });
   }
 
-  /**
-   * Submit a buyback request — flow=BUYBACK, no target product (pure cash-out).
-   * Dedup by (imei + sellerPhone) within 24h.
-   */
   async submit(dto: SubmitBuybackDto, customerId: string | undefined) {
-    if (dto.imei) {
-      const dup = await this.prisma.tradeIn.findFirst({
-        where: {
-          imei: dto.imei,
-          sellerPhone: dto.sellerPhone,
-          createdAt: { gt: new Date(Date.now() - 24 * 3600_000) },
-          deletedAt: null,
-        },
-      });
-      if (dup) {
-        throw new BadRequestException('เครื่องนี้อยู่ระหว่างประเมินราคาแล้ว');
-      }
-    }
-
-    const valuation = await this.prisma.tradeInValuation.findUnique({
-      where: {
-        brand_model_storage_condition: {
-          brand: dto.brand,
-          model: dto.model,
-          storage: dto.storage,
-          condition: dto.condition,
-        },
-      },
+    return this.intake.submit(dto, customerId, {
+      flow: 'BUYBACK',
+      flex: { altText: 'รับเรื่องรับซื้อแล้ว', title: 'รับเรื่องรับซื้อมือถือ' },
     });
-    if (!valuation || valuation.deletedAt) {
-      throw new NotFoundException('ไม่พบข้อมูลราคาประเมินสำหรับรุ่นนี้');
-    }
-
-    const tradeIn = await this.prisma.tradeIn.create({
-      data: {
-        submissionSource: 'ONLINE',
-        flow: 'BUYBACK',
-        status: 'PENDING_APPRAISAL',
-        deviceBrand: dto.brand,
-        deviceModel: dto.model,
-        deviceStorage: dto.storage,
-        deviceCondition: dto.condition,
-        batteryHealth: dto.batteryHealth,
-        imei: dto.imei,
-        photoUrls: dto.photoUrls,
-        customerNotes: dto.notes,
-        customerLineId: dto.lineUserId,
-        sellerName: dto.sellerName,
-        sellerPhone: dto.sellerPhone,
-        basePriceAtAppraisal: valuation.basePrice,
-        customerId,
-      },
-    });
-
-    if (dto.lineUserId) {
-      try {
-        await this.line.sendFlexMessage(dto.lineUserId, this.buildSubmittedFlex(tradeIn.id), 'line-shop');
-      } catch (err) {
-        this.logger.warn(`Failed to send buyback LINE flex: ${(err as Error).message}`);
-      }
-    }
-
-    return { id: tradeIn.id, status: tradeIn.status, etaHours: 24 };
   }
 
   async getStatus(id: string) {
-    const t = await this.prisma.tradeIn.findUnique({
-      where: { id },
-      select: {
-        id: true,
-        status: true,
-        offeredPrice: true,
-        agreedPrice: true,
-        photoUrls: true,
-        deviceBrand: true,
-        deviceModel: true,
-        deviceStorage: true,
-        deviceCondition: true,
-        batteryHealth: true,
-        flow: true,
-        submissionSource: true,
-        createdAt: true,
-      },
-    });
-    if (!t) throw new NotFoundException('ไม่พบคำขอ');
-    return t;
-  }
-
-  private buildSubmittedFlex(id: string): FlexMessagePayload {
-    return {
-      type: 'flex',
-      altText: 'รับเรื่องรับซื้อแล้ว',
-      contents: {
-        type: 'bubble',
-        body: {
-          type: 'box',
-          layout: 'vertical',
-          contents: [
-            { type: 'text', text: 'รับเรื่องรับซื้อมือถือ', weight: 'bold', size: 'lg' },
-            { type: 'text', text: `รหัส ${id.slice(0, 8).toUpperCase()}`, margin: 'md' },
-            {
-              type: 'text',
-              text: 'ราคาเสนอภายใน 24 ชั่วโมง',
-              size: 'xs',
-              color: '#888888',
-              margin: 'md',
-            },
-          ],
-        },
-      },
-    };
+    return this.intake.getStatus(id);
   }
 }

--- a/apps/api/src/modules/shop-trade-in/shop-trade-in.module.ts
+++ b/apps/api/src/modules/shop-trade-in/shop-trade-in.module.ts
@@ -1,13 +1,12 @@
 import { Module } from '@nestjs/common';
 import { ShopTradeInController } from './shop-trade-in.controller';
 import { ShopTradeInService } from './shop-trade-in.service';
-import { PrismaModule } from '../../prisma/prisma.module';
-import { LineOaModule } from '../line-oa/line-oa.module';
+import { TradeInIntakeModule } from './trade-in-intake.module';
 
 // ShopBotDefenseModule is @Global — guard is available without importing.
 
 @Module({
-  imports: [PrismaModule, LineOaModule],
+  imports: [TradeInIntakeModule],
   controllers: [ShopTradeInController],
   providers: [ShopTradeInService],
   exports: [ShopTradeInService],

--- a/apps/api/src/modules/shop-trade-in/shop-trade-in.service.spec.ts
+++ b/apps/api/src/modules/shop-trade-in/shop-trade-in.service.spec.ts
@@ -1,0 +1,127 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { ShopTradeInService } from './shop-trade-in.service';
+import { TradeInIntakeService } from './trade-in-intake.service';
+import { PrismaService } from '../../prisma/prisma.service';
+import { LineOaService } from '../line-oa/line-oa.service';
+
+/**
+ * Characterization tests — ShopTradeInService had ZERO coverage. Locks the
+ * trade-in margin (0.85/1.05), the EXCHANGE intake flow + target productId,
+ * dedup/valuation guards, non-fatal LINE flex, and getStatus — before the
+ * shared TradeInIntakeService extraction (Wave-4 fold of shop-buyback ≈
+ * shop-trade-in).
+ */
+describe('ShopTradeInService', () => {
+  let service: ShopTradeInService;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let line: any;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const valuation = (over: any = {}) => ({ basePrice: 10000, deletedAt: null, ...over });
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const dto = (over: any = {}): any => ({
+    brand: 'Apple',
+    model: 'iPhone 13',
+    storage: '128',
+    condition: 'A',
+    batteryHealth: 90,
+    imei: '111',
+    photoUrls: ['u'],
+    notes: 'n',
+    lineUserId: 'L1',
+    sellerName: 'S',
+    sellerPhone: '0800000000',
+    targetProductId: 'prod-9',
+    ...over,
+  });
+
+  beforeEach(async () => {
+    prisma = {
+      tradeInValuation: { findUnique: jest.fn().mockResolvedValue(valuation()) },
+      tradeIn: {
+        findFirst: jest.fn().mockResolvedValue(null),
+        create: jest.fn().mockResolvedValue({ id: 'ti-1', status: 'PENDING_APPRAISAL' }),
+        findUnique: jest.fn(),
+      },
+    };
+    line = { sendFlexMessage: jest.fn().mockResolvedValue(undefined) };
+
+    const mod: TestingModule = await Test.createTestingModule({
+      providers: [
+        ShopTradeInService,
+        TradeInIntakeService,
+        { provide: PrismaService, useValue: prisma },
+        { provide: LineOaService, useValue: line },
+      ],
+    }).compile();
+    service = mod.get(ShopTradeInService);
+  });
+
+  describe('estimate', () => {
+    it('applies the trade-in margin floor(base*0.85) / ceil(base*1.05)', async () => {
+      const r = await service.estimate(dto());
+      expect(r).toEqual({ min: 8500, max: 10500, available: true, basePrice: 10000 });
+    });
+
+    it('returns unavailable when no valuation row exists', async () => {
+      prisma.tradeInValuation.findUnique.mockResolvedValue(null);
+      const r = await service.estimate(dto());
+      expect(r).toEqual({ min: 0, max: 0, available: false });
+    });
+  });
+
+  describe('submit', () => {
+    it('creates a TradeIn with flow=EXCHANGE + target productId and returns id/status/etaHours', async () => {
+      const r = await service.submit(dto(), 'cust-1');
+      expect(prisma.tradeIn.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            flow: 'EXCHANGE',
+            status: 'PENDING_APPRAISAL',
+            basePriceAtAppraisal: 10000,
+            customerId: 'cust-1',
+            productId: 'prod-9',
+          }),
+        }),
+      );
+      expect(r).toEqual({ id: 'ti-1', status: 'PENDING_APPRAISAL', etaHours: 24 });
+    });
+
+    it('rejects a duplicate (same imei+phone within 24h)', async () => {
+      prisma.tradeIn.findFirst.mockResolvedValue({ id: 'dup' });
+      await expect(service.submit(dto(), 'c')).rejects.toThrow(BadRequestException);
+      expect(prisma.tradeIn.create).not.toHaveBeenCalled();
+    });
+
+    it('throws when no valuation exists for the model', async () => {
+      prisma.tradeInValuation.findUnique.mockResolvedValue(null);
+      await expect(service.submit(dto(), 'c')).rejects.toThrow(NotFoundException);
+    });
+
+    it('still succeeds when the LINE flex notification fails (non-fatal)', async () => {
+      line.sendFlexMessage.mockRejectedValue(new Error('LINE down'));
+      const r = await service.submit(dto(), 'c');
+      expect(r.id).toBe('ti-1');
+    });
+  });
+
+  describe('getStatus', () => {
+    it('returns the record when found', async () => {
+      prisma.tradeIn.findUnique.mockResolvedValue({
+        id: 'ti-1',
+        status: 'PENDING_APPRAISAL',
+        flow: 'EXCHANGE',
+      });
+      const r = await service.getStatus('ti-1');
+      expect(r.id).toBe('ti-1');
+    });
+
+    it('throws NotFoundException when missing', async () => {
+      prisma.tradeIn.findUnique.mockResolvedValue(null);
+      await expect(service.getStatus('x')).rejects.toThrow(NotFoundException);
+    });
+  });
+});

--- a/apps/api/src/modules/shop-trade-in/shop-trade-in.service.ts
+++ b/apps/api/src/modules/shop-trade-in/shop-trade-in.service.ts
@@ -1,162 +1,31 @@
-import { BadRequestException, Injectable, Logger, NotFoundException } from '@nestjs/common';
-import { PrismaService } from '../../prisma/prisma.service';
-import { LineOaService } from '../line-oa/line-oa.service';
-import type { FlexMessagePayload } from '../line-oa/flex-messages/base-template';
+import { Injectable } from '@nestjs/common';
 import { EstimateDto } from './dto/estimate.dto';
 import { SubmitTradeInDto } from './dto/submit.dto';
+import { TradeInIntakeService } from './trade-in-intake.service';
 
+/**
+ * Trade-in / exchange — pays more than a pure buyback because the downstream
+ * sale margin offsets it (margin floor 0.85 / ceil 1.05). The online-intake
+ * flow is shared with buyback via TradeInIntakeService; only the margin, the
+ * EXCHANGE flow tag, the optional target product, and the flex copy differ.
+ */
 @Injectable()
 export class ShopTradeInService {
-  private readonly logger = new Logger(ShopTradeInService.name);
+  constructor(private readonly intake: TradeInIntakeService) {}
 
-  constructor(
-    private prisma: PrismaService,
-    private line: LineOaService,
-  ) {}
-
-  /**
-   * Quick estimate — returns a price range based on the central valuation table.
-   * Margin: min = floor(base * 0.85), max = ceil(base * 1.05)
-   * Actual offer is made by staff after receiving the device.
-   */
   async estimate(dto: EstimateDto) {
-    const v = await this.prisma.tradeInValuation.findUnique({
-      where: {
-        brand_model_storage_condition: {
-          brand: dto.brand,
-          model: dto.model,
-          storage: dto.storage,
-          condition: dto.condition,
-        },
-      },
-    });
-    if (!v || v.deletedAt) {
-      return { min: 0, max: 0, available: false };
-    }
-    const base = Number(v.basePrice);
-    return {
-      min: Math.floor(base * 0.85),
-      max: Math.ceil(base * 1.05),
-      available: true,
-      basePrice: base,
-    };
+    return this.intake.quote(dto, { minMult: 0.85, maxMult: 1.05 });
   }
 
-  /**
-   * Submit an online trade-in request. Creates a TradeIn record with
-   * submissionSource=ONLINE, flow=EXCHANGE. Staff will appraise within 24h.
-   * De-duplicates by (imei) within the last 24h to prevent accidental re-submits.
-   */
   async submit(dto: SubmitTradeInDto, customerId: string | undefined) {
-    // Dedup by imei within 24h (also filter by phone when no imei? — skip: not
-    // all submissions have imei and we prefer to accept rather than block)
-    if (dto.imei) {
-      const dup = await this.prisma.tradeIn.findFirst({
-        where: {
-          imei: dto.imei,
-          sellerPhone: dto.sellerPhone,
-          createdAt: { gt: new Date(Date.now() - 24 * 3600_000) },
-          deletedAt: null,
-        },
-      });
-      if (dup) {
-        throw new BadRequestException('เครื่องนี้อยู่ระหว่างประเมินราคาแล้ว');
-      }
-    }
-
-    const valuation = await this.prisma.tradeInValuation.findUnique({
-      where: {
-        brand_model_storage_condition: {
-          brand: dto.brand,
-          model: dto.model,
-          storage: dto.storage,
-          condition: dto.condition,
-        },
-      },
+    return this.intake.submit(dto, customerId, {
+      flow: 'EXCHANGE',
+      productId: dto.targetProductId,
+      flex: { altText: 'รับเรื่องเก่าแลกใหม่แล้ว', title: 'รับเรื่องเก่าแลกใหม่' },
     });
-    if (!valuation || valuation.deletedAt) {
-      throw new NotFoundException('ไม่พบข้อมูลราคาประเมินสำหรับรุ่นนี้');
-    }
-
-    const tradeIn = await this.prisma.tradeIn.create({
-      data: {
-        submissionSource: 'ONLINE',
-        flow: 'EXCHANGE',
-        status: 'PENDING_APPRAISAL',
-        deviceBrand: dto.brand,
-        deviceModel: dto.model,
-        deviceStorage: dto.storage,
-        deviceCondition: dto.condition,
-        batteryHealth: dto.batteryHealth,
-        imei: dto.imei,
-        photoUrls: dto.photoUrls,
-        customerNotes: dto.notes,
-        customerLineId: dto.lineUserId,
-        sellerName: dto.sellerName,
-        sellerPhone: dto.sellerPhone,
-        basePriceAtAppraisal: valuation.basePrice,
-        customerId,
-        productId: dto.targetProductId,
-      },
-    });
-
-    // Non-fatal LINE flex notification — customer still sees the in-app confirmation
-    if (dto.lineUserId) {
-      try {
-        await this.line.sendFlexMessage(dto.lineUserId, this.buildSubmittedFlex(tradeIn.id), 'line-shop');
-      } catch (err) {
-        this.logger.warn(`Failed to send trade-in LINE flex: ${(err as Error).message}`);
-      }
-    }
-
-    return { id: tradeIn.id, status: tradeIn.status, etaHours: 24 };
   }
 
   async getStatus(id: string) {
-    const t = await this.prisma.tradeIn.findUnique({
-      where: { id },
-      select: {
-        id: true,
-        status: true,
-        offeredPrice: true,
-        agreedPrice: true,
-        photoUrls: true,
-        deviceBrand: true,
-        deviceModel: true,
-        deviceStorage: true,
-        deviceCondition: true,
-        batteryHealth: true,
-        flow: true,
-        submissionSource: true,
-        createdAt: true,
-      },
-    });
-    if (!t) throw new NotFoundException('ไม่พบคำขอ');
-    return t;
-  }
-
-  private buildSubmittedFlex(id: string): FlexMessagePayload {
-    return {
-      type: 'flex',
-      altText: 'รับเรื่องเก่าแลกใหม่แล้ว',
-      contents: {
-        type: 'bubble',
-        body: {
-          type: 'box',
-          layout: 'vertical',
-          contents: [
-            { type: 'text', text: 'รับเรื่องเก่าแลกใหม่', weight: 'bold', size: 'lg' },
-            { type: 'text', text: `รหัส ${id.slice(0, 8).toUpperCase()}`, margin: 'md' },
-            {
-              type: 'text',
-              text: 'ราคาเสนอภายใน 24 ชั่วโมง',
-              size: 'xs',
-              color: '#888888',
-              margin: 'md',
-            },
-          ],
-        },
-      },
-    };
+    return this.intake.getStatus(id);
   }
 }

--- a/apps/api/src/modules/shop-trade-in/trade-in-intake.module.ts
+++ b/apps/api/src/modules/shop-trade-in/trade-in-intake.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+import { TradeInIntakeService } from './trade-in-intake.service';
+import { PrismaModule } from '../../prisma/prisma.module';
+import { LineOaModule } from '../line-oa/line-oa.module';
+
+/**
+ * Shared device-intake service used by both ShopBuybackModule and
+ * ShopTradeInModule (Wave-4 fold of shop-buyback ≈ shop-trade-in).
+ */
+@Module({
+  imports: [PrismaModule, LineOaModule],
+  providers: [TradeInIntakeService],
+  exports: [TradeInIntakeService],
+})
+export class TradeInIntakeModule {}

--- a/apps/api/src/modules/shop-trade-in/trade-in-intake.service.ts
+++ b/apps/api/src/modules/shop-trade-in/trade-in-intake.service.ts
@@ -1,0 +1,187 @@
+import { BadRequestException, Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../../prisma/prisma.service';
+import { LineOaService } from '../line-oa/line-oa.service';
+import type { FlexMessagePayload } from '../line-oa/flex-messages/base-template';
+
+/** Shared online-intake input — the common subset of SubmitBuybackDto / SubmitTradeInDto. */
+export interface TradeInIntakeDto {
+  brand: string;
+  model: string;
+  storage: string;
+  condition: 'A' | 'B' | 'C';
+  batteryHealth: number;
+  photoUrls: string[];
+  imei?: string;
+  notes?: string;
+  sellerName: string;
+  sellerPhone: string;
+  lineUserId?: string;
+}
+
+interface IntakeOptions {
+  flow: 'BUYBACK' | 'EXCHANGE';
+  productId?: string;
+  flex: { altText: string; title: string };
+}
+
+/**
+ * Shared online-intake logic for the two near-identical SHOP device-intake
+ * flows: buyback (pure cash-out) and trade-in/exchange. Both read the same
+ * `tradeInValuation` table and create the same `tradeIn` record — they differ
+ * only in the price margin, the `flow` tag, an optional target product, and
+ * the confirmation-flex copy. (Wave-4 fold of shop-buyback ≈ shop-trade-in.)
+ */
+@Injectable()
+export class TradeInIntakeService {
+  private readonly logger = new Logger(TradeInIntakeService.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly line: LineOaService,
+  ) {}
+
+  /** Valuation lookup + price-range quote, parameterised by margin. */
+  async quote(
+    key: { brand: string; model: string; storage: string; condition: string },
+    margin: { minMult: number; maxMult: number },
+  ) {
+    const v = await this.prisma.tradeInValuation.findUnique({
+      where: {
+        brand_model_storage_condition: {
+          brand: key.brand,
+          model: key.model,
+          storage: key.storage,
+          condition: key.condition,
+        },
+      },
+    });
+    if (!v || v.deletedAt) {
+      return { min: 0, max: 0, available: false };
+    }
+    const base = Number(v.basePrice);
+    return {
+      min: Math.floor(base * margin.minMult),
+      max: Math.ceil(base * margin.maxMult),
+      available: true,
+      basePrice: base,
+    };
+  }
+
+  /** Dedup → valuation → create TradeIn → non-fatal LINE flex confirmation. */
+  async submit(dto: TradeInIntakeDto, customerId: string | undefined, opts: IntakeOptions) {
+    if (dto.imei) {
+      const dup = await this.prisma.tradeIn.findFirst({
+        where: {
+          imei: dto.imei,
+          sellerPhone: dto.sellerPhone,
+          createdAt: { gt: new Date(Date.now() - 24 * 3600_000) },
+          deletedAt: null,
+        },
+      });
+      if (dup) {
+        throw new BadRequestException('เครื่องนี้อยู่ระหว่างประเมินราคาแล้ว');
+      }
+    }
+
+    const valuation = await this.prisma.tradeInValuation.findUnique({
+      where: {
+        brand_model_storage_condition: {
+          brand: dto.brand,
+          model: dto.model,
+          storage: dto.storage,
+          condition: dto.condition,
+        },
+      },
+    });
+    if (!valuation || valuation.deletedAt) {
+      throw new NotFoundException('ไม่พบข้อมูลราคาประเมินสำหรับรุ่นนี้');
+    }
+
+    const tradeIn = await this.prisma.tradeIn.create({
+      data: {
+        submissionSource: 'ONLINE',
+        flow: opts.flow,
+        status: 'PENDING_APPRAISAL',
+        deviceBrand: dto.brand,
+        deviceModel: dto.model,
+        deviceStorage: dto.storage,
+        deviceCondition: dto.condition,
+        batteryHealth: dto.batteryHealth,
+        imei: dto.imei,
+        photoUrls: dto.photoUrls,
+        customerNotes: dto.notes,
+        customerLineId: dto.lineUserId,
+        sellerName: dto.sellerName,
+        sellerPhone: dto.sellerPhone,
+        basePriceAtAppraisal: valuation.basePrice,
+        customerId,
+        productId: opts.productId,
+      },
+    });
+
+    if (dto.lineUserId) {
+      try {
+        await this.line.sendFlexMessage(
+          dto.lineUserId,
+          this.buildSubmittedFlex(tradeIn.id, opts.flex),
+          'line-shop',
+        );
+      } catch (err) {
+        this.logger.warn(`Failed to send intake LINE flex: ${(err as Error).message}`);
+      }
+    }
+
+    return { id: tradeIn.id, status: tradeIn.status, etaHours: 24 };
+  }
+
+  async getStatus(id: string) {
+    const t = await this.prisma.tradeIn.findUnique({
+      where: { id },
+      select: {
+        id: true,
+        status: true,
+        offeredPrice: true,
+        agreedPrice: true,
+        photoUrls: true,
+        deviceBrand: true,
+        deviceModel: true,
+        deviceStorage: true,
+        deviceCondition: true,
+        batteryHealth: true,
+        flow: true,
+        submissionSource: true,
+        createdAt: true,
+      },
+    });
+    if (!t) throw new NotFoundException('ไม่พบคำขอ');
+    return t;
+  }
+
+  private buildSubmittedFlex(
+    id: string,
+    flex: { altText: string; title: string },
+  ): FlexMessagePayload {
+    return {
+      type: 'flex',
+      altText: flex.altText,
+      contents: {
+        type: 'bubble',
+        body: {
+          type: 'box',
+          layout: 'vertical',
+          contents: [
+            { type: 'text', text: flex.title, weight: 'bold', size: 'lg' },
+            { type: 'text', text: `รหัส ${id.slice(0, 8).toUpperCase()}`, margin: 'md' },
+            {
+              type: 'text',
+              text: 'ราคาเสนอภายใน 24 ชั่วโมง',
+              size: 'xs',
+              color: '#888888',
+              margin: 'md',
+            },
+          ],
+        },
+      },
+    };
+  }
+}


### PR DESCRIPTION
## Wave-4 dedup ("fold shop-buyback ≈ shop-trade-in")

`ShopBuybackService` and `ShopTradeInService` were **~90% identical**: same valuation lookup + quote, same `dedup → valuation → TradeIn.create` intake, **byte-identical** `getStatus`, and a near-identical confirmation flex. They differed only in:
- the price margin — buyback `0.80/0.95` vs trade-in `0.85/1.05`,
- the `flow` tag — `BUYBACK` vs `EXCHANGE`,
- an optional target product (trade-in only),
- the flex copy.

Extracted the shared online-intake logic into **`TradeInIntakeService`** (+ a small `TradeInIntakeModule` imported by both). Each service is now a thin delegator (~30 LOC, down from ~160). **Routes, DTOs and controllers are unchanged — no API surface change.**

## Test-first (Wave-3 safety net)
Both services had **zero** coverage. This PR adds **16 characterization tests first** (margins, flow + target productId, dedup + valuation guards, non-fatal LINE flex, getStatus) so the extraction is verifiably **behaviour-preserving** — the tests assert on the same `prisma.tradeIn.create` / quote outputs before and after, exercised end-to-end through the real `TradeInIntakeService`.

## Verification
- shop-buyback + shop-trade-in service specs — **16/16** green.
- `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)