### PR TITLE
refactor(expense-documents): extract pure maskPayrollTaxIds → tested util (Wave-4)

### DIFF
--- a/apps/api/src/modules/expense-documents/expense-documents.service.ts
+++ b/apps/api/src/modules/expense-documents/expense-documents.service.ts
@@ -11,6 +11,7 @@ import { PrismaService } from '../../prisma/prisma.service';
 import { JournalAutoService } from '../journal/journal-auto.service';
 import { resolvePostPermissionRoles } from './post-permission.guard';
 import { resolveReversePermissionRoles } from './reverse-permission.guard';
+import { maskPayrollTaxIds } from './payroll-pii-mask.util';
 import { DocNumberService } from './services/doc-number.service';
 import { StatusTransitionService } from './services/status-transition.service';
 import { ExpenseSameDayTemplate } from '../journal/cpa-templates/expense-same-day.template';
@@ -1032,26 +1033,8 @@ export class ExpenseDocumentsService implements OnModuleInit {
     // PR-C PII — the snapshot employeeTaxId === the employee's nationalId (or
     // override). Mask it in the response for roles PR-A blocks from national
     // IDs, so a draft payroll can't enumerate them.
-    this.maskPayrollTaxIds(doc, user.role);
+    maskPayrollTaxIds(doc, user.role);
     return doc;
-  }
-
-  /**
-   * PR-C PII — mask each payroll line's employeeTaxId (= nationalId/override)
-   * unless the viewer is OWNER/ACCOUNTANT. Mutates `doc` in place; the STORED
-   * value is never changed (response-only). No-op for non-payroll docs.
-   */
-  private maskPayrollTaxIds(
-    doc: { payroll?: { lines: Array<{ employeeTaxId: string | null }> } | null },
-    role?: string | null,
-  ): void {
-    // PII-cleared roles (see same set on the PND1 tax report): OWNER/ACCOUNTANT
-    // run the books; FINANCE_MANAGER files payroll tax (needs the real national IDs).
-    if (role === 'OWNER' || role === 'ACCOUNTANT' || role === 'FINANCE_MANAGER') return;
-    if (!doc.payroll) return;
-    for (const l of doc.payroll.lines) {
-      l.employeeTaxId = l.employeeTaxId ? '•••••••••' + l.employeeTaxId.slice(-4) : l.employeeTaxId;
-    }
   }
 
   // ─── Vendor Settlement create — multi-line clears ACCRUAL EXs ────────
@@ -1980,7 +1963,7 @@ export class ExpenseDocumentsService implements OnModuleInit {
     // PR-C PII — mask payroll taxIds in the read response. Cast required
     // because Prisma's conditional-include type for payroll doesn't statically
     // carry the nested lines shape; the runtime value is correct.
-    this.maskPayrollTaxIds(
+    maskPayrollTaxIds(
       doc as { payroll?: { lines: Array<{ employeeTaxId: string | null }> } | null },
       viewerRole,
     );

--- a/apps/api/src/modules/expense-documents/payroll-pii-mask.util.spec.ts
+++ b/apps/api/src/modules/expense-documents/payroll-pii-mask.util.spec.ts
@@ -1,0 +1,44 @@
+import { maskPayrollTaxIds } from './payroll-pii-mask.util';
+
+const payrollDoc = (...taxIds: Array<string | null>) => ({
+  payroll: { lines: taxIds.map((employeeTaxId) => ({ employeeTaxId })) },
+});
+
+describe('maskPayrollTaxIds', () => {
+  it.each(['OWNER', 'ACCOUNTANT', 'FINANCE_MANAGER'])(
+    'leaves tax IDs untouched for the PII-cleared role %s',
+    (role) => {
+      const doc = payrollDoc('1234567890123');
+      maskPayrollTaxIds(doc, role);
+      expect(doc.payroll.lines[0].employeeTaxId).toBe('1234567890123');
+    },
+  );
+
+  it.each(['SALES', 'BRANCH_MANAGER', undefined, null])(
+    'masks tax IDs (keeping the last 4) for non-cleared role %s',
+    (role) => {
+      const doc = payrollDoc('1234567890123');
+      maskPayrollTaxIds(doc, role);
+      expect(doc.payroll.lines[0].employeeTaxId).toBe('•••••••••0123');
+    },
+  );
+
+  it('masks every line', () => {
+    const doc = payrollDoc('1111111111111', '2222222222222');
+    maskPayrollTaxIds(doc, 'SALES');
+    expect(doc.payroll.lines.map((l) => l.employeeTaxId)).toEqual(['•••••••••1111', '•••••••••2222']);
+  });
+
+  it('leaves a null tax ID as null', () => {
+    const doc = payrollDoc(null);
+    maskPayrollTaxIds(doc, 'SALES');
+    expect(doc.payroll.lines[0].employeeTaxId).toBeNull();
+  });
+
+  it('is a no-op for a non-payroll doc', () => {
+    const doc: { payroll?: null } = { payroll: null };
+    expect(() => maskPayrollTaxIds(doc, 'SALES')).not.toThrow();
+    const doc2: Record<string, never> = {};
+    expect(() => maskPayrollTaxIds(doc2, 'SALES')).not.toThrow();
+  });
+});

--- a/apps/api/src/modules/expense-documents/payroll-pii-mask.util.ts
+++ b/apps/api/src/modules/expense-documents/payroll-pii-mask.util.ts
@@ -1,0 +1,23 @@
+/**
+ * PR-C PII — mask each payroll line's `employeeTaxId` (= the employee's
+ * nationalId / override) UNLESS the viewer is a PII-cleared role. Mutates
+ * `doc` in place (response-only — the STORED value is never changed); no-op
+ * for non-payroll docs.
+ *
+ * Pure helper extracted from ExpenseDocumentsService (Wave-4) so the masking
+ * rule has dedicated tests and a single definition shared by the create
+ * response + the payroll-detail GET.
+ *
+ * PII-cleared roles: OWNER + ACCOUNTANT run the books; FINANCE_MANAGER files
+ * payroll tax (ภ.ง.ด.1) and needs the real national IDs.
+ */
+export function maskPayrollTaxIds(
+  doc: { payroll?: { lines: Array<{ employeeTaxId: string | null }> } | null },
+  role?: string | null,
+): void {
+  if (role === 'OWNER' || role === 'ACCOUNTANT' || role === 'FINANCE_MANAGER') return;
+  if (!doc.payroll) return;
+  for (const l of doc.payroll.lines) {
+    l.employeeTaxId = l.employeeTaxId ? '•••••••••' + l.employeeTaxId.slice(-4) : l.employeeTaxId;
+  }
+}


### PR DESCRIPTION
## Wave-4 — first decomposition slice of `ExpenseDocumentsService` (2,774 LOC)

The payroll **PII-masking** rule (mask `employeeTaxId` for roles that aren't PII-cleared) was a private method with **no direct test**, called from two sites (create response + payroll-detail GET).

Moved it to a pure **`payroll-pii-mask.util`** with **+10 unit tests** covering:
- the PII-cleared role set (OWNER / ACCOUNTANT / FINANCE_MANAGER) → untouched,
- non-cleared roles (incl. `undefined` / `null`) → masked keeping the last 4,
- the `•••••••••0123` format, null tax IDs, multi-line docs, and the non-payroll no-op.

Pure, behaviour-preserving extraction — a security/PII rule now has a single definition + dedicated tests. The service shrinks by the method; the two call sites just drop `this.`.

> Note: a deliberately small, safe first slice — meaningfully decomposing the 2,774-LOC god-service is a multi-PR effort.

## Verification
- expense-documents.service + payroll-pii-mask specs — **98/98** green.
- `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)