### PR TITLE
refactor(aging): unify the 4-way AR aging boundary into one pure util (Wave-4)

### DIFF
--- a/apps/api/src/modules/accounting/accounting.service.ts
+++ b/apps/api/src/modules/accounting/accounting.service.ts
@@ -6,6 +6,7 @@ import {
   OnModuleInit,
 } from '@nestjs/common';
 import { PrismaService } from '../../prisma/prisma.service';
+import { agingBucket } from '../../utils/aging-bucket.util';
 import { Prisma } from '@prisma/client';
 import { JournalAutoService } from '../journal/journal-auto.service';
 import { CompanyResolverService } from '../journal/company-resolver.service';
@@ -2134,12 +2135,8 @@ export class AccountingService implements OnModuleInit {
       }
     >();
 
-    const calcBucket = (days: number): keyof typeof summary => {
-      if (days <= 30) return 'bucket_0_30';
-      if (days <= 60) return 'bucket_31_60';
-      if (days <= 90) return 'bucket_61_90';
-      return 'bucket_90_plus';
-    };
+    const calcBucket = (days: number): keyof typeof summary =>
+      agingBucket(days, ['bucket_0_30', 'bucket_31_60', 'bucket_61_90', 'bucket_90_plus'] as const);
 
     for (const p of overduePayments) {
       const daysOverdue = Math.floor(

--- a/apps/api/src/modules/inter-company/inter-company.service.ts
+++ b/apps/api/src/modules/inter-company/inter-company.service.ts
@@ -6,6 +6,7 @@ import {
 } from '@nestjs/common';
 import { PrismaService } from '../../prisma/prisma.service';
 import { CreateInterCompanyTransactionDto } from './dto/inter-company.dto';
+import { agingBucket } from '../../utils/aging-bucket.util';
 import { Prisma, InterCompanyTransactionStatus } from '@prisma/client';
 import { d, dAdd } from '../../utils/decimal.util';
 
@@ -416,11 +417,10 @@ export class InterCompanyService {
 
     const details = txns.map((t) => {
       const daysOutstanding = Math.floor((now - new Date(t.createdAt).getTime()) / dayMs);
-      let bucket: Bucket;
-      if (daysOutstanding <= 30) bucket = '0-30';
-      else if (daysOutstanding <= 60) bucket = '31-60';
-      else if (daysOutstanding <= 90) bucket = '61-90';
-      else bucket = '90+';
+      const bucket: Bucket = agingBucket(
+        daysOutstanding,
+        ['0-30', '31-60', '61-90', '90+'] as const,
+      );
 
       const principal = new Prisma.Decimal(t.principal);
       const commission = new Prisma.Decimal(t.commission);

--- a/apps/api/src/utils/aging-bucket.util.spec.ts
+++ b/apps/api/src/utils/aging-bucket.util.spec.ts
@@ -1,0 +1,26 @@
+import { agingBucket } from './aging-bucket.util';
+
+describe('agingBucket (canonical 4-way AR aging boundary)', () => {
+  const L = ['a', 'b', 'c', 'd'] as const;
+
+  it('maps ≤30 days to bucket 0 (incl. boundary 30, zero, negative)', () => {
+    expect(agingBucket(0, L)).toBe('a');
+    expect(agingBucket(30, L)).toBe('a');
+    expect(agingBucket(-5, L)).toBe('a');
+  });
+
+  it('maps 31-60 to bucket 1 (boundaries 31 and 60)', () => {
+    expect(agingBucket(31, L)).toBe('b');
+    expect(agingBucket(60, L)).toBe('b');
+  });
+
+  it('maps 61-90 to bucket 2 (boundaries 61 and 90)', () => {
+    expect(agingBucket(61, L)).toBe('c');
+    expect(agingBucket(90, L)).toBe('c');
+  });
+
+  it('maps 91+ to bucket 3', () => {
+    expect(agingBucket(91, L)).toBe('d');
+    expect(agingBucket(9999, L)).toBe('d');
+  });
+});

--- a/apps/api/src/utils/aging-bucket.util.ts
+++ b/apps/api/src/utils/aging-bucket.util.ts
@@ -1,0 +1,20 @@
+/**
+ * Canonical 4-way receivables aging split (by days overdue / outstanding):
+ *   ≤30 → labels[0]   31-60 → labels[1]   61-90 → labels[2]   90+ → labels[3]
+ *
+ * Single source of truth for the standard 0-30 / 31-60 / 61-90 / 90+ boundary
+ * shared by the AR aging report (accounting) and the inter-company outstanding
+ * report. Returns the caller-supplied label for the matched bucket, so each
+ * consumer keeps its own label strings (which are part of its API/report
+ * contract) while the boundary rule lives in one place.
+ *
+ * NOTE: bad-debt provisioning intentionally does NOT use this — it needs a
+ * finer 5-way split (…/91-180/180+) whose labels key the regulated ECL
+ * provision-rate table (NPAEs Ch.13).
+ */
+export function agingBucket<T>(daysOverdue: number, labels: readonly [T, T, T, T]): T {
+  if (daysOverdue <= 30) return labels[0];
+  if (daysOverdue <= 60) return labels[1];
+  if (daysOverdue <= 90) return labels[2];
+  return labels[3];
+}


### PR DESCRIPTION
## Wave-4 — unify the duplicated AR aging boundary (the *safe* read of "unify aging buckets")

`accounting.getAgingReport` and the inter-company outstanding report both inlined the **identical** `0-30 / 31-60 / 61-90 / 90+` day-boundary ladder. Extracted the rule into a pure **`agingBucket(days, labels)`** util.

**No output changes — only the rule is single-sourced.** Each consumer passes its OWN label set:
- accounting keeps `'bucket_0_30' / 'bucket_31_60' / 'bucket_61_90' / 'bucket_90_plus'`
- inter-company keeps `'0-30' / '31-60' / '61-90' / '90+'`

So the AgingReportPage frontend, the report API shape, and the accounting tests are untouched.

### Deliberately NOT unified (the trap)
`bad-debt` provisioning uses a **finer 5-way** split (`…/91-180/180+`) whose labels are the **keys of the regulated ECL provision-rate table** (NPAEs Ch.13). Folding it in would change those labels and break the rate map — left as-is, with a note in the util.

## Verification
- +4 util unit tests; accounting `getAgingReport` specs stay green (labels unchanged); `tsc --noEmit` clean.
- Touches `accounting.service.ts` only in the tiny `calcBucket` region → merges cleanly alongside #1183/#1184 (different regions of the same file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)