### PR TITLE
fix(ci): repair 3 pre-existing test failures blocking the merge gate

### DIFF
--- a/apps/api/src/modules/contracts/contract-signing-workflow.spec.ts
+++ b/apps/api/src/modules/contracts/contract-signing-workflow.spec.ts
@@ -92,6 +92,7 @@ describe('Contract Signing & Workflow', () => {
     financedAmount: 21800,
     monthlyPayment: 1817,
     paymentDueDay: 5,
+    createdAt: new Date('2026-01-15T00:00:00.000Z'),
     interestConfigId: null,
     notes: null,
     deletedAt: null,
@@ -143,6 +144,7 @@ describe('Contract Signing & Workflow', () => {
     const txMock = {
       contract: {
         findUnique: jest.fn().mockResolvedValue(mockContract),
+        findUniqueOrThrow: jest.fn().mockResolvedValue(mockContract),
         update: jest.fn().mockResolvedValue(mockContract),
       },
       product: {
@@ -156,6 +158,10 @@ describe('Contract Signing & Workflow', () => {
         createMany: jest.fn().mockResolvedValue({ count: 12 }),
         findFirst: jest.fn().mockResolvedValue(null),
       },
+      installmentSchedule: {
+        count: jest.fn().mockResolvedValue(0),
+        createMany: jest.fn().mockResolvedValue({ count: 12 }),
+      },
       sale: {
         create: jest.fn().mockResolvedValue({ id: 'sale-1' }),
       },
@@ -167,6 +173,7 @@ describe('Contract Signing & Workflow', () => {
     const mockPrisma = {
       contract: {
         findUnique: jest.fn().mockResolvedValue(mockContract),
+        findUniqueOrThrow: jest.fn().mockResolvedValue(mockContract),
         findMany: jest.fn().mockResolvedValue([]),
         count: jest.fn().mockResolvedValue(0),
         update: jest.fn().mockResolvedValue(mockContract),

--- a/apps/api/src/utils/env-validation.spec.ts
+++ b/apps/api/src/utils/env-validation.spec.ts
@@ -58,19 +58,12 @@ describe('env-validation', () => {
       expect(() => validateEnv()).not.toThrow();
     });
 
-    it('throws if ENCRYPTION_KEY missing in prod (TOTP secret protection)', () => {
-      process.env.PII_ENCRYPTION_KEY = 'a'.repeat(64);
-      process.env.PII_HASH_SALT = 'b'.repeat(32);
-      delete process.env.ENCRYPTION_KEY;
-      expect(() => validateEnv()).toThrow(/ENCRYPTION_KEY/);
-    });
-
-    it('throws if ENCRYPTION_KEY too short in prod', () => {
-      process.env.PII_ENCRYPTION_KEY = 'a'.repeat(64);
-      process.env.PII_HASH_SALT = 'b'.repeat(32);
-      process.env.ENCRYPTION_KEY = 'too-short';
-      expect(() => validateEnv()).toThrow(/ENCRYPTION_KEY/);
-    });
+    // NOTE (2026-06): two tests asserting validateEnv() throws on a missing /
+    // too-short ENCRYPTION_KEY in production were removed. That guard existed
+    // only to protect the 2FA TOTP secret, which was deleted in #1169 (remove
+    // staff-login 2FA). National-ID PII is guarded separately via
+    // PII_ENCRYPTION_KEY + PII_HASH_SALT (covered above); ENCRYPTION_KEY is now
+    // an unused legacy env var (ENV_VARS marks it required: false).
   });
 
   describe('development mode', () => {


### PR DESCRIPTION
## Why
The `lint-and-test` gate is **red on every open PR** — including #1185, which changes only `deploy-gcp.yml` (zero code). So the failures are **pre-existing on `main`**, not caused by any of the Wave-4 PRs. They block the whole merge queue. From the CI log: **3 failed / 4379**.

## The 3 failures
1. **`contract-signing-workflow.spec` → ACT-1** — the `activate` tx mock had drifted from the code. `generateInstallmentSchedules` now calls `tx.contract.findUniqueOrThrow`, `tx.installmentSchedule.count` / `.createMany`, and reads `contract.createdAt`. Added the missing mock methods + a `createdAt` to the fixture.
2-3. **`env-validation.spec`** — two tests asserting `validateEnv()` throws on a missing / too-short `ENCRYPTION_KEY` in prod. That guard existed only to protect the **2FA TOTP secret**, which was removed in **#1169** (remove staff-login 2FA). National-ID PII is now guarded via `PII_ENCRYPTION_KEY` (still tested). Removed the stale tests (with a note). **Not** re-adding the guard — that would risk crashing prod boot if the live `ENCRYPTION_KEY` isn't 32+ chars, and the feature it protected is gone.

## Scope / safety
- **Test-only changes.** No production code touched.
- Both suites green locally (**39/39**); resolves the full failing set; `tsc --noEmit` clean.

**Merge this first** — it makes the gate green so the rest of the queue (#1183–1190) can merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)