### PR TITLE
refactor(early-payoff): unify computeEarlyPayoffJE into one pure fn (Wave-4)

### DIFF
--- a/apps/api/src/modules/contracts/contract-payment.service.early-payoff-exec.spec.ts
+++ b/apps/api/src/modules/contracts/contract-payment.service.early-payoff-exec.spec.ts
@@ -326,18 +326,16 @@ describe('ContractPaymentService.earlyPayoff (EXECUTION / money-posting golden)'
     });
   });
 
-  // (e) discount = 0 path — PREVIEW omits 52-1106, but the EXEC JE does NOT ───
+  // (e) discount = 0 path — PREVIEW and EXEC both omit 52-1106 (CONVERGED) ────
   //
-  // BUG CHARACTERIZED (preview/exec divergence): getEarlyPayoffQuote guards the
-  // 52-1106 line with `if (epDiscount.gt(0))` (service line ~197) so a zero
-  // discount drops the line from the PREVIEW. The earlyPayoff() EXEC JE
-  // (service lines 382-391) pushes all 8 lines UNCONDITIONALLY — so when the
-  // discount is 0 the posted JE still carries a `52-1106` line with dr 0.00.
-  // The quote prompt said "discount=0 omits the 52-1106 line" — that is true of
-  // the READ path only. We pin BOTH so the divergence is visible and locked.
-  it('(e) discount 0 — PREVIEW omits 52-1106 but the EXEC JE keeps it at dr 0.00 (divergence pinned)', async () => {
-    // Zero-interest contract: interestTotal 0 → epRemainingDeferredInterest 0
-    // → epDiscount 0. (gross = financed + commission + 0 = 19800; vat 1512.)
+  // Post-unification (computeEarlyPayoffJE): both the preview READ path and the
+  // EXEC posting path guard the 52-1106 line, so a zero discount drops the line
+  // from BOTH. Previously the EXEC JE pushed all 8 lines unconditionally and
+  // carried a no-op `52-1106` dr 0.00 line — that benign divergence is now
+  // fixed. 'preview === posted' holds with no exceptions.
+  it('(e) discount 0 — PREVIEW and EXEC both omit 52-1106 (7 lines · converged)', async () => {
+    // Zero-interest contract: interestTotal 0 → remainingDeferredInterest 0
+    // → discount 0. (gross = financed + commission + 0 = 19800; vat 1512.)
     const zeroInterestContract = {
       ...quoteContract,
       interestTotal: dec('0'),
@@ -351,16 +349,18 @@ describe('ContractPaymentService.earlyPayoff (EXECUTION / money-posting golden)'
     expect(quote.journalPreview.lines.find((l) => l.accountCode === '52-1106')).toBeUndefined();
     expect(quote.journalPreview.lines).toHaveLength(7);
 
-    // WRITE path: the posted JE STILL carries 52-1106 (8 lines), dr 0.00.
+    // WRITE path: the posted JE now ALSO drops the discount line (7 lines).
     await service.earlyPayoff(quoteContract.id, 'user-1', baseDto);
     const je = getCapturedJe();
-    const discountLine = je.lines.find((l) => l.accountCode === '52-1106');
-    expect(discountLine).toBeDefined();
-    expect(discountLine!.dr.toString()).toBe('0'); // ep0 Decimal — toFixed(2) = '0.00'
-    expect(discountLine!.dr.toFixed(2)).toBe('0.00');
-    expect(je.lines).toHaveLength(8);
+    expect(je.lines.find((l) => l.accountCode === '52-1106')).toBeUndefined();
+    expect(je.lines).toHaveLength(7);
 
-    // Still balanced (the dr-0 line is a no-op for the totals).
+    // Preview and posting now carry the SAME codes in the SAME order.
+    expect(je.lines.map((l) => l.accountCode)).toEqual(
+      quote.journalPreview.lines.map((l) => l.accountCode),
+    );
+
+    // Still balanced.
     const totalDr = je.lines.reduce((s, l) => s.plus(l.dr), new Prisma.Decimal(0));
     const totalCr = je.lines.reduce((s, l) => s.plus(l.cr), new Prisma.Decimal(0));
     expect(totalDr.toFixed(2)).toBe(totalCr.toFixed(2));
@@ -381,17 +381,15 @@ describe('ContractPaymentService.earlyPayoff (EXECUTION / money-posting golden)'
     expect(je.metadata.discount).toBe('450.00');
   });
 
-  it('(f2) clamps a negative discountPct up to 0% — EXEC JE keeps 52-1106 at dr 0.00', async () => {
-    // Math.max(0, Math.min(50, -10)) / 100 = 0 → quote discountPct 0 →
-    // epDiscount = 900 × 0/100 = 0. The EXEC JE still pushes the 52-1106 line
-    // (dr 0.00) — same unconditional-line behavior characterized in (e).
+  it('(f2) clamps a negative discountPct up to 0% — EXEC JE omits 52-1106 (7 lines)', async () => {
+    // Math.max(0, Math.min(50, -10)) = 0 → quote discountPct 0 → discount
+    // = 900 × 0/100 = 0. The EXEC JE now guards the 52-1106 line (converged
+    // with the preview — see (e)).
     await service.earlyPayoff(quoteContract.id, 'user-1', { paymentMethod: 'CASH', discountPct: -10 });
     const je = getCapturedJe();
     expect(je.metadata.interestDiscountPercent).toBe(0);
-    const discountLine = je.lines.find((l) => l.accountCode === '52-1106');
-    expect(discountLine).toBeDefined();
-    expect(discountLine!.dr.toFixed(2)).toBe('0.00');
-    expect(je.lines).toHaveLength(8);
+    expect(je.lines.find((l) => l.accountCode === '52-1106')).toBeUndefined();
+    expect(je.lines).toHaveLength(7);
   });
 
   // ── CHARACTERIZATION of the documented quote-vs-JE cash divergence ─────────

--- a/apps/api/src/modules/contracts/contract-payment.service.ts
+++ b/apps/api/src/modules/contracts/contract-payment.service.ts
@@ -4,6 +4,7 @@ import { PrismaService } from '../../prisma/prisma.service';
 import { ProductsService } from '../products/products.service';
 import { JournalAutoService } from '../journal/journal-auto.service';
 import { EarlyPayoffJP4Template } from '../journal/cpa-templates/early-payoff-jp4.template';
+import { computeEarlyPayoffJE } from '../journal/compute-early-payoff-je';
 import { Decimal } from '@prisma/client/runtime/library';
 import { validatePeriodOpen } from '../../utils/period-lock.util';
 import { EarlyPayoffDto } from './dto/contract.dto';
@@ -133,8 +134,9 @@ export class ContractPaymentService {
 
     // (7) ส่วนลด (default 50%, max 50% ตามนโยบาย)
     // ถ้ากำไรติดลบ → ส่วนลด = 0 (ไม่ลดเพิ่ม ไม่บวกเพิ่ม)
-    const discountPct =
-      discountPctInput != null ? Math.max(0, Math.min(50, discountPctInput)) / 100 : 0.5;
+    const discountPercent =
+      discountPctInput != null ? Math.max(0, Math.min(50, discountPctInput)) : 50;
+    const discountPct = discountPercent / 100;
     const discountAmount = grossProfit > 0 ? round2(dMul(grossProfit, discountPct)) : 0;
 
     // (8) ยอดชำระปิดยอด
@@ -147,40 +149,25 @@ export class ContractPaymentService {
         .map(p => d(p.lateFee)),
     ).toNumber();
 
-    // ── JE preview (mirrors EarlyPayoffJP4Template.execute structure) ────────
-    // Computed from contract fields directly so the UI shows the same JE
-    // shape as what gets posted on confirm. Uses installment-level rounding
-    // (ROUND_DOWN principal, ROUND_HALF_UP interest+VAT) to match 2A/2B.
-    const epTotal = new Decimal(contract.totalMonths);
-    const epUnpaidD = new Decimal(remainingMonths);
-    const epFinanced = new Decimal(contract.financedAmount.toString());
-    const epCommission = contract.storeCommission != null
-      ? new Decimal(contract.storeCommission.toString())
-      : epFinanced.times('0.10').toDecimalPlaces(2);
-    const epInterest = new Decimal(contract.interestTotal.toString());
-    const epGrossExclVat = epFinanced.plus(epCommission).plus(epInterest);
-    const epVat = contract.vatAmount != null
-      ? new Decimal(contract.vatAmount.toString())
-      : epGrossExclVat.times('0.07').toDecimalPlaces(2);
-    const epInstallmentExclVat = epGrossExclVat.div(epTotal).toDecimalPlaces(2, Decimal.ROUND_DOWN);
-    const epInterestPerInst = epInterest.div(epTotal).toDecimalPlaces(2, Decimal.ROUND_HALF_UP);
-    const epVatPerInst = epVat.div(epTotal).toDecimalPlaces(2, Decimal.ROUND_HALF_UP);
-    const epRemainingGross = epInstallmentExclVat.times(epUnpaidD);
-    const epRemainingDeferredInterest = epInterestPerInst.times(epUnpaidD);
-    const epRemainingDeferredVat = epVatPerInst.times(epUnpaidD);
-    // discountPct here is fraction 0..1 (0.5 for 50%); epDiscount math takes
-    // the fraction directly, no scaling needed.
-    const epDiscount = epRemainingDeferredInterest
-      .times(new Decimal(discountPct))
-      .toDecimalPlaces(2);
-    // Policy A — VAT ไม่ลดตาม discount
-    const epSettleVat = epRemainingDeferredVat;
-    const epSettlement = epRemainingGross.minus(epDiscount).plus(epSettleVat);
-
+    // ── JE preview (single source of truth — computeEarlyPayoffJE) ───────────
+    // Computed from contract fields via the SAME pure function the ledger
+    // posting (earlyPayoff()) and the JP4 template use, so the preview shown to
+    // the UI/LIFF is byte-for-byte the JE that gets posted on confirm.
     // Cash dimension: caller-provided > fallback 11-1101 (matches accounting.md)
     const epDepositCode = depositAccountCode ?? '11-1101';
+    const je = computeEarlyPayoffJE({
+      depositAccountCode: epDepositCode,
+      financedAmount: contract.financedAmount.toString(),
+      storeCommission: contract.storeCommission != null ? contract.storeCommission.toString() : null,
+      interestTotal: contract.interestTotal.toString(),
+      vatAmount: contract.vatAmount != null ? contract.vatAmount.toString() : null,
+      totalMonths: contract.totalMonths,
+      unpaidCount: remainingMonths,
+      interestDiscountPercent: discountPercent,
+    });
+
     // Resolve all account names from CoA so preview shows real labels.
-    const epCodes = [epDepositCode, '11-2106', '21-2102', '52-1106', '11-2101', '11-2105', '41-1101', '21-2101'];
+    const epCodes = je.lines.map((l) => l.accountCode);
     const epCoaRows = await this.prisma.chartOfAccount.findMany({
       where: { code: { in: epCodes } },
       select: { code: true, name: true },
@@ -188,27 +175,28 @@ export class ContractPaymentService {
     const epNameMap = new Map(epCoaRows.map((r) => [r.code, r.name]));
     const nameOf = (code: string) => epNameMap.get(code) ?? code;
 
+    // Per-line UI descriptions (human-facing). Only the money — accountCode +
+    // debit + credit, shared via computeEarlyPayoffJE — must match the posting;
+    // the ledger words its descriptions differently and that's intentional.
+    const epDescriptions: Record<string, string> = {
+      [epDepositCode]: `รับ ${je.settlement.toFixed(2)} ฿ ปิดยอด`,
+      '11-2106': `ยกเลิกค่าอนาคต ${je.remainingDeferredInterest.toFixed(2)}`,
+      '21-2102': `ล้าง 21-2102 ${je.remainingDeferredVat.toFixed(2)}`,
+      '52-1106': `ส่วนลดดอกเบี้ย ${discountPercent}%`,
+      '11-2101': `ล้าง Gross ${je.remainingGross.toFixed(2)}`,
+      '11-2105': `ล้าง 11-2105 ${je.remainingDeferredVat.toFixed(2)}`,
+      '41-1101': 'รับรู้รายได้',
+      '21-2101': `VAT ถึงกำหนด ${je.settleVat.toFixed(2)}`,
+    };
+
     type JeLine = { accountCode: string; accountName: string; debit: string; credit: string; description: string };
-    const jeLines: JeLine[] = [
-      { accountCode: epDepositCode, accountName: nameOf(epDepositCode), debit: epSettlement.toFixed(2), credit: '0.00', description: `รับ ${epSettlement.toFixed(2)} ฿ ปิดยอด` },
-      { accountCode: '11-2106', accountName: nameOf('11-2106'), debit: epRemainingDeferredInterest.toFixed(2), credit: '0.00', description: `ยกเลิกค่าอนาคต ${epRemainingDeferredInterest.toFixed(2)}` },
-      { accountCode: '21-2102', accountName: nameOf('21-2102'), debit: epRemainingDeferredVat.toFixed(2), credit: '0.00', description: `ล้าง 21-2102 ${epRemainingDeferredVat.toFixed(2)}` },
-    ];
-    if (epDiscount.gt(0)) {
-      jeLines.push({
-        accountCode: '52-1106',
-        accountName: nameOf('52-1106'),
-        debit: epDiscount.toFixed(2),
-        credit: '0.00',
-        description: `ส่วนลดดอกเบี้ย ${discountPct * 100}%`,
-      });
-    }
-    jeLines.push(
-      { accountCode: '11-2101', accountName: nameOf('11-2101'), debit: '0.00', credit: epRemainingGross.toFixed(2), description: `ล้าง Gross ${epRemainingGross.toFixed(2)}` },
-      { accountCode: '11-2105', accountName: nameOf('11-2105'), debit: '0.00', credit: epRemainingDeferredVat.toFixed(2), description: `ล้าง 11-2105 ${epRemainingDeferredVat.toFixed(2)}` },
-      { accountCode: '41-1101', accountName: nameOf('41-1101'), debit: '0.00', credit: epRemainingDeferredInterest.toFixed(2), description: 'รับรู้รายได้' },
-      { accountCode: '21-2101', accountName: nameOf('21-2101'), debit: '0.00', credit: epSettleVat.toFixed(2), description: `VAT ถึงกำหนด ${epSettleVat.toFixed(2)}` },
-    );
+    const jeLines: JeLine[] = je.lines.map((l) => ({
+      accountCode: l.accountCode,
+      accountName: nameOf(l.accountCode),
+      debit: l.dr.toFixed(2),
+      credit: l.cr.toFixed(2),
+      description: epDescriptions[l.accountCode] ?? '',
+    }));
 
     let jeTotalDr = new Decimal(0);
     let jeTotalCr = new Decimal(0);
@@ -323,49 +311,48 @@ export class ContractPaymentService {
           });
         }
 
-        // Phase A.4b: replaced createEarlyPayoffJournal (old stub) with inline
-        // createAndPost mirroring JP4 template's JE structure.
-        // Payment rows are already updated above — JP4 template cannot be called
-        // directly here because it also creates Payment rows (duplicate conflict).
-        // JE accounts mirror EarlyPayoffJP4Template.execute() spec §6.4.
+        // Phase A.4b → Wave-4: post the early-payoff JE via the SINGLE source of
+        // truth computeEarlyPayoffJE — the SAME function getEarlyPayoffQuote()
+        // uses for the preview — so what is posted here is byte-for-byte the JE
+        // the customer was quoted (preview === posted, guaranteed).
+        // The JP4 template can't be called directly here: it also creates Payment
+        // rows, which were already updated above (duplicate conflict).
+        //
+        // ACCOUNTANT NOTE (Wave-1 #11): the JE cash debit (computeEarlyPayoffJE
+        // settlement = remainingGross − discount + deferred VAT) is the
+        // per-installment breakdown, while the cash the customer is QUOTED
+        // (quote.totalPayoff) is monthlyPayment-based, nets out creditBalance/
+        // advance, and discounts GROSS PROFIT. The two bases can diverge — the
+        // FIFO loop above distributes quote.totalPayoff; reconciling the payoff
+        // cash basis is an accounting-policy decision left unchanged pending sign-off.
         {
-          const ep0 = new Decimal(0);
-          const epUnpaid = installmentSnapshots.length;
           const epContract = await tx.contract.findUniqueOrThrow({ where: { id } });
-          const epUnpaidD = new Decimal(epUnpaid);
-          const epTotal = new Decimal(epContract.totalMonths);
-          const epFinanced = new Decimal(epContract.financedAmount.toString());
-          const epCommission = epContract.storeCommission != null
-            ? new Decimal(epContract.storeCommission.toString())
-            : epFinanced.times('0.10').toDecimalPlaces(2);
-          const epInterest = new Decimal(epContract.interestTotal.toString());
-          const epGrossExclVat = epFinanced.plus(epCommission).plus(epInterest);
-          const epVat = epContract.vatAmount != null
-            ? new Decimal(epContract.vatAmount.toString())
-            : epGrossExclVat.times('0.07').toDecimalPlaces(2);
-          const epInstallmentExclVat = epGrossExclVat.div(epTotal).toDecimalPlaces(2, Decimal.ROUND_DOWN);
-          const epInterestPerInst = epInterest.div(epTotal).toDecimalPlaces(2, Decimal.ROUND_HALF_UP);
-          const epVatPerInst = epVat.div(epTotal).toDecimalPlaces(2, Decimal.ROUND_HALF_UP);
-          const epRemainingGross = epInstallmentExclVat.times(epUnpaidD);
-          const epRemainingDeferredInterest = epInterestPerInst.times(epUnpaidD);
-          const epRemainingDeferredVat = epVatPerInst.times(epUnpaidD);
-          // NB (Wave-1 #4/#11): `quote.discountPct` is a PERCENTAGE 0..100
-          // (getEarlyPayoffQuote returns `discountPct: discountPct * 100`), so the
-          // `.div(100)` here is CORRECT and matches the quote's JE-preview epDiscount,
-          // which multiplies by the 0..1 fraction directly. This is NOT a 100× bug —
-          // do not "simplify" by removing the .div(100).
-          const epDiscount = epRemainingDeferredInterest
-            .times(new Decimal(quote.discountPct))
-            .div(100)
-            .toDecimalPlaces(2);
-          // ACCOUNTANT NOTE (Wave-1 #11, deeper than the false 100× alarm): epSettlement
-          // (this JE's cash debit) is built from the per-installment breakdown and discounts
-          // the DEFERRED INTEREST, while the cash the customer is quoted (quote.totalPayoff)
-          // is monthlyPayment-based, nets out creditBalance/advance, and discounts GROSS
-          // PROFIT. The two can diverge, so the cash debited here may differ from cash
-          // actually collected. Reconciling the payoff cash basis is an accounting-policy
-          // decision — left unchanged pending sign-off.
-          const epSettlement = epRemainingGross.minus(epDiscount).plus(epRemainingDeferredVat);
+          const epUnpaid = installmentSnapshots.length;
+          const epJe = computeEarlyPayoffJE({
+            depositAccountCode,
+            financedAmount: epContract.financedAmount.toString(),
+            storeCommission: epContract.storeCommission != null ? epContract.storeCommission.toString() : null,
+            interestTotal: epContract.interestTotal.toString(),
+            vatAmount: epContract.vatAmount != null ? epContract.vatAmount.toString() : null,
+            totalMonths: epContract.totalMonths,
+            unpaidCount: epUnpaid,
+            // quote.discountPct is a PERCENTAGE 0..100 (getEarlyPayoffQuote returns
+            // `discountPct * 100`); computeEarlyPayoffJE divides by 100 internally.
+            interestDiscountPercent: quote.discountPct,
+          });
+
+          // Ledger-side line descriptions (the preview words them differently —
+          // only the money, shared via computeEarlyPayoffJE, must match).
+          const epDescriptions: Record<string, string> = {
+            [depositAccountCode]: `รับ ${epJe.settlement.toFixed(2)} ฿ ปิดยอด`,
+            '11-2106': 'ยกเลิกรายได้รอตัดบัญชี-ดอกเบี้ย',
+            '21-2102': 'ล้างภาษีขายรอเรียกเก็บ',
+            '52-1106': 'ส่วนลดดอกเบี้ย-ปิดยอดก่อนกำหนด',
+            '11-2101': 'ล้างลูกหนี้ Gross (excl. VAT)',
+            '11-2105': 'ล้างลูกหนี้ภาษีขายรอฯ',
+            '41-1101': 'รับรู้รายได้ดอกเบี้ย',
+            '21-2101': 'ภาษีขาย ภ.พ.30 ถึงกำหนด',
+          };
 
           await this.journalAutoService.createAndPost(
             {
@@ -376,19 +363,15 @@ export class ContractPaymentService {
                 flow: 'early-payoff',
                 contractId: id,
                 unpaidInstallments: epUnpaid,
-                discount: epDiscount.toFixed(2),
+                discount: epJe.discount.toFixed(2),
                 interestDiscountPercent: quote.discountPct,
               },
-              lines: [
-                { accountCode: depositAccountCode, dr: epSettlement, cr: ep0, description: `รับ ${epSettlement.toFixed(2)} ฿ ปิดยอด` },
-                { accountCode: '11-2106', dr: epRemainingDeferredInterest, cr: ep0, description: 'ยกเลิกรายได้รอตัดบัญชี-ดอกเบี้ย' },
-                { accountCode: '21-2102', dr: epRemainingDeferredVat, cr: ep0, description: 'ล้างภาษีขายรอเรียกเก็บ' },
-                { accountCode: '52-1106', dr: epDiscount, cr: ep0, description: 'ส่วนลดดอกเบี้ย-ปิดยอดก่อนกำหนด' },
-                { accountCode: '11-2101', dr: ep0, cr: epRemainingGross, description: 'ล้างลูกหนี้ Gross (excl. VAT)' },
-                { accountCode: '11-2105', dr: ep0, cr: epRemainingDeferredVat, description: 'ล้างลูกหนี้ภาษีขายรอฯ' },
-                { accountCode: '41-1101', dr: ep0, cr: epRemainingDeferredInterest, description: 'รับรู้รายได้ดอกเบี้ย' },
-                { accountCode: '21-2101', dr: ep0, cr: epRemainingDeferredVat, description: 'ภาษีขาย ภ.พ.30 ถึงกำหนด' },
-              ],
+              lines: epJe.lines.map((l) => ({
+                accountCode: l.accountCode,
+                dr: l.dr,
+                cr: l.cr,
+                description: epDescriptions[l.accountCode] ?? '',
+              })),
             },
             tx,
           );

--- a/apps/api/src/modules/journal/compute-early-payoff-je.spec.ts
+++ b/apps/api/src/modules/journal/compute-early-payoff-je.spec.ts
@@ -1,0 +1,240 @@
+import { Decimal } from '@prisma/client/runtime/library';
+import { computeEarlyPayoffJE } from './compute-early-payoff-je';
+
+/**
+ * Golden / characterization test for the SINGLE source-of-truth early-payoff JE
+ * math. Before this extraction, the JE was re-implemented in THREE places that
+ * could silently drift:
+ *   A) EarlyPayoffJP4Template.execute()         — the JP4 posting template
+ *   B) ContractPaymentService.getEarlyPayoffQuote() — the UI/LIFF JE preview
+ *   C) ContractPaymentService.earlyPayoff()     — the inline ledger posting
+ *
+ * This spec pins the canonical money math for `computeEarlyPayoffJE` against the
+ * CPA golden fixtures so all three callers can never diverge by a satang.
+ *
+ * Rounding rules (.claude/rules/accounting.md — MUST match CPA CSV golden):
+ *   grossExclVat / totalMonths → ROUND_DOWN   (17000/12 = 1416.66, NOT .67)
+ *   interest    / totalMonths → ROUND_HALF_UP (1190/12 = 99.17)
+ *   vat         / totalMonths → ROUND_HALF_UP
+ *   per-installment total = sum of the above
+ *
+ * Policy A (CPA decision · 2026-05-09): VAT ไม่ลดตามส่วนลดดอกเบี้ย —
+ *   Cr 21-2101 = remainingDeferredVat เต็มยอด (settleVat = remainingDeferredVat).
+ */
+describe('computeEarlyPayoffJE (single-source early-payoff JE math)', () => {
+  const drOf = (r: ReturnType<typeof computeEarlyPayoffJE>, code: string) =>
+    r.lines.find((l) => l.accountCode === code)?.dr.toFixed(2);
+  const crOf = (r: ReturnType<typeof computeEarlyPayoffJE>, code: string) =>
+    r.lines.find((l) => l.accountCode === code)?.cr.toFixed(2);
+  const totals = (r: ReturnType<typeof computeEarlyPayoffJE>) => {
+    const dr = r.lines.reduce((s, l) => s.plus(l.dr), new Decimal(0));
+    const cr = r.lines.reduce((s, l) => s.plus(l.cr), new Decimal(0));
+    return { dr: dr.toFixed(2), cr: cr.toFixed(2) };
+  };
+
+  // ── CPA golden case-4 (17K/12M, 6 unpaid, 50% discount) ─────────────────────
+  // Mirrors apps/api/.../fixtures/cpa-cases/case-4-early-payoff.csv exactly.
+  describe('CPA golden case-4 (17K/12M · 6 unpaid · 50% discount)', () => {
+    const input = {
+      depositAccountCode: '11-1101',
+      financedAmount: '10000',
+      storeCommission: '1000',
+      interestTotal: '6000',
+      vatAmount: '1190',
+      totalMonths: 12,
+      unpaidCount: 6,
+      interestDiscountPercent: '50',
+    };
+
+    it('rounds per-installment principal ROUND_DOWN and interest/VAT ROUND_HALF_UP', () => {
+      const r = computeEarlyPayoffJE(input);
+      // 17000/12 = 1416.666.. → ROUND_DOWN → 1416.66
+      expect(r.installmentExclVat.toFixed(2)).toBe('1416.66');
+      // 6000/12 = 500.00
+      expect(r.interestPerInst.toFixed(2)).toBe('500.00');
+      // 1190/12 = 99.1666.. → ROUND_HALF_UP → 99.17
+      expect(r.vatPerInst.toFixed(2)).toBe('99.17');
+    });
+
+    it('produces the 8 documented FINANCE lines in order with the golden amounts', () => {
+      const r = computeEarlyPayoffJE(input);
+      expect(r.lines.map((l) => l.accountCode)).toEqual([
+        '11-1101', '11-2106', '21-2102', '52-1106', '11-2101', '11-2105', '41-1101', '21-2101',
+      ]);
+      expect(drOf(r, '11-1101')).toBe('7594.98'); // settlement
+      expect(drOf(r, '11-2106')).toBe('3000.00'); // remaining deferred interest
+      expect(drOf(r, '21-2102')).toBe('595.02'); // remaining deferred VAT
+      expect(drOf(r, '52-1106')).toBe('1500.00'); // 50% discount
+      expect(crOf(r, '11-2101')).toBe('8499.96'); // remaining gross
+      expect(crOf(r, '11-2105')).toBe('595.02');
+      expect(crOf(r, '41-1101')).toBe('3000.00');
+      expect(crOf(r, '21-2101')).toBe('595.02'); // Policy A — full deferred VAT
+    });
+
+    it('is balanced at 12,690.00', () => {
+      const r = computeEarlyPayoffJE(input);
+      const t = totals(r);
+      expect(t.dr).toBe('12690.00');
+      expect(t.cr).toBe('12690.00');
+    });
+
+    it('exposes derived scalars (settlement, discount, settleVat)', () => {
+      const r = computeEarlyPayoffJE(input);
+      expect(r.settlement.toFixed(2)).toBe('7594.98');
+      expect(r.discount.toFixed(2)).toBe('1500.00');
+      expect(r.settleVat.toFixed(2)).toBe('595.02');
+      expect(r.remainingDeferredInterest.toFixed(2)).toBe('3000.00');
+      expect(r.remainingDeferredVat.toFixed(2)).toBe('595.02');
+      expect(r.remainingGross.toFixed(2)).toBe('8499.96');
+    });
+
+    it('100% discount → settlement 6094.98, Cr 21-2101 still full (Policy A)', () => {
+      const r = computeEarlyPayoffJE({ ...input, interestDiscountPercent: '100' });
+      expect(drOf(r, '52-1106')).toBe('3000.00');
+      expect(drOf(r, '11-1101')).toBe('6094.98'); // 8499.96 - 3000 + 595.02
+      expect(crOf(r, '21-2101')).toBe('595.02');
+    });
+  });
+
+  // ── 18K/12M case (preview B + posting C golden) ─────────────────────────────
+  describe('18K/12M · 6 unpaid', () => {
+    const input = {
+      depositAccountCode: '11-1101',
+      financedAmount: '18000',
+      storeCommission: '1800',
+      interestTotal: '1800',
+      vatAmount: '1512',
+      totalMonths: 12,
+      unpaidCount: 6,
+      interestDiscountPercent: '50',
+    };
+
+    it('50% discount → cash 11106.00, discount 450.00, balanced 13212.00', () => {
+      const r = computeEarlyPayoffJE(input);
+      expect(drOf(r, '11-1101')).toBe('11106.00');
+      expect(drOf(r, '11-2106')).toBe('900.00');
+      expect(drOf(r, '21-2102')).toBe('756.00');
+      expect(drOf(r, '52-1106')).toBe('450.00');
+      expect(crOf(r, '11-2101')).toBe('10800.00');
+      expect(crOf(r, '11-2105')).toBe('756.00');
+      expect(crOf(r, '41-1101')).toBe('900.00');
+      expect(crOf(r, '21-2101')).toBe('756.00');
+      expect(totals(r).dr).toBe('13212.00');
+      expect(totals(r).cr).toBe('13212.00');
+    });
+
+    it('30% discount → discount 270.00, settlement 11286.00', () => {
+      const r = computeEarlyPayoffJE({ ...input, interestDiscountPercent: '30' });
+      expect(drOf(r, '52-1106')).toBe('270.00'); // 900 × 30/100
+      expect(drOf(r, '11-1101')).toBe('11286.00'); // 10800 - 270 + 756
+    });
+  });
+
+  // ── Zero-discount → GUARD: omit the 52-1106 line (canonical) ────────────────
+  describe('zero-discount guard (omit 52-1106)', () => {
+    const base = {
+      depositAccountCode: '11-1101',
+      financedAmount: '18000',
+      storeCommission: '1800',
+      interestTotal: '1800',
+      vatAmount: '1512',
+      totalMonths: 12,
+      unpaidCount: 6,
+    };
+
+    it('0% discount → no 52-1106 line, 7 lines, still balanced', () => {
+      const r = computeEarlyPayoffJE({ ...base, interestDiscountPercent: '0' });
+      expect(r.lines.find((l) => l.accountCode === '52-1106')).toBeUndefined();
+      expect(r.lines).toHaveLength(7);
+      expect(r.discount.toFixed(2)).toBe('0.00');
+      // settlement = 10800 - 0 + 756 = 11556.00
+      expect(drOf(r, '11-1101')).toBe('11556.00');
+      expect(totals(r).dr).toBe(totals(r).cr);
+      expect(totals(r).dr).toBe('13212.00');
+    });
+
+    it('zero interestTotal → discount 0 → omit 52-1106 (7 lines, 0.00 interest legs)', () => {
+      // Mirrors the contract-payment exec spec (e) scenario at the pure-fn level.
+      const r = computeEarlyPayoffJE({ ...base, interestTotal: '0', interestDiscountPercent: '50' });
+      expect(r.lines.find((l) => l.accountCode === '52-1106')).toBeUndefined();
+      expect(r.lines).toHaveLength(7);
+      expect(drOf(r, '11-2106')).toBe('0.00');
+      expect(crOf(r, '41-1101')).toBe('0.00');
+      // gross = 19800; installmentExclVat = 1650.00; remainingGross = 9900.00
+      expect(crOf(r, '11-2101')).toBe('9900.00');
+      expect(drOf(r, '11-1101')).toBe('10656.00'); // 9900 - 0 + 756
+      expect(totals(r).dr).toBe(totals(r).cr);
+    });
+  });
+
+  // ── Default derivations when storeCommission / vatAmount are null ────────────
+  describe('null storeCommission / vatAmount defaults', () => {
+    it('null storeCommission → financed × 10%', () => {
+      // financed 10000 → commission 1000 → identical to case-4
+      const r = computeEarlyPayoffJE({
+        depositAccountCode: '11-1101',
+        financedAmount: '10000',
+        storeCommission: null,
+        interestTotal: '6000',
+        vatAmount: '1190',
+        totalMonths: 12,
+        unpaidCount: 6,
+        interestDiscountPercent: '50',
+      });
+      expect(drOf(r, '11-1101')).toBe('7594.98');
+      expect(totals(r).dr).toBe('12690.00');
+    });
+
+    it('null vatAmount → grossExclVat × 7%', () => {
+      // (10000 + 1000 + 6000) × 0.07 = 1190.00 → identical to case-4
+      const r = computeEarlyPayoffJE({
+        depositAccountCode: '11-1101',
+        financedAmount: '10000',
+        storeCommission: '1000',
+        interestTotal: '6000',
+        vatAmount: null,
+        totalMonths: 12,
+        unpaidCount: 6,
+        interestDiscountPercent: '50',
+      });
+      expect(drOf(r, '21-2102')).toBe('595.02');
+      expect(crOf(r, '21-2101')).toBe('595.02');
+      expect(totals(r).dr).toBe('12690.00');
+    });
+  });
+
+  // ── Deposit account dimension flows into the cash (Dr) line ──────────────────
+  it('honours a custom depositAccountCode on the cash line', () => {
+    const r = computeEarlyPayoffJE({
+      depositAccountCode: '11-1201',
+      financedAmount: '18000',
+      storeCommission: '1800',
+      interestTotal: '1800',
+      vatAmount: '1512',
+      totalMonths: 12,
+      unpaidCount: 6,
+      interestDiscountPercent: '50',
+    });
+    expect(r.lines[0].accountCode).toBe('11-1201');
+    expect(r.lines[0].dr.toFixed(2)).toBe('11106.00');
+  });
+
+  // ── Accepts Decimal / number forms for the discount percent ──────────────────
+  it('accepts Decimal and number forms for interestDiscountPercent', () => {
+    const base = {
+      depositAccountCode: '11-1101',
+      financedAmount: '18000',
+      storeCommission: '1800',
+      interestTotal: '1800',
+      vatAmount: '1512',
+      totalMonths: 12,
+      unpaidCount: 6,
+    };
+    const asDecimal = computeEarlyPayoffJE({ ...base, interestDiscountPercent: new Decimal('50') });
+    const asNumber = computeEarlyPayoffJE({ ...base, interestDiscountPercent: 50 });
+    const asString = computeEarlyPayoffJE({ ...base, interestDiscountPercent: '50' });
+    expect(asDecimal.discount.toFixed(2)).toBe('450.00');
+    expect(asNumber.discount.toFixed(2)).toBe('450.00');
+    expect(asString.discount.toFixed(2)).toBe('450.00');
+  });
+});

--- a/apps/api/src/modules/journal/compute-early-payoff-je.ts
+++ b/apps/api/src/modules/journal/compute-early-payoff-je.ts
@@ -1,0 +1,150 @@
+import { Decimal } from '@prisma/client/runtime/library';
+
+/**
+ * Single source of truth for the Early-Payoff (JP4) journal-entry money math.
+ *
+ * Previously this computation was re-implemented in three places that could
+ * silently drift apart (preview showing one number, ledger posting another):
+ *   A) EarlyPayoffJP4Template.execute()             — the JP4 posting template
+ *   B) ContractPaymentService.getEarlyPayoffQuote() — the UI/LIFF JE preview
+ *   C) ContractPaymentService.earlyPayoff()         — the inline ledger posting
+ *
+ * All three now call this pure function, so `preview === posted` is guaranteed
+ * by construction. Verified against the CPA golden fixtures
+ * (apps/api/.../fixtures/cpa-cases/case-4-early-payoff.csv) — see the golden
+ * spec compute-early-payoff-je.spec.ts and the DB-backed template golden
+ * early-payoff-jp4.template.spec.ts.
+ *
+ * Rounding (.claude/rules/accounting.md — MUST match CPA CSV golden values):
+ *   grossExclVat / totalMonths → ROUND_DOWN
+ *   interest    / totalMonths → ROUND_HALF_UP
+ *   vat         / totalMonths → ROUND_HALF_UP
+ *   per-installment total      = sum of the above
+ *
+ * Policy A (CPA decision · 2026-05-09): VAT ไม่ลดตามส่วนลดดอกเบี้ย —
+ *   Cr 21-2101 (VAT ภ.พ.30) = remainingDeferredVat เต็มยอด (settleVat).
+ *   ไม่ออกใบลดหนี้ (Credit Note); บริษัทรับภาระ VAT ส่วนเกินจากส่วนลดเอง.
+ *   Ref: docs/superpowers/specs/2026-05-09-cpa-policy-a-100-compliance-design.md
+ */
+
+type DecimalInput = Decimal | string | number;
+
+export interface ComputeEarlyPayoffJeInput {
+  /** Cash/bank account the customer pays into (Dr leg). */
+  depositAccountCode: string;
+  /** ยอดจัด (FINANCE principal base). */
+  financedAmount: DecimalInput;
+  /** Store commission. null → financedAmount × 10% (ROUND to 2dp). */
+  storeCommission: DecimalInput | null;
+  /** Total deferred interest over the whole contract. */
+  interestTotal: DecimalInput;
+  /** Total VAT over the whole contract. null → grossExclVat × 7% (ROUND to 2dp). */
+  vatAmount: DecimalInput | null;
+  /** Number of installments in the contract. */
+  totalMonths: number;
+  /** Number of unpaid installments being closed out. */
+  unpaidCount: number;
+  /** Interest discount as a PERCENTAGE 0..100 (e.g. 50 for 50%). */
+  interestDiscountPercent: DecimalInput;
+}
+
+/** One canonical JE line — money only (accountCode + dr + cr). Descriptions are
+ * the caller's concern (UI preview vs ledger posting word them differently). */
+export interface EarlyPayoffJeLine {
+  accountCode: string;
+  dr: Decimal;
+  cr: Decimal;
+}
+
+export interface ComputeEarlyPayoffJeResult {
+  /** The canonical JE lines (52-1106 omitted when discount = 0). */
+  lines: EarlyPayoffJeLine[];
+  // Derived per-installment values (consistent with templates 2A/2B).
+  installmentExclVat: Decimal;
+  interestPerInst: Decimal;
+  vatPerInst: Decimal;
+  // Remaining balances for the unpaid installments.
+  remainingGross: Decimal;
+  remainingDeferredInterest: Decimal;
+  remainingDeferredVat: Decimal;
+  /** Interest discount (remainingDeferredInterest × pct / 100, ROUND to 2dp). */
+  discount: Decimal;
+  /** Policy A: settleVat = remainingDeferredVat (VAT not reduced by discount). */
+  settleVat: Decimal;
+  /** Cash the customer pays = remainingGross − discount + settleVat. */
+  settlement: Decimal;
+}
+
+export function computeEarlyPayoffJE(
+  input: ComputeEarlyPayoffJeInput,
+): ComputeEarlyPayoffJeResult {
+  const total = new Decimal(input.totalMonths);
+  const unpaidD = new Decimal(input.unpaidCount);
+
+  const financed = new Decimal(input.financedAmount);
+  const commission =
+    input.storeCommission != null
+      ? new Decimal(input.storeCommission)
+      : financed.times('0.10').toDecimalPlaces(2);
+  const interest = new Decimal(input.interestTotal);
+  const grossExclVat = financed.plus(commission).plus(interest);
+  const vat =
+    input.vatAmount != null
+      ? new Decimal(input.vatAmount)
+      : grossExclVat.times('0.07').toDecimalPlaces(2);
+
+  // Per-installment amounts (same rounding as templates 2A/2B).
+  const installmentExclVat = grossExclVat.div(total).toDecimalPlaces(2, Decimal.ROUND_DOWN);
+  const interestPerInst = interest.div(total).toDecimalPlaces(2, Decimal.ROUND_HALF_UP);
+  const vatPerInst = vat.div(total).toDecimalPlaces(2, Decimal.ROUND_HALF_UP);
+
+  // Remaining balances for the unpaid installments.
+  const remainingGross = installmentExclVat.times(unpaidD);
+  const remainingDeferredInterest = interestPerInst.times(unpaidD);
+  const remainingDeferredVat = vatPerInst.times(unpaidD);
+
+  // Discount on interest only (percentage 0..100 → divide by 100).
+  const discount = remainingDeferredInterest
+    .times(new Decimal(input.interestDiscountPercent))
+    .div(100)
+    .toDecimalPlaces(2);
+
+  // Policy A — VAT ไม่ลดตามส่วนลด (full deferred VAT settles).
+  const settleVat = remainingDeferredVat;
+
+  // Settlement the customer pays (reduced by discount only — VAT full).
+  const settlement = remainingGross.minus(discount).plus(settleVat);
+
+  const zero = new Decimal(0);
+  const lines: EarlyPayoffJeLine[] = [
+    { accountCode: input.depositAccountCode, dr: settlement, cr: zero },
+    { accountCode: '11-2106', dr: remainingDeferredInterest, cr: zero },
+    { accountCode: '21-2102', dr: remainingDeferredVat, cr: zero },
+  ];
+
+  // Guard: only emit the discount line when there is a discount (canonical —
+  // matches the golden template + preview; a 0.00 line is a no-op).
+  if (discount.gt(0)) {
+    lines.push({ accountCode: '52-1106', dr: discount, cr: zero });
+  }
+
+  lines.push(
+    { accountCode: '11-2101', dr: zero, cr: remainingGross },
+    { accountCode: '11-2105', dr: zero, cr: remainingDeferredVat },
+    { accountCode: '41-1101', dr: zero, cr: remainingDeferredInterest },
+    { accountCode: '21-2101', dr: zero, cr: settleVat },
+  );
+
+  return {
+    lines,
+    installmentExclVat,
+    interestPerInst,
+    vatPerInst,
+    remainingGross,
+    remainingDeferredInterest,
+    remainingDeferredVat,
+    discount,
+    settleVat,
+    settlement,
+  };
+}

--- a/apps/api/src/modules/journal/cpa-templates/early-payoff-jp4.template.ts
+++ b/apps/api/src/modules/journal/cpa-templates/early-payoff-jp4.template.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { Decimal } from '@prisma/client/runtime/library';
 import { Prisma } from '@prisma/client';
 import { JournalAutoService, JeLineInput } from '../journal-auto.service';
+import { computeEarlyPayoffJE } from '../compute-early-payoff-je';
 import { PrismaService } from '../../../prisma/prisma.service';
 import { Vat60dayReversalTemplate } from './vat-60day-reversal.template';
 
@@ -106,109 +107,57 @@ export class EarlyPayoffJP4Template {
     }
 
     const unpaidD = new Decimal(unpaid);
-    const total = new Decimal(c.totalMonths);
 
-    const financed = new Decimal(c.financedAmount.toString());
-    const commission =
-      c.storeCommission != null
-        ? new Decimal(c.storeCommission.toString())
-        : financed.times('0.10').toDecimalPlaces(2);
-    const interest = new Decimal(c.interestTotal.toString());
-    const grossExclVat = financed.plus(commission).plus(interest);
-    const vat =
-      c.vatAmount != null
-        ? new Decimal(c.vatAmount.toString())
-        : grossExclVat.times('0.07').toDecimalPlaces(2);
-
-    // Per-installment amounts (consistent with 2A/2B rounding)
-    const installmentExclVat = grossExclVat.div(total).toDecimalPlaces(2, Decimal.ROUND_DOWN);
-    const interestPerInst = interest.div(total).toDecimalPlaces(2, Decimal.ROUND_HALF_UP);
-    const vatPerInst = vat.div(total).toDecimalPlaces(2, Decimal.ROUND_HALF_UP);
-
-    // Remaining balances for unpaid installments
-    const remainingGross = installmentExclVat.times(unpaidD);
-    const remainingDeferredInterest = interestPerInst.times(unpaidD);
-    const remainingDeferredVat = vatPerInst.times(unpaidD);
-
-    // Discount on interest only
-    const discount = remainingDeferredInterest
-      .times(input.interestDiscountPercent)
-      .div(100)
-      .toDecimalPlaces(2);
-
-    // Policy A (CPA decision) — VAT ไม่ลดตามส่วนลดดอกเบี้ย
-    // CPA เลือก Policy A vs ม.79+86/10:
-    //   - Cr 21-2101 (VAT ภ.พ.30) = remainingDeferredVat เต็ม ไม่ลดตาม discount
-    //   - ไม่ออกใบลดหนี้ VAT (Credit Note)
-    //   - บริษัทรับภาระ VAT ส่วนเกินจาก discount เอง
-    // อ้างอิง: docs/superpowers/specs/2026-05-09-cpa-policy-a-100-compliance-design.md
-    //          + Handover_BestChoiceFinance v3.0.pdf §9 Policy Decisions
-    const settleVat = remainingDeferredVat;
-
-    // Settlement amount customer pays (reduced by discount only — VAT full)
-    const settlement = remainingGross.minus(discount).plus(settleVat);
-
-    const zero = new Decimal(0);
+    // Single source of truth — the SAME pure function the JE preview and the
+    // ledger posting (ContractPaymentService) use, so this template can never
+    // drift from what the customer is quoted (preview === posted).
+    // Policy A (CPA decision · 2026-05-09): VAT ไม่ลดตามส่วนลดดอกเบี้ย — Cr 21-2101
+    // = remainingDeferredVat เต็ม; ไม่ออกใบลดหนี้ (Credit Note); บริษัทรับภาระ VAT
+    // ส่วนเกินจาก discount เอง. Ref:
+    //   docs/superpowers/specs/2026-05-09-cpa-policy-a-100-compliance-design.md
+    //   + Handover_BestChoiceFinance v3.0.pdf §9 Policy Decisions
+    const {
+      installmentExclVat,
+      vatPerInst,
+      remainingGross,
+      remainingDeferredInterest,
+      remainingDeferredVat,
+      discount,
+      settleVat,
+      settlement,
+      lines: jeLines,
+    } = computeEarlyPayoffJE({
+      depositAccountCode: input.depositAccountCode,
+      financedAmount: c.financedAmount.toString(),
+      storeCommission: c.storeCommission != null ? c.storeCommission.toString() : null,
+      interestTotal: c.interestTotal.toString(),
+      vatAmount: c.vatAmount != null ? c.vatAmount.toString() : null,
+      totalMonths: c.totalMonths,
+      unpaidCount: unpaid,
+      interestDiscountPercent: input.interestDiscountPercent,
+    });
 
     // Wrap JE post + Payment.create loop in a single atomic transaction.
     // If JE post fails (unbalanced, missing account), Payment rows are rolled back — no orphans.
     const exec = async (tx: Prisma.TransactionClient) => {
-      const lines: JeLineInput[] = [
-        {
-          accountCode: input.depositAccountCode,
-          dr: settlement,
-          cr: zero,
-          description: `รับ ${settlement.toFixed(2)} ฿ ปิดยอด`,
-        },
-        {
-          accountCode: '11-2106',
-          dr: remainingDeferredInterest,
-          cr: zero,
-          description: 'ยกเลิกรายได้รอตัดบัญชี-ดอกเบี้ย',
-        },
-        {
-          accountCode: '21-2102',
-          dr: remainingDeferredVat,
-          cr: zero,
-          description: 'ล้างภาษีขายรอเรียกเก็บ',
-        },
-      ];
-
-      if (discount.gt(0)) {
-        lines.push({
-          accountCode: '52-1106',
-          dr: discount,
-          cr: zero,
-          description: `ส่วนลดดอกเบี้ย-ปิดยอดก่อนกำหนด ${input.interestDiscountPercent}%`,
-        });
-      }
-
-      lines.push(
-        {
-          accountCode: '11-2101',
-          dr: zero,
-          cr: remainingGross,
-          description: 'ล้างลูกหนี้ Gross (excl. VAT)',
-        },
-        {
-          accountCode: '11-2105',
-          dr: zero,
-          cr: remainingDeferredVat,
-          description: 'ล้างลูกหนี้ภาษีขายรอฯ',
-        },
-        {
-          accountCode: '41-1101',
-          dr: zero,
-          cr: remainingDeferredInterest,
-          description: 'รับรู้รายได้ดอกเบี้ย (เต็มจำนวน; ส่วนลดอยู่ฝั่ง Dr 52-1106)',
-        },
-        {
-          accountCode: '21-2101',
-          dr: zero,
-          cr: settleVat,
-          description: 'ภาษีขาย ภ.พ.30 ถึงกำหนด (Policy A: VAT ไม่ลดตามส่วนลด)',
-        },
-      );
+      // Ledger-side line descriptions; the money (accountCode/dr/cr, incl. the
+      // 52-1106 zero-discount guard) comes from the shared computeEarlyPayoffJE.
+      const descriptions: Record<string, string> = {
+        [input.depositAccountCode]: `รับ ${settlement.toFixed(2)} ฿ ปิดยอด`,
+        '11-2106': 'ยกเลิกรายได้รอตัดบัญชี-ดอกเบี้ย',
+        '21-2102': 'ล้างภาษีขายรอเรียกเก็บ',
+        '52-1106': `ส่วนลดดอกเบี้ย-ปิดยอดก่อนกำหนด ${input.interestDiscountPercent}%`,
+        '11-2101': 'ล้างลูกหนี้ Gross (excl. VAT)',
+        '11-2105': 'ล้างลูกหนี้ภาษีขายรอฯ',
+        '41-1101': 'รับรู้รายได้ดอกเบี้ย (เต็มจำนวน; ส่วนลดอยู่ฝั่ง Dr 52-1106)',
+        '21-2101': 'ภาษีขาย ภ.พ.30 ถึงกำหนด (Policy A: VAT ไม่ลดตามส่วนลด)',
+      };
+      const lines: JeLineInput[] = jeLines.map((l) => ({
+        accountCode: l.accountCode,
+        dr: l.dr,
+        cr: l.cr,
+        description: descriptions[l.accountCode] ?? '',
+      }));
 
       const result = await this.journal.createAndPost(
         {

--- a/apps/api/src/modules/journal/early-payoff-jp4.template.golden.spec.ts
+++ b/apps/api/src/modules/journal/early-payoff-jp4.template.golden.spec.ts
@@ -1,0 +1,120 @@
+import { Prisma } from '@prisma/client';
+import { Decimal } from '@prisma/client/runtime/library';
+import { EarlyPayoffJP4Template } from './cpa-templates/early-payoff-jp4.template';
+
+/**
+ * Fast (mock-based, NO DB) golden for EarlyPayoffJP4Template.execute().
+ *
+ * The canonical CPA golden for JP4 is the DB-backed vitest suite
+ * early-payoff-jp4.template.spec.ts (case-4: 17K/12M · 6 unpaid · 50% discount →
+ * settlement 7,594.98 · totalDr 12,690.00). That suite needs a live Postgres and
+ * cannot run in every environment. This jest spec mirrors its assertions on the
+ * SAME case-4 fixture so the template's posted JE is guarded by the standard
+ * `npm run test --workspace=apps/api` run too — important now that the template
+ * delegates its math to the shared computeEarlyPayoffJE.
+ */
+describe('EarlyPayoffJP4Template.execute (case-4 golden · mock-based)', () => {
+  const dec = (v: string | number) => new Decimal(v);
+
+  // case-4 contract: financed 10000 + commission 1000 + interest 6000 = 17000
+  // grossExclVat; vat 1190; totalMonths 12.
+  const contract = {
+    id: 'contract-jp4-1',
+    contractNumber: 'CT-JP4-001',
+    totalMonths: 12,
+    financedAmount: dec('10000'),
+    storeCommission: dec('1000'),
+    interestTotal: dec('6000'),
+    vatAmount: dec('1190'),
+  };
+
+  // 12 installment schedules; first 6 covered by a PAID Payment row → 6 unpaid.
+  const installments = Array.from({ length: 12 }, (_, i) => ({
+    id: `inst-${i + 1}`,
+    installmentNo: i + 1,
+    dueDate: new Date('2026-01-01'),
+    amountDue: dec('1515.83'),
+    vat60dayJournalEntryId: null as string | null,
+  }));
+  const paidPayments = Array.from({ length: 6 }, (_, i) => ({ installmentNo: i + 1 }));
+
+  type CapturedLine = { accountCode: string; dr: Decimal; cr: Decimal; description?: string };
+  type CapturedJe = { description: string; reference?: string; metadata?: Record<string, unknown>; lines: CapturedLine[] };
+
+  let createAndPost: jest.Mock;
+  let tmpl: EarlyPayoffJP4Template;
+
+  const build = () => {
+    createAndPost = jest.fn().mockResolvedValue({ id: 'je-1', entryNumber: 'JE-JP4-0001' });
+    const tx = {
+      payment: { create: jest.fn().mockResolvedValue({}) },
+    };
+    const prisma = {
+      contract: { findUniqueOrThrow: jest.fn().mockResolvedValue(contract) },
+      installmentSchedule: { findMany: jest.fn().mockResolvedValue(installments) },
+      payment: { findMany: jest.fn().mockResolvedValue(paidPayments) },
+      $transaction: jest.fn((cb: (t: unknown) => Promise<unknown>) => cb(tx)),
+    };
+    const journal = { createAndPost } as unknown;
+    const vat60Reversal = { execute: jest.fn() } as unknown;
+    tmpl = new EarlyPayoffJP4Template(
+      journal as never,
+      prisma as never,
+      vat60Reversal as never,
+    );
+  };
+
+  const run = async (interestDiscountPercent: string) => {
+    await tmpl.execute({
+      contractId: contract.id,
+      depositAccountCode: '11-1101',
+      interestDiscountPercent: new Prisma.Decimal(interestDiscountPercent),
+    });
+    return createAndPost.mock.calls[0][0] as CapturedJe;
+  };
+  const lineFor = (je: CapturedJe, code: string) => je.lines.find((l) => l.accountCode === code);
+
+  beforeEach(build);
+
+  it('50% discount → 8 lines, case-4 golden amounts, balanced 12,690.00 (Policy A)', async () => {
+    const je = await run('50');
+
+    expect(je.lines.map((l) => l.accountCode)).toEqual([
+      '11-1101', '11-2106', '21-2102', '52-1106', '11-2101', '11-2105', '41-1101', '21-2101',
+    ]);
+    expect(lineFor(je, '11-1101')!.dr.toFixed(2)).toBe('7594.98'); // settlement
+    expect(lineFor(je, '11-2106')!.dr.toFixed(2)).toBe('3000.00');
+    expect(lineFor(je, '21-2102')!.dr.toFixed(2)).toBe('595.02');
+    expect(lineFor(je, '52-1106')!.dr.toFixed(2)).toBe('1500.00');
+    expect(lineFor(je, '11-2101')!.cr.toFixed(2)).toBe('8499.96');
+    expect(lineFor(je, '11-2105')!.cr.toFixed(2)).toBe('595.02');
+    expect(lineFor(je, '41-1101')!.cr.toFixed(2)).toBe('3000.00');
+    expect(lineFor(je, '21-2101')!.cr.toFixed(2)).toBe('595.02'); // Policy A — full deferred VAT
+
+    const totalDr = je.lines.reduce((s, l) => s.plus(l.dr), new Decimal(0));
+    const totalCr = je.lines.reduce((s, l) => s.plus(l.cr), new Decimal(0));
+    expect(totalDr.toFixed(2)).toBe('12690.00');
+    expect(totalDr.toFixed(2)).toBe(totalCr.toFixed(2));
+
+    const meta = je.metadata as Record<string, string>;
+    expect(meta.policy).toBe('A');
+    expect(meta.settleVat).toBe('595.02');
+    expect(meta.discount).toBe('1500.00');
+    expect(meta.vatCreditBackOnDiscount).toBeUndefined();
+  });
+
+  it('zero discount → omits 52-1106 (7 lines), cash 9094.98, Cr 21-2101 still full', async () => {
+    const je = await run('0');
+    expect(lineFor(je, '52-1106')).toBeUndefined();
+    expect(je.lines).toHaveLength(7);
+    expect(lineFor(je, '11-1101')!.dr.toFixed(2)).toBe('9094.98'); // 8499.96 + 595.02
+    expect(lineFor(je, '21-2101')!.cr.toFixed(2)).toBe('595.02');
+  });
+
+  it('100% discount → discount 3000.00, cash 6094.98, Cr 21-2101 still full (Policy A)', async () => {
+    const je = await run('100');
+    expect(lineFor(je, '52-1106')!.dr.toFixed(2)).toBe('3000.00');
+    expect(lineFor(je, '11-1101')!.dr.toFixed(2)).toBe('6094.98'); // 8499.96 - 3000 + 595.02
+    expect(lineFor(je, '21-2101')!.cr.toFixed(2)).toBe('595.02');
+  });
+});


### PR DESCRIPTION
## Goal
Eliminate early-payoff (JP4) JE **drift** — the preview the customer/staff sees must be byte-for-byte the JE that posts to the ledger. The money-math was re-implemented in **three** places that could silently diverge.

## What changed
Extracted one pure function `computeEarlyPayoffJE()` ([compute-early-payoff-je.ts](apps/api/src/modules/journal/compute-early-payoff-je.ts)) and routed all three call sites through it:

| | Site | Role |
|---|---|---|
| **A** | `EarlyPayoffJP4Template.execute()` | JP4 posting template (CPA golden-verified) |
| **B** | `ContractPaymentService.getEarlyPayoffQuote()` | UI / LIFF JE **preview** |
| **C** | `ContractPaymentService.earlyPayoff()` | inline **ledger posting** (the real poster on the contract path) |

`preview === posted` is now guaranteed by construction.

## Characterization first (the gate)
Before extracting, I pinned the current behavior. Finding: **no money drift** — A, B, C already agreed to the satang on every line for non-zero discount (the existing exec spec even asserts `execDiscount === previewDiscount`). The *only* divergence was structural and benign: at **zero discount**, posting C emitted a no-op `Dr 52-1106 0.00` line that the golden template (A) and preview (B) both omit.

Per owner decision, C was **converged to the canonical guarded form** (omit the 0.00 line). JE balances are unchanged; the pinned exec tests `(e)`/`(f2)` were updated to assert convergence.

> Note: the task described the **template (A)** as the live poster — it isn't. The template is injected into `ContractPaymentService` but never called; the real posting is the inline block C. This was surfaced and the unify scope (all three) confirmed with the owner.

## Invariants preserved
- **Rounding** (`.claude/rules/accounting.md`): `grossExclVat/months` = ROUND_DOWN; `interest/months` + `vat/months` = ROUND_HALF_UP; per-installment = sum.
- **Policy A**: VAT not reduced by interest discount (`Cr 21-2101` = full deferred VAT).
- Line descriptions stay per-context (ledger vs UI wording); only the money (`accountCode`/`dr`/`cr`) is shared.

## Tests — all green (`--runInBand`)
- `compute-early-payoff-je.spec.ts` — **13** (CPA case-4 → 12,690.00; 18K → 13,212.00; zero-discount/zero-interest guards; 30%/100%; null commission/VAT defaults; rounding)
- `early-payoff-jp4.template.golden.spec.ts` — **3** (new mock-based jest golden for the template, mirroring the DB vitest golden)
- `contract-payment.service.early-payoff*.spec.ts` — **15**
- Regression sweeps: contracts **211**, journal **145**, line-oa **111**
- `tsc --noEmit -p apps/api`: **0 errors**

⚠️ The DB-backed vitest golden `early-payoff-jp4.template.spec.ts` was **not executed** here — its `setup()` wipes contracts/payments/journal on the configured dev DB. Its assertions are mirrored 1:1 by the new jest mock-golden, and the template change is pure delegation. Please run it in CI / against a disposable DB to close the loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)