### PR TITLE
refactor(installments): extract computeInstallmentBreakdown single source (Wave-4)

### DIFF
--- a/apps/api/src/modules/journal/compute-early-payoff-je.ts
+++ b/apps/api/src/modules/journal/compute-early-payoff-je.ts
@@ -1,4 +1,5 @@
 import { Decimal } from '@prisma/client/runtime/library';
+import { computeInstallmentBreakdown } from './compute-installment-breakdown';
 
 /**
  * Single source of truth for the Early-Payoff (JP4) journal-entry money math.
@@ -78,25 +79,17 @@ export interface ComputeEarlyPayoffJeResult {
 export function computeEarlyPayoffJE(
   input: ComputeEarlyPayoffJeInput,
 ): ComputeEarlyPayoffJeResult {
-  const total = new Decimal(input.totalMonths);
   const unpaidD = new Decimal(input.unpaidCount);
 
-  const financed = new Decimal(input.financedAmount);
-  const commission =
-    input.storeCommission != null
-      ? new Decimal(input.storeCommission)
-      : financed.times('0.10').toDecimalPlaces(2);
-  const interest = new Decimal(input.interestTotal);
-  const grossExclVat = financed.plus(commission).plus(interest);
-  const vat =
-    input.vatAmount != null
-      ? new Decimal(input.vatAmount)
-      : grossExclVat.times('0.07').toDecimalPlaces(2);
-
-  // Per-installment amounts (same rounding as templates 2A/2B).
-  const installmentExclVat = grossExclVat.div(total).toDecimalPlaces(2, Decimal.ROUND_DOWN);
-  const interestPerInst = interest.div(total).toDecimalPlaces(2, Decimal.ROUND_HALF_UP);
-  const vatPerInst = vat.div(total).toDecimalPlaces(2, Decimal.ROUND_HALF_UP);
+  // Per-installment amounts — shared single source of truth (same rounding the
+  // 2A accrual / 2B receipt templates use).
+  const { installmentExclVat, interestPerInst, vatPerInst } = computeInstallmentBreakdown({
+    financedAmount: input.financedAmount,
+    storeCommission: input.storeCommission,
+    interestTotal: input.interestTotal,
+    vatAmount: input.vatAmount,
+    totalMonths: input.totalMonths,
+  });
 
   // Remaining balances for the unpaid installments.
   const remainingGross = installmentExclVat.times(unpaidD);

--- a/apps/api/src/modules/journal/compute-installment-breakdown.spec.ts
+++ b/apps/api/src/modules/journal/compute-installment-breakdown.spec.ts
@@ -1,0 +1,88 @@
+import { Decimal } from '@prisma/client/runtime/library';
+import { computeInstallmentBreakdown } from './compute-installment-breakdown';
+
+/**
+ * Golden for the SINGLE source-of-truth per-installment breakdown.
+ *
+ * The same derivation — financed + commission(default 10%) + interest → gross;
+ * vat(default 7%); installmentExclVat = gross/months ROUND_DOWN; interestPerInst
+ * & vatPerInst = .../months ROUND_HALF_UP; installmentTotal = exclVat + vatPerInst
+ * — was copy-pasted into 2A, 2B, 2B-split and the early-payoff JE. This pins the
+ * canonical values so every caller stays satang-identical.
+ *
+ * Rounding (.claude/rules/accounting.md): grossExclVat/months ROUND_DOWN;
+ * interest/months + vat/months ROUND_HALF_UP; per-installment total = sum.
+ */
+describe('computeInstallmentBreakdown (single-source per-installment math)', () => {
+  it('CPA case-4 (17K/12M): 1416.66 / 500.00 / 99.17 → installmentTotal 1515.83', () => {
+    const b = computeInstallmentBreakdown({
+      financedAmount: '10000',
+      storeCommission: '1000',
+      interestTotal: '6000',
+      vatAmount: '1190',
+      totalMonths: 12,
+    });
+    expect(b.grossExclVat.toFixed(2)).toBe('17000.00');
+    expect(b.vat.toFixed(2)).toBe('1190.00');
+    expect(b.installmentExclVat.toFixed(2)).toBe('1416.66'); // ROUND_DOWN (not .67)
+    expect(b.interestPerInst.toFixed(2)).toBe('500.00');
+    expect(b.vatPerInst.toFixed(2)).toBe('99.17'); // ROUND_HALF_UP
+    expect(b.installmentTotal.toFixed(2)).toBe('1515.83');
+  });
+
+  it('18K/12M: 1800.00 / 150.00 / 126.00 → installmentTotal 1926.00', () => {
+    const b = computeInstallmentBreakdown({
+      financedAmount: '18000',
+      storeCommission: '1800',
+      interestTotal: '1800',
+      vatAmount: '1512',
+      totalMonths: 12,
+    });
+    expect(b.grossExclVat.toFixed(2)).toBe('21600.00');
+    expect(b.installmentExclVat.toFixed(2)).toBe('1800.00');
+    expect(b.interestPerInst.toFixed(2)).toBe('150.00');
+    expect(b.vatPerInst.toFixed(2)).toBe('126.00');
+    expect(b.installmentTotal.toFixed(2)).toBe('1926.00');
+  });
+
+  it('null storeCommission → financed × 10%', () => {
+    const b = computeInstallmentBreakdown({
+      financedAmount: '10000',
+      storeCommission: null,
+      interestTotal: '6000',
+      vatAmount: '1190',
+      totalMonths: 12,
+    });
+    expect(b.commission.toFixed(2)).toBe('1000.00');
+    expect(b.installmentTotal.toFixed(2)).toBe('1515.83');
+  });
+
+  it('null vatAmount → grossExclVat × 7%', () => {
+    const b = computeInstallmentBreakdown({
+      financedAmount: '10000',
+      storeCommission: '1000',
+      interestTotal: '6000',
+      vatAmount: null,
+      totalMonths: 12,
+    });
+    expect(b.vat.toFixed(2)).toBe('1190.00'); // 17000 × 0.07
+    expect(b.vatPerInst.toFixed(2)).toBe('99.17');
+    expect(b.installmentTotal.toFixed(2)).toBe('1515.83');
+  });
+
+  it('accepts Decimal / string / number inputs interchangeably', () => {
+    const asStr = computeInstallmentBreakdown({
+      financedAmount: '10000', storeCommission: '1000', interestTotal: '6000', vatAmount: '1190', totalMonths: 12,
+    });
+    const asDec = computeInstallmentBreakdown({
+      financedAmount: new Decimal('10000'), storeCommission: new Decimal('1000'),
+      interestTotal: new Decimal('6000'), vatAmount: new Decimal('1190'), totalMonths: 12,
+    });
+    const asNum = computeInstallmentBreakdown({
+      financedAmount: 10000, storeCommission: 1000, interestTotal: 6000, vatAmount: 1190, totalMonths: 12,
+    });
+    expect(asStr.installmentTotal.toFixed(2)).toBe('1515.83');
+    expect(asDec.installmentTotal.toFixed(2)).toBe('1515.83');
+    expect(asNum.installmentTotal.toFixed(2)).toBe('1515.83');
+  });
+});

--- a/apps/api/src/modules/journal/compute-installment-breakdown.ts
+++ b/apps/api/src/modules/journal/compute-installment-breakdown.ts
@@ -1,0 +1,86 @@
+import { Decimal } from '@prisma/client/runtime/library';
+
+/**
+ * Single source of truth for the per-installment money breakdown of a FINANCE
+ * installment contract.
+ *
+ * The same derivation was copy-pasted across the JE templates that need it
+ * (InstallmentAccrual2A, PaymentReceipt2B, PaymentReceipt2BSplit, and the
+ * early-payoff JE). Centralising it here guarantees they all round identically.
+ *
+ * Rounding (.claude/rules/accounting.md — MUST match CPA CSV golden values):
+ *   grossExclVat / totalMonths → ROUND_DOWN   (17000/12 = 1416.66, NOT .67)
+ *   interest    / totalMonths → ROUND_HALF_UP (6000/12  =  500.00)
+ *   vat         / totalMonths → ROUND_HALF_UP (1190/12  =   99.17)
+ *   installmentTotal           = installmentExclVat + vatPerInst   (= 1515.83)
+ *
+ * NOTE: this is the BASE per-installment breakdown. The 2A accrual additionally
+ * trues-up the LAST installment to absorb the rounding residual so the contract
+ * nets exactly to zero — that last-period adjustment stays in 2A and is layered
+ * on top of these base values.
+ */
+
+type DecimalInput = Decimal | string | number;
+
+export interface InstallmentBreakdownInput {
+  /** ยอดจัด (FINANCE principal base). */
+  financedAmount: DecimalInput;
+  /** Store commission. null → financedAmount × 10% (ROUND to 2dp). */
+  storeCommission: DecimalInput | null;
+  /** Total deferred interest over the whole contract. */
+  interestTotal: DecimalInput;
+  /** Total VAT over the whole contract. null → grossExclVat × 7% (ROUND to 2dp). */
+  vatAmount: DecimalInput | null;
+  /** Number of installments in the contract. */
+  totalMonths: number;
+}
+
+export interface InstallmentBreakdown {
+  /** financed + commission + interest (excl VAT). */
+  grossExclVat: Decimal;
+  /** Resolved store commission (defaulted to 10% when null). */
+  commission: Decimal;
+  /** Resolved total VAT (defaulted to 7% of gross when null). */
+  vat: Decimal;
+  /** grossExclVat / totalMonths, ROUND_DOWN. */
+  installmentExclVat: Decimal;
+  /** interestTotal / totalMonths, ROUND_HALF_UP. */
+  interestPerInst: Decimal;
+  /** vat / totalMonths, ROUND_HALF_UP. */
+  vatPerInst: Decimal;
+  /** installmentExclVat + vatPerInst (the cash a customer pays per installment). */
+  installmentTotal: Decimal;
+}
+
+export function computeInstallmentBreakdown(
+  input: InstallmentBreakdownInput,
+): InstallmentBreakdown {
+  const total = new Decimal(input.totalMonths);
+
+  const financed = new Decimal(input.financedAmount);
+  const commission =
+    input.storeCommission != null
+      ? new Decimal(input.storeCommission)
+      : financed.times('0.10').toDecimalPlaces(2);
+  const interest = new Decimal(input.interestTotal);
+  const grossExclVat = financed.plus(commission).plus(interest);
+  const vat =
+    input.vatAmount != null
+      ? new Decimal(input.vatAmount)
+      : grossExclVat.times('0.07').toDecimalPlaces(2);
+
+  const installmentExclVat = grossExclVat.div(total).toDecimalPlaces(2, Decimal.ROUND_DOWN);
+  const interestPerInst = interest.div(total).toDecimalPlaces(2, Decimal.ROUND_HALF_UP);
+  const vatPerInst = vat.div(total).toDecimalPlaces(2, Decimal.ROUND_HALF_UP);
+  const installmentTotal = installmentExclVat.plus(vatPerInst);
+
+  return {
+    grossExclVat,
+    commission,
+    vat,
+    installmentExclVat,
+    interestPerInst,
+    vatPerInst,
+    installmentTotal,
+  };
+}

--- a/apps/api/src/modules/journal/cpa-templates/payment-receipt-2b-split.template.ts
+++ b/apps/api/src/modules/journal/cpa-templates/payment-receipt-2b-split.template.ts
@@ -5,6 +5,7 @@ import { Prisma } from '@prisma/client';
 import { JournalAutoService } from '../journal-auto.service';
 import { PrismaService } from '../../../prisma/prisma.service';
 import { AccountRoleService } from '../account-role.service';
+import { computeInstallmentBreakdown } from '../compute-installment-breakdown';
 
 const TOLERANCE = new Decimal('1.00');
 
@@ -91,22 +92,14 @@ export class PaymentReceipt2BSplitTemplate {
     interestTotal: Decimal | any;
     vatAmount: Decimal | null | any;
   }): Decimal {
-    const total = new Decimal(c.totalMonths);
-    const financed = new Decimal(c.financedAmount.toString());
-    const commission =
-      c.storeCommission != null
-        ? new Decimal(c.storeCommission.toString())
-        : financed.times('0.10').toDecimalPlaces(2);
-    const interest = new Decimal(c.interestTotal.toString());
-    const grossExclVat = financed.plus(commission).plus(interest);
-    const vat =
-      c.vatAmount != null
-        ? new Decimal(c.vatAmount.toString())
-        : grossExclVat.times('0.07').toDecimalPlaces(2);
-
-    const installmentExclVat = grossExclVat.div(total).toDecimalPlaces(2, Decimal.ROUND_DOWN);
-    const vatPerInst = vat.div(total).toDecimalPlaces(2, Decimal.ROUND_HALF_UP);
-    return installmentExclVat.plus(vatPerInst);
+    // Shared single source of truth (same rounding as the 2A accrual).
+    return computeInstallmentBreakdown({
+      financedAmount: c.financedAmount.toString(),
+      storeCommission: c.storeCommission != null ? c.storeCommission.toString() : null,
+      interestTotal: c.interestTotal.toString(),
+      vatAmount: c.vatAmount != null ? c.vatAmount.toString() : null,
+      totalMonths: c.totalMonths,
+    }).installmentTotal;
   }
 
   /**

--- a/apps/api/src/modules/journal/cpa-templates/payment-receipt-2b.template.ts
+++ b/apps/api/src/modules/journal/cpa-templates/payment-receipt-2b.template.ts
@@ -5,6 +5,7 @@ import { JournalAutoService } from '../journal-auto.service';
 import { PrismaService } from '../../../prisma/prisma.service';
 import { AccountRoleService } from '../account-role.service';
 import { Vat60dayReversalTemplate } from './vat-60day-reversal.template';
+import { computeInstallmentBreakdown } from '../compute-installment-breakdown';
 
 const TOLERANCE = new Decimal('1.00');
 
@@ -153,23 +154,15 @@ export class PaymentReceipt2BTemplate {
 
     const c = inst.contract;
 
-    // Compute installmentTotal using same rounding as 2A
-    const total = new Decimal(c.totalMonths);
-    const financed = new Decimal(c.financedAmount.toString());
-    const commission =
-      c.storeCommission != null
-        ? new Decimal(c.storeCommission.toString())
-        : financed.times('0.10').toDecimalPlaces(2);
-    const interest = new Decimal(c.interestTotal.toString());
-    const grossExclVat = financed.plus(commission).plus(interest);
-    const vat =
-      c.vatAmount != null
-        ? new Decimal(c.vatAmount.toString())
-        : grossExclVat.times('0.07').toDecimalPlaces(2);
-
-    const installmentExclVat = grossExclVat.div(total).toDecimalPlaces(2, Decimal.ROUND_DOWN);
-    const vatPerInst = vat.div(total).toDecimalPlaces(2, Decimal.ROUND_HALF_UP);
-    const installmentTotal = installmentExclVat.plus(vatPerInst); // 1,515.83
+    // Per-installment amount via the shared single source of truth (same
+    // rounding as the 2A accrual): installmentTotal = 1,515.83 for 17K/12M.
+    const { installmentTotal } = computeInstallmentBreakdown({
+      financedAmount: c.financedAmount.toString(),
+      storeCommission: c.storeCommission != null ? c.storeCommission.toString() : null,
+      interestTotal: c.interestTotal.toString(),
+      vatAmount: c.vatAmount != null ? c.vatAmount.toString() : null,
+      totalMonths: c.totalMonths,
+    });
 
     const advCredit = input.advanceCredit ?? new Decimal(0);
     const advConsume = input.advanceConsume ?? new Decimal(0);

--- a/apps/api/src/modules/journal/payment-receipt-2b-split.template.golden.spec.ts
+++ b/apps/api/src/modules/journal/payment-receipt-2b-split.template.golden.spec.ts
@@ -1,0 +1,88 @@
+import { Decimal } from '@prisma/client/runtime/library';
+import { PaymentReceipt2BSplitTemplate } from './cpa-templates/payment-receipt-2b-split.template';
+
+/**
+ * Fast (mock-based, NO DB) golden for PaymentReceipt2BSplitTemplate — pins that
+ * the final-partial close-out uses installmentTotal = 1,515.83 (via the shared
+ * computeInstallmentBreakdown) for both the remaining-receivable and the
+ * tolerance diff. Mirrors the DB-backed vitest golden
+ * payment-receipt-2b-split.template.spec.ts (case 3).
+ */
+describe('PaymentReceipt2BSplitTemplate.executePartial (installment-total golden · mock-based)', () => {
+  const dec = (v: string | number) => new Decimal(v);
+
+  // 17K/12M contract → installmentTotal = 1515.83.
+  const contract = {
+    id: 'contract-split-1',
+    contractNumber: 'CT-SPLIT-001',
+    totalMonths: 12,
+    financedAmount: dec('10000'),
+    storeCommission: dec('1000'),
+    interestTotal: dec('6000'),
+    vatAmount: dec('1190'),
+  };
+  const inst = {
+    id: 'inst-split-1',
+    installmentNo: 1,
+    dueDate: new Date('2026-01-01'),
+    contract,
+  };
+
+  type CapturedLine = { accountCode: string; dr: Decimal; cr: Decimal; description?: string };
+  type CapturedJe = { metadata?: Record<string, unknown>; lines: CapturedLine[] };
+
+  let createAndPost: jest.Mock;
+  let priorEntries: Array<{ lines: Array<{ debit: string; credit: string }> }>;
+  let tmpl: PaymentReceipt2BSplitTemplate;
+
+  const build = () => {
+    createAndPost = jest.fn().mockResolvedValue({ id: 'je-split', entryNumber: 'JE-SPLIT-0001' });
+    const prisma = {
+      installmentSchedule: { findUniqueOrThrow: jest.fn().mockResolvedValue(inst) },
+      journalEntry: { findMany: jest.fn().mockResolvedValue(priorEntries) },
+      payment: { create: jest.fn().mockResolvedValue({ id: 'pay-split-1' }) },
+      systemConfig: { findFirst: jest.fn().mockResolvedValue(null) }, // adj_auto_route → TRUE
+      $transaction: jest.fn((cb: (t: unknown) => Promise<unknown>) => cb(prisma)),
+    };
+    const journal = { createAndPost } as unknown;
+    tmpl = new PaymentReceipt2BSplitTemplate(journal as never, prisma as never);
+  };
+
+  const lineFor = (je: CapturedJe, code: string) => je.lines.find((l) => l.accountCode === code);
+
+  it('final partial (no prior) 1515.83 → Cr 11-2103 1515.83 (installmentTotal), balanced', async () => {
+    priorEntries = [];
+    build();
+    await tmpl.executePartial({
+      installmentScheduleId: inst.id,
+      partialAmount: dec('1515.83'),
+      depositAccountCode: '11-1101',
+      isFinalPartial: true,
+    });
+    const je = createAndPost.mock.calls[0][0] as CapturedJe;
+    expect(lineFor(je, '11-1101')!.dr.toFixed(2)).toBe('1515.83');
+    expect(lineFor(je, '11-2103')!.cr.toFixed(2)).toBe('1515.83');
+    const totalDr = je.lines.reduce((s, l) => s.plus(l.dr), new Decimal(0));
+    const totalCr = je.lines.reduce((s, l) => s.plus(l.cr), new Decimal(0));
+    expect(totalDr.toFixed(2)).toBe(totalCr.toFixed(2));
+  });
+
+  it('final partial after a 1000 prior → remainingReceivable 515.83 = installmentTotal − prior', async () => {
+    // Prior non-final partial JE with a 1000.00 cash debit line.
+    priorEntries = [{ lines: [{ debit: '1000.00', credit: '0' }, { debit: '0', credit: '1000.00' }] }];
+    build();
+    await tmpl.executePartial({
+      installmentScheduleId: inst.id,
+      partialAmount: dec('516.00'), // grandTotal 1516.00 → overpay 0.17
+      depositAccountCode: '11-1101',
+      isFinalPartial: true,
+    });
+    const je = createAndPost.mock.calls[0][0] as CapturedJe;
+    expect(lineFor(je, '11-1101')!.dr.toFixed(2)).toBe('516.00');
+    expect(lineFor(je, '11-2103')!.cr.toFixed(2)).toBe('515.83'); // 1515.83 − 1000.00
+    expect(lineFor(je, '53-1503')!.cr.toFixed(2)).toBe('0.17'); // 1516.00 − 1515.83
+    const totalDr = je.lines.reduce((s, l) => s.plus(l.dr), new Decimal(0));
+    const totalCr = je.lines.reduce((s, l) => s.plus(l.cr), new Decimal(0));
+    expect(totalDr.toFixed(2)).toBe(totalCr.toFixed(2));
+  });
+});

--- a/apps/api/src/modules/journal/payment-receipt-2b.template.golden.spec.ts
+++ b/apps/api/src/modules/journal/payment-receipt-2b.template.golden.spec.ts
@@ -1,0 +1,84 @@
+import { Decimal } from '@prisma/client/runtime/library';
+import { PaymentReceipt2BTemplate } from './cpa-templates/payment-receipt-2b.template';
+
+/**
+ * Fast (mock-based, NO DB) golden for PaymentReceipt2BTemplate — pins that the
+ * per-installment amount it clears (installmentTotal) is computed via the shared
+ * computeInstallmentBreakdown and equals 1,515.83 for the 17K/12M contract.
+ *
+ * The canonical CPA golden is the DB-backed vitest suite
+ * payment-receipt-2b.template.spec.ts (cases 1/2). That needs live Postgres;
+ * this mirrors its installment-total assertion under plain `npm run test`.
+ */
+describe('PaymentReceipt2BTemplate.execute (installment-total golden · mock-based)', () => {
+  const dec = (v: string | number) => new Decimal(v);
+
+  // 17K/12M contract → installmentTotal = 1416.66 + 99.17 = 1515.83.
+  const contract = {
+    id: 'contract-2b-1',
+    contractNumber: 'CT-2B-001',
+    totalMonths: 12,
+    financedAmount: dec('10000'),
+    storeCommission: dec('1000'),
+    interestTotal: dec('6000'),
+    vatAmount: dec('1190'),
+  };
+  const inst = {
+    id: 'inst-2b-1',
+    installmentNo: 1,
+    dueDate: new Date('2026-01-01'),
+    vat60dayJournalEntryId: null as string | null,
+    contract,
+  };
+
+  type CapturedLine = { accountCode: string; dr: Decimal; cr: Decimal; description?: string };
+  type CapturedJe = { metadata?: Record<string, unknown>; lines: CapturedLine[] };
+
+  let createAndPost: jest.Mock;
+  let tmpl: PaymentReceipt2BTemplate;
+
+  const build = () => {
+    createAndPost = jest.fn().mockResolvedValue({ id: 'je-2b', entryNumber: 'JE-2B-0001' });
+    const tx = { payment: { create: jest.fn().mockResolvedValue({ id: 'pay-2b-1' }) } };
+    const prisma = {
+      installmentSchedule: { findUniqueOrThrow: jest.fn().mockResolvedValue(inst) },
+      systemConfig: { findFirst: jest.fn().mockResolvedValue(null) }, // adj_auto_route → default TRUE
+      $transaction: jest.fn((cb: (t: unknown) => Promise<unknown>) => cb(tx)),
+    };
+    const journal = { createAndPost } as unknown;
+    tmpl = new PaymentReceipt2BTemplate(journal as never, prisma as never);
+  };
+
+  const lineFor = (je: CapturedJe, code: string) => je.lines.find((l) => l.accountCode === code);
+
+  beforeEach(build);
+
+  it('exact payment 1515.83 → Dr cash 1515.83 / Cr 11-2103 1515.83 (installmentTotal), balanced', async () => {
+    await tmpl.execute({
+      installmentScheduleId: inst.id,
+      amountReceived: dec('1515.83'),
+      depositAccountCode: '11-1101',
+    });
+    const je = createAndPost.mock.calls[0][0] as CapturedJe;
+    expect(lineFor(je, '11-1101')!.dr.toFixed(2)).toBe('1515.83');
+    expect(lineFor(je, '11-2103')!.cr.toFixed(2)).toBe('1515.83'); // installmentTotal from helper
+    const totalDr = je.lines.reduce((s, l) => s.plus(l.dr), new Decimal(0));
+    const totalCr = je.lines.reduce((s, l) => s.plus(l.cr), new Decimal(0));
+    expect(totalDr.toFixed(2)).toBe(totalCr.toFixed(2));
+    expect((je.metadata as Record<string, string>).tag).toBe('2B');
+  });
+
+  it('overpay within tolerance 1516.00 → Cr 11-2103 1515.83 + Cr 53-1503 0.17', async () => {
+    await tmpl.execute({
+      installmentScheduleId: inst.id,
+      amountReceived: dec('1516.00'),
+      depositAccountCode: '11-1101',
+    });
+    const je = createAndPost.mock.calls[0][0] as CapturedJe;
+    expect(lineFor(je, '11-2103')!.cr.toFixed(2)).toBe('1515.83'); // still installmentTotal
+    expect(lineFor(je, '53-1503')!.cr.toFixed(2)).toBe('0.17'); // rounding gain
+    const totalDr = je.lines.reduce((s, l) => s.plus(l.dr), new Decimal(0));
+    const totalCr = je.lines.reduce((s, l) => s.plus(l.cr), new Decimal(0));
+    expect(totalDr.toFixed(2)).toBe(totalCr.toFixed(2));
+  });
+});


### PR DESCRIPTION
> **Stacked on #1194** (base = `wave4/unify-compute-early-payoff-je`). GitHub will auto-retarget to `main` once #1194 merges. Review/merge #1194 first.

## Goal
The per-installment money breakdown was copy-pasted across many JE templates → risk of rounding drift. Extract **one** pure `computeInstallmentBreakdown()` and route the duplicates through it.

## The shared math (single source now)
```
grossExclVat   = financed + commission(10% default) + interest
vat            = vatAmount ?? grossExclVat × 7%
installmentExclVat = grossExclVat / months   ROUND_DOWN     (1416.66)
interestPerInst    = interest    / months   ROUND_HALF_UP  (500.00)
vatPerInst         = vat         / months   ROUND_HALF_UP  (99.17)
installmentTotal   = installmentExclVat + vatPerInst        (1515.83)
```

## What changed (this slice — exact-identical base, no extra logic)
| File | Before | After |
|---|---|---|
| [compute-installment-breakdown.ts](apps/api/src/modules/journal/compute-installment-breakdown.ts) | — | **new** single source of truth |
| [compute-early-payoff-je.ts](apps/api/src/modules/journal/compute-early-payoff-je.ts) | own copy of the base | builds on the helper |
| [payment-receipt-2b.template.ts](apps/api/src/modules/journal/cpa-templates/payment-receipt-2b.template.ts) | inline breakdown | helper call |
| [payment-receipt-2b-split.template.ts](apps/api/src/modules/journal/cpa-templates/payment-receipt-2b-split.template.ts) | private `computeInstallmentTotal()` | helper call |

**Characterization first:** the three base copies (2B inline, 2B-split method, early-payoff fn) were **byte-identical** → no drift, pure dedup. Rounding rules (`accounting.md`) preserved exactly.

## Deferred to a follow-on PR
Each of these layers extra logic on the **same** base and carries its own DB-backed golden, so they migrate separately:
- `InstallmentAccrual2A` (last-installment residual true-up + advance-consume)
- `ContractActivation1A`, `RepossessionJP5`, `Vat60dayMandatory`/`Reversal`, `ExchangeNewContract1A`, `ContractCancellation`

## Tests — all green (`--runInBand`)
- `compute-installment-breakdown.spec.ts` — **5** (CPA case-4 = 1515.83, 18K = 1926.00, null commission/VAT defaults, rounding)
- `payment-receipt-2b.template.golden.spec.ts` — **2** (mock-based wiring golden: exact + overpay tolerance)
- `payment-receipt-2b-split.template.golden.spec.ts` — **2** (mock-based: final-partial + prior-partial close-out)
- early-payoff goldens re-proven — **16**
- Regression sweeps: journal **154**, payments+paysolutions **110**, contracts **211**
- `tsc --noEmit -p apps/api`: **0 errors**

⚠️ The DB-backed vitest goldens `payment-receipt-2b*.template.spec.ts` were **not executed** here (their `setup()` wipes the dev DB). Their installment-total assertions are mirrored by the new jest mock-goldens; the changes are pure delegation. Please run them in CI / against a disposable DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)