### PR TITLE
refactor(installments): migrate 2A + vat-60day templates onto computeInstallmentBreakdown (Wave-4)

### DIFF
--- a/apps/api/src/modules/journal/cpa-templates/installment-accrual-2a.template.ts
+++ b/apps/api/src/modules/journal/cpa-templates/installment-accrual-2a.template.ts
@@ -3,6 +3,7 @@ import { Decimal } from '@prisma/client/runtime/library';
 import { Prisma } from '@prisma/client';
 import { JournalAutoService } from '../journal-auto.service';
 import { PrismaService } from '../../../prisma/prisma.service';
+import { computeInstallmentBreakdown } from '../compute-installment-breakdown';
 // EIR utility removed — CPA Policy A revert (#783) reverted to straight-line allocation.
 
 /**
@@ -73,24 +74,19 @@ export class InstallmentAccrual2ATemplate {
 
     const c = await client.contract.findUniqueOrThrow({ where: { id: inst.contractId } });
 
-    const total = new Decimal(c.totalMonths);
-    const financed = new Decimal(c.financedAmount.toString());
-    const commission =
-      c.storeCommission != null
-        ? new Decimal(c.storeCommission.toString())
-        : financed.times('0.10').toDecimalPlaces(2);
-    const interest = new Decimal(c.interestTotal.toString());
-    const grossExclVat = financed.plus(commission).plus(interest);
-    const vat =
-      c.vatAmount != null
-        ? new Decimal(c.vatAmount.toString())
-        : grossExclVat.times('0.07').toDecimalPlaces(2);
-
-    // Per-installment amounts — rounding modes match CSV spec.
-    // Straight-line interest allocation per CPA Policy A (post-#783 revert from EIR).
-    let installmentExclVat = grossExclVat.div(total).toDecimalPlaces(2, Decimal.ROUND_DOWN); // 1,416.66
-    let interestPerInst = interest.div(total).toDecimalPlaces(2, Decimal.ROUND_HALF_UP); //   500.00
-    let vatPerInst = vat.div(total).toDecimalPlaces(2, Decimal.ROUND_HALF_UP); //    99.17
+    // Per-installment amounts via the shared single source of truth — same
+    // rounding the 2B receipt / early-payoff use (ROUND_DOWN principal,
+    // ROUND_HALF_UP interest+VAT). Straight-line per CPA Policy A (post-#783).
+    const base = computeInstallmentBreakdown({
+      financedAmount: c.financedAmount.toString(),
+      storeCommission: c.storeCommission != null ? c.storeCommission.toString() : null,
+      interestTotal: c.interestTotal.toString(),
+      vatAmount: c.vatAmount != null ? c.vatAmount.toString() : null,
+      totalMonths: c.totalMonths,
+    });
+    let installmentExclVat = base.installmentExclVat; // 1,416.66
+    let interestPerInst = base.interestPerInst; //       500.00
+    let vatPerInst = base.vatPerInst; //                  99.17
 
     // Final-period residual adjustment (Wave 1 / Task 6 — Audit P0 TFRS 15 C-1).
     // ROUND_DOWN/ROUND_HALF_UP per-installment rounding can leak residuals
@@ -99,12 +95,11 @@ export class InstallmentAccrual2ATemplate {
     // hit exactly 0 after the cycle completes.
     if (inst.installmentNo === c.totalMonths) {
       const priorPeriods = new Decimal(c.totalMonths - 1);
-      const priorExclVat = installmentExclVat.times(priorPeriods);
-      const priorVat = vatPerInst.times(priorPeriods);
-      const priorInterest = interestPerInst.times(priorPeriods);
-      installmentExclVat = grossExclVat.minus(priorExclVat);
-      vatPerInst = vat.minus(priorVat);
-      interestPerInst = interest.minus(priorInterest);
+      installmentExclVat = base.grossExclVat.minus(installmentExclVat.times(priorPeriods));
+      vatPerInst = base.vat.minus(vatPerInst.times(priorPeriods));
+      interestPerInst = new Decimal(c.interestTotal.toString()).minus(
+        interestPerInst.times(priorPeriods),
+      );
     }
 
     const installmentTotal = installmentExclVat.plus(vatPerInst); // 1,515.83

--- a/apps/api/src/modules/journal/cpa-templates/vat-60day-mandatory.template.ts
+++ b/apps/api/src/modules/journal/cpa-templates/vat-60day-mandatory.template.ts
@@ -3,6 +3,7 @@ import { Decimal } from '@prisma/client/runtime/library';
 import { Prisma } from '@prisma/client';
 import { JournalAutoService } from '../journal-auto.service';
 import { PrismaService } from '../../../prisma/prisma.service';
+import { computeInstallmentBreakdown } from '../compute-installment-breakdown';
 
 /**
  * Template Feature I — VAT 60-Day Mandatory
@@ -57,21 +58,15 @@ export class Vat60dayMandatoryTemplate {
 
       const c = await tx.contract.findUniqueOrThrow({ where: { id: inst.contractId } });
 
-      const total = new Decimal(c.totalMonths);
-      // grossExclVat (financed + commission + interest) × 0.07
-      const financed = new Decimal(c.financedAmount.toString());
-      const commission =
-        c.storeCommission != null
-          ? new Decimal(c.storeCommission.toString())
-          : financed.times('0.10').toDecimalPlaces(2);
-      const interest = new Decimal(c.interestTotal.toString());
-      const grossExclVat = financed.plus(commission).plus(interest);
-      const vat =
-        c.vatAmount != null
-          ? new Decimal(c.vatAmount.toString())
-          : grossExclVat.times('0.07').toDecimalPlaces(2);
-
-      const vatPerInst = vat.div(total).toDecimalPlaces(2, Decimal.ROUND_HALF_UP);
+      // vatPerInst via the shared single source of truth (same rounding as 2A):
+      // (financed + commission[10%] + interest) × 7% / totalMonths, ROUND_HALF_UP.
+      const { vatPerInst } = computeInstallmentBreakdown({
+        financedAmount: c.financedAmount.toString(),
+        storeCommission: c.storeCommission != null ? c.storeCommission.toString() : null,
+        interestTotal: c.interestTotal.toString(),
+        vatAmount: c.vatAmount != null ? c.vatAmount.toString() : null,
+        totalMonths: c.totalMonths,
+      });
 
       const zero = new Decimal(0);
 

--- a/apps/api/src/modules/journal/cpa-templates/vat-60day-reversal.template.ts
+++ b/apps/api/src/modules/journal/cpa-templates/vat-60day-reversal.template.ts
@@ -4,6 +4,7 @@ import { Prisma } from '@prisma/client';
 import * as Sentry from '@sentry/nestjs';
 import { JournalAutoService } from '../journal-auto.service';
 import { PrismaService } from '../../../prisma/prisma.service';
+import { computeInstallmentBreakdown } from '../compute-installment-breakdown';
 
 /**
  * Template Feature I — VAT 60-Day Reversal
@@ -79,22 +80,16 @@ export class Vat60dayReversalTemplate {
       if (typeof meta.vatPerInst === 'string' && meta.vatPerInst) {
         vatPerInst = new Decimal(meta.vatPerInst);
       } else {
-        // Legacy fallback — recompute from current Contract fields. Mirrors
-        // Vat60dayMandatoryTemplate's formula exactly so values match for
-        // any contract whose VAT/interest fields haven't drifted.
-        const total = new Decimal(c.totalMonths);
-        const financed = new Decimal(c.financedAmount.toString());
-        const commission =
-          c.storeCommission != null
-            ? new Decimal(c.storeCommission.toString())
-            : financed.times('0.10').toDecimalPlaces(2);
-        const interest = new Decimal(c.interestTotal.toString());
-        const grossExclVat = financed.plus(commission).plus(interest);
-        const vat =
-          c.vatAmount != null
-            ? new Decimal(c.vatAmount.toString())
-            : grossExclVat.times('0.07').toDecimalPlaces(2);
-        vatPerInst = vat.div(total).toDecimalPlaces(2, Decimal.ROUND_HALF_UP);
+        // Legacy fallback — recompute from current Contract fields via the
+        // shared single source of truth (mirrors Vat60dayMandatoryTemplate
+        // exactly so values match for any contract whose fields haven't drifted).
+        vatPerInst = computeInstallmentBreakdown({
+          financedAmount: c.financedAmount.toString(),
+          storeCommission: c.storeCommission != null ? c.storeCommission.toString() : null,
+          interestTotal: c.interestTotal.toString(),
+          vatAmount: c.vatAmount != null ? c.vatAmount.toString() : null,
+          totalMonths: c.totalMonths,
+        }).vatPerInst;
         Sentry.captureMessage(
           'VAT 60-day reversal missing vatPerInst — falling back to recompute',
           {

--- a/apps/api/src/modules/journal/installment-accrual-2a.template.golden.spec.ts
+++ b/apps/api/src/modules/journal/installment-accrual-2a.template.golden.spec.ts
@@ -1,0 +1,93 @@
+import { Decimal } from '@prisma/client/runtime/library';
+import { InstallmentAccrual2ATemplate } from './cpa-templates/installment-accrual-2a.template';
+
+/**
+ * Fast (mock-based, NO DB) golden for InstallmentAccrual2ATemplate — pins that
+ * the per-installment legs come from the shared computeInstallmentBreakdown
+ * (1416.66 / 500.00 / 99.17 for 17K/12M) AND that the LAST-installment residual
+ * true-up still absorbs the rounding remainder (1416.74 / 99.13 / 500.00).
+ *
+ * Mirrors the DB-backed vitest golden installment-accrual-2a.template.spec.ts.
+ */
+describe('InstallmentAccrual2ATemplate.execute (golden · mock-based)', () => {
+  const dec = (v: string | number) => new Decimal(v);
+
+  const contract = {
+    id: 'contract-2a-1',
+    contractNumber: 'CT-2A-001',
+    totalMonths: 12,
+    financedAmount: dec('10000'),
+    storeCommission: dec('1000'),
+    interestTotal: dec('6000'),
+    vatAmount: dec('1190'),
+    advanceBalance: dec('0'), // skip the advance-consume sub-flow
+  };
+
+  type CapturedLine = { accountCode: string; dr: Decimal; cr: Decimal; description?: string };
+  type CapturedJe = { metadata?: Record<string, unknown>; lines: CapturedLine[] };
+
+  let createAndPost: jest.Mock;
+  let tmpl: InstallmentAccrual2ATemplate;
+
+  const buildFor = (installmentNo: number) => {
+    createAndPost = jest.fn().mockResolvedValue({ id: 'je-2a', entryNumber: 'JE-2A-0001' });
+    const inst = {
+      id: `inst-2a-${installmentNo}`,
+      installmentNo,
+      contractId: contract.id,
+      dueDate: new Date('2026-01-01'),
+      accrualJournalEntryId: null as string | null,
+    };
+    const prisma = {
+      installmentSchedule: {
+        findUniqueOrThrow: jest.fn().mockResolvedValue(inst),
+        update: jest.fn().mockResolvedValue({}),
+      },
+      contract: { findUniqueOrThrow: jest.fn().mockResolvedValue(contract) },
+    };
+    const journal = { createAndPost } as unknown;
+    tmpl = new InstallmentAccrual2ATemplate(journal as never, prisma as never);
+    return inst;
+  };
+
+  const run = async (installmentNo: number) => {
+    const inst = buildFor(installmentNo);
+    await tmpl.execute(inst.id);
+    return createAndPost.mock.calls[0][0] as CapturedJe;
+  };
+  const lineFor = (je: CapturedJe, code: string) => je.lines.find((l) => l.accountCode === code);
+  const balanced = (je: CapturedJe) => {
+    const dr = je.lines.reduce((s, l) => s.plus(l.dr), new Decimal(0));
+    const cr = je.lines.reduce((s, l) => s.plus(l.cr), new Decimal(0));
+    return dr.toFixed(2) === cr.toFixed(2);
+  };
+
+  it('normal installment → base legs 1416.66 / 500.00 / 99.17 (installmentTotal 1515.83)', async () => {
+    const je = await run(1);
+    expect(lineFor(je, '11-2103')!.dr.toFixed(2)).toBe('1515.83'); // installmentTotal
+    expect(lineFor(je, '21-2102')!.dr.toFixed(2)).toBe('99.17');
+    expect(lineFor(je, '11-2106')!.dr.toFixed(2)).toBe('500.00');
+    expect(lineFor(je, '11-2101')!.cr.toFixed(2)).toBe('1416.66');
+    expect(lineFor(je, '11-2105')!.cr.toFixed(2)).toBe('99.17');
+    expect(lineFor(je, '41-1101')!.cr.toFixed(2)).toBe('500.00');
+    expect(lineFor(je, '21-2101')!.cr.toFixed(2)).toBe('99.17');
+    expect(balanced(je)).toBe(true);
+    expect((je.metadata as Record<string, string>).tag).toBe('2A');
+  });
+
+  it('LAST installment → residual true-up: 1416.74 / 99.13 / 500.00 (installmentTotal 1515.87)', async () => {
+    const je = await run(12);
+    // installmentExclVat = 17000 − 1416.66×11 = 1416.74
+    expect(lineFor(je, '11-2101')!.cr.toFixed(2)).toBe('1416.74');
+    // vatPerInst = 1190 − 99.17×11 = 99.13
+    expect(lineFor(je, '21-2102')!.dr.toFixed(2)).toBe('99.13');
+    expect(lineFor(je, '11-2105')!.cr.toFixed(2)).toBe('99.13');
+    expect(lineFor(je, '21-2101')!.cr.toFixed(2)).toBe('99.13');
+    // interestPerInst = 6000 − 500×11 = 500.00
+    expect(lineFor(je, '41-1101')!.cr.toFixed(2)).toBe('500.00');
+    expect(lineFor(je, '11-2106')!.dr.toFixed(2)).toBe('500.00');
+    // installmentTotal = 1416.74 + 99.13 = 1515.87
+    expect(lineFor(je, '11-2103')!.dr.toFixed(2)).toBe('1515.87');
+    expect(balanced(je)).toBe(true);
+  });
+});

--- a/apps/api/src/modules/journal/vat-60day-mandatory.template.golden.spec.ts
+++ b/apps/api/src/modules/journal/vat-60day-mandatory.template.golden.spec.ts
@@ -1,0 +1,53 @@
+import { Decimal } from '@prisma/client/runtime/library';
+import { Vat60dayMandatoryTemplate } from './cpa-templates/vat-60day-mandatory.template';
+
+/**
+ * Fast (mock-based, NO DB) golden for Vat60dayMandatoryTemplate — pins that the
+ * vatPerInst it remits (Dr 11-2104 / Cr 21-2103) comes from the shared
+ * computeInstallmentBreakdown and equals 99.17 for 17K/12M.
+ * Mirrors the DB-backed vitest golden vat-60day-mandatory.template.spec.ts.
+ */
+describe('Vat60dayMandatoryTemplate.execute (golden · mock-based)', () => {
+  const dec = (v: string | number) => new Decimal(v);
+
+  const contract = {
+    id: 'contract-v60m-1',
+    contractNumber: 'CT-V60M-001',
+    totalMonths: 12,
+    financedAmount: dec('10000'),
+    storeCommission: dec('1000'),
+    interestTotal: dec('6000'),
+    vatAmount: dec('1190'),
+  };
+  const inst = {
+    id: 'inst-v60m-1',
+    installmentNo: 3,
+    contractId: contract.id,
+    vat60dayJournalEntryId: null as string | null,
+  };
+
+  it('posts Dr 11-2104 99.17 / Cr 21-2103 99.17 (vatPerInst from helper), metadata.vatPerInst 99.17', async () => {
+    const createAndPost = jest.fn().mockResolvedValue({ id: 'je', entryNumber: 'JE-V60M-0001' });
+    const tx = {
+      installmentSchedule: {
+        findUniqueOrThrow: jest.fn().mockResolvedValue(inst),
+        update: jest.fn().mockResolvedValue({}),
+      },
+      contract: { findUniqueOrThrow: jest.fn().mockResolvedValue(contract) },
+    };
+    const prisma = { $transaction: jest.fn((cb: (t: unknown) => Promise<unknown>) => cb(tx)) };
+    const tmpl = new Vat60dayMandatoryTemplate({ createAndPost } as never, prisma as never);
+
+    await tmpl.execute(inst.id);
+    const je = createAndPost.mock.calls[0][0] as {
+      metadata: Record<string, unknown>;
+      lines: Array<{ accountCode: string; dr: Decimal; cr: Decimal }>;
+    };
+    const dr11_2104 = je.lines.find((l) => l.accountCode === '11-2104')!;
+    const cr21_2103 = je.lines.find((l) => l.accountCode === '21-2103')!;
+    expect(dr11_2104.dr.toFixed(2)).toBe('99.17');
+    expect(cr21_2103.cr.toFixed(2)).toBe('99.17');
+    expect(je.metadata.vatPerInst).toBe('99.17');
+    expect(je.metadata.tag).toBe('VAT60-MANDATORY');
+  });
+});

--- a/apps/api/src/modules/journal/vat-60day-reversal.template.golden.spec.ts
+++ b/apps/api/src/modules/journal/vat-60day-reversal.template.golden.spec.ts
@@ -1,0 +1,54 @@
+jest.mock('@sentry/nestjs', () => ({ captureMessage: jest.fn() }));
+
+import { Decimal } from '@prisma/client/runtime/library';
+import { Vat60dayReversalTemplate } from './cpa-templates/vat-60day-reversal.template';
+
+/**
+ * Fast (mock-based, NO DB) golden for Vat60dayReversalTemplate's LEGACY FALLBACK
+ * path — when the mandatory JE has no persisted vatPerInst, the reversal
+ * recomputes it via the shared computeInstallmentBreakdown (99.17 for 17K/12M)
+ * and posts Dr 21-2103 / Cr 11-2104. Mirrors the DB-backed vitest golden.
+ */
+describe('Vat60dayReversalTemplate.execute (legacy-fallback golden · mock-based)', () => {
+  const dec = (v: string | number) => new Decimal(v);
+
+  const contract = {
+    id: 'contract-v60r-1',
+    contractNumber: 'CT-V60R-001',
+    totalMonths: 12,
+    financedAmount: dec('10000'),
+    storeCommission: dec('1000'),
+    interestTotal: dec('6000'),
+    vatAmount: dec('1190'),
+  };
+  const inst = {
+    id: 'inst-v60r-1',
+    installmentNo: 3,
+    contractId: contract.id,
+    vat60dayJournalEntryId: 'JE-MAND-1',
+  };
+
+  it('fallback (no persisted vatPerInst) → recompute 99.17 via helper; Dr 21-2103 / Cr 11-2104', async () => {
+    const createAndPost = jest.fn().mockResolvedValue({ id: 'je', entryNumber: 'JE-V60R-0001' });
+    const tx = {
+      installmentSchedule: {
+        findUniqueOrThrow: jest.fn().mockResolvedValue(inst),
+        update: jest.fn().mockResolvedValue({}),
+      },
+      contract: { findUniqueOrThrow: jest.fn().mockResolvedValue(contract) },
+      // mandatory JE metadata WITHOUT vatPerInst → triggers the recompute fallback
+      journalEntry: { findUnique: jest.fn().mockResolvedValue({ metadata: {} }) },
+    };
+    const prisma = { $transaction: jest.fn((cb: (t: unknown) => Promise<unknown>) => cb(tx)) };
+    const tmpl = new Vat60dayReversalTemplate({ createAndPost } as never, prisma as never);
+
+    await tmpl.execute(inst.id);
+    const je = createAndPost.mock.calls[0][0] as {
+      metadata: Record<string, unknown>;
+      lines: Array<{ accountCode: string; dr: Decimal; cr: Decimal }>;
+    };
+    expect(je.lines.find((l) => l.accountCode === '21-2103')!.dr.toFixed(2)).toBe('99.17');
+    expect(je.lines.find((l) => l.accountCode === '11-2104')!.cr.toFixed(2)).toBe('99.17');
+    expect(je.metadata.tag).toBe('VAT60-REVERSAL');
+  });
+});


### PR DESCRIPTION
> **Stacked on #1195** (base = `wave4/unify-installment-breakdown`, which is stacked on #1194). GitHub auto-retargets as the stack merges. **Merge order: #1194 → #1195 → this.**

## Goal
Continue the per-installment-math dedup started in #1195 — route the remaining **per-installment-value consumers** through the shared `computeInstallmentBreakdown`.

## What changed
| Template | What it now sources from the helper |
|---|---|
| [installment-accrual-2a.template.ts](apps/api/src/modules/journal/cpa-templates/installment-accrual-2a.template.ts) | base `installmentExclVat` / `interestPerInst` / `vatPerInst`; the **last-installment residual true-up stays in 2A**, layered on the shared base |
| [vat-60day-mandatory.template.ts](apps/api/src/modules/journal/cpa-templates/vat-60day-mandatory.template.ts) | `vatPerInst` |
| [vat-60day-reversal.template.ts](apps/api/src/modules/journal/cpa-templates/vat-60day-reversal.template.ts) | `vatPerInst` (legacy-fallback path only) |

**Characterization:** the base in all three was **byte-identical** to the helper → no drift, pure dedup. Rounding (`accounting.md`) and the 2A true-up behaviour are preserved exactly.

## Tests — all green (`--runInBand`)
- `installment-accrual-2a.template.golden.spec.ts` — **2** (normal installment 1515.83 **+ last-installment true-up 1416.74 / 99.13 / 500.00**)
- `vat-60day-mandatory.template.golden.spec.ts` — **1**
- `vat-60day-reversal.template.golden.spec.ts` — **1** (legacy fallback path, Sentry mocked)
- Regression sweeps: journal **158**, contracts **211**, payments+paysolutions **110**
- `tsc --noEmit -p apps/api`: **0 errors**

## Still duplicating (deliberately deferred)
- **RepossessionJP5** — complex loss/gain + provision-consumption + accrued/deferred JE. Its base swap is trivial/safe, but a *correct* golden needs care → own focused PR rather than a hastily-mocked one that risks false confidence.
- **ContractActivation1A + ExchangeNewContract1A** — these use contract-**level** totals + the `commission[10%]`/`vat[7%]` **defaulting** (no `÷ months`), so they're a separate "defaulting dedup" slice, not per-installment.

⚠️ The DB-backed vitest goldens (`installment-accrual-2a` / `vat-60day-*.template.spec.ts`) were **not executed** here (their `setup()` wipes the dev DB). Their assertions are mirrored by the new jest mock-goldens; the changes are pure delegation. Please run them in CI / against a disposable DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)