### PR TITLE
docs(payments): fix PR-843/I2 prod-gate queries (camelCase deletedAt + DB name)

### DIFF
--- a/PR843_I2_ACCOUNTANT_SIGNOFF.md
+++ b/PR843_I2_ACCOUNTANT_SIGNOFF.md
@@ -33,7 +33,8 @@
 ## งานปฏิบัติการก่อน deploy (operational gates — ไม่ใช่บัญชี แต่ต้องทำ)
 - [ ] **ยืนยันบัญชีในผัง prod ครบทุกโค้ดที่ JE ใหม่อ้าง** (ไม่ใช่แค่ 21-5101). รัน `npm run seed:coa` (upsert ไม่ทำลายข้อมูล) แล้วตรวจ:
   ```sql
-  SELECT code FROM chart_of_accounts WHERE deleted_at IS NULL AND code IN
+  -- chart_of_accounts ใช้ camelCase "deletedAt"; payments/journal_entries ใช้ snake_case (mixed-case prod)
+  SELECT code FROM chart_of_accounts WHERE "deletedAt" IS NULL AND code IN
    ('11-2103','42-1103','52-1104','53-1503','21-1103','21-5101','11-1202',
     '11-1101','11-1102','11-1103','11-1201','11-1203') ORDER BY code;
   -- คาดหวัง: ครบทุกแถว. ขาดตัวใด → template throw 'Account code not found' → post ไม่ได้

--- a/PR843_I2_DEPLOY_RUNBOOK.md
+++ b/PR843_I2_DEPLOY_RUNBOOK.md
@@ -13,17 +13,19 @@
    # Cloud Run Job (image build แล้ว) ชี้ DATABASE_URL=prod:
    npm run seed:coa          # = node dist/src/cli/seed-coa.cli.js (idempotent upsert ผัง FINANCE+SHOP)
    # ตรวจครบทุกโค้ด:
-   psql "$PROD_DATABASE_URL" -tc "SELECT code FROM chart_of_accounts WHERE deleted_at IS NULL AND code IN ('11-2103','42-1103','52-1104','53-1503','21-1103','21-5101','11-1202','11-1101','11-1102','11-1103','11-1201','11-1203') ORDER BY code;"
+   # หมายเหตุ: chart_of_accounts ใช้คอลัมน์ camelCase "deletedAt" (ต้องใส่ double-quote);
+   #          ส่วน payments/journal_entries ใช้ snake_case (deleted_at) — prod เป็น mixed-case
+   psql "$PROD_DATABASE_URL" -tc "SELECT code FROM chart_of_accounts WHERE \"deletedAt\" IS NULL AND code IN ('11-2103','42-1103','52-1104','53-1503','21-1103','21-5101','11-1202','11-1101','11-1102','11-1103','11-1201','11-1203') ORDER BY code;"
    # คาดหวัง: ครบ 12 แถว
    ```
 3. **นับ Risk-5 + backfill** — ใช้ CLI `backfill:orphan-receipts` (dry-run คือตัวนับเลย):
    ```bash
    # 3a. DRY-RUN (read-only) — list งวด partial ที่ไม่มี receipt JE + ยอดรวม:
-   EXPECTED_DB_NAME=bestchoice_prod npm --prefix apps/api run backfill:orphan-receipts
+   EXPECTED_DB_NAME=bestchoice npm --prefix apps/api run backfill:orphan-receipts
    #   - 0 รายการ → ข้ามไป ②
    #   - >0 รายการ → ตรวจ list แล้วรัน 3b เพื่อ post catch-up receipt JE:
    # 3b. POST (idempotent — รันซ้ำได้):
-   CONFIRM_BACKFILL=YES_I_AM_SURE EXPECTED_DB_NAME=bestchoice_prod ALLOW_PROD_BACKFILL=YES_I_AM_SURE NODE_ENV=production \
+   CONFIRM_BACKFILL=YES_I_AM_SURE EXPECTED_DB_NAME=bestchoice ALLOW_PROD_BACKFILL=YES_I_AM_SURE NODE_ENV=production \
      npm --prefix apps/api run backfill:orphan-receipts
    #   (prod = Cloud Run Job backfill-orphan-receipts — ดู env ในหัวไฟล์ CLI)
    ```


### PR DESCRIPTION
Follow-up doc fix after PR #1199 shipped. While running the prod deploy gates we found:

- `chart_of_accounts` uses **camelCase** `"deletedAt"` (Prisma no-@map) — the CoA check SQL in the runbook + sign-off used `deleted_at` and errored. `payments`/`journal_entries` correctly use snake_case (`deleted_at`, `amount_paid`, `reference_id`) — those are unchanged. Prod is mixed-case.
- The real prod DB name is **`bestchoice`** (not `bestchoice_prod`) → fixed `EXPECTED_DB_NAME` in the backfill examples.

Docs only (`**.md` → paths-ignore, no deploy). Both gates already passed on prod and #1199 is deployed; this just makes the reference docs accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)