### PR TITLE
refactor(accounting): extract PeakExportService from AccountingService (Wave-4 P3)

### DIFF
--- a/apps/api/src/modules/accounting/accounting.module.ts
+++ b/apps/api/src/modules/accounting/accounting.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { AccountingController } from './accounting.controller';
 import { AccountingClosingController } from './closing.controller';
 import { AccountingService } from './accounting.service';
+import { PeakExportService } from './peak-export.service';
 import { BadDebtService } from './bad-debt.service';
 import { BadDebtProvisionCron } from './bad-debt-provision.cron';
 import { MonthlyCloseService } from './monthly-close.service';
@@ -18,6 +19,7 @@ import { PeakModule } from '../peak/peak.module';
   controllers: [AccountingController, AccountingClosingController, ConsolidatedController],
   providers: [
     AccountingService,
+    PeakExportService,
     BadDebtService,
     BadDebtProvisionCron,
     MonthlyCloseService,

--- a/apps/api/src/modules/accounting/accounting.pl-expense.spec.ts
+++ b/apps/api/src/modules/accounting/accounting.pl-expense.spec.ts
@@ -3,6 +3,7 @@ import { PrismaService } from '../../prisma/prisma.service';
 import { JournalAutoService } from '../journal/journal-auto.service';
 import { CompanyResolverService } from '../journal/company-resolver.service';
 import { AccountingService } from './accounting.service';
+import { PeakExportService } from './peak-export.service';
 
 type GroupRow = { accountCode: string; _sum: { debit: Prisma.Decimal | null; credit: Prisma.Decimal | null } };
 
@@ -16,7 +17,12 @@ function makeService(groupRows: GroupRow[]) {
   const companyResolver = {
     getFinanceCompanyId: jest.fn().mockResolvedValue('finance-co-1'),
   } as unknown as CompanyResolverService;
-  const svc = new AccountingService(prisma, {} as JournalAutoService, companyResolver);
+  const svc = new AccountingService(
+    prisma,
+    {} as JournalAutoService,
+    companyResolver,
+    {} as PeakExportService,
+  );
   return { svc, journalLineGroupBy };
 }
 
@@ -85,7 +91,12 @@ function makeFullService(groupRows: GroupRow[]) {
   const companyResolver = {
     getFinanceCompanyId: jest.fn().mockResolvedValue('finance-co-1'),
   } as unknown as CompanyResolverService;
-  return new AccountingService(prisma, {} as JournalAutoService, companyResolver);
+  return new AccountingService(
+    prisma,
+    {} as JournalAutoService,
+    companyResolver,
+    {} as PeakExportService,
+  );
 }
 
 describe('AccountingService.getProfitLossReport (expense wiring)', () => {
@@ -138,7 +149,12 @@ describe('AccountingService.getMonthlyPLSummary (expense wiring)', () => {
     const companyResolver = {
       getFinanceCompanyId: jest.fn().mockResolvedValue('finance-co-1'),
     } as unknown as CompanyResolverService;
-    return new AccountingService(prisma, {} as JournalAutoService, companyResolver);
+    return new AccountingService(
+      prisma,
+      {} as JournalAutoService,
+      companyResolver,
+      {} as PeakExportService,
+    );
   }
 
   it('includeFinanceExpenses=true: per-month FINANCE expenses subtracted from revenue', async () => {

--- a/apps/api/src/modules/accounting/accounting.service.spec.ts
+++ b/apps/api/src/modules/accounting/accounting.service.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { Prisma } from '@prisma/client';
 import { AccountingService } from './accounting.service';
+import { PeakExportService } from './peak-export.service';
 import { PrismaService } from '../../prisma/prisma.service';
 import { JournalAutoService } from '../journal/journal-auto.service';
 import { CompanyResolverService } from '../journal/company-resolver.service';
@@ -110,6 +111,7 @@ describe('AccountingService', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         AccountingService,
+        PeakExportService,
         { provide: PrismaService, useValue: prisma },
         { provide: JournalAutoService, useValue: journalAutoService },
         {

--- a/apps/api/src/modules/accounting/accounting.service.ts
+++ b/apps/api/src/modules/accounting/accounting.service.ts
@@ -1,15 +1,10 @@
-import {
-  BadRequestException,
-  Injectable,
-  Logger,
-  NotFoundException,
-  OnModuleInit,
-} from '@nestjs/common';
+import { Injectable, Logger, NotFoundException, OnModuleInit } from '@nestjs/common';
 import { PrismaService } from '../../prisma/prisma.service';
 import { agingBucket } from '../../utils/aging-bucket.util';
 import { Prisma } from '@prisma/client';
 import { JournalAutoService } from '../journal/journal-auto.service';
 import { CompanyResolverService } from '../journal/company-resolver.service';
+import { PeakExportService } from './peak-export.service';
 import {
   EXPENSE_ACCOUNT_CATEGORY,
   SECTION_MAP,
@@ -63,6 +58,8 @@ export class AccountingService implements OnModuleInit {
     private journalAutoService: JournalAutoService,
     // P3-SP5 W7: defense-in-depth filter on companyId for SHOP/FINANCE scoping.
     private companyResolver: CompanyResolverService,
+    // Wave-4 P3: PEAK CSV export extracted into a collaborator service.
+    private peakExport: PeakExportService,
   ) {}
 
   /**
@@ -1936,120 +1933,7 @@ export class AccountingService implements OnModuleInit {
     periodStart: Date,
     periodEnd: Date,
   ): Promise<{ csv: string; rowCount: number; skippedLineCount: number }> {
-    // Guard: max 186 days (~6 months) per spec — protects DB + filesystem.
-    const ms = periodEnd.getTime() - periodStart.getTime();
-    const MAX_DAYS = 186;
-    if (ms < 0) {
-      throw new BadRequestException('วันที่สิ้นสุดต้องไม่อยู่ก่อนวันเริ่มต้น');
-    }
-    if (ms > MAX_DAYS * 24 * 60 * 60 * 1000) {
-      throw new BadRequestException('ช่วงเวลาส่งออกต้องไม่เกิน 6 เดือนต่อครั้ง');
-    }
-
-    // 1) Build a peakCode lookup for every account that has one. Single query
-    //    is cheaper than joining inline because there are ~99 accounts total.
-    const mappedAccounts = await this.prisma.chartOfAccount.findMany({
-      where: { deletedAt: null, peakCode: { not: null } },
-      select: { code: true, name: true, peakCode: true },
-    });
-    const peakByCode = new Map(
-      mappedAccounts.map((a) => [a.code, { name: a.name, peakCode: a.peakCode! }]),
-    );
-
-    // Also load account names for un-mapped lines so we can report what was skipped.
-    const allAccounts = await this.prisma.chartOfAccount.findMany({
-      where: { deletedAt: null },
-      select: { code: true, name: true },
-    });
-    const nameByCode = new Map(allAccounts.map((a) => [a.code, a.name]));
-
-    // 2) Fetch journal lines in range. Order by entryDate then entryNumber so
-    //    the CSV is deterministic for reconciliation diffs.
-    const lines = await this.prisma.journalLine.findMany({
-      where: {
-        deletedAt: null,
-        journalEntry: {
-          status: 'POSTED',
-          entryDate: { gte: periodStart, lte: periodEnd },
-          deletedAt: null,
-        },
-      },
-      select: {
-        accountCode: true,
-        debit: true,
-        credit: true,
-        description: true,
-        journalEntry: {
-          select: {
-            entryNumber: true,
-            entryDate: true,
-            description: true,
-            referenceType: true,
-            referenceId: true,
-          },
-        },
-      },
-      orderBy: [
-        { journalEntry: { entryDate: 'asc' } },
-        { journalEntry: { entryNumber: 'asc' } },
-      ],
-    });
-
-    // 3) Render rows; skip un-mapped accounts.
-    const escape = (v: string | null | undefined) => {
-      if (v == null) return '';
-      const s = String(v);
-      if (s.includes(',') || s.includes('"') || s.includes('\n')) {
-        return `"${s.replace(/"/g, '""')}"`;
-      }
-      return s;
-    };
-
-    const header = [
-      'entryDate',
-      'entryNumber',
-      'peakCode',
-      'accountCode',
-      'accountName',
-      'debit',
-      'credit',
-      'description',
-      'reference',
-    ].join(',');
-
-    const body: string[] = [];
-    let skipped = 0;
-    for (const ln of lines) {
-      const mapping = peakByCode.get(ln.accountCode);
-      if (!mapping) {
-        skipped++;
-        continue;
-      }
-      const ref = ln.journalEntry.referenceType
-        ? `${ln.journalEntry.referenceType}:${ln.journalEntry.referenceId ?? ''}`
-        : '';
-      body.push(
-        [
-          ln.journalEntry.entryDate.toISOString().slice(0, 10),
-          escape(ln.journalEntry.entryNumber),
-          escape(mapping.peakCode),
-          escape(ln.accountCode),
-          escape(nameByCode.get(ln.accountCode) ?? mapping.name),
-          // String form keeps full Decimal precision — never Number()
-          new Prisma.Decimal(ln.debit).toString(),
-          new Prisma.Decimal(ln.credit).toString(),
-          escape(ln.description ?? ln.journalEntry.description),
-          escape(ref),
-        ].join(','),
-      );
-    }
-
-    return {
-      // UTF-8 BOM so Excel renders Thai correctly.
-      csv: '﻿' + [header, ...body].join('\n'),
-      rowCount: body.length,
-      skippedLineCount: skipped,
-    };
+    return this.peakExport.exportJournalWithPeakCodes(periodStart, periodEnd);
   }
 
   // ─── General Journal ──────────────────────────────────────────────────────

--- a/apps/api/src/modules/accounting/peak-export.service.ts
+++ b/apps/api/src/modules/accounting/peak-export.service.ts
@@ -1,0 +1,146 @@
+import { BadRequestException, Injectable } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import { PrismaService } from '../../prisma/prisma.service';
+
+// ============================================================
+// P3-SP3: PEAK CSV export (journal lines tagged with PEAK code)
+// ============================================================
+
+@Injectable()
+export class PeakExportService {
+  constructor(private prisma: PrismaService) {}
+
+  /**
+   * Build a CSV of POSTED journal lines within `[periodStart, periodEnd]`
+   * joined with their `ChartOfAccount.peakCode`. Lines whose account has no
+   * PEAK mapping are SKIPPED (returned `skippedLineCount`) so the caller can
+   * surface a warning. Date range is capped at ~6 months (186 days) so accidental
+   * "give me everything" queries don't dump millions of rows.
+   *
+   * Output columns:
+   *   entryDate, entryNumber, peakCode, accountCode, accountName,
+   *   debit, credit, description, reference
+   *
+   * Money values are emitted via `.toString()` to preserve Decimal precision
+   * (matches the "DO NOT Number() on Prisma.Decimal in export" rule).
+   */
+  async exportJournalWithPeakCodes(
+    periodStart: Date,
+    periodEnd: Date,
+  ): Promise<{ csv: string; rowCount: number; skippedLineCount: number }> {
+    // Guard: max 186 days (~6 months) per spec — protects DB + filesystem.
+    const ms = periodEnd.getTime() - periodStart.getTime();
+    const MAX_DAYS = 186;
+    if (ms < 0) {
+      throw new BadRequestException('วันที่สิ้นสุดต้องไม่อยู่ก่อนวันเริ่มต้น');
+    }
+    if (ms > MAX_DAYS * 24 * 60 * 60 * 1000) {
+      throw new BadRequestException('ช่วงเวลาส่งออกต้องไม่เกิน 6 เดือนต่อครั้ง');
+    }
+
+    // 1) Build a peakCode lookup for every account that has one. Single query
+    //    is cheaper than joining inline because there are ~99 accounts total.
+    const mappedAccounts = await this.prisma.chartOfAccount.findMany({
+      where: { deletedAt: null, peakCode: { not: null } },
+      select: { code: true, name: true, peakCode: true },
+    });
+    const peakByCode = new Map(
+      mappedAccounts.map((a) => [a.code, { name: a.name, peakCode: a.peakCode! }]),
+    );
+
+    // Also load account names for un-mapped lines so we can report what was skipped.
+    const allAccounts = await this.prisma.chartOfAccount.findMany({
+      where: { deletedAt: null },
+      select: { code: true, name: true },
+    });
+    const nameByCode = new Map(allAccounts.map((a) => [a.code, a.name]));
+
+    // 2) Fetch journal lines in range. Order by entryDate then entryNumber so
+    //    the CSV is deterministic for reconciliation diffs.
+    const lines = await this.prisma.journalLine.findMany({
+      where: {
+        deletedAt: null,
+        journalEntry: {
+          status: 'POSTED',
+          entryDate: { gte: periodStart, lte: periodEnd },
+          deletedAt: null,
+        },
+      },
+      select: {
+        accountCode: true,
+        debit: true,
+        credit: true,
+        description: true,
+        journalEntry: {
+          select: {
+            entryNumber: true,
+            entryDate: true,
+            description: true,
+            referenceType: true,
+            referenceId: true,
+          },
+        },
+      },
+      orderBy: [
+        { journalEntry: { entryDate: 'asc' } },
+        { journalEntry: { entryNumber: 'asc' } },
+      ],
+    });
+
+    // 3) Render rows; skip un-mapped accounts.
+    const escape = (v: string | null | undefined) => {
+      if (v == null) return '';
+      const s = String(v);
+      if (s.includes(',') || s.includes('"') || s.includes('\n')) {
+        return `"${s.replace(/"/g, '""')}"`;
+      }
+      return s;
+    };
+
+    const header = [
+      'entryDate',
+      'entryNumber',
+      'peakCode',
+      'accountCode',
+      'accountName',
+      'debit',
+      'credit',
+      'description',
+      'reference',
+    ].join(',');
+
+    const body: string[] = [];
+    let skipped = 0;
+    for (const ln of lines) {
+      const mapping = peakByCode.get(ln.accountCode);
+      if (!mapping) {
+        skipped++;
+        continue;
+      }
+      const ref = ln.journalEntry.referenceType
+        ? `${ln.journalEntry.referenceType}:${ln.journalEntry.referenceId ?? ''}`
+        : '';
+      body.push(
+        [
+          ln.journalEntry.entryDate.toISOString().slice(0, 10),
+          escape(ln.journalEntry.entryNumber),
+          escape(mapping.peakCode),
+          escape(ln.accountCode),
+          escape(nameByCode.get(ln.accountCode) ?? mapping.name),
+          // String form keeps full Decimal precision — never Number()
+          new Prisma.Decimal(ln.debit).toString(),
+          new Prisma.Decimal(ln.credit).toString(),
+          escape(ln.description ?? ln.journalEntry.description),
+          escape(ref),
+        ].join(','),
+      );
+    }
+
+    return {
+      // UTF-8 BOM so Excel renders Thai correctly.
+      csv: '﻿' + [header, ...body].join('\n'),
+      rowCount: body.length,
+      skippedLineCount: skipped,
+    };
+  }
+}

--- a/apps/api/src/modules/journal/shop-templates/accounting-multi-scope.spec.ts
+++ b/apps/api/src/modules/journal/shop-templates/accounting-multi-scope.spec.ts
@@ -66,7 +66,7 @@ describe('AccountingService — multi-scope reports', () => {
     };
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const svc = new AccountingService(prisma, {} as any, resolver as any);
+    const svc = new AccountingService(prisma, {} as any, resolver as any, {} as any);
     return { svc, prisma, resolver, groupByCalls, findManyCalls };
   }
 


### PR DESCRIPTION
## Wave-4 P3 — extract `PeakExportService` (warm-up slice)

**Behavior-preserving.** Moves `exportJournalWithPeakCodes` (the PEAK CSV export, ~118 LOC, read-only, no shared private helpers) out of the 2,229-LOC `AccountingService` into a new `PeakExportService`. `AccountingService.exportJournalWithPeakCodes` keeps its public signature and **delegates** in one line — controller wiring unchanged.

> Stacked on #1201 (P0). Base will auto-retarget to `main` once P0 merges.

### Changes
- **NEW** `accounting/peak-export.service.ts` — `@Injectable`, injects `PrismaService`; method body cut **byte-for-byte** from the original (186-day guard + Thai messages, `escape` closure, UTF-8 BOM, `Prisma.Decimal(...).toString()` precision — all verbatim).
- **MOD** `accounting.service.ts` — injects `PeakExportService` (4th ctor param), `exportJournalWithPeakCodes` → 1-line delegation; removed the now-unused `BadRequestException` import.
- **MOD** `accounting.module.ts` — `PeakExportService` added to `providers` (internal-only; not exported).
- **MOD** specs — `PeakExportService` wired into `accounting.service.spec.ts`'s test module so the existing peak-export tests pass **unchanged via delegation**; 2 specs that `new AccountingService(...)` directly (`accounting.pl-expense.spec.ts`, `journal/shop-templates/accounting-multi-scope.spec.ts`) got a stub 4th arg (arity-only, no assertion changes).
- **Controller: untouched.**

### Verification
- Body byte-identity independently confirmed (BOM, both Thai guard messages, Decimal emission, `escape`, header all intact).
- `./tools/check-types.sh api` → **API: OK**.
- `npm --prefix apps/api run test -- accounting` → **212 passed / 10 suites** (incl. the 4 `exportJournalWithPeakCodes` tests via the delegating facade).

🤖 Generated with [Claude Code](https://claude.com/claude-code)