### PR TITLE
refactor(accounting): extract ReceivablesReportService from AccountingService (Wave-4 P4)

### DIFF
--- a/apps/api/src/modules/accounting/accounting.module.ts
+++ b/apps/api/src/modules/accounting/accounting.module.ts
@@ -3,6 +3,7 @@ import { AccountingController } from './accounting.controller';
 import { AccountingClosingController } from './closing.controller';
 import { AccountingService } from './accounting.service';
 import { PeakExportService } from './peak-export.service';
+import { ReceivablesReportService } from './receivables-report.service';
 import { BadDebtService } from './bad-debt.service';
 import { BadDebtProvisionCron } from './bad-debt-provision.cron';
 import { MonthlyCloseService } from './monthly-close.service';
@@ -20,6 +21,7 @@ import { PeakModule } from '../peak/peak.module';
   providers: [
     AccountingService,
     PeakExportService,
+    ReceivablesReportService,
     BadDebtService,
     BadDebtProvisionCron,
     MonthlyCloseService,

--- a/apps/api/src/modules/accounting/accounting.pl-expense.spec.ts
+++ b/apps/api/src/modules/accounting/accounting.pl-expense.spec.ts
@@ -4,6 +4,7 @@ import { JournalAutoService } from '../journal/journal-auto.service';
 import { CompanyResolverService } from '../journal/company-resolver.service';
 import { AccountingService } from './accounting.service';
 import { PeakExportService } from './peak-export.service';
+import { ReceivablesReportService } from './receivables-report.service';
 
 type GroupRow = { accountCode: string; _sum: { debit: Prisma.Decimal | null; credit: Prisma.Decimal | null } };
 
@@ -22,6 +23,7 @@ function makeService(groupRows: GroupRow[]) {
     {} as JournalAutoService,
     companyResolver,
     {} as PeakExportService,
+    {} as ReceivablesReportService,
   );
   return { svc, journalLineGroupBy };
 }
@@ -96,6 +98,7 @@ function makeFullService(groupRows: GroupRow[]) {
     {} as JournalAutoService,
     companyResolver,
     {} as PeakExportService,
+    {} as ReceivablesReportService,
   );
 }
 
@@ -154,6 +157,7 @@ describe('AccountingService.getMonthlyPLSummary (expense wiring)', () => {
       {} as JournalAutoService,
       companyResolver,
       {} as PeakExportService,
+      {} as ReceivablesReportService,
     );
   }
 

--- a/apps/api/src/modules/accounting/accounting.service.spec.ts
+++ b/apps/api/src/modules/accounting/accounting.service.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { Prisma } from '@prisma/client';
 import { AccountingService } from './accounting.service';
 import { PeakExportService } from './peak-export.service';
+import { ReceivablesReportService } from './receivables-report.service';
 import { PrismaService } from '../../prisma/prisma.service';
 import { JournalAutoService } from '../journal/journal-auto.service';
 import { CompanyResolverService } from '../journal/company-resolver.service';
@@ -112,6 +113,7 @@ describe('AccountingService', () => {
       providers: [
         AccountingService,
         PeakExportService,
+        ReceivablesReportService,
         { provide: PrismaService, useValue: prisma },
         { provide: JournalAutoService, useValue: journalAutoService },
         {

--- a/apps/api/src/modules/accounting/accounting.service.ts
+++ b/apps/api/src/modules/accounting/accounting.service.ts
@@ -1,10 +1,10 @@
 import { Injectable, Logger, NotFoundException, OnModuleInit } from '@nestjs/common';
 import { PrismaService } from '../../prisma/prisma.service';
-import { agingBucket } from '../../utils/aging-bucket.util';
 import { Prisma } from '@prisma/client';
 import { JournalAutoService } from '../journal/journal-auto.service';
 import { CompanyResolverService } from '../journal/company-resolver.service';
 import { PeakExportService } from './peak-export.service';
+import { ReceivablesReportService } from './receivables-report.service';
 import {
   EXPENSE_ACCOUNT_CATEGORY,
   SECTION_MAP,
@@ -60,6 +60,8 @@ export class AccountingService implements OnModuleInit {
     private companyResolver: CompanyResolverService,
     // Wave-4 P3: PEAK CSV export extracted into a collaborator service.
     private peakExport: PeakExportService,
+    // Wave-4 P4: aging + bad-debt receivables reports extracted into a collaborator service.
+    private receivablesReport: ReceivablesReportService,
   ) {}
 
   /**
@@ -1982,82 +1984,7 @@ export class AccountingService implements OnModuleInit {
   // ─── P4-SP1: Aging Report ────────────────────────────────────────────────
 
   async getAgingReport(asOf: Date) {
-    const overduePayments = await this.prisma.payment.findMany({
-      where: {
-        status: { in: ['PENDING', 'OVERDUE'] },
-        dueDate: { lt: asOf },
-        deletedAt: null,
-      },
-      include: {
-        contract: {
-          include: {
-            customer: {
-              select: { id: true, name: true, phone: true },
-            },
-          },
-        },
-      },
-    });
-
-    const summary = {
-      bucket_0_30: 0,
-      bucket_31_60: 0,
-      bucket_61_90: 0,
-      bucket_90_plus: 0,
-    };
-
-    const customerMap = new Map<
-      string,
-      {
-        customerId: string;
-        customerName: string;
-        phone: string;
-        totalOverdue: number;
-        daysOverdue: number;
-        bucket: string;
-        contracts: number;
-      }
-    >();
-
-    const calcBucket = (days: number): keyof typeof summary =>
-      agingBucket(days, ['bucket_0_30', 'bucket_31_60', 'bucket_61_90', 'bucket_90_plus'] as const);
-
-    for (const p of overduePayments) {
-      const daysOverdue = Math.floor(
-        (asOf.getTime() - p.dueDate.getTime()) / (1000 * 60 * 60 * 24),
-      );
-      const remaining = Number(p.amountDue) - Number(p.amountPaid ?? 0);
-      if (remaining <= 0) continue;
-
-      const bucket = calcBucket(daysOverdue);
-      summary[bucket] += remaining;
-
-      const cid = p.contract.customer.id;
-      const existing = customerMap.get(cid);
-      if (existing) {
-        existing.totalOverdue += remaining;
-        existing.daysOverdue = Math.max(existing.daysOverdue, daysOverdue);
-        existing.bucket = calcBucket(existing.daysOverdue);
-      } else {
-        customerMap.set(cid, {
-          customerId: cid,
-          customerName: p.contract.customer.name,
-          phone: p.contract.customer.phone ?? '',
-          totalOverdue: remaining,
-          daysOverdue,
-          bucket,
-          contracts: 1,
-        });
-      }
-    }
-
-    return {
-      asOf,
-      summary,
-      customers: Array.from(customerMap.values()).sort(
-        (a, b) => b.daysOverdue - a.daysOverdue,
-      ),
-    };
+    return this.receivablesReport.getAgingReport(asOf);
   }
 
   // ─── P4-SP1 Task 3: Bad Debt Report ─────────────────────────────────────────
@@ -2070,44 +1997,6 @@ export class AccountingService implements OnModuleInit {
    *   51-1102 = หนี้สูญ/ขาดทุนจากยึดเครื่อง (RepossessionJP5Template loss branch)
    */
   async getBadDebtReport(periodStart: Date, periodEnd: Date, companyId?: string) {
-    const lines = await this.prisma.journalLine.findMany({
-      where: {
-        accountCode: '51-1102',
-        journalEntry: {
-          postedAt: { gte: periodStart, lte: periodEnd },
-          deletedAt: null,
-          ...(companyId ? { companyId } : {}),
-        },
-      },
-      include: {
-        journalEntry: {
-          select: {
-            id: true,
-            entryNumber: true,
-            description: true,
-            postedAt: true,
-            referenceType: true,
-            referenceId: true,
-          },
-        },
-      },
-      orderBy: { journalEntry: { postedAt: 'desc' } },
-    });
-
-    const total = lines.reduce((sum, l) => sum + Number(l.debit ?? 0), 0);
-
-    return {
-      period: { start: periodStart, end: periodEnd },
-      totalBadDebt: total,
-      entries: lines.map((l) => ({
-        journalEntryId: l.journalEntry.id,
-        documentNumber: l.journalEntry.entryNumber,
-        postedAt: l.journalEntry.postedAt,
-        description: l.description ?? l.journalEntry.description,
-        amount: Number(l.debit ?? 0),
-        sourceType: l.journalEntry.referenceType,
-        sourceId: l.journalEntry.referenceId,
-      })),
-    };
+    return this.receivablesReport.getBadDebtReport(periodStart, periodEnd, companyId);
   }
 }

--- a/apps/api/src/modules/accounting/receivables-report.service.ts
+++ b/apps/api/src/modules/accounting/receivables-report.service.ts
@@ -1,0 +1,140 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../../prisma/prisma.service';
+import { agingBucket } from '../../utils/aging-bucket.util';
+
+@Injectable()
+export class ReceivablesReportService {
+  constructor(private prisma: PrismaService) {}
+
+  // ─── P4-SP1: Aging Report ────────────────────────────────────────────────
+
+  async getAgingReport(asOf: Date) {
+    const overduePayments = await this.prisma.payment.findMany({
+      where: {
+        status: { in: ['PENDING', 'OVERDUE'] },
+        dueDate: { lt: asOf },
+        deletedAt: null,
+      },
+      include: {
+        contract: {
+          include: {
+            customer: {
+              select: { id: true, name: true, phone: true },
+            },
+          },
+        },
+      },
+    });
+
+    const summary = {
+      bucket_0_30: 0,
+      bucket_31_60: 0,
+      bucket_61_90: 0,
+      bucket_90_plus: 0,
+    };
+
+    const customerMap = new Map<
+      string,
+      {
+        customerId: string;
+        customerName: string;
+        phone: string;
+        totalOverdue: number;
+        daysOverdue: number;
+        bucket: string;
+        contracts: number;
+      }
+    >();
+
+    const calcBucket = (days: number): keyof typeof summary =>
+      agingBucket(days, ['bucket_0_30', 'bucket_31_60', 'bucket_61_90', 'bucket_90_plus'] as const);
+
+    for (const p of overduePayments) {
+      const daysOverdue = Math.floor(
+        (asOf.getTime() - p.dueDate.getTime()) / (1000 * 60 * 60 * 24),
+      );
+      const remaining = Number(p.amountDue) - Number(p.amountPaid ?? 0);
+      if (remaining <= 0) continue;
+
+      const bucket = calcBucket(daysOverdue);
+      summary[bucket] += remaining;
+
+      const cid = p.contract.customer.id;
+      const existing = customerMap.get(cid);
+      if (existing) {
+        existing.totalOverdue += remaining;
+        existing.daysOverdue = Math.max(existing.daysOverdue, daysOverdue);
+        existing.bucket = calcBucket(existing.daysOverdue);
+      } else {
+        customerMap.set(cid, {
+          customerId: cid,
+          customerName: p.contract.customer.name,
+          phone: p.contract.customer.phone ?? '',
+          totalOverdue: remaining,
+          daysOverdue,
+          bucket,
+          contracts: 1,
+        });
+      }
+    }
+
+    return {
+      asOf,
+      summary,
+      customers: Array.from(customerMap.values()).sort(
+        (a, b) => b.daysOverdue - a.daysOverdue,
+      ),
+    };
+  }
+
+  // ─── P4-SP1 Task 3: Bad Debt Report ─────────────────────────────────────────
+
+  /**
+   * Returns journal lines posted to account 51-1102 (หนี้สูญ/ขาดทุนจากยึดเครื่อง)
+   * within the given period. Used by BadDebtReportPage to display write-off history.
+   *
+   * Per .claude/rules/accounting.md:
+   *   51-1102 = หนี้สูญ/ขาดทุนจากยึดเครื่อง (RepossessionJP5Template loss branch)
+   */
+  async getBadDebtReport(periodStart: Date, periodEnd: Date, companyId?: string) {
+    const lines = await this.prisma.journalLine.findMany({
+      where: {
+        accountCode: '51-1102',
+        journalEntry: {
+          postedAt: { gte: periodStart, lte: periodEnd },
+          deletedAt: null,
+          ...(companyId ? { companyId } : {}),
+        },
+      },
+      include: {
+        journalEntry: {
+          select: {
+            id: true,
+            entryNumber: true,
+            description: true,
+            postedAt: true,
+            referenceType: true,
+            referenceId: true,
+          },
+        },
+      },
+      orderBy: { journalEntry: { postedAt: 'desc' } },
+    });
+
+    const total = lines.reduce((sum, l) => sum + Number(l.debit ?? 0), 0);
+
+    return {
+      period: { start: periodStart, end: periodEnd },
+      totalBadDebt: total,
+      entries: lines.map((l) => ({
+        journalEntryId: l.journalEntry.id,
+        documentNumber: l.journalEntry.entryNumber,
+        postedAt: l.journalEntry.postedAt,
+        description: l.description ?? l.journalEntry.description,
+        amount: Number(l.debit ?? 0),
+        sourceType: l.journalEntry.referenceType,
+        sourceId: l.journalEntry.referenceId,
+      })),
+    };
+  }
+}

--- a/apps/api/src/modules/journal/shop-templates/accounting-multi-scope.spec.ts
+++ b/apps/api/src/modules/journal/shop-templates/accounting-multi-scope.spec.ts
@@ -66,7 +66,7 @@ describe('AccountingService — multi-scope reports', () => {
     };
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const svc = new AccountingService(prisma, {} as any, resolver as any, {} as any);
+    const svc = new AccountingService(prisma, {} as any, resolver as any, {} as any, {} as any);
     return { svc, prisma, resolver, groupByCalls, findManyCalls };
   }
 


### PR DESCRIPTION
## Wave-4 P4 — extract `ReceivablesReportService`

**Behavior-preserving.** Moves the two AR/receivables reports — `getAgingReport` and `getBadDebtReport` (read-only, no shared private helpers) — out of `AccountingService` into a new `ReceivablesReportService`. `AccountingService` keeps both public methods (identical signatures) and **delegates**. Controller wiring unchanged.

> Stacked on #1202 (P3) → #1201 (P0). Bases auto-retarget to `main` as the stack merges in order.

### ⚠️ Aging-bucket trap respected
The `summary` keys and the `agingBucket(days, ['bucket_0_30','bucket_31_60','bucket_61_90','bucket_90_plus'] as const)` tuple were moved **byte-for-byte** — no rename / reorder / unify (the label canonicalization is a separate owner-pending decision).

### Changes
- **NEW** `accounting/receivables-report.service.ts` — `@Injectable`, injects `PrismaService`, holds both method bodies **verbatim** (MD5-confirmed identical) + their doc-comment banners; imports only `Injectable`, `PrismaService`, `agingBucket`.
- **MOD** `accounting.service.ts` — injects `ReceivablesReportService` (5th ctor param); both methods → one-line delegations; relocated the now-unused `agingBucket` import out.
- **MOD** `accounting.module.ts` — `ReceivablesReportService` in `providers` (internal-only).
- **MOD** specs — `ReceivablesReportService` wired into `accounting.service.spec.ts`'s test module so the existing aging/bad-debt tests (incl. the Wave-4 P0 characterization tests asserting `prisma.payment.findMany` / `prisma.journalLine.findMany` call args + `Number()` coercion) pass **unchanged via delegation**; 2 direct-construction specs got a stub 5th arg (arity-only).
- **Controller: untouched.**

### Naming note
`ReceivablesReportService` (read-side: aging + bad-debt journal history) is intentionally distinct from the existing `BadDebtService` (write-side: provisioning/write-off) — complementary, no method-name collision.

### Verification
- Both bodies byte-identical (MD5); aging tuple untouched.
- `./tools/check-types.sh api` → **API: OK**.
- `npm --prefix apps/api run test -- accounting` → **212 passed / 10 suites** (aging 7/7 + bad-debt 12/12 via delegation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)