### PR TITLE
refactor(expense-documents): extract validateAdjustments (V12/V13/V14) into pure expense-validators.util

### DIFF
--- a/apps/api/src/modules/expense-documents/__tests__/expense-validators.util.spec.ts
+++ b/apps/api/src/modules/expense-documents/__tests__/expense-validators.util.spec.ts
@@ -1,0 +1,153 @@
+import { Prisma } from '@prisma/client';
+import { BadRequestException } from '@nestjs/common';
+import { ADJUSTMENT_ALLOWLIST, validateAdjustments } from '../expense-validators.util';
+
+/**
+ * Characterization spec for validateAdjustments (V12/V13/V14).
+ *
+ * Pure unit test — no DI, no DB. Mocks the only tx surface the validator
+ * touches: tx.chartOfAccount.findMany. Pins the EXACT Thai messages and the
+ * signed-sum convention (CR=+, DR=−). Behavior was previously covered only
+ * INDIRECTLY via create()/createSettlement() integration tests.
+ */
+describe('validateAdjustments (expense-validators.util)', () => {
+  const D = (v: string | number) => new Prisma.Decimal(v);
+
+  // Builds a mock tx whose chartOfAccount.findMany returns the given codes.
+  const makeTx = (foundCodes: string[]) => {
+    const findMany = jest
+      .fn()
+      .mockResolvedValue(foundCodes.map((code) => ({ code })));
+    return {
+      tx: { chartOfAccount: { findMany } } as unknown as Prisma.TransactionClient,
+      findMany,
+    };
+  };
+
+  it('fast path: no adjustments + diff 0 → resolves and never queries CoA', async () => {
+    const { tx, findMany } = makeTx([]);
+    await expect(
+      validateAdjustments(tx, {
+        adjustments: [],
+        netExpected: D('100.00'),
+        amountPaid: D('100.00'),
+      }),
+    ).resolves.toBeUndefined();
+    expect(findMany).not.toHaveBeenCalled();
+  });
+
+  it('V14 (empty accountCode): throws with the pre-existing "V13:" label', async () => {
+    const { tx } = makeTx([]);
+    await expect(
+      validateAdjustments(tx, {
+        adjustments: [{ accountCode: '   ', side: 'CR', amount: 10 }],
+        netExpected: D('100.00'),
+        amountPaid: D('110.00'),
+      }),
+    ).rejects.toThrow(
+      new BadRequestException('V13: บัญชีปรับผลต่างแถวที่ 1 ยังไม่ได้เลือกบัญชี'),
+    );
+  });
+
+  it('V14 (amount <= 0): throws จำนวนต้องมากกว่า 0', async () => {
+    const { tx } = makeTx([]);
+    await expect(
+      validateAdjustments(tx, {
+        adjustments: [{ accountCode: '52-1104', side: 'CR', amount: 0 }],
+        netExpected: D('100.00'),
+        amountPaid: D('100.00'),
+      }),
+    ).rejects.toThrow(
+      new BadRequestException('V14: บัญชีปรับผลต่างแถวที่ 1: จำนวนต้องมากกว่า 0'),
+    );
+  });
+
+  it('V13 (code not in CoA): throws ไม่พบในผังบัญชี', async () => {
+    const { tx } = makeTx([]); // findMany returns nothing
+    await expect(
+      validateAdjustments(tx, {
+        adjustments: [{ accountCode: '52-1104', side: 'CR', amount: 10 }],
+        netExpected: D('100.00'),
+        amountPaid: D('110.00'),
+      }),
+    ).rejects.toThrow(
+      new BadRequestException('V13: บัญชีปรับผลต่าง 52-1104 ไม่พบในผังบัญชี'),
+    );
+  });
+
+  it('V13 (in CoA but not on allow-list): throws ไม่อยู่ในรายการที่อนุญาต', async () => {
+    const { tx } = makeTx(['51-1101']); // exists in CoA but NOT allow-listed
+    await expect(
+      validateAdjustments(tx, {
+        adjustments: [{ accountCode: '51-1101', side: 'CR', amount: 10 }],
+        netExpected: D('100.00'),
+        amountPaid: D('110.00'),
+      }),
+    ).rejects.toThrow(
+      new BadRequestException(
+        `V13: บัญชีปรับผลต่าง 51-1101 ไม่อยู่ในรายการที่อนุญาต — ` +
+          `อนุญาตเฉพาะ ${[...ADJUSTMENT_ALLOWLIST].join(', ')}`,
+      ),
+    );
+  });
+
+  it('V12 (signed-sum mismatch): throws ผลรวมบัญชีปรับผลต่าง', async () => {
+    const { tx } = makeTx(['52-1104']); // passes V13/V14 — fails only V12
+    // diff = 110 − 100 = 10, but signed sum = +5 (CR) ≠ 10
+    await expect(
+      validateAdjustments(tx, {
+        adjustments: [{ accountCode: '52-1104', side: 'CR', amount: 5 }],
+        netExpected: D('100.00'),
+        amountPaid: D('110.00'),
+      }),
+    ).rejects.toThrow(
+      new BadRequestException(
+        `V12: ผลรวมบัญชีปรับผลต่าง (signed = 5.00) ` +
+          `ไม่เท่ากับผลต่าง amount_paid − net_expected (10.00)`,
+      ),
+    );
+  });
+
+  it('happy path (CR = +amount): overpay diff matched by a CR adjustment → resolves', async () => {
+    const { tx } = makeTx(['52-1104']);
+    // diff = 110 − 100 = +10; CR 10 → signed +10 === diff
+    await expect(
+      validateAdjustments(tx, {
+        adjustments: [{ accountCode: '52-1104', side: 'CR', amount: 10 }],
+        netExpected: D('100.00'),
+        amountPaid: D('110.00'),
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('happy path (DR = −amount): underpay diff matched by a DR adjustment → resolves', async () => {
+    const { tx } = makeTx(['52-1104']);
+    // diff = 90 − 100 = −10; DR 10 → signed −10 === diff
+    await expect(
+      validateAdjustments(tx, {
+        adjustments: [{ accountCode: '52-1104', side: 'DR', amount: 10 }],
+        netExpected: D('100.00'),
+        amountPaid: D('90.00'),
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('dedup: duplicate accountCode → findMany queried with deduped code set', async () => {
+    const { tx, findMany } = makeTx(['52-1104']);
+    // two CR rows of the same code, 6 + 4 = +10 === diff (110 − 100)
+    await expect(
+      validateAdjustments(tx, {
+        adjustments: [
+          { accountCode: '52-1104', side: 'CR', amount: 6 },
+          { accountCode: '52-1104', side: 'CR', amount: 4 },
+        ],
+        netExpected: D('100.00'),
+        amountPaid: D('110.00'),
+      }),
+    ).resolves.toBeUndefined();
+    expect(findMany).toHaveBeenCalledTimes(1);
+    const whereArg = findMany.mock.calls[0][0].where;
+    expect(whereArg.code.in).toEqual(['52-1104']);
+    expect(whereArg.deletedAt).toBeNull();
+  });
+});

--- a/apps/api/src/modules/expense-documents/expense-documents.service.ts
+++ b/apps/api/src/modules/expense-documents/expense-documents.service.ts
@@ -12,6 +12,7 @@ import { JournalAutoService } from '../journal/journal-auto.service';
 import { resolvePostPermissionRoles } from './post-permission.guard';
 import { resolveReversePermissionRoles } from './reverse-permission.guard';
 import { maskPayrollTaxIds } from './payroll-pii-mask.util';
+import { ADJUSTMENT_ALLOWLIST, validateAdjustments } from './expense-validators.util';
 import { DocNumberService } from './services/doc-number.service';
 import { StatusTransitionService } from './services/status-transition.service';
 import { ExpenseSameDayTemplate } from '../journal/cpa-templates/expense-same-day.template';
@@ -37,26 +38,6 @@ import { PettyCashService } from './services/petty-cash.service';
 import { PayrollCustomService } from './services/payroll-custom.service';
 import { validatePeriodOpen } from '../../utils/period-lock.util';
 import { readBoolFlag, readJsonFlag } from '../../utils/config.util';
-
-/**
- * Allow-list of account codes that may appear on a multi-line Adjustment row
- * (W1 hardening). The adjustment rows absorb cash-leg deltas between
- * amount_paid and (totalAmount − wht); only small-amount tolerance / bank-fee
- * / discount accounts are sensible here. Allowing arbitrary CoA codes lets the
- * preparer pick Revenue or Cash, balancing the JE but causing accounting drift.
- *
- * Codes from accounting.md FINANCE chart (apps/api/src/modules/journal/__tests__/fixtures/cpa-cases/finance-coa.csv):
- *   52-1104 — ส่วนลดเศษสตางค์ (≤1฿ rounding tolerance)
- *   52-1106 — ส่วนลดดอกเบี้ย-ปิดยอด (Early payoff discount)
- *   53-1303 — ค่าธรรมเนียมธนาคาร
- *   53-1503 — กำไร/ขาดทุนจากการปัดเศษ
- */
-const ADJUSTMENT_ALLOWLIST = new Set<string>([
-  '52-1104',
-  '52-1106',
-  '53-1303',
-  '53-1503',
-]);
 
 /**
  * Returns a Date representing 12:00 noon Asia/Bangkok on the same calendar day
@@ -384,73 +365,6 @@ export class ExpenseDocumentsService implements OnModuleInit {
     );
   }
 
-  // ─── V12/V13/V14 — Multi-line Adjustment validation (shared) ────────
-  // Fix Report P0-4 + B2. Validates that:
-  //   V12  Σ signed(adjustments) === amountPaid − netExpected
-  //   V13  every accountCode exists in CoA and is on ADJUSTMENT_ALLOWLIST
-  //   V14  every row.amount > 0 and accountCode is non-empty
-  // Signed convention: CR contributes +amount, DR contributes −amount.
-  private async validateAdjustments(
-    tx: Prisma.TransactionClient,
-    opts: {
-      adjustments: { accountCode: string; side: 'DR' | 'CR'; amount: string | number; note?: string }[];
-      netExpected: Prisma.Decimal;
-      amountPaid: Prisma.Decimal;
-    },
-  ): Promise<void> {
-    const { adjustments, netExpected, amountPaid } = opts;
-    const diff = amountPaid.minus(netExpected);
-
-    if (adjustments.length === 0 && diff.eq(0)) return; // fast path — no adjustments needed
-
-    // V14 — non-empty accountCode + positive amount
-    for (let i = 0; i < adjustments.length; i++) {
-      const a = adjustments[i];
-      if (!a.accountCode || !a.accountCode.trim()) {
-        throw new BadRequestException(`V13: บัญชีปรับผลต่างแถวที่ ${i + 1} ยังไม่ได้เลือกบัญชี`);
-      }
-      const amt = new Prisma.Decimal(a.amount);
-      if (amt.lte(0)) {
-        throw new BadRequestException(
-          `V14: บัญชีปรับผลต่างแถวที่ ${i + 1}: จำนวนต้องมากกว่า 0`,
-        );
-      }
-    }
-
-    // V13 — code exists in CoA AND on the allow-list
-    if (adjustments.length > 0) {
-      const adjCodes = [...new Set(adjustments.map((a) => a.accountCode))];
-      const adjCoaRows = await tx.chartOfAccount.findMany({
-        where: { code: { in: adjCodes }, deletedAt: null },
-        select: { code: true },
-      });
-      const adjFound = new Set(adjCoaRows.map((r) => r.code));
-      for (const c of adjCodes) {
-        if (!adjFound.has(c)) {
-          throw new BadRequestException(`V13: บัญชีปรับผลต่าง ${c} ไม่พบในผังบัญชี`);
-        }
-        if (!ADJUSTMENT_ALLOWLIST.has(c)) {
-          throw new BadRequestException(
-            `V13: บัญชีปรับผลต่าง ${c} ไม่อยู่ในรายการที่อนุญาต — ` +
-              `อนุญาตเฉพาะ ${[...ADJUSTMENT_ALLOWLIST].join(', ')}`,
-          );
-        }
-      }
-    }
-
-    // V12 — Σ signed(adjustments) === diff
-    const signedSum = adjustments.reduce<Prisma.Decimal>((s, a) => {
-      const amt = new Prisma.Decimal(a.amount);
-      return a.side === 'CR' ? s.plus(amt) : s.minus(amt);
-    }, new Prisma.Decimal(0));
-    if (!signedSum.eq(diff)) {
-      throw new BadRequestException(
-        `V12: ผลรวมบัญชีปรับผลต่าง (signed = ${signedSum.toFixed(2)}) ` +
-          `ไม่เท่ากับผลต่าง amount_paid − net_expected (${diff.toFixed(2)})`,
-      );
-    }
-  }
-
   // ─── Create ──────────────────────────────────────────────────────────
   async create(dto: CreateExpenseDocumentDto, userId: string) {
     const documentDate = new Date(dto.documentDate);
@@ -485,7 +399,7 @@ export class ExpenseDocumentsService implements OnModuleInit {
       const amountPaid =
         dto.amountPaid !== undefined ? new Prisma.Decimal(dto.amountPaid) : netExpected;
       const adjustments = dto.adjustments ?? [];
-      await this.validateAdjustments(tx, { adjustments, netExpected, amountPaid });
+      await validateAdjustments(tx, { adjustments, netExpected, amountPaid });
 
       const number = await this.docNumber.next(tx, 'EXPENSE', documentDate);
 
@@ -1172,7 +1086,7 @@ export class ExpenseDocumentsService implements OnModuleInit {
       const amountPaid =
         dto.amountPaid !== undefined ? new Prisma.Decimal(dto.amountPaid) : netExpected;
       const adjustments = dto.adjustments ?? [];
-      await this.validateAdjustments(tx, { adjustments, netExpected, amountPaid });
+      await validateAdjustments(tx, { adjustments, netExpected, amountPaid });
 
       const documentDate = new Date(dto.documentDate);
       const number = await this.docNumber.next(tx, 'VENDOR_SETTLEMENT', documentDate);

--- a/apps/api/src/modules/expense-documents/expense-validators.util.ts
+++ b/apps/api/src/modules/expense-documents/expense-validators.util.ts
@@ -1,0 +1,91 @@
+import { BadRequestException } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+
+/**
+ * Allow-list of account codes that may appear on a multi-line Adjustment row
+ * (W1 hardening). The adjustment rows absorb cash-leg deltas between
+ * amount_paid and (totalAmount − wht); only small-amount tolerance / bank-fee
+ * / discount accounts are sensible here. Allowing arbitrary CoA codes lets the
+ * preparer pick Revenue or Cash, balancing the JE but causing accounting drift.
+ *
+ * Codes from accounting.md FINANCE chart (apps/api/src/modules/journal/__tests__/fixtures/cpa-cases/finance-coa.csv):
+ *   52-1104 — ส่วนลดเศษสตางค์ (≤1฿ rounding tolerance)
+ *   52-1106 — ส่วนลดดอกเบี้ย-ปิดยอด (Early payoff discount)
+ *   53-1303 — ค่าธรรมเนียมธนาคาร
+ *   53-1503 — กำไร/ขาดทุนจากการปัดเศษ
+ */
+export const ADJUSTMENT_ALLOWLIST = new Set<string>([
+  '52-1104',
+  '52-1106',
+  '53-1303',
+  '53-1503',
+]);
+
+// ─── V12/V13/V14 — Multi-line Adjustment validation (shared) ────────
+// Fix Report P0-4 + B2. Validates that:
+//   V12  Σ signed(adjustments) === amountPaid − netExpected
+//   V13  every accountCode exists in CoA and is on ADJUSTMENT_ALLOWLIST
+//   V14  every row.amount > 0 and accountCode is non-empty
+// Signed convention: CR contributes +amount, DR contributes −amount.
+export async function validateAdjustments(
+  tx: Prisma.TransactionClient,
+  opts: {
+    adjustments: { accountCode: string; side: 'DR' | 'CR'; amount: string | number; note?: string }[];
+    netExpected: Prisma.Decimal;
+    amountPaid: Prisma.Decimal;
+  },
+): Promise<void> {
+  const { adjustments, netExpected, amountPaid } = opts;
+  const diff = amountPaid.minus(netExpected);
+
+  if (adjustments.length === 0 && diff.eq(0)) return; // fast path — no adjustments needed
+
+  // V14 — non-empty accountCode + positive amount
+  for (let i = 0; i < adjustments.length; i++) {
+    const a = adjustments[i];
+    if (!a.accountCode || !a.accountCode.trim()) {
+      // NOTE: message intentionally carries the "V13:" prefix (pre-existing behavior) even though
+      // this is the V14 block — clients may key off the prefix; do NOT "fix" it to "V14:".
+      throw new BadRequestException(`V13: บัญชีปรับผลต่างแถวที่ ${i + 1} ยังไม่ได้เลือกบัญชี`);
+    }
+    const amt = new Prisma.Decimal(a.amount);
+    if (amt.lte(0)) {
+      throw new BadRequestException(
+        `V14: บัญชีปรับผลต่างแถวที่ ${i + 1}: จำนวนต้องมากกว่า 0`,
+      );
+    }
+  }
+
+  // V13 — code exists in CoA AND on the allow-list
+  if (adjustments.length > 0) {
+    const adjCodes = [...new Set(adjustments.map((a) => a.accountCode))];
+    const adjCoaRows = await tx.chartOfAccount.findMany({
+      where: { code: { in: adjCodes }, deletedAt: null },
+      select: { code: true },
+    });
+    const adjFound = new Set(adjCoaRows.map((r) => r.code));
+    for (const c of adjCodes) {
+      if (!adjFound.has(c)) {
+        throw new BadRequestException(`V13: บัญชีปรับผลต่าง ${c} ไม่พบในผังบัญชี`);
+      }
+      if (!ADJUSTMENT_ALLOWLIST.has(c)) {
+        throw new BadRequestException(
+          `V13: บัญชีปรับผลต่าง ${c} ไม่อยู่ในรายการที่อนุญาต — ` +
+            `อนุญาตเฉพาะ ${[...ADJUSTMENT_ALLOWLIST].join(', ')}`,
+        );
+      }
+    }
+  }
+
+  // V12 — Σ signed(adjustments) === diff
+  const signedSum = adjustments.reduce<Prisma.Decimal>((s, a) => {
+    const amt = new Prisma.Decimal(a.amount);
+    return a.side === 'CR' ? s.plus(amt) : s.minus(amt);
+  }, new Prisma.Decimal(0));
+  if (!signedSum.eq(diff)) {
+    throw new BadRequestException(
+      `V12: ผลรวมบัญชีปรับผลต่าง (signed = ${signedSum.toFixed(2)}) ` +
+        `ไม่เท่ากับผลต่าง amount_paid − net_expected (${diff.toFixed(2)})`,
+    );
+  }
+}


### PR DESCRIPTION
## Expense-documents decompose — slice E1

First slice of decomposing the 2,757-LOC `ExpenseDocumentsService`. **Behavior-preserving.** Moves the `validateAdjustments` (V12/V13/V14) multi-line adjustment validator + the `ADJUSTMENT_ALLOWLIST` const out into a new pure util `expense-validators.util.ts`, and adds the isolated characterization spec it was missing.

**No constructor change** — extracted as a free function (not an injected service), so the 15-param constructor and its 8 `new ExpenseDocumentsService(...)` spec sites are untouched. (Mirrors the existing `payroll-pii-mask.util.ts` precedent.)

### Changes
- **NEW** `expense-validators.util.ts` — exports `validateAdjustments(tx, opts)` + `ADJUSTMENT_ALLOWLIST`; body moved **byte-for-byte** (exact Thai messages, signed-sum CR=+/DR=− convention, `deletedAt:null` CoA lookup with dedup, fast-path). Added a one-line comment flagging the **intentional `"V13:"` prefix on the V14 empty-accountCode branch** (pre-existing; clients may key off it — don't "fix" it).
- **MOD** `expense-documents.service.ts` — deleted the local const + private method; imports both from the util; `onModuleInit` (boot-time CoA hardening) uses the imported allowlist identically; `create()` + `createSettlement()` call the free function.
- **NEW** `__tests__/expense-validators.util.spec.ts` — 9 characterization cases (fast-path/never-queries-CoA, V14 empty-code, V14 amount≤0, V13 not-in-CoA, V13 not-allow-listed, V12 signed-sum mismatch, CR-overpay + DR-underpay happy paths, dedup) asserting the exact production Thai messages. The validator was previously covered only *indirectly* via `create`/`createSettlement`.

### Verification
- Body + allowlist byte-identical (independently confirmed); the "V13"/V14 label quirk preserved.
- `./tools/check-types.sh api` → **API: OK**.
- `npm --prefix apps/api run test -- expense-documents` → **378 passed / 31 suites** (369 baseline + 9 new); existing adjustment integration tests (W1 / V12-fast-path / overpay-underpay) green via the rewired util call.

> Standalone PR off `main` (unrelated to the accounting Wave-4 stack #1201–1205). First of several planned expense-documents slices; transactional core (`post`/`approve`/`void`/`create*`) left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)