### PR TITLE
refactor(config): consolidate SystemConfig flag-readers (readIntFlag → config.util + dedup 3 readBoolFlag copies)

### DIFF
--- a/apps/api/src/modules/expense-documents/crons/ap-due-alerts.cron.ts
+++ b/apps/api/src/modules/expense-documents/crons/ap-due-alerts.cron.ts
@@ -4,6 +4,7 @@ import * as Sentry from '@sentry/nestjs';
 import { PrismaService } from '../../../prisma/prisma.service';
 import { NotificationsService } from '../../notifications/notifications.service';
 import { NotificationCategory } from '../../notifications/notification-category.enum';
+import { readBoolFlag } from '../../../utils/config.util';
 
 /**
  * D1.3.1.2 — Accounts-Payable due alerts.
@@ -55,7 +56,7 @@ export class ApDueAlertsCron {
   async tick(): Promise<{ enabled: boolean; alerted: number; skipped: number; failed: number }> {
     try {
       // Default OFF until ExpenseDocument has a real dueDate column (currently uses documentDate proxy)
-      const enabled = await this.readBoolFlag('ap_due_alerts_enabled', false);
+      const enabled = await readBoolFlag(this.prisma, 'ap_due_alerts_enabled', false);
       if (!enabled) {
         this.logger.debug('[D1.3.1.2] AP-due alerts disabled — skipping');
         return { enabled: false, alerted: 0, skipped: 0, failed: 0 };
@@ -176,22 +177,11 @@ export class ApDueAlertsCron {
     }
   }
 
-  private async readBoolFlag(key: string, fallback: boolean): Promise<boolean> {
-    try {
-      const row = await this.prisma.systemConfig.findFirst({
-        where: { key, deletedAt: null },
-        select: { value: true },
-      });
-      if (!row?.value) return fallback;
-      const v = row.value.trim().toLowerCase();
-      if (v === 'true' || v === '1') return true;
-      if (v === 'false' || v === '0') return false;
-      return fallback;
-    } catch {
-      return fallback;
-    }
-  }
-
+  /**
+   * Intentionally NOT consolidated onto config.util.readNumberFlag — this clamps
+   * to n >= 0 (due-alert window of 0 = alert immediately is valid). config.util's
+   * variant allows negatives. Do not dedup without preserving this clamp.
+   */
   private async readNumberFlag(key: string, fallback: number): Promise<number> {
     try {
       const row = await this.prisma.systemConfig.findFirst({

--- a/apps/api/src/modules/expense-documents/crons/draft-alerts.cron.ts
+++ b/apps/api/src/modules/expense-documents/crons/draft-alerts.cron.ts
@@ -4,6 +4,7 @@ import * as Sentry from '@sentry/nestjs';
 import { PrismaService } from '../../../prisma/prisma.service';
 import { NotificationsService } from '../../notifications/notifications.service';
 import { NotificationCategory } from '../../notifications/notification-category.enum';
+import { readBoolFlag } from '../../../utils/config.util';
 
 /**
  * D1.3.1.1 — DRAFT alerts.
@@ -43,7 +44,7 @@ export class DraftAlertsCron {
   @Cron('1 9 * * *', { timeZone: 'Asia/Bangkok' })
   async tick(): Promise<{ enabled: boolean; alerted: number; skipped: number; failed: number }> {
     try {
-      const enabled = await this.readBoolFlag('draft_alerts_enabled', false);
+      const enabled = await readBoolFlag(this.prisma, 'draft_alerts_enabled', false);
       if (!enabled) {
         // Default-off + opt-in. Silent skip so quiet deploys don't fill logs.
         this.logger.debug('[D1.3.1.1] DRAFT alerts disabled — skipping');
@@ -129,31 +130,13 @@ export class DraftAlertsCron {
   }
 
   /**
-   * Reads a boolean-shaped SystemConfig row directly via PrismaService.
-   * Matches the helper pattern in ExpenseDocumentsService.readBoolFlag
-   * (PR #884) — avoids dragging the full SettingsModule into the cron just
-   * to read one key. Swallows DB errors → returns fallback.
-   */
-  private async readBoolFlag(key: string, fallback: boolean): Promise<boolean> {
-    try {
-      const row = await this.prisma.systemConfig.findFirst({
-        where: { key, deletedAt: null },
-        select: { value: true },
-      });
-      if (!row?.value) return fallback;
-      const v = row.value.trim().toLowerCase();
-      if (v === 'true' || v === '1') return true;
-      if (v === 'false' || v === '0') return false;
-      return fallback;
-    } catch {
-      return fallback;
-    }
-  }
-
-  /**
    * Reads a numeric-shaped SystemConfig row. Coerces with Number(); falls
    * back when parse fails or value is non-positive (alert thresholds <1
    * day make no sense and would spam everyone).
+   *
+   * Intentionally NOT consolidated onto config.util.readNumberFlag — this clamps
+   * to n > 0 (strictly positive); config.util's variant allows 0/negatives.
+   * Do not dedup without preserving this clamp.
    */
   private async readNumberFlag(key: string, fallback: number): Promise<number> {
     try {

--- a/apps/api/src/modules/expense-documents/expense-documents.service.ts
+++ b/apps/api/src/modules/expense-documents/expense-documents.service.ts
@@ -36,7 +36,7 @@ import { NotificationsService } from '../notifications/notifications.service';
 import { PettyCashService } from './services/petty-cash.service';
 import { PayrollCustomService } from './services/payroll-custom.service';
 import { validatePeriodOpen } from '../../utils/period-lock.util';
-import { readBoolFlag, readJsonFlag } from '../../utils/config.util';
+import { readBoolFlag, readIntFlag, readJsonFlag } from '../../utils/config.util';
 
 /**
  * Allow-list of account codes that may appear on a multi-line Adjustment row
@@ -301,6 +301,10 @@ export class ExpenseDocumentsService implements OnModuleInit {
    * unparseable values returns the fallback. Used by the approval-threshold
    * gate where negatives would yield bizarre "every doc requires approval"
    * behaviour.
+   *
+   * Intentionally NOT consolidated onto config.util.readNumberFlag — that returns
+   * a plain number with no clamp; this returns Prisma.Decimal clamped to ≥ 0.
+   * Do not dedup without preserving the Decimal return + clamp.
    */
   private async readNumberFlag(
     tx: Prisma.TransactionClient | PrismaService,
@@ -320,33 +324,6 @@ export class ExpenseDocumentsService implements OnModuleInit {
       return new Prisma.Decimal(clamped);
     } catch {
       return new Prisma.Decimal(fallback);
-    }
-  }
-
-  /**
-   * D1.3.6.1 — Read an integer SystemConfig flag with min/max clamp.
-   * Returns `fallback` when the row is missing, the value isn't a finite
-   * integer, or it falls outside [min, max]. Mirrors `readBoolFlag` so
-   * future numeric flags share one code path.
-   */
-  private async readIntFlag(
-    tx: Prisma.TransactionClient | PrismaService,
-    key: string,
-    fallback: number,
-    min: number,
-    max: number,
-  ): Promise<number> {
-    try {
-      const row = await tx.systemConfig.findFirst({
-        where: { key, deletedAt: null },
-        select: { value: true },
-      });
-      if (!row?.value) return fallback;
-      const n = Number(row.value);
-      if (!Number.isInteger(n) || n < min || n > max) return fallback;
-      return n;
-    } catch {
-      return fallback;
     }
   }
 
@@ -1052,7 +1029,7 @@ export class ExpenseDocumentsService implements OnModuleInit {
     // PrismaService here (outside the $transaction below) because
     // SystemConfig values rarely change mid-request and this is a soft gate
     // rather than a row-level invariant.
-    const maxBills = await this.readIntFlag(
+    const maxBills = await readIntFlag(
       this.prisma,
       'settlement_max_bills_per_doc',
       100,

--- a/apps/api/src/modules/notifications/notifications.service.ts
+++ b/apps/api/src/modules/notifications/notifications.service.ts
@@ -2,6 +2,7 @@ import { Injectable, NotFoundException, BadRequestException, InternalServerError
 import { formatDateShort, formatDateTime } from '../../utils/thai-date.util';
 import { maskPhone } from '../../utils/mask.util';
 import { isSmsPaymentReminderDisabled } from '../../utils/sms-payment-reminder.util';
+import { readBoolFlag } from '../../utils/config.util';
 import { ConfigService } from '@nestjs/config';
 import { PrismaService } from '../../prisma/prisma.service';
 import { SendNotificationDto } from './dto/create-notification.dto';
@@ -50,29 +51,6 @@ export class NotificationsService {
     return (await this.integrationConfig.getValue('sms', 'force')) || 'standard';
   }
 
-  /**
-   * D1.3.1.4 — Read a SystemConfig boolean directly via PrismaService.
-   * Mirrors `ExpenseDocumentsService.readBoolFlag` (PR #884) — used here to
-   * gate IN_APP notifications without dragging SettingsModule into the
-   * NotificationsService DI graph. Returns the fallback when key is absent,
-   * malformed, or a transient DB error occurs.
-   */
-  private async readBoolFlag(key: string, fallback: boolean): Promise<boolean> {
-    try {
-      const row = await this.prisma.systemConfig.findFirst({
-        where: { key, deletedAt: null },
-        select: { value: true },
-      });
-      if (!row?.value) return fallback;
-      const v = row.value.trim().toLowerCase();
-      if (v === 'true' || v === '1') return true;
-      if (v === 'false' || v === '0') return false;
-      return fallback;
-    } catch {
-      return fallback;
-    }
-  }
-
   // ============================================================
   // NOTIFICATION SENDING
   // ============================================================
@@ -99,7 +77,7 @@ export class NotificationsService {
     // NotificationsService independent of SettingsModule (avoids a wide DI
     // expansion just to read one boolean). Same pattern as PR #884.
     if (dto.channel === 'IN_APP') {
-      const inAppEnabled = await this.readBoolFlag('in_app_notifications_enabled', true);
+      const inAppEnabled = await readBoolFlag(this.prisma, 'in_app_notifications_enabled', true);
       if (!inAppEnabled) {
         return { id: '', status: 'SKIPPED', blockReason: 'IN_APP_DISABLED' };
       }

--- a/apps/api/src/utils/config.util.spec.ts
+++ b/apps/api/src/utils/config.util.spec.ts
@@ -1,6 +1,7 @@
 import {
   readBoolFlag,
   readNumberFlag,
+  readIntFlag,
   readStringFlag,
   readJsonFlag,
 } from './config.util';
@@ -90,6 +91,49 @@ describe('config.util — SystemConfig flag readers', () => {
     it('swallows DB errors and returns fallback', async () => {
       const stub = makeStub({}, 'boom');
       expect(await readNumberFlag(stub, 'boom', 5)).toBe(5);
+    });
+  });
+
+  describe('readIntFlag', () => {
+    it('returns the value for a valid integer in range', async () => {
+      const stub = makeStub({ a: '100', b: '1', c: '500' });
+      expect(await readIntFlag(stub, 'a', 50, 1, 500)).toBe(100);
+      expect(await readIntFlag(stub, 'b', 50, 1, 500)).toBe(1);
+      expect(await readIntFlag(stub, 'c', 50, 1, 500)).toBe(500);
+    });
+
+    it('returns fallback when out of range (>max or <min)', async () => {
+      const stub = makeStub({ over: '501', under: '0' });
+      expect(await readIntFlag(stub, 'over', 100, 1, 500)).toBe(100);
+      expect(await readIntFlag(stub, 'under', 100, 1, 500)).toBe(100);
+    });
+
+    it('returns fallback on non-integer value', async () => {
+      const stub = makeStub({ a: '1.5', b: 'abc' });
+      expect(await readIntFlag(stub, 'a', 100, 1, 500)).toBe(100);
+      expect(await readIntFlag(stub, 'b', 100, 1, 500)).toBe(100);
+    });
+
+    it('returns fallback on empty string', async () => {
+      const stub = makeStub({ empty: '' });
+      expect(await readIntFlag(stub, 'empty', 100, 1, 500)).toBe(100);
+    });
+
+    it('returns fallback when key missing or row null', async () => {
+      const stub = makeStub({ nullval: null });
+      expect(await readIntFlag(stub, 'missing', 100, 1, 500)).toBe(100);
+      expect(await readIntFlag(stub, 'nullval', 100, 1, 500)).toBe(100);
+    });
+
+    it('swallows DB errors and returns fallback', async () => {
+      const stub = makeStub({}, 'boom');
+      expect(await readIntFlag(stub, 'boom', 100, 1, 500)).toBe(100);
+    });
+
+    it('returns the value at exactly min and max boundaries', async () => {
+      const stub = makeStub({ atMin: '1', atMax: '500' });
+      expect(await readIntFlag(stub, 'atMin', 100, 1, 500)).toBe(1);
+      expect(await readIntFlag(stub, 'atMax', 100, 1, 500)).toBe(500);
     });
   });
 

--- a/apps/api/src/utils/config.util.ts
+++ b/apps/api/src/utils/config.util.ts
@@ -86,6 +86,25 @@ export async function readNumberFlag(
 }
 
 /**
+ * Read an integer SystemConfig flag with fallback + [min,max] clamp. Non-integer,
+ * out-of-range, empty, missing, or DB-error all yield the fallback. (No trim — matches
+ * the original Number(value) parse.)
+ */
+export async function readIntFlag(
+  prisma: SystemConfigReader,
+  key: string,
+  fallback: number,
+  min: number,
+  max: number,
+): Promise<number> {
+  const raw = await readRawValue(prisma, key);
+  if (!raw) return fallback; // matches original `!row?.value` (null AND '' → fallback)
+  const n = Number(raw);
+  if (!Number.isInteger(n) || n < min || n > max) return fallback;
+  return n;
+}
+
+/**
  * Read a string SystemConfig flag with fallback. Returns the raw string
  * value (no parsing). Empty string → fallback (treat "" as unset).
  *


### PR DESCRIPTION
## Flag-reader consolidation (expense-documents slice E2)

Behavior-preserving cleanup of duplicated `SystemConfig` flag-readers. Net **−93/+84 LOC**.

### Part 1 — `readIntFlag` → `config.util`
- Moved the private `readIntFlag(prisma, key, fallback, min, max)` out of `expense-documents.service.ts` into `config.util.ts` (exported), reusing the shared `readRawValue`. **Behavior-identical**: uses `if (!raw)` so `null` AND empty-string `''` fall back exactly like the original `!row?.value`; non-integer / out-of-range / DB-error → fallback unchanged (no `trim()` added). `expense-documents` imports + calls it (`settlement_max_bills_per_doc`).
- **+7 characterization tests** in `config.util.spec.ts` (valid in-range, >max/<min, non-integer, empty `''`, missing/null, DB-error, exact min/max boundaries).

### Part 2 — dedup 3 byte-equivalent `readBoolFlag` copies
Three private `readBoolFlag` methods — verified char-identical to `config.util.readBoolFlag` (same `true/false/1/0` mapping, `trim().toLowerCase()`, `try/catch → fallback`) — replaced with the shared util:
- `crons/ap-due-alerts.cron.ts` (`ap_due_alerts_enabled`)
- `crons/draft-alerts.cron.ts` (`draft_alerts_enabled`)
- `notifications/notifications.service.ts` (`in_app_notifications_enabled`)

Specs mock `prisma.systemConfig.findFirst` (not the private method) → they exercise the shared util via the same mock → all green.

### Intentional divergence preserved (NOT consolidated)
The `readNumberFlag` variants are **semantically different** and left in place, each now annotated with a "do not dedup without preserving this clamp" note:
- `expense-documents.service` → returns `Prisma.Decimal`, clamps `≥ 0`
- `ap-due-alerts.cron` → clamps `n >= 0`
- `draft-alerts.cron` → clamps `n > 0`

> The pre-existing delegating `readBoolFlag` *wrapper* on `ExpenseDocumentsService` (PR #884; forwards a `tx`/`prisma` client, used at several in-service sites) was intentionally left as-is — it's not duplicate logic, and unwinding it across the god-service is out of scope for this focused dedup.

### Verification
- `./tools/check-types.sh api` → **API: OK**.
- `npm --prefix apps/api run test -- config.util` → **22** (incl. 7 new); `-- expense-documents` → **369**; `-- alerts.cron` → **13**; `-- notifications` → **74**. All green.

> Standalone PR off `main`; complements expense-documents slice E1 (#1206).

🤖 Generated with [Claude Code](https://claude.com/claude-code)