### PR TITLE
refactor(expense-documents): dedup CoA 'ค่าใช้จ่าย' type guard into assertCategoriesAreExpense (4 sites)

### DIFF
--- a/apps/api/src/modules/expense-documents/__tests__/expense-validators.util.spec.ts
+++ b/apps/api/src/modules/expense-documents/__tests__/expense-validators.util.spec.ts
@@ -1,6 +1,10 @@
 import { Prisma } from '@prisma/client';
 import { BadRequestException } from '@nestjs/common';
-import { ADJUSTMENT_ALLOWLIST, validateAdjustments } from '../expense-validators.util';
+import {
+  ADJUSTMENT_ALLOWLIST,
+  assertCategoriesAreExpense,
+  validateAdjustments,
+} from '../expense-validators.util';
 
 /**
  * Characterization spec for validateAdjustments (V12/V13/V14).
@@ -149,5 +153,88 @@ describe('validateAdjustments (expense-validators.util)', () => {
     const whereArg = findMany.mock.calls[0][0].where;
     expect(whereArg.code.in).toEqual(['52-1104']);
     expect(whereArg.deletedAt).toBeNull();
+  });
+});
+
+/**
+ * Characterization spec for assertCategoriesAreExpense.
+ *
+ * Pure unit test — mocks the only tx surface the guard touches:
+ * tx.chartOfAccount.findMany. Pins the EXACT Thai messages, the deduped/insertion-
+ * order query, and the first-offender throw order. Behavior was previously
+ * copy-pasted (byte-equivalent) across create / createCreditNote /
+ * createPettyCash / update and covered only INDIRECTLY via those integration tests.
+ */
+describe('assertCategoriesAreExpense (expense-validators.util)', () => {
+  // Builds a mock tx whose chartOfAccount.findMany returns the given {code,type} rows.
+  const makeTx = (rows: { code: string; type: string }[]) => {
+    const findMany = jest.fn().mockResolvedValue(rows);
+    return {
+      tx: { chartOfAccount: { findMany } } as unknown as Prisma.TransactionClient,
+      findMany,
+    };
+  };
+
+  it('all categories valid (type ค่าใช้จ่าย) → resolves; queries deduped code set + deletedAt null + select {code,type}', async () => {
+    const { tx, findMany } = makeTx([
+      { code: '51-1101', type: 'ค่าใช้จ่าย' },
+      { code: '52-1104', type: 'ค่าใช้จ่าย' },
+    ]);
+    await expect(
+      assertCategoriesAreExpense(tx, ['51-1101', '52-1104']),
+    ).resolves.toBeUndefined();
+    expect(findMany).toHaveBeenCalledTimes(1);
+    const arg = findMany.mock.calls[0][0];
+    expect(arg.where.code.in).toEqual(['51-1101', '52-1104']);
+    expect(arg.where.deletedAt).toBeNull();
+    expect(arg.select).toEqual({ code: true, type: true });
+  });
+
+  it('code missing from CoA → throws ไม่พบในผังบัญชี', async () => {
+    const { tx } = makeTx([]); // findMany omits it
+    await expect(assertCategoriesAreExpense(tx, ['51-1101'])).rejects.toThrow(
+      new BadRequestException('หมวดบัญชี 51-1101 ไม่พบในผังบัญชี'),
+    );
+  });
+
+  it('code present but wrong type (รายได้) → throws ไม่ใช่ "ค่าใช้จ่าย"', async () => {
+    const { tx } = makeTx([{ code: '41-1101', type: 'รายได้' }]);
+    await expect(assertCategoriesAreExpense(tx, ['41-1101'])).rejects.toThrow(
+      new BadRequestException('หมวดบัญชี 41-1101 ไม่ใช่ "ค่าใช้จ่าย"'),
+    );
+  });
+
+  it('dedup: duplicate categories → findMany queried once with the deduped set', async () => {
+    const { tx, findMany } = makeTx([{ code: '51-1101', type: 'ค่าใช้จ่าย' }]);
+    await expect(
+      assertCategoriesAreExpense(tx, ['51-1101', '51-1101', '51-1101']),
+    ).resolves.toBeUndefined();
+    expect(findMany).toHaveBeenCalledTimes(1);
+    expect(findMany.mock.calls[0][0].where.code.in).toEqual(['51-1101']);
+  });
+
+  it('first-offender: [valid, missing] → the missing code throws', async () => {
+    // findMany returns only the valid one; the second (missing) trips the loop.
+    const { tx } = makeTx([{ code: '51-1101', type: 'ค่าใช้จ่าย' }]);
+    await expect(
+      assertCategoriesAreExpense(tx, ['51-1101', '99-9999']),
+    ).rejects.toThrow(new BadRequestException('หมวดบัญชี 99-9999 ไม่พบในผังบัญชี'));
+  });
+
+  it('first-offender: wrong-type before missing (by insertion order) → the wrong-type code throws first', async () => {
+    // Iteration follows Set insertion order: 41-1101 (wrong type) is reached
+    // before 99-9999 (missing), so the ไม่ใช่ message wins.
+    const { tx } = makeTx([{ code: '41-1101', type: 'รายได้' }]);
+    await expect(
+      assertCategoriesAreExpense(tx, ['41-1101', '99-9999']),
+    ).rejects.toThrow(new BadRequestException('หมวดบัญชี 41-1101 ไม่ใช่ "ค่าใช้จ่าย"'));
+  });
+
+  it('empty array → resolves; findMany still called once with empty in: []', async () => {
+    const { tx, findMany } = makeTx([]);
+    await expect(assertCategoriesAreExpense(tx, [])).resolves.toBeUndefined();
+    // The guard always queries (no fast-path); the for-loop over [] is a no-op.
+    expect(findMany).toHaveBeenCalledTimes(1);
+    expect(findMany.mock.calls[0][0].where.code.in).toEqual([]);
   });
 });

--- a/apps/api/src/modules/expense-documents/expense-documents.service.ts
+++ b/apps/api/src/modules/expense-documents/expense-documents.service.ts
@@ -12,7 +12,11 @@ import { JournalAutoService } from '../journal/journal-auto.service';
 import { resolvePostPermissionRoles } from './post-permission.guard';
 import { resolveReversePermissionRoles } from './reverse-permission.guard';
 import { maskPayrollTaxIds } from './payroll-pii-mask.util';
-import { ADJUSTMENT_ALLOWLIST, validateAdjustments } from './expense-validators.util';
+import {
+  ADJUSTMENT_ALLOWLIST,
+  assertCategoriesAreExpense,
+  validateAdjustments,
+} from './expense-validators.util';
 import { DocNumberService } from './services/doc-number.service';
 import { StatusTransitionService } from './services/status-transition.service';
 import { ExpenseSameDayTemplate } from '../journal/cpa-templates/expense-same-day.template';
@@ -379,17 +383,10 @@ export class ExpenseDocumentsService implements OnModuleInit {
 
     return this.prisma.$transaction(async (tx) => {
       // CoA validation — every category must exist + be type "ค่าใช้จ่าย"
-      const codes = [...new Set(linesPrepared.map((l) => l.category))];
-      const coaRows = await tx.chartOfAccount.findMany({
-        where: { code: { in: codes }, deletedAt: null },
-        select: { code: true, type: true },
-      });
-      const byCode = new Map(coaRows.map((r) => [r.code, r.type]));
-      for (const c of codes) {
-        const t = byCode.get(c);
-        if (!t) throw new BadRequestException(`หมวดบัญชี ${c} ไม่พบในผังบัญชี`);
-        if (t !== 'ค่าใช้จ่าย') throw new BadRequestException(`หมวดบัญชี ${c} ไม่ใช่ "ค่าใช้จ่าย"`);
-      }
+      await assertCategoriesAreExpense(
+        tx,
+        linesPrepared.map((l) => l.category),
+      );
 
       // Fix Report P0-4 — multi-line adjustment validation (V12/V13/V14).
       // Shared helper used here (EXPENSE) and by createSettlement (B2 / SE).
@@ -597,17 +594,10 @@ export class ExpenseDocumentsService implements OnModuleInit {
 
     return this.prisma.$transaction(async (tx) => {
       // CoA validation — every category must exist + be type "ค่าใช้จ่าย"
-      const codes = [...new Set(linesPrepared.map((l) => l.category))];
-      const coaRows = await tx.chartOfAccount.findMany({
-        where: { code: { in: codes }, deletedAt: null },
-        select: { code: true, type: true },
-      });
-      const byCode = new Map(coaRows.map((r) => [r.code, r.type]));
-      for (const c of codes) {
-        const t = byCode.get(c);
-        if (!t) throw new BadRequestException(`หมวดบัญชี ${c} ไม่พบในผังบัญชี`);
-        if (t !== 'ค่าใช้จ่าย') throw new BadRequestException(`หมวดบัญชี ${c} ไม่ใช่ "ค่าใช้จ่าย"`);
-      }
+      await assertCategoriesAreExpense(
+        tx,
+        linesPrepared.map((l) => l.category),
+      );
 
       // LINKED-mode validation: source lookup + cap + WHT guard under advisory lock.
       // STANDALONE-mode skips this — there is no source document.
@@ -1217,19 +1207,10 @@ export class ExpenseDocumentsService implements OnModuleInit {
 
     return this.prisma.$transaction(async (tx) => {
       // CoA validation — each category must exist + be type "ค่าใช้จ่าย"
-      const codes = [...new Set(linesPrepared.map((l) => l.category))];
-      const coaRows = await tx.chartOfAccount.findMany({
-        where: { code: { in: codes }, deletedAt: null },
-        select: { code: true, type: true },
-      });
-      const byCode = new Map(coaRows.map((r) => [r.code, r.type]));
-      for (const c of codes) {
-        const t = byCode.get(c);
-        if (!t) throw new BadRequestException(`หมวดบัญชี ${c} ไม่พบในผังบัญชี`);
-        if (t !== 'ค่าใช้จ่าย') {
-          throw new BadRequestException(`หมวดบัญชี ${c} ไม่ใช่ "ค่าใช้จ่าย"`);
-        }
-      }
+      await assertCategoriesAreExpense(
+        tx,
+        linesPrepared.map((l) => l.category),
+      );
 
       const number = await this.docNumber.next(tx, 'PETTY_CASH_REIMBURSEMENT', documentDate);
 
@@ -1929,17 +1910,10 @@ export class ExpenseDocumentsService implements OnModuleInit {
         });
 
         // CoA validation — every category must exist + be type "ค่าใช้จ่าย"
-        const codes = [...new Set(linesPrepared.map((l) => l.category))];
-        const coaRows = await tx.chartOfAccount.findMany({
-          where: { code: { in: codes }, deletedAt: null },
-          select: { code: true, type: true },
-        });
-        const byCode = new Map(coaRows.map((r) => [r.code, r.type]));
-        for (const c of codes) {
-          const t = byCode.get(c);
-          if (!t) throw new BadRequestException(`หมวดบัญชี ${c} ไม่พบในผังบัญชี`);
-          if (t !== 'ค่าใช้จ่าย') throw new BadRequestException(`หมวดบัญชี ${c} ไม่ใช่ "ค่าใช้จ่าย"`);
-        }
+        await assertCategoriesAreExpense(
+          tx,
+          linesPrepared.map((l) => l.category),
+        );
 
         const totals = this.aggregator.aggregateLines(linesPrepared);
 

--- a/apps/api/src/modules/expense-documents/expense-validators.util.ts
+++ b/apps/api/src/modules/expense-documents/expense-validators.util.ts
@@ -89,3 +89,27 @@ export async function validateAdjustments(
     );
   }
 }
+
+/**
+ * Asserts every supplied category code exists in the chart of accounts and is of
+ * type "ค่าใช้จ่าย" (expense). Throws BadRequestException on the FIRST offending code
+ * (missing → ไม่พบในผังบัญชี; wrong type → ไม่ใช่ "ค่าใช้จ่าย"), preserving insertion
+ * order via Set dedup. Extracted verbatim from the 4 copies in ExpenseDocumentsService
+ * (create / createCreditNote / createPettyCash / update).
+ */
+export async function assertCategoriesAreExpense(
+  tx: Prisma.TransactionClient,
+  categories: string[],
+): Promise<void> {
+  const codes = [...new Set(categories)];
+  const coaRows = await tx.chartOfAccount.findMany({
+    where: { code: { in: codes }, deletedAt: null },
+    select: { code: true, type: true },
+  });
+  const byCode = new Map(coaRows.map((r) => [r.code, r.type]));
+  for (const c of codes) {
+    const t = byCode.get(c);
+    if (!t) throw new BadRequestException(`หมวดบัญชี ${c} ไม่พบในผังบัญชี`);
+    if (t !== 'ค่าใช้จ่าย') throw new BadRequestException(`หมวดบัญชี ${c} ไม่ใช่ "ค่าใช้จ่าย"`);
+  }
+}


### PR DESCRIPTION
## Expense-documents decompose — slice E3

**Behavior-preserving dedup.** The identical chart-of-accounts expense-type guard was copy-pasted in **4 methods** of `ExpenseDocumentsService` (`create`, `createCreditNote`, `createPettyCash`, `update`). Extracted verbatim into a shared `assertCategoriesAreExpense(tx, categories)` in `expense-validators.util.ts` (alongside E1's `validateAdjustments`); all 4 sites route through it. **No constructor change** (free function).

> Stacked on #1206 (E1, which created `expense-validators.util.ts`). Base auto-retargets to `main` once E1 merges.

### What's preserved (byte-faithful)
- Same first-offender throws: `หมวดบัญชี ${c} ไม่พบในผังบัญชี` (missing) / `หมวดบัญชี ${c} ไม่ใช่ "ค่าใช้จ่าย"` (wrong type).
- Same `[...new Set(categories)]` dedup → same insertion-order iteration → same first-failing code thrown.
- Same query `chartOfAccount.findMany({ where:{code:{in},deletedAt:null}, select:{code,type} })`.
- All 4 originals independently confirmed logically identical (only cosmetic comment/indent/single-vs-multiline `if` differed); `codes`/`coaRows`/`byCode` verified NOT reused downstream in any of the 4 methods, so the locals were safely removed.

### Changes
- **MOD** `expense-validators.util.ts` — `+assertCategoriesAreExpense` (reuses existing `BadRequestException`/`Prisma` imports).
- **MOD** `expense-documents.service.ts` — import extended; 4 inline guard blocks → `await assertCategoriesAreExpense(tx, linesPrepared.map((l) => l.category))` (service now has **0** copies of the guard; −48 net).
- **MOD** `__tests__/expense-validators.util.spec.ts` — `+describe('assertCategoriesAreExpense')` with 7 cases (happy/query-shape, missing→ไม่พบ, wrong-type→ไม่ใช่, dedup, first-offender ×2 incl. order, empty-array reality).

### Verification
- `./tools/check-types.sh api` → **API: OK**.
- `npm --prefix apps/api run test -- expense-documents` → **385 / 31 suites** (378 baseline on the E1 base + 7 new); integration guards (multi-line-create / credit-note CoA-type rejections) green via the routed helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)