### PR TITLE
refactor(expense-documents): extract pure collectJePreviewCodes + bkkBusinessDate helpers (E4+E5)

### DIFF
--- a/apps/api/src/modules/expense-documents/bkk-business-date.util.spec.ts
+++ b/apps/api/src/modules/expense-documents/bkk-business-date.util.spec.ts
@@ -1,0 +1,21 @@
+import { bkkBusinessDate } from './bkk-business-date.util';
+
+describe('bkkBusinessDate', () => {
+  it('maps a mid-day UTC instant to noon BKK (05:00:00.000Z) of the same date', () => {
+    // 2026-06-09 09:00 UTC = 2026-06-09 16:00 BKK → same BKK calendar day.
+    const out = bkkBusinessDate(new Date('2026-06-09T09:00:00.000Z'));
+    expect(out.toISOString()).toBe('2026-06-09T05:00:00.000Z');
+  });
+
+  it('rolls to the NEXT BKK calendar day for a UTC instant at/after 17:00 UTC', () => {
+    // 2026-06-09 18:30 UTC = 2026-06-10 01:30 BKK → next BKK calendar day.
+    const out = bkkBusinessDate(new Date('2026-06-09T18:30:00.000Z'));
+    expect(out.toISOString()).toBe('2026-06-10T05:00:00.000Z');
+  });
+
+  it('always pins the time to noon BKK = 05:00:00.000Z', () => {
+    const out = bkkBusinessDate(new Date('2026-12-31T23:59:59.999Z'));
+    // 23:59 UTC Dec 31 = 06:59 BKK Jan 1 → noon BKK Jan 1.
+    expect(out.toISOString()).toBe('2027-01-01T05:00:00.000Z');
+  });
+});

--- a/apps/api/src/modules/expense-documents/bkk-business-date.util.ts
+++ b/apps/api/src/modules/expense-documents/bkk-business-date.util.ts
@@ -1,0 +1,16 @@
+/**
+ * Returns a Date representing 12:00 noon Asia/Bangkok on the same calendar day
+ * as `now`. Used as a stable `postedAt` for journal entries that should land
+ * on the BKK business day regardless of the server's UTC clock — without this,
+ * a void after 17:00 BKK (= next UTC day) would post in the wrong accounting period.
+ */
+export function bkkBusinessDate(now: Date): Date {
+  const ymd = now.toLocaleString('en-CA', {
+    timeZone: 'Asia/Bangkok',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  });
+  // ymd is "YYYY-MM-DD" in BKK; build noon BKK = 05:00 UTC of the same date
+  return new Date(`${ymd}T05:00:00.000Z`);
+}

--- a/apps/api/src/modules/expense-documents/expense-documents.service.ts
+++ b/apps/api/src/modules/expense-documents/expense-documents.service.ts
@@ -42,23 +42,8 @@ import { PettyCashService } from './services/petty-cash.service';
 import { PayrollCustomService } from './services/payroll-custom.service';
 import { validatePeriodOpen } from '../../utils/period-lock.util';
 import { readBoolFlag, readJsonFlag } from '../../utils/config.util';
-
-/**
- * Returns a Date representing 12:00 noon Asia/Bangkok on the same calendar day
- * as `now`. Used as a stable `postedAt` for journal entries that should land
- * on the BKK business day regardless of the server's UTC clock — without this,
- * a void after 17:00 BKK (= next UTC day) would post in the wrong accounting period.
- */
-function bkkBusinessDate(now: Date): Date {
-  const ymd = now.toLocaleString('en-CA', {
-    timeZone: 'Asia/Bangkok',
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-  });
-  // ymd is "YYYY-MM-DD" in BKK; build noon BKK = 05:00 UTC of the same date
-  return new Date(`${ymd}T05:00:00.000Z`);
-}
+import { collectJePreviewCodes } from './je-preview-codes.util';
+import { bkkBusinessDate } from './bkk-business-date.util';
 
 @Injectable()
 export class ExpenseDocumentsService implements OnModuleInit {
@@ -1750,23 +1735,7 @@ export class ExpenseDocumentsService implements OnModuleInit {
 
   // ─── JE Preview (pure — no DB write) ────────────────────────────────
   async previewJe(dto: CreateExpenseDocumentDto) {
-    const codes = new Set<string>();
-    for (const l of dto.lines) codes.add(l.category);
-    if (dto.depositAccountCode) codes.add(dto.depositAccountCode);
-    // W8 — preload adjustment row codes + per-line WHT routes so the preview
-    // can resolve names for the new sections (adjustments + multi-line WHT).
-    for (const adj of dto.adjustments ?? []) {
-      if (adj.accountCode) codes.add(adj.accountCode);
-    }
-    // 11-4101 = ภาษีซื้อ (Input Tax Credit, claimable). Mirrors expense
-    // templates' VAT routing — must match what post() actually books.
-    codes.add('11-4101');
-    codes.add('21-1104');
-    // Always preload both WHT routes — the preview may emit either or both
-    // depending on per-line whtFormType (P2-4).
-    codes.add('21-3102');
-    codes.add('21-3103');
-
+    const codes = collectJePreviewCodes(dto);
     const rows = await this.prisma.chartOfAccount.findMany({
       where: { code: { in: [...codes] }, deletedAt: null },
       select: { code: true, name: true },

--- a/apps/api/src/modules/expense-documents/je-preview-codes.util.spec.ts
+++ b/apps/api/src/modules/expense-documents/je-preview-codes.util.spec.ts
@@ -1,0 +1,66 @@
+import { collectJePreviewCodes } from './je-preview-codes.util';
+import { CreateExpenseDocumentDto } from './dto/create.dto';
+
+// The 4 hardcoded codes collectJePreviewCodes always preloads (mirror post()).
+const HARDCODED = ['11-4101', '21-1104', '21-3102', '21-3103'];
+
+const dto = (partial: Partial<CreateExpenseDocumentDto>): CreateExpenseDocumentDto =>
+  ({ lines: [], ...partial }) as unknown as CreateExpenseDocumentDto;
+
+describe('collectJePreviewCodes', () => {
+  it('always includes the 4 hardcoded VAT/WHT-route codes', () => {
+    const codes = collectJePreviewCodes(dto({}));
+    for (const c of HARDCODED) expect(codes.has(c)).toBe(true);
+  });
+
+  it('includes every line category', () => {
+    const codes = collectJePreviewCodes(
+      dto({ lines: [{ category: '53-1101' }, { category: '53-1102' }] as never }),
+    );
+    expect(codes.has('53-1101')).toBe(true);
+    expect(codes.has('53-1102')).toBe(true);
+  });
+
+  it('includes depositAccountCode when present', () => {
+    const codes = collectJePreviewCodes(dto({ depositAccountCode: '11-1201' }));
+    expect(codes.has('11-1201')).toBe(true);
+  });
+
+  it('does NOT include depositAccountCode when absent/undefined', () => {
+    const codes = collectJePreviewCodes(dto({}));
+    // Only the 4 hardcoded codes when lines empty + no deposit + no adjustments.
+    expect([...codes].sort()).toEqual([...HARDCODED].sort());
+  });
+
+  it('includes every non-empty adjustments[].accountCode', () => {
+    const codes = collectJePreviewCodes(
+      dto({ adjustments: [{ accountCode: '52-1104' }, { accountCode: '53-1503' }] as never }),
+    );
+    expect(codes.has('52-1104')).toBe(true);
+    expect(codes.has('53-1503')).toBe(true);
+  });
+
+  it('skips empty/undefined adjustment accountCodes', () => {
+    const codes = collectJePreviewCodes(
+      dto({ adjustments: [{ accountCode: '' }, { accountCode: undefined }, {}] as never }),
+    );
+    expect(codes.has('')).toBe(false);
+    // Only the 4 hardcoded remain.
+    expect([...codes].sort()).toEqual([...HARDCODED].sort());
+  });
+
+  it('handles omitted adjustments (the ?? [] guard)', () => {
+    const codes = collectJePreviewCodes(dto({ lines: [{ category: '53-1101' }] as never }));
+    expect(codes.has('53-1101')).toBe(true);
+    expect([...codes].sort()).toEqual(['53-1101', ...HARDCODED].sort());
+  });
+
+  it('dedups a line category equal to a hardcoded code (appears once)', () => {
+    const codes = collectJePreviewCodes(
+      dto({ lines: [{ category: '11-4101' }, { category: '11-4101' }] as never }),
+    );
+    expect([...codes].filter((c) => c === '11-4101')).toHaveLength(1);
+    // Set still has exactly the 4 hardcoded (11-4101 is one of them).
+    expect([...codes].sort()).toEqual([...HARDCODED].sort());
+  });
+});

--- a/apps/api/src/modules/expense-documents/je-preview-codes.util.ts
+++ b/apps/api/src/modules/expense-documents/je-preview-codes.util.ts
@@ -1,0 +1,27 @@
+import { CreateExpenseDocumentDto } from './dto/create.dto';
+
+/**
+ * Pure account-code collection for the JE preview (E4 — extracted from
+ * ExpenseDocumentsService.previewJe). Builds the Set of chart-of-account codes
+ * whose names the preview must resolve, so the preview matches what post()
+ * actually books. No DB access — the caller does the findMany.
+ */
+export function collectJePreviewCodes(dto: CreateExpenseDocumentDto): Set<string> {
+  const codes = new Set<string>();
+  for (const l of dto.lines) codes.add(l.category);
+  if (dto.depositAccountCode) codes.add(dto.depositAccountCode);
+  // W8 — preload adjustment row codes + per-line WHT routes so the preview
+  // can resolve names for the new sections (adjustments + multi-line WHT).
+  for (const adj of dto.adjustments ?? []) {
+    if (adj.accountCode) codes.add(adj.accountCode);
+  }
+  // 11-4101 = ภาษีซื้อ (Input Tax Credit, claimable). Mirrors expense
+  // templates' VAT routing — must match what post() actually books.
+  codes.add('11-4101');
+  codes.add('21-1104');
+  // Always preload both WHT routes — the preview may emit either or both
+  // depending on per-line whtFormType (P2-4).
+  codes.add('21-3102');
+  codes.add('21-3103');
+  return codes;
+}


### PR DESCRIPTION
## Expense-documents decompose — slices E4 + E5 (bundled)

Two **behavior-preserving** pure-function extractions, no constructor change.

> Stacked on #1208 (E3) → #1206 (E1). Bases auto-retarget to `main` as the chain merges.

### E4 — `collectJePreviewCodes`
The pure account-code Set-building inside `previewJe` → new `je-preview-codes.util.ts`. `previewJe` now: `collectJePreviewCodes(dto)` → same `chartOfAccount.findMany` → same `accountNames` map → `jePreview.preview(dto, accountNames)`. **Set contents byte-identical** (every line category, `depositAccountCode` when present, non-empty adjustment codes, + the 4 hardcoded `11-4101`/`21-1104`/`21-3102`/`21-3103`, same order; W8 + VAT-route comments moved verbatim).

### E5 — `bkkBusinessDate`
The top-level noon-BKK date helper (timezone-safe `postedAt` for journal entries) → new module-local `bkk-business-date.util.ts`; the 2 `voidDocument` call sites import it; the service's copy is deleted. **Date math byte-identical** (`en-CA`/`Asia/Bangkok` → `${ymd}T05:00:00.000Z`). Home check: `thai-date.util.ts` has only Thai-text formatters (no `Date`-returning noon-BKK helper) → new file is correct, no missed dedup. (If a second consumer of noon-pinned-BKK emerges, promote to shared `utils/date.util.ts` then.)

### Changes
- **MOD** `expense-documents.service.ts` — `previewJe` calls the helper; top-level `bkkBusinessDate` removed + imported; 2 call sites updated.
- **NEW** `je-preview-codes.util.ts` (+ spec, 8 cases: hardcoded-4, deposit present/absent, empty/omitted adjustments, dedup).
- **NEW** `bkk-business-date.util.ts` (+ spec, 3 cases: noon-pin, mid-day same-day, ≥17:00 UTC next-day rollover, year-end rollover).

### Verification
- `./tools/check-types.sh api` → **API: OK**.
- `npm --prefix apps/api run test -- expense-documents` → **396 / 33 suites** (385 baseline + 11 new); `previewJe` + `voidDocument` tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)