### PR TITLE
refactor(expense-documents): extract approval-config helpers into approval-config.util (E6)

### DIFF
--- a/apps/api/src/modules/expense-documents/__tests__/approval-config.util.spec.ts
+++ b/apps/api/src/modules/expense-documents/__tests__/approval-config.util.spec.ts
@@ -1,0 +1,159 @@
+import { ForbiddenException } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import { PrismaService } from '../../../prisma/prisma.service';
+import {
+  assertUserCanApprove,
+  getApprovalRequiredDocTypes,
+  getApproversList,
+  getReverseReasons,
+} from '../approval-config.util';
+
+/**
+ * Characterization spec for approval-config.util — pins the CURRENT behaviour
+ * of the 4 free functions extracted out of ExpenseDocumentsService (slice E6).
+ * Pure unit: tx is a mock with `systemConfig.findFirst` + `user.findMany`.
+ */
+
+type MockTx = {
+  systemConfig: { findFirst: jest.Mock };
+  user: { findMany: jest.Mock };
+};
+
+function makeTx(): MockTx {
+  return {
+    systemConfig: { findFirst: jest.fn() },
+    user: { findMany: jest.fn() },
+  };
+}
+
+// Cast the mock to the union type accepted by the util functions.
+const asClient = (tx: MockTx) => tx as unknown as Prisma.TransactionClient | PrismaService;
+
+describe('approval-config.util', () => {
+  let tx: MockTx;
+
+  beforeEach(() => {
+    tx = makeTx();
+  });
+
+  describe('getApproversList', () => {
+    it('returns [] when the SystemConfig row is missing', async () => {
+      tx.systemConfig.findFirst.mockResolvedValue(null);
+      await expect(getApproversList(asClient(tx))).resolves.toEqual([]);
+      expect(tx.user.findMany).not.toHaveBeenCalled();
+    });
+
+    it('filters a valid JSON list to active/non-deleted users', async () => {
+      tx.systemConfig.findFirst.mockResolvedValue({ value: '["u1","u2"]' });
+      // user.findMany returns only u1 (u2 inactive/deleted → filtered out by query)
+      tx.user.findMany.mockResolvedValue([{ id: 'u1' }]);
+      await expect(getApproversList(asClient(tx))).resolves.toEqual(['u1']);
+      expect(tx.user.findMany).toHaveBeenCalledWith({
+        where: { id: { in: ['u1', 'u2'] }, isActive: true, deletedAt: null },
+        select: { id: true },
+      });
+    });
+
+    it('returns [] on malformed JSON', async () => {
+      tx.systemConfig.findFirst.mockResolvedValue({ value: 'not-json' });
+      await expect(getApproversList(asClient(tx))).resolves.toEqual([]);
+      expect(tx.user.findMany).not.toHaveBeenCalled();
+    });
+
+    it('returns [] when the parsed value is not an array', async () => {
+      tx.systemConfig.findFirst.mockResolvedValue({ value: '{"foo":"bar"}' });
+      await expect(getApproversList(asClient(tx))).resolves.toEqual([]);
+      expect(tx.user.findMany).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('assertUserCanApprove', () => {
+    it('resolves for OWNER WITHOUT querying approvers (fast path)', async () => {
+      await expect(
+        assertUserCanApprove(asClient(tx), 'someone', 'OWNER'),
+      ).resolves.toBeUndefined();
+      expect(tx.systemConfig.findFirst).not.toHaveBeenCalled();
+    });
+
+    it('resolves for a non-OWNER user who is IN the approvers list', async () => {
+      tx.systemConfig.findFirst.mockResolvedValue({ value: '["u1"]' });
+      tx.user.findMany.mockResolvedValue([{ id: 'u1' }]);
+      await expect(
+        assertUserCanApprove(asClient(tx), 'u1', 'ACCOUNTANT'),
+      ).resolves.toBeUndefined();
+    });
+
+    it('throws ForbiddenException with the exact Thai message when NOT in the list', async () => {
+      tx.systemConfig.findFirst.mockResolvedValue({ value: '["u1"]' });
+      tx.user.findMany.mockResolvedValue([{ id: 'u1' }]);
+      await expect(
+        assertUserCanApprove(asClient(tx), 'u2', 'ACCOUNTANT'),
+      ).rejects.toThrow(ForbiddenException);
+      await expect(
+        assertUserCanApprove(asClient(tx), 'u2', 'ACCOUNTANT'),
+      ).rejects.toThrow('ไม่มีสิทธิ์อนุมัติเอกสาร — ผู้ใช้นี้ไม่อยู่ในรายชื่อผู้อนุมัติ');
+    });
+  });
+
+  describe('getApprovalRequiredDocTypes', () => {
+    it("returns ['PAYROLL'] when the row is missing", async () => {
+      tx.systemConfig.findFirst.mockResolvedValue(null);
+      await expect(getApprovalRequiredDocTypes(asClient(tx))).resolves.toEqual(['PAYROLL']);
+    });
+
+    it('returns the valid list verbatim', async () => {
+      tx.systemConfig.findFirst.mockResolvedValue({ value: '["PAYROLL","EXPENSE"]' });
+      await expect(getApprovalRequiredDocTypes(asClient(tx))).resolves.toEqual([
+        'PAYROLL',
+        'EXPENSE',
+      ]);
+    });
+
+    it('filters out invalid enum values', async () => {
+      tx.systemConfig.findFirst.mockResolvedValue({
+        value: '["EXPENSE","BOGUS","CREDIT_NOTE"]',
+      });
+      await expect(getApprovalRequiredDocTypes(asClient(tx))).resolves.toEqual([
+        'EXPENSE',
+        'CREDIT_NOTE',
+      ]);
+    });
+
+    it("returns ['PAYROLL'] when all values are invalid", async () => {
+      tx.systemConfig.findFirst.mockResolvedValue({ value: '["BOGUS","NOPE"]' });
+      await expect(getApprovalRequiredDocTypes(asClient(tx))).resolves.toEqual(['PAYROLL']);
+    });
+
+    it("returns ['PAYROLL'] for an empty array", async () => {
+      tx.systemConfig.findFirst.mockResolvedValue({ value: '[]' });
+      await expect(getApprovalRequiredDocTypes(asClient(tx))).resolves.toEqual(['PAYROLL']);
+    });
+
+    it("returns ['PAYROLL'] on malformed JSON", async () => {
+      tx.systemConfig.findFirst.mockResolvedValue({ value: 'not-json' });
+      await expect(getApprovalRequiredDocTypes(asClient(tx))).resolves.toEqual(['PAYROLL']);
+    });
+  });
+
+  describe('getReverseReasons', () => {
+    it('returns the 6 canonical defaults when the row is missing', async () => {
+      tx.systemConfig.findFirst.mockResolvedValue(null);
+      const reasons = await getReverseReasons(asClient(tx));
+      expect(reasons).toHaveLength(6);
+      expect(reasons.map((r) => r.code)).toContain('data_entry_error');
+    });
+
+    it('returns a valid custom array verbatim', async () => {
+      const custom = [{ code: 'oops', label: 'พิมพ์ผิด' }];
+      tx.systemConfig.findFirst.mockResolvedValue({ value: JSON.stringify(custom) });
+      await expect(getReverseReasons(asClient(tx))).resolves.toEqual(custom);
+    });
+
+    it('falls back to the 6 defaults on malformed JSON', async () => {
+      tx.systemConfig.findFirst.mockResolvedValue({ value: 'not-json' });
+      const reasons = await getReverseReasons(asClient(tx));
+      expect(reasons).toHaveLength(6);
+      expect(reasons.map((r) => r.code)).toContain('data_entry_error');
+    });
+  });
+});

--- a/apps/api/src/modules/expense-documents/approval-config.util.ts
+++ b/apps/api/src/modules/expense-documents/approval-config.util.ts
@@ -1,0 +1,127 @@
+import { ForbiddenException } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import { PrismaService } from '../../prisma/prisma.service';
+import { readJsonFlag } from '../../utils/config.util';
+
+/**
+ * D1.2.1.3 — Approvers whitelist. JSON-encoded array of User UUIDs stored
+ * in SystemConfig key `approvers_list`. Default = empty array (only OWNER
+ * may approve when the workflow is enabled but no list is configured).
+ *
+ * Returns the list filtered to USERS that still exist + are active +
+ * not soft-deleted — so a stale ID in the SystemConfig row can never
+ * grant approval rights to a deleted account.
+ */
+export async function getApproversList(
+  tx: Prisma.TransactionClient | PrismaService,
+): Promise<string[]> {
+  try {
+    const row = await tx.systemConfig.findFirst({
+      where: { key: 'approvers_list', deletedAt: null },
+      select: { value: true },
+    });
+    if (!row?.value) return [];
+    const parsed: unknown = JSON.parse(row.value);
+    if (!Array.isArray(parsed)) return [];
+    const candidateIds = parsed.filter((v): v is string => typeof v === 'string');
+    if (candidateIds.length === 0) return [];
+    const valid = await tx.user.findMany({
+      where: { id: { in: candidateIds }, isActive: true, deletedAt: null },
+      select: { id: true },
+    });
+    return valid.map((u) => u.id);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * D1.2.1.3 — Approver gate. OWNER is always allowed (root-of-trust).
+ * Anyone else must be in the configured `approvers_list`. Throws
+ * `ForbiddenException` when the caller cannot approve.
+ */
+export async function assertUserCanApprove(
+  tx: Prisma.TransactionClient | PrismaService,
+  userId: string,
+  userRole?: string,
+): Promise<void> {
+  if (userRole === 'OWNER') return;
+  const approvers = await getApproversList(tx);
+  if (!approvers.includes(userId)) {
+    throw new ForbiddenException(
+      'ไม่มีสิทธิ์อนุมัติเอกสาร — ผู้ใช้นี้ไม่อยู่ในรายชื่อผู้อนุมัติ',
+    );
+  }
+}
+
+/**
+ * D1.2.1.4 — Doc-type filter for the Approval Workflow gate. JSON-encoded
+ * array of DocumentType enum values stored in SystemConfig key
+ * `approval_required_doc_types`. Default = `['PAYROLL']` — the most
+ * common controlled-cost category. Other doc types skip approval even
+ * when `approval_enabled` is true.
+ *
+ * Returns the set as a parsed array, defaulting to ['PAYROLL'] when the
+ * row is missing / malformed / contains invalid enum values.
+ */
+export async function getApprovalRequiredDocTypes(
+  tx: Prisma.TransactionClient | PrismaService,
+): Promise<string[]> {
+  const defaults: string[] = ['PAYROLL'];
+  const validValues: string[] = [
+    'EXPENSE',
+    'CREDIT_NOTE',
+    'PAYROLL',
+    'VENDOR_SETTLEMENT',
+    'PETTY_CASH_REIMBURSEMENT',
+  ];
+  try {
+    const row = await tx.systemConfig.findFirst({
+      where: { key: 'approval_required_doc_types', deletedAt: null },
+      select: { value: true },
+    });
+    if (!row?.value) return defaults;
+    const parsed: unknown = JSON.parse(row.value);
+    if (!Array.isArray(parsed) || parsed.length === 0) return defaults;
+    const filtered = parsed.filter(
+      (v): v is string => typeof v === 'string' && validValues.includes(v),
+    );
+    return filtered.length > 0 ? filtered : defaults;
+  } catch {
+    return defaults;
+  }
+}
+
+/**
+ * D1.2.7.2 — reverse-reasons whitelist. Uses shared `readJsonFlag` for
+ * uniform JSON-parse + validator semantics. Empty / malformed lists fall
+ * back to the canonical 6-reason default so the UI never shows an empty
+ * dropdown.
+ */
+export async function getReverseReasons(
+  tx: Prisma.TransactionClient | PrismaService,
+): Promise<{ code: string; label: string }[]> {
+  const defaults: { code: string; label: string }[] = [
+    { code: 'data_entry_error', label: 'ป้อนข้อมูลผิด' },
+    { code: 'wrong_vendor', label: 'ผู้ขายผิด' },
+    { code: 'wrong_amount', label: 'จำนวนเงินผิด' },
+    { code: 'duplicate_entry', label: 'ข้อมูลซ้ำ' },
+    { code: 'cancel_transaction', label: 'ยกเลิกรายการ' },
+    { code: 'other', label: 'อื่นๆ (ระบุรายละเอียด)' },
+  ];
+  return readJsonFlag<{ code: string; label: string }[]>(
+    tx,
+    'reverse_reasons',
+    defaults,
+    (v): v is { code: string; label: string }[] =>
+      Array.isArray(v) &&
+      v.length > 0 &&
+      v.every(
+        (r) =>
+          r != null &&
+          typeof r === 'object' &&
+          typeof (r as { code: unknown }).code === 'string' &&
+          typeof (r as { label: unknown }).label === 'string',
+      ),
+  );
+}

--- a/apps/api/src/modules/expense-documents/expense-documents.service.ts
+++ b/apps/api/src/modules/expense-documents/expense-documents.service.ts
@@ -41,9 +41,15 @@ import { NotificationsService } from '../notifications/notifications.service';
 import { PettyCashService } from './services/petty-cash.service';
 import { PayrollCustomService } from './services/payroll-custom.service';
 import { validatePeriodOpen } from '../../utils/period-lock.util';
-import { readBoolFlag, readJsonFlag } from '../../utils/config.util';
+import { readBoolFlag } from '../../utils/config.util';
 import { collectJePreviewCodes } from './je-preview-codes.util';
 import { bkkBusinessDate } from './bkk-business-date.util';
+import {
+  assertUserCanApprove,
+  getApprovalRequiredDocTypes,
+  getApproversList,
+  getReverseReasons,
+} from './approval-config.util';
 
 @Injectable()
 export class ExpenseDocumentsService implements OnModuleInit {
@@ -127,7 +133,7 @@ export class ExpenseDocumentsService implements OnModuleInit {
       if (!this.notifications) return;
 
       // Resolve recipients: approvers_list → fallback to OWNER users.
-      let recipients = await this.getApproversList(this.prisma);
+      let recipients = await getApproversList(this.prisma);
       if (recipients.length === 0) {
         const owners = await this.prisma.user.findMany({
           where: { role: 'OWNER', isActive: true, deletedAt: null },
@@ -163,7 +169,7 @@ export class ExpenseDocumentsService implements OnModuleInit {
   }
 
   // ─── D1.* — Service-side SystemConfig flag readers ─────────────────────
-  // Delegates to shared `readBoolFlag` / `readJsonFlag` in utils/config.util
+  // Delegates to shared `readBoolFlag` in utils/config.util
   // so every service uses identical parsing + defensive try/catch semantics.
   // Kept as private wrappers for ergonomic (this.readBoolFlag) call sites.
   // Spec-defined defaults flow through `fallback` and preserve first-boot
@@ -174,95 +180,6 @@ export class ExpenseDocumentsService implements OnModuleInit {
     fallback: boolean,
   ): Promise<boolean> {
     return readBoolFlag(tx, key, fallback);
-  }
-
-  /**
-   * D1.2.1.3 — Approvers whitelist. JSON-encoded array of User UUIDs stored
-   * in SystemConfig key `approvers_list`. Default = empty array (only OWNER
-   * may approve when the workflow is enabled but no list is configured).
-   *
-   * Returns the list filtered to USERS that still exist + are active +
-   * not soft-deleted — so a stale ID in the SystemConfig row can never
-   * grant approval rights to a deleted account.
-   */
-  private async getApproversList(
-    tx: Prisma.TransactionClient | PrismaService,
-  ): Promise<string[]> {
-    try {
-      const row = await tx.systemConfig.findFirst({
-        where: { key: 'approvers_list', deletedAt: null },
-        select: { value: true },
-      });
-      if (!row?.value) return [];
-      const parsed: unknown = JSON.parse(row.value);
-      if (!Array.isArray(parsed)) return [];
-      const candidateIds = parsed.filter((v): v is string => typeof v === 'string');
-      if (candidateIds.length === 0) return [];
-      const valid = await tx.user.findMany({
-        where: { id: { in: candidateIds }, isActive: true, deletedAt: null },
-        select: { id: true },
-      });
-      return valid.map((u) => u.id);
-    } catch {
-      return [];
-    }
-  }
-
-  /**
-   * D1.2.1.3 — Approver gate. OWNER is always allowed (root-of-trust).
-   * Anyone else must be in the configured `approvers_list`. Throws
-   * `ForbiddenException` when the caller cannot approve.
-   */
-  private async assertUserCanApprove(
-    tx: Prisma.TransactionClient | PrismaService,
-    userId: string,
-    userRole?: string,
-  ): Promise<void> {
-    if (userRole === 'OWNER') return;
-    const approvers = await this.getApproversList(tx);
-    if (!approvers.includes(userId)) {
-      throw new ForbiddenException(
-        'ไม่มีสิทธิ์อนุมัติเอกสาร — ผู้ใช้นี้ไม่อยู่ในรายชื่อผู้อนุมัติ',
-      );
-    }
-  }
-
-  /**
-   * D1.2.1.4 — Doc-type filter for the Approval Workflow gate. JSON-encoded
-   * array of DocumentType enum values stored in SystemConfig key
-   * `approval_required_doc_types`. Default = `['PAYROLL']` — the most
-   * common controlled-cost category. Other doc types skip approval even
-   * when `approval_enabled` is true.
-   *
-   * Returns the set as a parsed array, defaulting to ['PAYROLL'] when the
-   * row is missing / malformed / contains invalid enum values.
-   */
-  private async getApprovalRequiredDocTypes(
-    tx: Prisma.TransactionClient | PrismaService,
-  ): Promise<string[]> {
-    const defaults: string[] = ['PAYROLL'];
-    const validValues: string[] = [
-      'EXPENSE',
-      'CREDIT_NOTE',
-      'PAYROLL',
-      'VENDOR_SETTLEMENT',
-      'PETTY_CASH_REIMBURSEMENT',
-    ];
-    try {
-      const row = await tx.systemConfig.findFirst({
-        where: { key: 'approval_required_doc_types', deletedAt: null },
-        select: { value: true },
-      });
-      if (!row?.value) return defaults;
-      const parsed: unknown = JSON.parse(row.value);
-      if (!Array.isArray(parsed) || parsed.length === 0) return defaults;
-      const filtered = parsed.filter(
-        (v): v is string => typeof v === 'string' && validValues.includes(v),
-      );
-      return filtered.length > 0 ? filtered : defaults;
-    } catch {
-      return defaults;
-    }
   }
 
   /**
@@ -318,40 +235,6 @@ export class ExpenseDocumentsService implements OnModuleInit {
     } catch {
       return fallback;
     }
-  }
-
-  /**
-   * D1.2.7.2 — reverse-reasons whitelist. Uses shared `readJsonFlag` for
-   * uniform JSON-parse + validator semantics. Empty / malformed lists fall
-   * back to the canonical 6-reason default so the UI never shows an empty
-   * dropdown.
-   */
-  private async getReverseReasons(
-    tx: Prisma.TransactionClient | PrismaService,
-  ): Promise<{ code: string; label: string }[]> {
-    const defaults: { code: string; label: string }[] = [
-      { code: 'data_entry_error', label: 'ป้อนข้อมูลผิด' },
-      { code: 'wrong_vendor', label: 'ผู้ขายผิด' },
-      { code: 'wrong_amount', label: 'จำนวนเงินผิด' },
-      { code: 'duplicate_entry', label: 'ข้อมูลซ้ำ' },
-      { code: 'cancel_transaction', label: 'ยกเลิกรายการ' },
-      { code: 'other', label: 'อื่นๆ (ระบุรายละเอียด)' },
-    ];
-    return readJsonFlag<{ code: string; label: string }[]>(
-      tx,
-      'reverse_reasons',
-      defaults,
-      (v): v is { code: string; label: string }[] =>
-        Array.isArray(v) &&
-        v.length > 0 &&
-        v.every(
-          (r) =>
-            r != null &&
-            typeof r === 'object' &&
-            typeof (r as { code: unknown }).code === 'string' &&
-            typeof (r as { label: unknown }).label === 'string',
-        ),
-    );
   }
 
   // ─── Create ──────────────────────────────────────────────────────────
@@ -2055,7 +1938,7 @@ export class ExpenseDocumentsService implements OnModuleInit {
         // Reads SystemConfig key `approval_required_doc_types` (JSON array),
         // filters to valid DocumentType enum values, defaults to ['PAYROLL']
         // on missing/malformed rows.
-        const requiredDocTypes = await this.getApprovalRequiredDocTypes(tx);
+        const requiredDocTypes = await getApprovalRequiredDocTypes(tx);
         const isRequiredType = requiredDocTypes.includes(doc.documentType);
 
         if (overThreshold || isRequiredType) {
@@ -2291,7 +2174,7 @@ export class ExpenseDocumentsService implements OnModuleInit {
 
       // D1.2.1.3 — approver membership check. OWNER always passes; everyone
       // else must appear in SystemConfig `approvers_list`.
-      await this.assertUserCanApprove(tx, userId, userRole);
+      await assertUserCanApprove(tx, userId, userRole);
 
       const doc = await tx.expenseDocument.findUniqueOrThrow({ where: { id } });
       if (doc.deletedAt) throw new NotFoundException('เอกสารถูกลบแล้ว');
@@ -2432,7 +2315,7 @@ export class ExpenseDocumentsService implements OnModuleInit {
       // codes). Validate dto.reasonCode against the configured whitelist
       // when present. OWNER can extend/override the list via SettingsService.
       if (dto.reasonCode?.trim()) {
-        const reasons = await this.getReverseReasons(tx);
+        const reasons = await getReverseReasons(tx);
         const allowed = new Set(reasons.map((r) => r.code));
         if (!allowed.has(dto.reasonCode)) {
           throw new BadRequestException(


### PR DESCRIPTION
## Expense-documents decompose — slice E6 (final safe slice)

**Behavior-preserving.** Moves the 4 approval/reverse-workflow SystemConfig helpers out of `ExpenseDocumentsService` into a new `approval-config.util.ts` as exported **free functions** (they take `tx`/`prisma`, no `this.X` → no constructor change).

> Stacked on #1209 (E4+E5) → #1208 (E3) → #1206 (E1). Bases auto-retarget to `main` as the chain merges.

### Moved (verbatim — byte-identical, independently verified)
- `getApproversList(tx)` — reads `approvers_list`, filters to active users.
- `assertUserCanApprove(tx, userId, userRole?)` — **OWNER fast-path preserved** (returns before any query); throws `ForbiddenException('ไม่มีสิทธิ์อนุมัติเอกสาร — ผู้ใช้นี้ไม่อยู่ในรายชื่อผู้อนุมัติ')` verbatim.
- `getApprovalRequiredDocTypes(tx)` — enum-validated, default `['PAYROLL']`.
- `getReverseReasons(tx)` — `readJsonFlag` + the 6 canonical defaults verbatim.

### Changes
- **NEW** `approval-config.util.ts` — 4 free functions (imports only `ForbiddenException`, `Prisma`, `PrismaService`, `readJsonFlag`). `assertUserCanApprove` calls the free `getApproversList`.
- **MOD** `expense-documents.service.ts` — 4 methods deleted; import added; 4 call sites rewired (`notifyApprovers`/`post`/`approve`/`voidDocument`, 0 stray `this.`); now-unused `readJsonFlag` import narrowed out (kept `readBoolFlag`/`ForbiddenException`, still used); stale flag-reader comment corrected.
- **NEW** `__tests__/approval-config.util.spec.ts` — 16 characterization cases (OWNER no-query fast-path, active-user filtering, enum filtering, malformed→default, exact messages/defaults).
- **`SettingsService` untouched** — its `getReverseReasons` is a *different* method (reads a `ReverseReason` admin table first), not a duplicate.

### Verification
- `./tools/check-types.sh api` → **API: OK**.
- `npm --prefix apps/api run test -- expense-documents` → **412 / 34 suites** (396 baseline + 16 new); approval-workflow integration tests green via the rewired free functions.

> **Completes the "safe set" of the expense-documents decompose** (E1–E6). What remains (~2,000 LOC transactional core: create*/post/approve/void/update + read-query methods) is a larger architectural decomposition needing its own plan + owner direction — not quick util-extractions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)