### PR TITLE
refactor(expense-documents): re-land E4/E5/E6 (recover dropped stacked merge)

### DIFF
--- a/apps/api/src/modules/expense-documents/__tests__/approval-config.util.spec.ts
+++ b/apps/api/src/modules/expense-documents/__tests__/approval-config.util.spec.ts
@@ -1,0 +1,159 @@
+import { ForbiddenException } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import { PrismaService } from '../../../prisma/prisma.service';
+import {
+  assertUserCanApprove,
+  getApprovalRequiredDocTypes,
+  getApproversList,
+  getReverseReasons,
+} from '../approval-config.util';
+
+/**
+ * Characterization spec for approval-config.util — pins the CURRENT behaviour
+ * of the 4 free functions extracted out of ExpenseDocumentsService (slice E6).
+ * Pure unit: tx is a mock with `systemConfig.findFirst` + `user.findMany`.
+ */
+
+type MockTx = {
+  systemConfig: { findFirst: jest.Mock };
+  user: { findMany: jest.Mock };
+};
+
+function makeTx(): MockTx {
+  return {
+    systemConfig: { findFirst: jest.fn() },
+    user: { findMany: jest.fn() },
+  };
+}
+
+// Cast the mock to the union type accepted by the util functions.
+const asClient = (tx: MockTx) => tx as unknown as Prisma.TransactionClient | PrismaService;
+
+describe('approval-config.util', () => {
+  let tx: MockTx;
+
+  beforeEach(() => {
+    tx = makeTx();
+  });
+
+  describe('getApproversList', () => {
+    it('returns [] when the SystemConfig row is missing', async () => {
+      tx.systemConfig.findFirst.mockResolvedValue(null);
+      await expect(getApproversList(asClient(tx))).resolves.toEqual([]);
+      expect(tx.user.findMany).not.toHaveBeenCalled();
+    });
+
+    it('filters a valid JSON list to active/non-deleted users', async () => {
+      tx.systemConfig.findFirst.mockResolvedValue({ value: '["u1","u2"]' });
+      // user.findMany returns only u1 (u2 inactive/deleted → filtered out by query)
+      tx.user.findMany.mockResolvedValue([{ id: 'u1' }]);
+      await expect(getApproversList(asClient(tx))).resolves.toEqual(['u1']);
+      expect(tx.user.findMany).toHaveBeenCalledWith({
+        where: { id: { in: ['u1', 'u2'] }, isActive: true, deletedAt: null },
+        select: { id: true },
+      });
+    });
+
+    it('returns [] on malformed JSON', async () => {
+      tx.systemConfig.findFirst.mockResolvedValue({ value: 'not-json' });
+      await expect(getApproversList(asClient(tx))).resolves.toEqual([]);
+      expect(tx.user.findMany).not.toHaveBeenCalled();
+    });
+
+    it('returns [] when the parsed value is not an array', async () => {
+      tx.systemConfig.findFirst.mockResolvedValue({ value: '{"foo":"bar"}' });
+      await expect(getApproversList(asClient(tx))).resolves.toEqual([]);
+      expect(tx.user.findMany).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('assertUserCanApprove', () => {
+    it('resolves for OWNER WITHOUT querying approvers (fast path)', async () => {
+      await expect(
+        assertUserCanApprove(asClient(tx), 'someone', 'OWNER'),
+      ).resolves.toBeUndefined();
+      expect(tx.systemConfig.findFirst).not.toHaveBeenCalled();
+    });
+
+    it('resolves for a non-OWNER user who is IN the approvers list', async () => {
+      tx.systemConfig.findFirst.mockResolvedValue({ value: '["u1"]' });
+      tx.user.findMany.mockResolvedValue([{ id: 'u1' }]);
+      await expect(
+        assertUserCanApprove(asClient(tx), 'u1', 'ACCOUNTANT'),
+      ).resolves.toBeUndefined();
+    });
+
+    it('throws ForbiddenException with the exact Thai message when NOT in the list', async () => {
+      tx.systemConfig.findFirst.mockResolvedValue({ value: '["u1"]' });
+      tx.user.findMany.mockResolvedValue([{ id: 'u1' }]);
+      await expect(
+        assertUserCanApprove(asClient(tx), 'u2', 'ACCOUNTANT'),
+      ).rejects.toThrow(ForbiddenException);
+      await expect(
+        assertUserCanApprove(asClient(tx), 'u2', 'ACCOUNTANT'),
+      ).rejects.toThrow('ไม่มีสิทธิ์อนุมัติเอกสาร — ผู้ใช้นี้ไม่อยู่ในรายชื่อผู้อนุมัติ');
+    });
+  });
+
+  describe('getApprovalRequiredDocTypes', () => {
+    it("returns ['PAYROLL'] when the row is missing", async () => {
+      tx.systemConfig.findFirst.mockResolvedValue(null);
+      await expect(getApprovalRequiredDocTypes(asClient(tx))).resolves.toEqual(['PAYROLL']);
+    });
+
+    it('returns the valid list verbatim', async () => {
+      tx.systemConfig.findFirst.mockResolvedValue({ value: '["PAYROLL","EXPENSE"]' });
+      await expect(getApprovalRequiredDocTypes(asClient(tx))).resolves.toEqual([
+        'PAYROLL',
+        'EXPENSE',
+      ]);
+    });
+
+    it('filters out invalid enum values', async () => {
+      tx.systemConfig.findFirst.mockResolvedValue({
+        value: '["EXPENSE","BOGUS","CREDIT_NOTE"]',
+      });
+      await expect(getApprovalRequiredDocTypes(asClient(tx))).resolves.toEqual([
+        'EXPENSE',
+        'CREDIT_NOTE',
+      ]);
+    });
+
+    it("returns ['PAYROLL'] when all values are invalid", async () => {
+      tx.systemConfig.findFirst.mockResolvedValue({ value: '["BOGUS","NOPE"]' });
+      await expect(getApprovalRequiredDocTypes(asClient(tx))).resolves.toEqual(['PAYROLL']);
+    });
+
+    it("returns ['PAYROLL'] for an empty array", async () => {
+      tx.systemConfig.findFirst.mockResolvedValue({ value: '[]' });
+      await expect(getApprovalRequiredDocTypes(asClient(tx))).resolves.toEqual(['PAYROLL']);
+    });
+
+    it("returns ['PAYROLL'] on malformed JSON", async () => {
+      tx.systemConfig.findFirst.mockResolvedValue({ value: 'not-json' });
+      await expect(getApprovalRequiredDocTypes(asClient(tx))).resolves.toEqual(['PAYROLL']);
+    });
+  });
+
+  describe('getReverseReasons', () => {
+    it('returns the 6 canonical defaults when the row is missing', async () => {
+      tx.systemConfig.findFirst.mockResolvedValue(null);
+      const reasons = await getReverseReasons(asClient(tx));
+      expect(reasons).toHaveLength(6);
+      expect(reasons.map((r) => r.code)).toContain('data_entry_error');
+    });
+
+    it('returns a valid custom array verbatim', async () => {
+      const custom = [{ code: 'oops', label: 'พิมพ์ผิด' }];
+      tx.systemConfig.findFirst.mockResolvedValue({ value: JSON.stringify(custom) });
+      await expect(getReverseReasons(asClient(tx))).resolves.toEqual(custom);
+    });
+
+    it('falls back to the 6 defaults on malformed JSON', async () => {
+      tx.systemConfig.findFirst.mockResolvedValue({ value: 'not-json' });
+      const reasons = await getReverseReasons(asClient(tx));
+      expect(reasons).toHaveLength(6);
+      expect(reasons.map((r) => r.code)).toContain('data_entry_error');
+    });
+  });
+});

--- a/apps/api/src/modules/expense-documents/approval-config.util.ts
+++ b/apps/api/src/modules/expense-documents/approval-config.util.ts
@@ -1,0 +1,127 @@
+import { ForbiddenException } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import { PrismaService } from '../../prisma/prisma.service';
+import { readJsonFlag } from '../../utils/config.util';
+
+/**
+ * D1.2.1.3 — Approvers whitelist. JSON-encoded array of User UUIDs stored
+ * in SystemConfig key `approvers_list`. Default = empty array (only OWNER
+ * may approve when the workflow is enabled but no list is configured).
+ *
+ * Returns the list filtered to USERS that still exist + are active +
+ * not soft-deleted — so a stale ID in the SystemConfig row can never
+ * grant approval rights to a deleted account.
+ */
+export async function getApproversList(
+  tx: Prisma.TransactionClient | PrismaService,
+): Promise<string[]> {
+  try {
+    const row = await tx.systemConfig.findFirst({
+      where: { key: 'approvers_list', deletedAt: null },
+      select: { value: true },
+    });
+    if (!row?.value) return [];
+    const parsed: unknown = JSON.parse(row.value);
+    if (!Array.isArray(parsed)) return [];
+    const candidateIds = parsed.filter((v): v is string => typeof v === 'string');
+    if (candidateIds.length === 0) return [];
+    const valid = await tx.user.findMany({
+      where: { id: { in: candidateIds }, isActive: true, deletedAt: null },
+      select: { id: true },
+    });
+    return valid.map((u) => u.id);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * D1.2.1.3 — Approver gate. OWNER is always allowed (root-of-trust).
+ * Anyone else must be in the configured `approvers_list`. Throws
+ * `ForbiddenException` when the caller cannot approve.
+ */
+export async function assertUserCanApprove(
+  tx: Prisma.TransactionClient | PrismaService,
+  userId: string,
+  userRole?: string,
+): Promise<void> {
+  if (userRole === 'OWNER') return;
+  const approvers = await getApproversList(tx);
+  if (!approvers.includes(userId)) {
+    throw new ForbiddenException(
+      'ไม่มีสิทธิ์อนุมัติเอกสาร — ผู้ใช้นี้ไม่อยู่ในรายชื่อผู้อนุมัติ',
+    );
+  }
+}
+
+/**
+ * D1.2.1.4 — Doc-type filter for the Approval Workflow gate. JSON-encoded
+ * array of DocumentType enum values stored in SystemConfig key
+ * `approval_required_doc_types`. Default = `['PAYROLL']` — the most
+ * common controlled-cost category. Other doc types skip approval even
+ * when `approval_enabled` is true.
+ *
+ * Returns the set as a parsed array, defaulting to ['PAYROLL'] when the
+ * row is missing / malformed / contains invalid enum values.
+ */
+export async function getApprovalRequiredDocTypes(
+  tx: Prisma.TransactionClient | PrismaService,
+): Promise<string[]> {
+  const defaults: string[] = ['PAYROLL'];
+  const validValues: string[] = [
+    'EXPENSE',
+    'CREDIT_NOTE',
+    'PAYROLL',
+    'VENDOR_SETTLEMENT',
+    'PETTY_CASH_REIMBURSEMENT',
+  ];
+  try {
+    const row = await tx.systemConfig.findFirst({
+      where: { key: 'approval_required_doc_types', deletedAt: null },
+      select: { value: true },
+    });
+    if (!row?.value) return defaults;
+    const parsed: unknown = JSON.parse(row.value);
+    if (!Array.isArray(parsed) || parsed.length === 0) return defaults;
+    const filtered = parsed.filter(
+      (v): v is string => typeof v === 'string' && validValues.includes(v),
+    );
+    return filtered.length > 0 ? filtered : defaults;
+  } catch {
+    return defaults;
+  }
+}
+
+/**
+ * D1.2.7.2 — reverse-reasons whitelist. Uses shared `readJsonFlag` for
+ * uniform JSON-parse + validator semantics. Empty / malformed lists fall
+ * back to the canonical 6-reason default so the UI never shows an empty
+ * dropdown.
+ */
+export async function getReverseReasons(
+  tx: Prisma.TransactionClient | PrismaService,
+): Promise<{ code: string; label: string }[]> {
+  const defaults: { code: string; label: string }[] = [
+    { code: 'data_entry_error', label: 'ป้อนข้อมูลผิด' },
+    { code: 'wrong_vendor', label: 'ผู้ขายผิด' },
+    { code: 'wrong_amount', label: 'จำนวนเงินผิด' },
+    { code: 'duplicate_entry', label: 'ข้อมูลซ้ำ' },
+    { code: 'cancel_transaction', label: 'ยกเลิกรายการ' },
+    { code: 'other', label: 'อื่นๆ (ระบุรายละเอียด)' },
+  ];
+  return readJsonFlag<{ code: string; label: string }[]>(
+    tx,
+    'reverse_reasons',
+    defaults,
+    (v): v is { code: string; label: string }[] =>
+      Array.isArray(v) &&
+      v.length > 0 &&
+      v.every(
+        (r) =>
+          r != null &&
+          typeof r === 'object' &&
+          typeof (r as { code: unknown }).code === 'string' &&
+          typeof (r as { label: unknown }).label === 'string',
+      ),
+  );
+}

--- a/apps/api/src/modules/expense-documents/bkk-business-date.util.spec.ts
+++ b/apps/api/src/modules/expense-documents/bkk-business-date.util.spec.ts
@@ -1,0 +1,21 @@
+import { bkkBusinessDate } from './bkk-business-date.util';
+
+describe('bkkBusinessDate', () => {
+  it('maps a mid-day UTC instant to noon BKK (05:00:00.000Z) of the same date', () => {
+    // 2026-06-09 09:00 UTC = 2026-06-09 16:00 BKK → same BKK calendar day.
+    const out = bkkBusinessDate(new Date('2026-06-09T09:00:00.000Z'));
+    expect(out.toISOString()).toBe('2026-06-09T05:00:00.000Z');
+  });
+
+  it('rolls to the NEXT BKK calendar day for a UTC instant at/after 17:00 UTC', () => {
+    // 2026-06-09 18:30 UTC = 2026-06-10 01:30 BKK → next BKK calendar day.
+    const out = bkkBusinessDate(new Date('2026-06-09T18:30:00.000Z'));
+    expect(out.toISOString()).toBe('2026-06-10T05:00:00.000Z');
+  });
+
+  it('always pins the time to noon BKK = 05:00:00.000Z', () => {
+    const out = bkkBusinessDate(new Date('2026-12-31T23:59:59.999Z'));
+    // 23:59 UTC Dec 31 = 06:59 BKK Jan 1 → noon BKK Jan 1.
+    expect(out.toISOString()).toBe('2027-01-01T05:00:00.000Z');
+  });
+});

--- a/apps/api/src/modules/expense-documents/bkk-business-date.util.ts
+++ b/apps/api/src/modules/expense-documents/bkk-business-date.util.ts
@@ -1,0 +1,16 @@
+/**
+ * Returns a Date representing 12:00 noon Asia/Bangkok on the same calendar day
+ * as `now`. Used as a stable `postedAt` for journal entries that should land
+ * on the BKK business day regardless of the server's UTC clock — without this,
+ * a void after 17:00 BKK (= next UTC day) would post in the wrong accounting period.
+ */
+export function bkkBusinessDate(now: Date): Date {
+  const ymd = now.toLocaleString('en-CA', {
+    timeZone: 'Asia/Bangkok',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  });
+  // ymd is "YYYY-MM-DD" in BKK; build noon BKK = 05:00 UTC of the same date
+  return new Date(`${ymd}T05:00:00.000Z`);
+}

--- a/apps/api/src/modules/expense-documents/expense-documents.service.ts
+++ b/apps/api/src/modules/expense-documents/expense-documents.service.ts
@@ -41,9 +41,15 @@ import { NotificationsService } from '../notifications/notifications.service';
 import { PettyCashService } from './services/petty-cash.service';
 import { PayrollCustomService } from './services/payroll-custom.service';
 import { validatePeriodOpen } from '../../utils/period-lock.util';
-import { readBoolFlag, readIntFlag, readJsonFlag } from '../../utils/config.util';
+import { readBoolFlag, readIntFlag } from '../../utils/config.util';
 import { collectJePreviewCodes } from './je-preview-codes.util';
 import { bkkBusinessDate } from './bkk-business-date.util';
+import {
+  assertUserCanApprove,
+  getApprovalRequiredDocTypes,
+  getApproversList,
+  getReverseReasons,
+} from './approval-config.util';
 
 @Injectable()
 export class ExpenseDocumentsService implements OnModuleInit {
@@ -127,7 +133,7 @@ export class ExpenseDocumentsService implements OnModuleInit {
       if (!this.notifications) return;
 
       // Resolve recipients: approvers_list → fallback to OWNER users.
-      let recipients = await this.getApproversList(this.prisma);
+      let recipients = await getApproversList(this.prisma);
       if (recipients.length === 0) {
         const owners = await this.prisma.user.findMany({
           where: { role: 'OWNER', isActive: true, deletedAt: null },
@@ -163,7 +169,7 @@ export class ExpenseDocumentsService implements OnModuleInit {
   }
 
   // ─── D1.* — Service-side SystemConfig flag readers ─────────────────────
-  // Delegates to shared `readBoolFlag` / `readJsonFlag` in utils/config.util
+  // Delegates to shared `readBoolFlag` in utils/config.util
   // so every service uses identical parsing + defensive try/catch semantics.
   // Kept as private wrappers for ergonomic (this.readBoolFlag) call sites.
   // Spec-defined defaults flow through `fallback` and preserve first-boot
@@ -174,95 +180,6 @@ export class ExpenseDocumentsService implements OnModuleInit {
     fallback: boolean,
   ): Promise<boolean> {
     return readBoolFlag(tx, key, fallback);
-  }
-
-  /**
-   * D1.2.1.3 — Approvers whitelist. JSON-encoded array of User UUIDs stored
-   * in SystemConfig key `approvers_list`. Default = empty array (only OWNER
-   * may approve when the workflow is enabled but no list is configured).
-   *
-   * Returns the list filtered to USERS that still exist + are active +
-   * not soft-deleted — so a stale ID in the SystemConfig row can never
-   * grant approval rights to a deleted account.
-   */
-  private async getApproversList(
-    tx: Prisma.TransactionClient | PrismaService,
-  ): Promise<string[]> {
-    try {
-      const row = await tx.systemConfig.findFirst({
-        where: { key: 'approvers_list', deletedAt: null },
-        select: { value: true },
-      });
-      if (!row?.value) return [];
-      const parsed: unknown = JSON.parse(row.value);
-      if (!Array.isArray(parsed)) return [];
-      const candidateIds = parsed.filter((v): v is string => typeof v === 'string');
-      if (candidateIds.length === 0) return [];
-      const valid = await tx.user.findMany({
-        where: { id: { in: candidateIds }, isActive: true, deletedAt: null },
-        select: { id: true },
-      });
-      return valid.map((u) => u.id);
-    } catch {
-      return [];
-    }
-  }
-
-  /**
-   * D1.2.1.3 — Approver gate. OWNER is always allowed (root-of-trust).
-   * Anyone else must be in the configured `approvers_list`. Throws
-   * `ForbiddenException` when the caller cannot approve.
-   */
-  private async assertUserCanApprove(
-    tx: Prisma.TransactionClient | PrismaService,
-    userId: string,
-    userRole?: string,
-  ): Promise<void> {
-    if (userRole === 'OWNER') return;
-    const approvers = await this.getApproversList(tx);
-    if (!approvers.includes(userId)) {
-      throw new ForbiddenException(
-        'ไม่มีสิทธิ์อนุมัติเอกสาร — ผู้ใช้นี้ไม่อยู่ในรายชื่อผู้อนุมัติ',
-      );
-    }
-  }
-
-  /**
-   * D1.2.1.4 — Doc-type filter for the Approval Workflow gate. JSON-encoded
-   * array of DocumentType enum values stored in SystemConfig key
-   * `approval_required_doc_types`. Default = `['PAYROLL']` — the most
-   * common controlled-cost category. Other doc types skip approval even
-   * when `approval_enabled` is true.
-   *
-   * Returns the set as a parsed array, defaulting to ['PAYROLL'] when the
-   * row is missing / malformed / contains invalid enum values.
-   */
-  private async getApprovalRequiredDocTypes(
-    tx: Prisma.TransactionClient | PrismaService,
-  ): Promise<string[]> {
-    const defaults: string[] = ['PAYROLL'];
-    const validValues: string[] = [
-      'EXPENSE',
-      'CREDIT_NOTE',
-      'PAYROLL',
-      'VENDOR_SETTLEMENT',
-      'PETTY_CASH_REIMBURSEMENT',
-    ];
-    try {
-      const row = await tx.systemConfig.findFirst({
-        where: { key: 'approval_required_doc_types', deletedAt: null },
-        select: { value: true },
-      });
-      if (!row?.value) return defaults;
-      const parsed: unknown = JSON.parse(row.value);
-      if (!Array.isArray(parsed) || parsed.length === 0) return defaults;
-      const filtered = parsed.filter(
-        (v): v is string => typeof v === 'string' && validValues.includes(v),
-      );
-      return filtered.length > 0 ? filtered : defaults;
-    } catch {
-      return defaults;
-    }
   }
 
   /**
@@ -297,39 +214,6 @@ export class ExpenseDocumentsService implements OnModuleInit {
     }
   }
 
-  /**
-   * D1.2.7.2 — reverse-reasons whitelist. Uses shared `readJsonFlag` for
-   * uniform JSON-parse + validator semantics. Empty / malformed lists fall
-   * back to the canonical 6-reason default so the UI never shows an empty
-   * dropdown.
-   */
-  private async getReverseReasons(
-    tx: Prisma.TransactionClient | PrismaService,
-  ): Promise<{ code: string; label: string }[]> {
-    const defaults: { code: string; label: string }[] = [
-      { code: 'data_entry_error', label: 'ป้อนข้อมูลผิด' },
-      { code: 'wrong_vendor', label: 'ผู้ขายผิด' },
-      { code: 'wrong_amount', label: 'จำนวนเงินผิด' },
-      { code: 'duplicate_entry', label: 'ข้อมูลซ้ำ' },
-      { code: 'cancel_transaction', label: 'ยกเลิกรายการ' },
-      { code: 'other', label: 'อื่นๆ (ระบุรายละเอียด)' },
-    ];
-    return readJsonFlag<{ code: string; label: string }[]>(
-      tx,
-      'reverse_reasons',
-      defaults,
-      (v): v is { code: string; label: string }[] =>
-        Array.isArray(v) &&
-        v.length > 0 &&
-        v.every(
-          (r) =>
-            r != null &&
-            typeof r === 'object' &&
-            typeof (r as { code: unknown }).code === 'string' &&
-            typeof (r as { label: unknown }).label === 'string',
-        ),
-    );
-  }
 
   // ─── Create ──────────────────────────────────────────────────────────
   async create(dto: CreateExpenseDocumentDto, userId: string) {
@@ -2032,7 +1916,7 @@ export class ExpenseDocumentsService implements OnModuleInit {
         // Reads SystemConfig key `approval_required_doc_types` (JSON array),
         // filters to valid DocumentType enum values, defaults to ['PAYROLL']
         // on missing/malformed rows.
-        const requiredDocTypes = await this.getApprovalRequiredDocTypes(tx);
+        const requiredDocTypes = await getApprovalRequiredDocTypes(tx);
         const isRequiredType = requiredDocTypes.includes(doc.documentType);
 
         if (overThreshold || isRequiredType) {
@@ -2268,7 +2152,7 @@ export class ExpenseDocumentsService implements OnModuleInit {
 
       // D1.2.1.3 — approver membership check. OWNER always passes; everyone
       // else must appear in SystemConfig `approvers_list`.
-      await this.assertUserCanApprove(tx, userId, userRole);
+      await assertUserCanApprove(tx, userId, userRole);
 
       const doc = await tx.expenseDocument.findUniqueOrThrow({ where: { id } });
       if (doc.deletedAt) throw new NotFoundException('เอกสารถูกลบแล้ว');
@@ -2409,7 +2293,7 @@ export class ExpenseDocumentsService implements OnModuleInit {
       // codes). Validate dto.reasonCode against the configured whitelist
       // when present. OWNER can extend/override the list via SettingsService.
       if (dto.reasonCode?.trim()) {
-        const reasons = await this.getReverseReasons(tx);
+        const reasons = await getReverseReasons(tx);
         const allowed = new Set(reasons.map((r) => r.code));
         if (!allowed.has(dto.reasonCode)) {
           throw new BadRequestException(

--- a/apps/api/src/modules/expense-documents/expense-documents.service.ts
+++ b/apps/api/src/modules/expense-documents/expense-documents.service.ts
@@ -42,23 +42,8 @@ import { PettyCashService } from './services/petty-cash.service';
 import { PayrollCustomService } from './services/payroll-custom.service';
 import { validatePeriodOpen } from '../../utils/period-lock.util';
 import { readBoolFlag, readIntFlag, readJsonFlag } from '../../utils/config.util';
-
-/**
- * Returns a Date representing 12:00 noon Asia/Bangkok on the same calendar day
- * as `now`. Used as a stable `postedAt` for journal entries that should land
- * on the BKK business day regardless of the server's UTC clock — without this,
- * a void after 17:00 BKK (= next UTC day) would post in the wrong accounting period.
- */
-function bkkBusinessDate(now: Date): Date {
-  const ymd = now.toLocaleString('en-CA', {
-    timeZone: 'Asia/Bangkok',
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-  });
-  // ymd is "YYYY-MM-DD" in BKK; build noon BKK = 05:00 UTC of the same date
-  return new Date(`${ymd}T05:00:00.000Z`);
-}
+import { collectJePreviewCodes } from './je-preview-codes.util';
+import { bkkBusinessDate } from './bkk-business-date.util';
 
 @Injectable()
 export class ExpenseDocumentsService implements OnModuleInit {
@@ -1727,23 +1712,7 @@ export class ExpenseDocumentsService implements OnModuleInit {
 
   // ─── JE Preview (pure — no DB write) ────────────────────────────────
   async previewJe(dto: CreateExpenseDocumentDto) {
-    const codes = new Set<string>();
-    for (const l of dto.lines) codes.add(l.category);
-    if (dto.depositAccountCode) codes.add(dto.depositAccountCode);
-    // W8 — preload adjustment row codes + per-line WHT routes so the preview
-    // can resolve names for the new sections (adjustments + multi-line WHT).
-    for (const adj of dto.adjustments ?? []) {
-      if (adj.accountCode) codes.add(adj.accountCode);
-    }
-    // 11-4101 = ภาษีซื้อ (Input Tax Credit, claimable). Mirrors expense
-    // templates' VAT routing — must match what post() actually books.
-    codes.add('11-4101');
-    codes.add('21-1104');
-    // Always preload both WHT routes — the preview may emit either or both
-    // depending on per-line whtFormType (P2-4).
-    codes.add('21-3102');
-    codes.add('21-3103');
-
+    const codes = collectJePreviewCodes(dto);
     const rows = await this.prisma.chartOfAccount.findMany({
       where: { code: { in: [...codes] }, deletedAt: null },
       select: { code: true, name: true },

--- a/apps/api/src/modules/expense-documents/je-preview-codes.util.spec.ts
+++ b/apps/api/src/modules/expense-documents/je-preview-codes.util.spec.ts
@@ -1,0 +1,66 @@
+import { collectJePreviewCodes } from './je-preview-codes.util';
+import { CreateExpenseDocumentDto } from './dto/create.dto';
+
+// The 4 hardcoded codes collectJePreviewCodes always preloads (mirror post()).
+const HARDCODED = ['11-4101', '21-1104', '21-3102', '21-3103'];
+
+const dto = (partial: Partial<CreateExpenseDocumentDto>): CreateExpenseDocumentDto =>
+  ({ lines: [], ...partial }) as unknown as CreateExpenseDocumentDto;
+
+describe('collectJePreviewCodes', () => {
+  it('always includes the 4 hardcoded VAT/WHT-route codes', () => {
+    const codes = collectJePreviewCodes(dto({}));
+    for (const c of HARDCODED) expect(codes.has(c)).toBe(true);
+  });
+
+  it('includes every line category', () => {
+    const codes = collectJePreviewCodes(
+      dto({ lines: [{ category: '53-1101' }, { category: '53-1102' }] as never }),
+    );
+    expect(codes.has('53-1101')).toBe(true);
+    expect(codes.has('53-1102')).toBe(true);
+  });
+
+  it('includes depositAccountCode when present', () => {
+    const codes = collectJePreviewCodes(dto({ depositAccountCode: '11-1201' }));
+    expect(codes.has('11-1201')).toBe(true);
+  });
+
+  it('does NOT include depositAccountCode when absent/undefined', () => {
+    const codes = collectJePreviewCodes(dto({}));
+    // Only the 4 hardcoded codes when lines empty + no deposit + no adjustments.
+    expect([...codes].sort()).toEqual([...HARDCODED].sort());
+  });
+
+  it('includes every non-empty adjustments[].accountCode', () => {
+    const codes = collectJePreviewCodes(
+      dto({ adjustments: [{ accountCode: '52-1104' }, { accountCode: '53-1503' }] as never }),
+    );
+    expect(codes.has('52-1104')).toBe(true);
+    expect(codes.has('53-1503')).toBe(true);
+  });
+
+  it('skips empty/undefined adjustment accountCodes', () => {
+    const codes = collectJePreviewCodes(
+      dto({ adjustments: [{ accountCode: '' }, { accountCode: undefined }, {}] as never }),
+    );
+    expect(codes.has('')).toBe(false);
+    // Only the 4 hardcoded remain.
+    expect([...codes].sort()).toEqual([...HARDCODED].sort());
+  });
+
+  it('handles omitted adjustments (the ?? [] guard)', () => {
+    const codes = collectJePreviewCodes(dto({ lines: [{ category: '53-1101' }] as never }));
+    expect(codes.has('53-1101')).toBe(true);
+    expect([...codes].sort()).toEqual(['53-1101', ...HARDCODED].sort());
+  });
+
+  it('dedups a line category equal to a hardcoded code (appears once)', () => {
+    const codes = collectJePreviewCodes(
+      dto({ lines: [{ category: '11-4101' }, { category: '11-4101' }] as never }),
+    );
+    expect([...codes].filter((c) => c === '11-4101')).toHaveLength(1);
+    // Set still has exactly the 4 hardcoded (11-4101 is one of them).
+    expect([...codes].sort()).toEqual([...HARDCODED].sort());
+  });
+});

--- a/apps/api/src/modules/expense-documents/je-preview-codes.util.ts
+++ b/apps/api/src/modules/expense-documents/je-preview-codes.util.ts
@@ -1,0 +1,27 @@
+import { CreateExpenseDocumentDto } from './dto/create.dto';
+
+/**
+ * Pure account-code collection for the JE preview (E4 — extracted from
+ * ExpenseDocumentsService.previewJe). Builds the Set of chart-of-account codes
+ * whose names the preview must resolve, so the preview matches what post()
+ * actually books. No DB access — the caller does the findMany.
+ */
+export function collectJePreviewCodes(dto: CreateExpenseDocumentDto): Set<string> {
+  const codes = new Set<string>();
+  for (const l of dto.lines) codes.add(l.category);
+  if (dto.depositAccountCode) codes.add(dto.depositAccountCode);
+  // W8 — preload adjustment row codes + per-line WHT routes so the preview
+  // can resolve names for the new sections (adjustments + multi-line WHT).
+  for (const adj of dto.adjustments ?? []) {
+    if (adj.accountCode) codes.add(adj.accountCode);
+  }
+  // 11-4101 = ภาษีซื้อ (Input Tax Credit, claimable). Mirrors expense
+  // templates' VAT routing — must match what post() actually books.
+  codes.add('11-4101');
+  codes.add('21-1104');
+  // Always preload both WHT routes — the preview may emit either or both
+  // depending on per-line whtFormType (P2-4).
+  codes.add('21-3102');
+  codes.add('21-3103');
+  return codes;
+}


### PR DESCRIPTION
## ⚠️ Recovery PR — expense-documents E4/E5/E6 never reached `main`

Same stacked-merge gotcha as the accounting decompose: **#1209 (E4+E5)** and **#1210 (E6)** show **MERGED** but their content landed on the intermediate stacked branches, not `main`. `main` is missing `je-preview-codes.util.ts`, `bkk-business-date.util.ts`, and `approval-config.util.ts`, and the corresponding `expense-documents.service.ts` extractions.

This re-applies E4/E5/E6 onto **current `main`** (which already has E1 #1206, E2 #1207, E3 #1208), as a single `base=main` PR. The E4/E5/E6 commits were **rebased** onto current main (they branched off E3 without E2), with two small conflicts in `expense-documents.service.ts` resolved to the correct merged state:
- import line → `readBoolFlag, readIntFlag` (kept E2's `readIntFlag`; dropped `readJsonFlag` since E6 moved its only user `getReverseReasons` to the util)
- removed the `getReverseReasons` private method (E6) — and confirmed the E1→E6 chain's stale private `readIntFlag` is NOT re-introduced (E2 already extracted it to config.util)

### What lands
- **NEW** `je-preview-codes.util.ts` (E4), `bkk-business-date.util.ts` (E5), `approval-config.util.ts` (E6) + their specs
- `expense-documents.service.ts`: `previewJe` → `collectJePreviewCodes`; `bkkBusinessDate` imported; 4 approval-config helpers → `approval-config.util`

### Already reviewed
Behavior-preserving content already spec+quality reviewed in #1209/#1210 (byte-identical moves; OWNER fast-path + exact Thai messages preserved).

### Verification on current `main`
- `./tools/check-types.sh api` → **API: OK**
- `npm --prefix apps/api run test -- expense-documents config.util notifications alerts.cron` → **508 / 47 suites** green

🤖 Generated with [Claude Code](https://claude.com/claude-code)