### PR TITLE
Slice 0: makeExpenseDocumentsService test factory (decompose de-risk)

### DIFF
--- a/apps/api/src/modules/expense-documents/__tests__/credit-note.service.spec.ts
+++ b/apps/api/src/modules/expense-documents/__tests__/credit-note.service.spec.ts
@@ -1,7 +1,7 @@
 import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { Decimal } from '@prisma/client/runtime/library';
 import { ExpenseDocumentsService } from '../expense-documents.service';
-import { LineAggregatorService } from '../services/line-aggregator.service';
+import { makeExpenseDocumentsService } from './support/make-expense-documents-service';
 
 const VALID_LINES = [
   { category: '53-1302', quantity: 1, unitPrice: 200, vatPercent: 0, whtPercent: 0 },
@@ -50,24 +50,23 @@ describe('ExpenseDocumentsService.createCreditNote', () => {
     creditNote = { execute: jest.fn() };
     payroll = { execute: jest.fn() };
     settlement = { execute: jest.fn() };
-    service = new ExpenseDocumentsService(
+    service = makeExpenseDocumentsService({
       prisma,
       docNumber,
       transition,
-      sameDay,
-      accrual,
-      creditNote,
-      payroll,
-      settlement,
-      { createAndPost: jest.fn() } as never,
-      new LineAggregatorService(),
-      { preview: jest.fn() } as never,
-      { validateContribution: jest.fn().mockResolvedValue(undefined) } as never,
-      { execute: jest.fn() } as never,
-      { getConfig: jest.fn(), validate: jest.fn() } as never,
-      { loadWhitelist: jest.fn().mockResolvedValue(new Set()), validateLine: jest.fn() } as never,
-      { send: jest.fn().mockResolvedValue({ id: 'notif-1', status: 'SENT' }) } as never,
-    );
+      sameDayTemplate: sameDay,
+      accrualTemplate: accrual,
+      creditNoteTemplate: creditNote,
+      payrollTemplate: payroll,
+      settlementTemplate: settlement,
+      journal: { createAndPost: jest.fn() },
+      jePreview: { preview: jest.fn() },
+      ssoConfig: { validateContribution: jest.fn().mockResolvedValue(undefined) },
+      pettyCashTemplate: { execute: jest.fn() },
+      pettyCash: { getConfig: jest.fn(), validate: jest.fn() },
+      payrollCustom: { loadWhitelist: jest.fn().mockResolvedValue(new Set()), validateLine: jest.fn() },
+      notifications: { send: jest.fn().mockResolvedValue({ id: 'notif-1', status: 'SENT' }) },
+    }).service;
   });
 
   it('rejects when original not found', async () => {

--- a/apps/api/src/modules/expense-documents/__tests__/expense-documents.service.spec.ts
+++ b/apps/api/src/modules/expense-documents/__tests__/expense-documents.service.spec.ts
@@ -1,7 +1,7 @@
 import { BadRequestException, ForbiddenException, NotFoundException } from '@nestjs/common';
 import { Decimal } from '@prisma/client/runtime/library';
 import { ExpenseDocumentsService } from '../expense-documents.service';
-import { LineAggregatorService } from '../services/line-aggregator.service';
+import { makeExpenseDocumentsService } from './support/make-expense-documents-service';
 
 describe('ExpenseDocumentsService', () => {
   let service: ExpenseDocumentsService;
@@ -112,23 +112,22 @@ describe('ExpenseDocumentsService', () => {
     creditNote = { execute: jest.fn().mockResolvedValue({ entryNo: 'JE-3' }) };
     payroll = { execute: jest.fn().mockResolvedValue({ entryNo: 'JE-4' }) };
     settlement = { execute: jest.fn().mockResolvedValue({ entryNo: 'JE-5' }) };
-    service = new ExpenseDocumentsService(
+    service = makeExpenseDocumentsService({
       prisma,
       docNumber,
       transition,
-      sameDay,
-      accrual,
-      creditNote,
-      payroll,
-      settlement,
-      { createAndPost: jest.fn() } as never,
-      new LineAggregatorService(),
-      { preview: jest.fn() } as never,
-      { validateContribution: jest.fn().mockResolvedValue(undefined) } as never,
-      { execute: jest.fn() } as never,
-      { getConfig: jest.fn(), validate: jest.fn() } as never,
-      { loadWhitelist: jest.fn().mockResolvedValue(new Set(['53-1104', '53-1105'])), validateLine: jest.fn().mockResolvedValue({ taxableBase: new Decimal(0) }) } as never,
-    );
+      sameDayTemplate: sameDay,
+      accrualTemplate: accrual,
+      creditNoteTemplate: creditNote,
+      payrollTemplate: payroll,
+      settlementTemplate: settlement,
+      journal: { createAndPost: jest.fn() },
+      jePreview: { preview: jest.fn() },
+      ssoConfig: { validateContribution: jest.fn().mockResolvedValue(undefined) },
+      pettyCashTemplate: { execute: jest.fn() },
+      pettyCash: { getConfig: jest.fn(), validate: jest.fn() },
+      payrollCustom: { loadWhitelist: jest.fn().mockResolvedValue(new Set(['53-1104', '53-1105'])), validateLine: jest.fn().mockResolvedValue({ taxableBase: new Decimal(0) }) },
+    }).service;
   });
 
   describe('create', () => {
@@ -869,17 +868,22 @@ describe('ExpenseDocumentsService', () => {
       // eslint-disable-next-line @typescript-eslint/no-require-imports
       const { StatusTransitionService } = require('../services/status-transition.service');
       const realTransition = new StatusTransitionService();
-      service = new ExpenseDocumentsService(
-        prisma, docNumber, realTransition, sameDay, accrual, creditNote,
-        payroll, settlement,
-        { createAndPost: jest.fn() } as never,
-        new LineAggregatorService(),
-        { preview: jest.fn() } as never,
-        { validateContribution: jest.fn().mockResolvedValue(undefined) } as never,
-        { execute: jest.fn() } as never,
-        { getConfig: jest.fn(), validate: jest.fn() } as never,
-        { loadWhitelist: jest.fn().mockResolvedValue(new Set(['53-1104'])), validateLine: jest.fn() } as never,
-      );
+      service = makeExpenseDocumentsService({
+        prisma,
+        docNumber,
+        transition: realTransition,
+        sameDayTemplate: sameDay,
+        accrualTemplate: accrual,
+        creditNoteTemplate: creditNote,
+        payrollTemplate: payroll,
+        settlementTemplate: settlement,
+        journal: { createAndPost: jest.fn() },
+        jePreview: { preview: jest.fn() },
+        ssoConfig: { validateContribution: jest.fn().mockResolvedValue(undefined) },
+        pettyCashTemplate: { execute: jest.fn() },
+        pettyCash: { getConfig: jest.fn(), validate: jest.fn() },
+        payrollCustom: { loadWhitelist: jest.fn().mockResolvedValue(new Set(['53-1104'])), validateLine: jest.fn() },
+      }).service;
       prisma.expenseDocument.findUniqueOrThrow.mockResolvedValue({
         id: 'doc-approved',
         status: 'APPROVED',
@@ -1470,16 +1474,22 @@ describe('ExpenseDocumentsService', () => {
         }),
       };
       const journalMock = { createAndPost: jest.fn().mockResolvedValue({ id: 'je-r1', entryNumber: 'JE-202605-00002' }) };
-      const svc = new ExpenseDocumentsService(
-        prisma, docNumber, transition, sameDay, accrual, creditNote, payroll, settlement,
-        journalMock as never,
-        new LineAggregatorService(),
-        { preview: jest.fn() } as never,
-        { validateContribution: jest.fn().mockResolvedValue(undefined) } as never,
-        { execute: jest.fn() } as never,
-        { getConfig: jest.fn(), validate: jest.fn() } as never,
-        { loadWhitelist: jest.fn().mockResolvedValue(new Set(['53-1104', '53-1105'])), validateLine: jest.fn().mockResolvedValue({ taxableBase: new Decimal(0) }) } as never,
-      );
+      const svc = makeExpenseDocumentsService({
+        prisma,
+        docNumber,
+        transition,
+        sameDayTemplate: sameDay,
+        accrualTemplate: accrual,
+        creditNoteTemplate: creditNote,
+        payrollTemplate: payroll,
+        settlementTemplate: settlement,
+        journal: journalMock,
+        jePreview: { preview: jest.fn() },
+        ssoConfig: { validateContribution: jest.fn().mockResolvedValue(undefined) },
+        pettyCashTemplate: { execute: jest.fn() },
+        pettyCash: { getConfig: jest.fn(), validate: jest.fn() },
+        payrollCustom: { loadWhitelist: jest.fn().mockResolvedValue(new Set(['53-1104', '53-1105'])), validateLine: jest.fn().mockResolvedValue({ taxableBase: new Decimal(0) }) },
+      }).service;
       await svc.voidDocument('doc-1', 'user-1');
       expect(journalMock.createAndPost).toHaveBeenCalledTimes(1);
       const call = journalMock.createAndPost.mock.calls[0][0];
@@ -1515,16 +1525,22 @@ describe('ExpenseDocumentsService', () => {
         }),
       };
       const journalMock = { createAndPost: jest.fn().mockResolvedValue({ id: 'je-r2', entryNumber: 'JE-202605-00003' }) };
-      const svc = new ExpenseDocumentsService(
-        prisma, docNumber, transition, sameDay, accrual, creditNote, payroll, settlement,
-        journalMock as never,
-        new LineAggregatorService(),
-        { preview: jest.fn() } as never,
-        { validateContribution: jest.fn().mockResolvedValue(undefined) } as never,
-        { execute: jest.fn() } as never,
-        { getConfig: jest.fn(), validate: jest.fn() } as never,
-        { loadWhitelist: jest.fn().mockResolvedValue(new Set(['53-1104', '53-1105'])), validateLine: jest.fn().mockResolvedValue({ taxableBase: new Decimal(0) }) } as never,
-      );
+      const svc = makeExpenseDocumentsService({
+        prisma,
+        docNumber,
+        transition,
+        sameDayTemplate: sameDay,
+        accrualTemplate: accrual,
+        creditNoteTemplate: creditNote,
+        payrollTemplate: payroll,
+        settlementTemplate: settlement,
+        journal: journalMock,
+        jePreview: { preview: jest.fn() },
+        ssoConfig: { validateContribution: jest.fn().mockResolvedValue(undefined) },
+        pettyCashTemplate: { execute: jest.fn() },
+        pettyCash: { getConfig: jest.fn(), validate: jest.fn() },
+        payrollCustom: { loadWhitelist: jest.fn().mockResolvedValue(new Set(['53-1104', '53-1105'])), validateLine: jest.fn().mockResolvedValue({ taxableBase: new Decimal(0) }) },
+      }).service;
       await svc.voidDocument('se-1', 'user-1');
       // Both cleared EXs reverted via updateMany with deletedAt:null guard
       const updateManyCalls = prisma.expenseDocument.updateMany.mock.calls;
@@ -1610,16 +1626,22 @@ describe('ExpenseDocumentsService', () => {
       const journalMock = {
         createAndPost: jest.fn().mockResolvedValue({ id: 'je-rev', entryNumber: 'JE-REV-001' }),
       };
-      const svc = new ExpenseDocumentsService(
-        prisma, docNumber, transition, sameDay, accrual, creditNote, payroll, settlement,
-        journalMock as never,
-        new LineAggregatorService(),
-        { preview: jest.fn() } as never,
-        { validateContribution: jest.fn().mockResolvedValue(undefined) } as never,
-        { execute: jest.fn() } as never,
-        { getConfig: jest.fn(), validate: jest.fn() } as never,
-        { loadWhitelist: jest.fn().mockResolvedValue(new Set()), validateLine: jest.fn() } as never,
-      );
+      const svc = makeExpenseDocumentsService({
+        prisma,
+        docNumber,
+        transition,
+        sameDayTemplate: sameDay,
+        accrualTemplate: accrual,
+        creditNoteTemplate: creditNote,
+        payrollTemplate: payroll,
+        settlementTemplate: settlement,
+        journal: journalMock,
+        jePreview: { preview: jest.fn() },
+        ssoConfig: { validateContribution: jest.fn().mockResolvedValue(undefined) },
+        pettyCashTemplate: { execute: jest.fn() },
+        pettyCash: { getConfig: jest.fn(), validate: jest.fn() },
+        payrollCustom: { loadWhitelist: jest.fn().mockResolvedValue(new Set()), validateLine: jest.fn() },
+      }).service;
       // Should NOT throw — both cascade checks are bypassed
       await expect(svc.voidDocument('doc-1', 'user-1')).resolves.toBeDefined();
     });
@@ -1691,16 +1713,22 @@ describe('ExpenseDocumentsService', () => {
       const journalMock = {
         createAndPost: jest.fn().mockResolvedValue({ id: 'je-rev', entryNumber: 'JE-REV-001' }),
       };
-      const svc = new ExpenseDocumentsService(
-        prisma, docNumber, transition, sameDay, accrual, creditNote, payroll, settlement,
-        journalMock as never,
-        new LineAggregatorService(),
-        { preview: jest.fn() } as never,
-        { validateContribution: jest.fn().mockResolvedValue(undefined) } as never,
-        { execute: jest.fn() } as never,
-        { getConfig: jest.fn(), validate: jest.fn() } as never,
-        { loadWhitelist: jest.fn().mockResolvedValue(new Set()), validateLine: jest.fn() } as never,
-      );
+      const svc = makeExpenseDocumentsService({
+        prisma,
+        docNumber,
+        transition,
+        sameDayTemplate: sameDay,
+        accrualTemplate: accrual,
+        creditNoteTemplate: creditNote,
+        payrollTemplate: payroll,
+        settlementTemplate: settlement,
+        journal: journalMock,
+        jePreview: { preview: jest.fn() },
+        ssoConfig: { validateContribution: jest.fn().mockResolvedValue(undefined) },
+        pettyCashTemplate: { execute: jest.fn() },
+        pettyCash: { getConfig: jest.fn(), validate: jest.fn() },
+        payrollCustom: { loadWhitelist: jest.fn().mockResolvedValue(new Set()), validateLine: jest.fn() },
+      }).service;
       await expect(
         svc.voidDocument('doc-1', 'user-1', { reasonCode: 'manager_decision' }),
       ).resolves.toBeDefined();
@@ -1739,16 +1767,22 @@ describe('ExpenseDocumentsService', () => {
       const journalMock = {
         createAndPost: jest.fn().mockResolvedValue({ id: 'je-rev', entryNumber: 'JE-REV-001' }),
       };
-      const svc = new ExpenseDocumentsService(
-        prisma, docNumber, transition, sameDay, accrual, creditNote, payroll, settlement,
-        journalMock as never,
-        new LineAggregatorService(),
-        { preview: jest.fn() } as never,
-        { validateContribution: jest.fn().mockResolvedValue(undefined) } as never,
-        { execute: jest.fn() } as never,
-        { getConfig: jest.fn(), validate: jest.fn() } as never,
-        { loadWhitelist: jest.fn().mockResolvedValue(new Set()), validateLine: jest.fn() } as never,
-      );
+      const svc = makeExpenseDocumentsService({
+        prisma,
+        docNumber,
+        transition,
+        sameDayTemplate: sameDay,
+        accrualTemplate: accrual,
+        creditNoteTemplate: creditNote,
+        payrollTemplate: payroll,
+        settlementTemplate: settlement,
+        journal: journalMock,
+        jePreview: { preview: jest.fn() },
+        ssoConfig: { validateContribution: jest.fn().mockResolvedValue(undefined) },
+        pettyCashTemplate: { execute: jest.fn() },
+        pettyCash: { getConfig: jest.fn(), validate: jest.fn() },
+        payrollCustom: { loadWhitelist: jest.fn().mockResolvedValue(new Set()), validateLine: jest.fn() },
+      }).service;
       const future = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
       await expect(
         svc.voidDocument('doc-1', 'user-1', { reverseDate: future }),
@@ -1774,16 +1808,22 @@ describe('ExpenseDocumentsService', () => {
       const journalMock = {
         createAndPost: jest.fn().mockResolvedValue({ id: 'je-rev', entryNumber: 'JE-REV-001' }),
       };
-      const svc = new ExpenseDocumentsService(
-        prisma, docNumber, transition, sameDay, accrual, creditNote, payroll, settlement,
-        journalMock as never,
-        new LineAggregatorService(),
-        { preview: jest.fn() } as never,
-        { validateContribution: jest.fn().mockResolvedValue(undefined) } as never,
-        { execute: jest.fn() } as never,
-        { getConfig: jest.fn(), validate: jest.fn() } as never,
-        { loadWhitelist: jest.fn().mockResolvedValue(new Set()), validateLine: jest.fn() } as never,
-      );
+      const svc = makeExpenseDocumentsService({
+        prisma,
+        docNumber,
+        transition,
+        sameDayTemplate: sameDay,
+        accrualTemplate: accrual,
+        creditNoteTemplate: creditNote,
+        payrollTemplate: payroll,
+        settlementTemplate: settlement,
+        journal: journalMock,
+        jePreview: { preview: jest.fn() },
+        ssoConfig: { validateContribution: jest.fn().mockResolvedValue(undefined) },
+        pettyCashTemplate: { execute: jest.fn() },
+        pettyCash: { getConfig: jest.fn(), validate: jest.fn() },
+        payrollCustom: { loadWhitelist: jest.fn().mockResolvedValue(new Set()), validateLine: jest.fn() },
+      }).service;
       await expect(svc.voidDocument('doc-1', 'user-1')).resolves.toBeDefined();
     });
 
@@ -1811,16 +1851,22 @@ describe('ExpenseDocumentsService', () => {
           ],
         }),
       };
-      const svc = new ExpenseDocumentsService(
-        prisma, docNumber, transition, sameDay, accrual, creditNote, payroll, settlement,
-        journalMock as never,
-        new LineAggregatorService(),
-        { preview: jest.fn() } as never,
-        { validateContribution: jest.fn().mockResolvedValue(undefined) } as never,
-        { execute: jest.fn() } as never,
-        { getConfig: jest.fn(), validate: jest.fn() } as never,
-        { loadWhitelist: jest.fn().mockResolvedValue(new Set(['53-1104', '53-1105'])), validateLine: jest.fn().mockResolvedValue({ taxableBase: new Decimal(0) }) } as never,
-      );
+      const svc = makeExpenseDocumentsService({
+        prisma,
+        docNumber,
+        transition,
+        sameDayTemplate: sameDay,
+        accrualTemplate: accrual,
+        creditNoteTemplate: creditNote,
+        payrollTemplate: payroll,
+        settlementTemplate: settlement,
+        journal: journalMock,
+        jePreview: { preview: jest.fn() },
+        ssoConfig: { validateContribution: jest.fn().mockResolvedValue(undefined) },
+        pettyCashTemplate: { execute: jest.fn() },
+        pettyCash: { getConfig: jest.fn(), validate: jest.fn() },
+        payrollCustom: { loadWhitelist: jest.fn().mockResolvedValue(new Set(['53-1104', '53-1105'])), validateLine: jest.fn().mockResolvedValue({ taxableBase: new Decimal(0) }) },
+      }).service;
 
       await svc.voidDocument('doc-1', 'user-1', {
         reasonCode: 'data_entry_error',
@@ -1865,16 +1911,22 @@ describe('ExpenseDocumentsService', () => {
           ],
         }),
       };
-      const svc = new ExpenseDocumentsService(
-        prisma, docNumber, transition, sameDay, accrual, creditNote, payroll, settlement,
-        journalMock as never,
-        new LineAggregatorService(),
-        { preview: jest.fn() } as never,
-        { validateContribution: jest.fn().mockResolvedValue(undefined) } as never,
-        { execute: jest.fn() } as never,
-        { getConfig: jest.fn(), validate: jest.fn() } as never,
-        { loadWhitelist: jest.fn().mockResolvedValue(new Set(['53-1104', '53-1105'])), validateLine: jest.fn().mockResolvedValue({ taxableBase: new Decimal(0) }) } as never,
-      );
+      const svc = makeExpenseDocumentsService({
+        prisma,
+        docNumber,
+        transition,
+        sameDayTemplate: sameDay,
+        accrualTemplate: accrual,
+        creditNoteTemplate: creditNote,
+        payrollTemplate: payroll,
+        settlementTemplate: settlement,
+        journal: journalMock,
+        jePreview: { preview: jest.fn() },
+        ssoConfig: { validateContribution: jest.fn().mockResolvedValue(undefined) },
+        pettyCashTemplate: { execute: jest.fn() },
+        pettyCash: { getConfig: jest.fn(), validate: jest.fn() },
+        payrollCustom: { loadWhitelist: jest.fn().mockResolvedValue(new Set(['53-1104', '53-1105'])), validateLine: jest.fn().mockResolvedValue({ taxableBase: new Decimal(0) }) },
+      }).service;
 
       await svc.voidDocument('doc-1', 'user-1', {
         reasonCode: 'cancel_transaction',

--- a/apps/api/src/modules/expense-documents/__tests__/multi-line-create.service.spec.ts
+++ b/apps/api/src/modules/expense-documents/__tests__/multi-line-create.service.spec.ts
@@ -1,12 +1,11 @@
 import { Prisma } from '@prisma/client';
 import { ExpenseDocumentsService } from '../expense-documents.service';
-import { LineAggregatorService } from '../services/line-aggregator.service';
+import { makeExpenseDocumentsService } from './support/make-expense-documents-service';
 
 describe('ExpenseDocumentsService.create — multi-line', () => {
   let service: ExpenseDocumentsService;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let prisma: any;
-  let aggregator: LineAggregatorService;
 
   beforeEach(() => {
     prisma = {
@@ -32,32 +31,30 @@ describe('ExpenseDocumentsService.create — multi-line', () => {
       // readBoolFlag('petty_cash_enabled', true) → null row ⇒ default true
       systemConfig: { findFirst: jest.fn().mockResolvedValue(null) },
     };
-    aggregator = new LineAggregatorService();
-    service = new ExpenseDocumentsService(
+    service = makeExpenseDocumentsService({
       prisma,
-      { next: jest.fn().mockResolvedValue('EX-20260511-0001') } as never,
-      { assertCanPost: jest.fn(), assertCanVoid: jest.fn(), assertCanEdit: jest.fn(), resolveTargetStatus: jest.fn().mockReturnValue('POSTED') } as never,
-      { execute: jest.fn() } as never,
-      { execute: jest.fn() } as never,
-      { execute: jest.fn() } as never,
-      { execute: jest.fn() } as never,
-      { execute: jest.fn() } as never,
-      { createAndPost: jest.fn() } as never,
-      aggregator,
-      { preview: jest.fn() } as never,
-      { validateContribution: jest.fn().mockResolvedValue(undefined) } as never,
-      { execute: jest.fn() } as never,
-      {
+      docNumber: { next: jest.fn().mockResolvedValue('EX-20260511-0001') },
+      transition: { assertCanPost: jest.fn(), assertCanVoid: jest.fn(), assertCanEdit: jest.fn(), resolveTargetStatus: jest.fn().mockReturnValue('POSTED') },
+      sameDayTemplate: { execute: jest.fn() },
+      accrualTemplate: { execute: jest.fn() },
+      creditNoteTemplate: { execute: jest.fn() },
+      payrollTemplate: { execute: jest.fn() },
+      settlementTemplate: { execute: jest.fn() },
+      journal: { createAndPost: jest.fn() },
+      jePreview: { preview: jest.fn() },
+      ssoConfig: { validateContribution: jest.fn().mockResolvedValue(undefined) },
+      pettyCashTemplate: { execute: jest.fn() },
+      pettyCash: {
         getConfig: jest.fn().mockResolvedValue({
           account: '11-1103',
           limit: new Prisma.Decimal('5000'),
           replenishThreshold: null,
         }),
         validate: jest.fn(),
-      } as never,
-      { loadWhitelist: jest.fn().mockResolvedValue(new Set()), validateLine: jest.fn() } as never,
-      { send: jest.fn().mockResolvedValue({ id: 'notif-1', status: 'SENT' }) } as never,
-    );
+      },
+      payrollCustom: { loadWhitelist: jest.fn().mockResolvedValue(new Set()), validateLine: jest.fn() },
+      notifications: { send: jest.fn().mockResolvedValue({ id: 'notif-1', status: 'SENT' }) },
+    }).service;
   });
 
   it('aggregates 3 lines into document totals', async () => {

--- a/apps/api/src/modules/expense-documents/__tests__/payroll-user-link.service.spec.ts
+++ b/apps/api/src/modules/expense-documents/__tests__/payroll-user-link.service.spec.ts
@@ -1,7 +1,7 @@
 import { BadRequestException } from '@nestjs/common';
 import { Prisma } from '@prisma/client';
 import { ExpenseDocumentsService } from '../expense-documents.service';
-import { LineAggregatorService } from '../services/line-aggregator.service';
+import { makeExpenseDocumentsService } from './support/make-expense-documents-service';
 
 describe('ExpenseDocumentsService.createPayroll — userId link & snapshot derive', () => {
   let service: ExpenseDocumentsService;
@@ -31,27 +31,26 @@ describe('ExpenseDocumentsService.createPayroll — userId link & snapshot deriv
       },
     };
     const docNumber = { next: jest.fn().mockResolvedValue('PR-20260601-0001') };
-    service = new ExpenseDocumentsService(
+    service = makeExpenseDocumentsService({
       prisma,
-      docNumber as never,
-      {} as never, // transition
-      {} as never, // sameDay
-      {} as never, // accrual
-      {} as never, // cn
-      { execute: jest.fn() } as never, // payroll template
-      { execute: jest.fn() } as never, // settlement
-      { createAndPost: jest.fn() } as never, // journalAuto
-      new LineAggregatorService(),
-      { preview: jest.fn() } as never, // jePreview
-      { validateContribution: jest.fn().mockResolvedValue(undefined) } as never, // ssoConfig
-      { execute: jest.fn() } as never, // pettyCash template
-      { getConfig: jest.fn(), validate: jest.fn() } as never,
-      {
+      docNumber,
+      transition: {}, // transition
+      sameDayTemplate: {}, // sameDay
+      accrualTemplate: {}, // accrual
+      creditNoteTemplate: {}, // cn
+      payrollTemplate: { execute: jest.fn() }, // payroll template
+      settlementTemplate: { execute: jest.fn() }, // settlement
+      journal: { createAndPost: jest.fn() }, // journalAuto
+      jePreview: { preview: jest.fn() }, // jePreview
+      ssoConfig: { validateContribution: jest.fn().mockResolvedValue(undefined) }, // ssoConfig
+      pettyCashTemplate: { execute: jest.fn() }, // pettyCash template
+      pettyCash: { getConfig: jest.fn(), validate: jest.fn() },
+      payrollCustom: {
         loadWhitelist: jest.fn().mockResolvedValue(new Set(['53-1104', '53-1105'])),
         validateLine: jest.fn().mockResolvedValue({ taxableBase: undefined }),
-      } as never, // payrollCustom
-      { send: jest.fn().mockResolvedValue({ id: 'n-1', status: 'SENT' }) } as never,
-    );
+      }, // payrollCustom
+      notifications: { send: jest.fn().mockResolvedValue({ id: 'n-1', status: 'SENT' }) },
+    }).service;
   });
 
   const linesCreated = () =>

--- a/apps/api/src/modules/expense-documents/__tests__/payroll.service.spec.ts
+++ b/apps/api/src/modules/expense-documents/__tests__/payroll.service.spec.ts
@@ -1,6 +1,6 @@
 import { BadRequestException, ForbiddenException } from '@nestjs/common';
 import { ExpenseDocumentsService } from '../expense-documents.service';
-import { LineAggregatorService } from '../services/line-aggregator.service';
+import { makeExpenseDocumentsService } from './support/make-expense-documents-service';
 
 describe('ExpenseDocumentsService.createPayroll', () => {
   let service: ExpenseDocumentsService;
@@ -23,30 +23,29 @@ describe('ExpenseDocumentsService.createPayroll', () => {
     const cn: any = {};
     const payroll: any = { execute: jest.fn() };
     const settlement: any = { execute: jest.fn() };
-    service = new ExpenseDocumentsService(
+    service = makeExpenseDocumentsService({
       prisma,
       docNumber,
       transition,
-      sameDay,
-      accrual,
-      cn,
-      payroll,
-      settlement,
-      { createAndPost: jest.fn() } as never,
-      new LineAggregatorService(),
-      { preview: jest.fn() } as never,
+      sameDayTemplate: sameDay,
+      accrualTemplate: accrual,
+      creditNoteTemplate: cn,
+      payrollTemplate: payroll,
+      settlementTemplate: settlement,
+      journal: { createAndPost: jest.fn() },
+      jePreview: { preview: jest.fn() },
       // ssoConfig: pass-through. Cap-validation behavior is tested in
       // sso-config.service.spec.ts. Tests here use ssoEmployee values within
       // the 2569+ cap of 875, so a no-op validator is sound.
-      { validateContribution: jest.fn().mockResolvedValue(undefined) } as never,
+      ssoConfig: { validateContribution: jest.fn().mockResolvedValue(undefined) },
       // pettyCashTemplate + pettyCash mocks (C1) — payroll path doesn't touch them
-      { execute: jest.fn() } as never,
-      { getConfig: jest.fn(), validate: jest.fn() } as never,
+      pettyCashTemplate: { execute: jest.fn() },
+      pettyCash: { getConfig: jest.fn(), validate: jest.fn() },
       // payrollCustom mock — fixtures don't exercise custom income/deduction; loadWhitelist
       // returns the seeded default + validateLine no-ops.
-      { loadWhitelist: jest.fn().mockResolvedValue(new Set(['53-1104', '53-1105'])), validateLine: jest.fn().mockResolvedValue({ taxableBase: undefined }) } as never,
-      { send: jest.fn().mockResolvedValue({ id: 'notif-1', status: 'SENT' }) } as never,
-    );
+      payrollCustom: { loadWhitelist: jest.fn().mockResolvedValue(new Set(['53-1104', '53-1105'])), validateLine: jest.fn().mockResolvedValue({ taxableBase: undefined }) },
+      notifications: { send: jest.fn().mockResolvedValue({ id: 'notif-1', status: 'SENT' }) },
+    }).service;
   });
 
   it('rejects negative netPaid (sso + wht > baseSalary)', async () => {

--- a/apps/api/src/modules/expense-documents/__tests__/settlement.service.spec.ts
+++ b/apps/api/src/modules/expense-documents/__tests__/settlement.service.spec.ts
@@ -1,7 +1,7 @@
 import { BadRequestException, ForbiddenException } from '@nestjs/common';
 import { Decimal } from '@prisma/client/runtime/library';
 import { ExpenseDocumentsService } from '../expense-documents.service';
-import { LineAggregatorService } from '../services/line-aggregator.service';
+import { makeExpenseDocumentsService } from './support/make-expense-documents-service';
 
 describe('ExpenseDocumentsService.createSettlement', () => {
   let service: ExpenseDocumentsService;
@@ -58,24 +58,23 @@ describe('ExpenseDocumentsService.createSettlement', () => {
     creditNote = { execute: jest.fn() };
     payroll = { execute: jest.fn() };
     settlement = { execute: jest.fn() };
-    service = new ExpenseDocumentsService(
+    service = makeExpenseDocumentsService({
       prisma,
       docNumber,
       transition,
-      sameDay,
-      accrual,
-      creditNote,
-      payroll,
-      settlement,
-      { createAndPost: jest.fn() } as never,
-      new LineAggregatorService(),
-      { preview: jest.fn() } as never,
-      { validateContribution: jest.fn().mockResolvedValue(undefined) } as never,
-      { execute: jest.fn() } as never,
-      { getConfig: jest.fn(), validate: jest.fn() } as never,
-      { loadWhitelist: jest.fn().mockResolvedValue(new Set()), validateLine: jest.fn() } as never,
-      { send: jest.fn().mockResolvedValue({ id: 'notif-1', status: 'SENT' }) } as never,
-    );
+      sameDayTemplate: sameDay,
+      accrualTemplate: accrual,
+      creditNoteTemplate: creditNote,
+      payrollTemplate: payroll,
+      settlementTemplate: settlement,
+      journal: { createAndPost: jest.fn() },
+      jePreview: { preview: jest.fn() },
+      ssoConfig: { validateContribution: jest.fn().mockResolvedValue(undefined) },
+      pettyCashTemplate: { execute: jest.fn() },
+      pettyCash: { getConfig: jest.fn(), validate: jest.fn() },
+      payrollCustom: { loadWhitelist: jest.fn().mockResolvedValue(new Set()), validateLine: jest.fn() },
+      notifications: { send: jest.fn().mockResolvedValue({ id: 'notif-1', status: 'SENT' }) },
+    }).service;
   });
 
   it('rejects when cleared doc not found', async () => {

--- a/apps/api/src/modules/expense-documents/__tests__/support/make-expense-documents-service.ts
+++ b/apps/api/src/modules/expense-documents/__tests__/support/make-expense-documents-service.ts
@@ -1,0 +1,151 @@
+/**
+ * Test factory for ExpenseDocumentsService.
+ *
+ * Slice 0 of the transactional-core decompose. This is the SINGLE positional
+ * facade construction site in the codebase (see the lone `new` below) — every
+ * spec constructs through this factory using a named-object interface keyed by
+ * the constructor parameter NAMES (see expense-documents.service.ts:87-107).
+ *
+ * Why: the facade has a 15-required + 1-optional positional constructor that
+ * later slices will reshape (injecting extracted sub-services). Routing all
+ * spec construction through one named-object factory means a future
+ * constructor change touches ONE place instead of 16 call sites across 7 files.
+ *
+ * Typing is intentionally loose (`any`) to match the existing `as never` style
+ * used by the specs — these are test doubles, not production wiring.
+ *
+ * NOT a test file: lives under `support/` with a non-`.spec.ts` name so jest's
+ * `testRegex: ".*\.spec\.ts$"` never collects it.
+ */
+import { Decimal } from '@prisma/client/runtime/library';
+import { ExpenseDocumentsService } from '../../expense-documents.service';
+import { LineAggregatorService } from '../../services/line-aggregator.service';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+/**
+ * Overrides keyed by the constructor PARAMETER names. All optional. Anything
+ * omitted falls back to the minimal default below. The two exceptions to "mock
+ * default" are:
+ *   - `aggregator` defaults to a REAL `new LineAggregatorService()` (every site
+ *     uses the real aggregator today).
+ *   - `notifications` defaults to `undefined` (the facade early-returns from
+ *     notifyApprovers when it is undefined — preserves the 15-arg behavior of
+ *     the specs that omit it).
+ */
+export interface ExpenseDocumentsServiceOverrides {
+  prisma?: any;
+  docNumber?: any;
+  transition?: any;
+  sameDayTemplate?: any;
+  accrualTemplate?: any;
+  creditNoteTemplate?: any;
+  payrollTemplate?: any;
+  settlementTemplate?: any;
+  journal?: any;
+  aggregator?: any;
+  jePreview?: any;
+  ssoConfig?: any;
+  pettyCashTemplate?: any;
+  pettyCash?: any;
+  payrollCustom?: any;
+  notifications?: any;
+}
+
+export interface MadeExpenseDocumentsService {
+  service: ExpenseDocumentsService;
+  prisma: any;
+  docNumber: any;
+  transition: any;
+  sameDayTemplate: any;
+  accrualTemplate: any;
+  creditNoteTemplate: any;
+  payrollTemplate: any;
+  settlementTemplate: any;
+  journal: any;
+  aggregator: any;
+  jePreview: any;
+  ssoConfig: any;
+  pettyCashTemplate: any;
+  pettyCash: any;
+  payrollCustom: any;
+  notifications: any;
+}
+
+export function makeExpenseDocumentsService(
+  overrides: ExpenseDocumentsServiceOverrides = {},
+): MadeExpenseDocumentsService {
+  const prisma = overrides.prisma ?? {};
+  const docNumber = overrides.docNumber ?? { next: jest.fn() };
+  const transition =
+    overrides.transition ??
+    {
+      assertCanPost: jest.fn(),
+      assertCanVoid: jest.fn(),
+      assertCanEdit: jest.fn(),
+      assertCanApprove: jest.fn(),
+      resolveTargetStatus: jest.fn(),
+    };
+  const sameDayTemplate = overrides.sameDayTemplate ?? { execute: jest.fn() };
+  const accrualTemplate = overrides.accrualTemplate ?? { execute: jest.fn() };
+  const creditNoteTemplate = overrides.creditNoteTemplate ?? { execute: jest.fn() };
+  const payrollTemplate = overrides.payrollTemplate ?? { execute: jest.fn() };
+  const settlementTemplate = overrides.settlementTemplate ?? { execute: jest.fn() };
+  const journal = overrides.journal ?? { createAndPost: jest.fn() };
+  // REAL aggregator by default — every construction site uses it today.
+  const aggregator = overrides.aggregator ?? new LineAggregatorService();
+  const jePreview = overrides.jePreview ?? { preview: jest.fn() };
+  const ssoConfig =
+    overrides.ssoConfig ?? { validateContribution: jest.fn().mockResolvedValue(undefined) };
+  const pettyCashTemplate = overrides.pettyCashTemplate ?? { execute: jest.fn() };
+  const pettyCash = overrides.pettyCash ?? { getConfig: jest.fn(), validate: jest.fn() };
+  const payrollCustom =
+    overrides.payrollCustom ??
+    {
+      loadWhitelist: jest.fn().mockResolvedValue(new Set()),
+      validateLine: jest.fn().mockResolvedValue({ taxableBase: new Decimal(0) }),
+    };
+  // notifications: undefined unless explicitly provided — preserves the
+  // 15-arg early-return behavior of specs that omit it.
+  const notifications = overrides.notifications;
+
+  // THE single positional construction in the codebase.
+  const service = new ExpenseDocumentsService(
+    prisma,
+    docNumber,
+    transition,
+    sameDayTemplate,
+    accrualTemplate,
+    creditNoteTemplate,
+    payrollTemplate,
+    settlementTemplate,
+    journal,
+    aggregator,
+    jePreview,
+    ssoConfig,
+    pettyCashTemplate,
+    pettyCash,
+    payrollCustom,
+    notifications,
+  );
+
+  return {
+    service,
+    prisma,
+    docNumber,
+    transition,
+    sameDayTemplate,
+    accrualTemplate,
+    creditNoteTemplate,
+    payrollTemplate,
+    settlementTemplate,
+    journal,
+    aggregator,
+    jePreview,
+    ssoConfig,
+    pettyCashTemplate,
+    pettyCash,
+    payrollCustom,
+    notifications,
+  };
+}

--- a/apps/api/src/modules/expense-documents/__tests__/tax-disallowed.service.spec.ts
+++ b/apps/api/src/modules/expense-documents/__tests__/tax-disallowed.service.spec.ts
@@ -1,6 +1,6 @@
 import { Decimal } from '@prisma/client/runtime/library';
 import { ExpenseDocumentsService } from '../expense-documents.service';
-import { LineAggregatorService } from '../services/line-aggregator.service';
+import { makeExpenseDocumentsService } from './support/make-expense-documents-service';
 
 /**
  * Phase A.5 — Tax-disallowed expense flag.
@@ -57,23 +57,22 @@ describe('ExpenseDocumentsService — tax-disallowed (Phase A.5)', () => {
       },
     };
     docNumber = { next: jest.fn().mockResolvedValue('EX-20260510-0001') };
-    service = new ExpenseDocumentsService(
+    service = makeExpenseDocumentsService({
       prisma,
       docNumber,
-      { assertCanPost: jest.fn(), assertCanVoid: jest.fn(), assertCanEdit: jest.fn() } as never,
-      { execute: jest.fn() } as never,
-      { execute: jest.fn() } as never,
-      { execute: jest.fn() } as never,
-      { execute: jest.fn() } as never,
-      { execute: jest.fn() } as never,
-      { createAndPost: jest.fn() } as never,
-      new LineAggregatorService(),
-      { preview: jest.fn() } as never,
-      { validateContribution: jest.fn().mockResolvedValue(undefined) } as never,
-      { execute: jest.fn() } as never,
-      { getConfig: jest.fn(), validate: jest.fn() } as never,
-      { loadWhitelist: jest.fn().mockResolvedValue(new Set()), validateLine: jest.fn().mockResolvedValue({ taxableBase: new Decimal(0) }) } as never,
-    );
+      transition: { assertCanPost: jest.fn(), assertCanVoid: jest.fn(), assertCanEdit: jest.fn() },
+      sameDayTemplate: { execute: jest.fn() },
+      accrualTemplate: { execute: jest.fn() },
+      creditNoteTemplate: { execute: jest.fn() },
+      payrollTemplate: { execute: jest.fn() },
+      settlementTemplate: { execute: jest.fn() },
+      journal: { createAndPost: jest.fn() },
+      jePreview: { preview: jest.fn() },
+      ssoConfig: { validateContribution: jest.fn().mockResolvedValue(undefined) },
+      pettyCashTemplate: { execute: jest.fn() },
+      pettyCash: { getConfig: jest.fn(), validate: jest.fn() },
+      payrollCustom: { loadWhitelist: jest.fn().mockResolvedValue(new Set()), validateLine: jest.fn().mockResolvedValue({ taxableBase: new Decimal(0) }) },
+    }).service;
   });
 
   describe('create() — persists tax-disallowed flag', () => {

--- a/docs/superpowers/specs/2026-06-10-expense-documents-transactional-core-decompose-design.md
+++ b/docs/superpowers/specs/2026-06-10-expense-documents-transactional-core-decompose-design.md
@@ -1,0 +1,200 @@
+# Expense-Documents Transactional-Core Decompose — Design Proposal (PHASE 0)
+
+> **STATUS: DESIGN-ONLY. รออนุมัติเจ้าของก่อนแตะโค้ดใด ๆ ที่ใช้ `$transaction` / โพสต์ JE / เปลี่ยน document status.**
+> เอกสารนี้คือ Phase 0 ตามโจทย์ — recon + ออกแบบ seam + slice plan + risk register. ยังไม่มี implementation code.
+
+**Goal:** แตก transactional core ของ `apps/api/src/modules/expense-documents/expense-documents.service.ts` (2,475 LOC) ออกเป็น collaborator services แบบ **behavior-preserving** (TFRS regulated — JE output + document state transitions ห้ามเปลี่ยน) โดยย้ายเมธอด **verbatim** (ยกทั้ง `$transaction` block) และคง public signature ทั้งหมดผ่าน facade.
+
+**Baseline:** origin/main = local HEAD = `afc008e6` (#1170) — ยืนยันด้วย `git fetch origin main` แล้ว (ไม่ stale). E1–E6 util extractions landed แล้ว (utils + `services/` 7 ตัว). ที่เหลือ = transactional core นี้.
+
+---
+
+## 0. Preconditions & Gates
+
+| # | Precondition | สถานะ |
+|---|---|---|
+| P1 | local == origin/main == `afc008e6` | ✅ ยืนยันแล้ว (fetch สด) — memory's `6fa34ee3`/#1211/#1212 **ไม่อยู่บน origin/main**; เป็นงาน accounting/expense E4–E6 ที่ไม่เกี่ยวไฟล์นี้ หรือยังไม่ landed. ก่อนเริ่มแต่ละ slice ให้ re-confirm `git rev-parse origin/main` ยังเป็น afc008e6 (หรือ rebase ถ้า main เคลื่อน) |
+| P2 | service = 2,475 LOC, 13 `$transaction` sites, 412 jest tests / 34 suites | ✅ ยืนยันแล้ว (jest run) |
+| Gates | ทุก slice ต้องเขียว | `./tools/check-types.sh api` (tsc 0) **และ** `npm --prefix apps/api run test -- expense-documents` (412 → ต้องไม่ลด, --runInBand baked in) |
+| Evidence | ยืนยันด้วยการ trace runtime path ไม่ใช่ diff | byte-identity ของเมธอดที่ย้าย + JE-call-args/state-transition ที่ pin ไว้ |
+
+---
+
+## 1. Method Inventory (28 members)
+
+Purity: **READ** = ไม่มี write/`$tx` · **WRITE-TX** = เปิด/รับ `$transaction` · **HELPER/INIT** = private/lifecycle
+
+| # | Method | LOC (lines) | Purity | `$tx` boundary | Collaborators ที่เรียก | Guards | State transition |
+|---|--------|-----|--------|-----------|------------------------|--------|------------------|
+| 1 | `onModuleInit` | 66–85 (20) | INIT | none | `prisma.chartOfAccount`, `ADJUSTMENT_ALLOWLIST` | boot CoA-exists check (throw) | — |
+| 2 | `constructor` | 87–107 | — | — | (15 req + `notifications?`) | — | — |
+| 3 | `notifyApprovers` | 120–169 (50) | HELPER (async, **นอก** tx) | none | `readBoolFlag`, `getApproversList`, `prisma.user`, `notifications?.send` | opt-out flag, null-guard notifications | — |
+| 4 | `readBoolFlag` | 177–183 (7) | HELPER | passthrough | util `readBoolFlag` | — | — |
+| 5 | `readNumberFlag` | 196–215 (20) | HELPER | none | `tx.systemConfig` | clamp ≥0, Decimal (จงใจไม่ dedup) | — |
+| 6 | `create` | 219–320 (102) | WRITE-TX | **opens** (230) | `aggregator.computeLine/aggregateLines`, `assertCategoriesAreExpense`, `validateAdjustments`, `docNumber.next` | CoA-type, V12/13/14 adjustments | → DRAFT (EXPENSE) |
+| 7 | `createDraftForRepair` | 339–414 (76) | WRITE-TX | **รับ tx จากภายนอก** (RepairTickets) | `aggregator`, `docNumber.next` | (ข้าม CoA/adjustment โดยตั้งใจ) | → DRAFT (REPAIR_SERVICE) |
+| 8 | `createCreditNote` | 423–576 (154) | WRITE-TX | **opens** (441) + `pg_advisory_xact_lock` | `aggregator`, `assertCategoriesAreExpense`, `docNumber.next`, `tx.expenseDocument` | mode LINKED/STANDALONE, orig lookup, branch, type, status, orig-WHT, cap | → DRAFT (CREDIT_NOTE) |
+| 9 | `createPayroll` | 579–788 (210) | WRITE-TX | **opens** (721) | `ssoConfig.validateContribution`, `payrollCustom.loadWhitelist/validateLine`, `prisma.employeeProfile`, `docNumber.next`, `maskPayrollTaxIds` | cross-branch, SSO cap, PR-C employee link, netPaid≥0 | → DRAFT (PAYROLL) |
+| 10 | `createSettlement` | 791–984 (194) | WRITE-TX | **opens** (842) + sorted advisory locks | `readBoolFlag`, `readIntFlag`, `validateAdjustments`, `docNumber.next`, `tx.settlementLine` | cross-branch, max-bills, partial-pay flag, dedup, ACCRUAL-only, cap, WHT≤sum | → DRAFT (VENDOR_SETTLEMENT) |
+| 11 | `createPettyCash` | 987–1113 (127) | WRITE-TX | **opens** (1054) | `readBoolFlag`, `pettyCash.getConfig/validate`, `assertCategoriesAreExpense`, `docNumber.next` | feature-flag, cross-branch, V20 limit/supplier/account | → DRAFT (PETTY_CASH_REIMBURSEMENT) |
+| 12 | `list` | 1116–1201 (86) | READ | none | `prisma.expenseDocument` | branch-scope, tab/status filters | — |
+| 13 | `getSummary` | 1204–1250 (47) | READ | none | `prisma.expenseDocument.groupBy/aggregate` | — | — |
+| 14 | `getTaxDisallowedSummary` | 1270–1324 (55) | READ | none | `prisma.expenseDocument/expenseLine.aggregate` | — | — |
+| 15 | `getApAging` ⚠️**TRAP** | 1339–1447 (109) | READ | none | `prisma.expenseDocument` | — (labels `0-30/31-60/61-90/90+` = aging-bucket trap, **ห้ามแตะ**) | — |
+| 16 | `getDailySummary` | 1450–1564 (115) | READ | none | `prisma.expenseDocument`, `hasCrossBranchAccess` | branch req | — |
+| 17 | `getCreditNoteCap` | 1569–1595 (27) | READ | none | `prisma.expenseDocument` | EXPENSE-only | — |
+| 18 | `previewJe` | 1598–1606 (9) | READ | none | `collectJePreviewCodes`, `prisma.chartOfAccount`, `jePreview.preview` | — | — (no write) |
+| 19 | `getAuditTrail` | 1614–1642 (29) | READ | none | **`this.findOne`** (intra), `prisma.auditLog`, `hasCrossBranchAccess` | branch-scope | — |
+| 20 | `findOne` | 1649–1696 (48) | READ | none | `prisma.expenseDocument`, `maskPayrollTaxIds` | deletedAt | — |
+| 21 | `update` | 1699–1791 (93) | WRITE-TX | **opens** (1700) | `transition.assertCanEdit`, `aggregator`, `assertCategoriesAreExpense` | assertCanEdit (DRAFT/ACCRUAL) | edit (no status change) |
+| 22 | `submitForApproval` | 1803–1861 (59) | WRITE-TX | **opens** (1804) + advisory lock; `notifyApprovers` **นอก tx** | `readBoolFlag`, `prisma.auditLog`, `notifyApprovers` | approval_enabled, DRAFT-only | DRAFT → PENDING_APPROVAL |
+| 23 | `post` | 1871–1938 (68) | WRITE-TX | **opens** (1883) + advisory lock; **เรียก `executePostBody` ในtx** | `resolvePostPermissionRoles`, `readBoolFlag/readNumberFlag`, `getApprovalRequiredDocTypes`, `transition.assertCanPost`, **`executePostBody`** | post-permission, approval-gate, assertCanPost | DRAFT/APPROVED → (template) |
+| 24 | `executePostBody` ⚠️**shared** | 1958–2127 (170) | WRITE-TX (private, **รับ tx**) | **ไม่เปิดเอง — รับจาก post/approve** | `validatePeriodOpen`, **6 JE templates `.execute(id, tx)`**, `transition.resolveTargetStatus`, `tx.expenseDetail` | period-open, attachment-threshold, WHT-routing (C12), type-allowlist, V15 ACCRUAL-no-WHT | dispatch JE → ACCRUAL/POSTED |
+| 25 | `approve` | 2146–2208 (63) | WRITE-TX | **opens** (2147) + advisory lock; **เรียก `executePostBody` ในtx** | `assertUserCanApprove`, `transition.assertCanApprove`, `readBoolFlag`, `prisma.auditLog`, **`executePostBody`** | approver-membership, assertCanApprove, auto_post flag | PENDING_APPROVAL → APPROVED → (POSTED) |
+| 26 | `voidDocument` | 2216–2459 (244) | WRITE-TX | **opens** (2233) + advisory lock | `resolveReversePermissionRoles`, `readBoolFlag`, `getReverseReasons`, `bkkBusinessDate`, `validatePeriodOpen`, **`journal.createAndPost`** (reversal JE), `transition.assertCanVoid`, `prisma.auditLog` | reverse-permission, cascade-block (CN/SE), reason-required/whitelist, future-date, assertCanVoid, period | (any) → VOIDED + SE→ACCRUAL revert |
+| 27 | `softDelete` | 2462–2474 (13) | WRITE (no $tx) | none | `prisma.expenseDocument` | DRAFT-only, deletedAt | DRAFT → (soft-deleted) |
+
+**Cross-method call graph (สำคัญต่อ seam):**
+- `getAuditTrail` → `findOne` (READ → READ)
+- `post` → `executePostBody` (ใน tx เดียวกัน)
+- `approve` → `executePostBody` (ใน tx เดียวกัน) — **executePostBody ถูกแชร์**
+- `submitForApproval` → `notifyApprovers` (นอก tx)
+- ทุก create*/update → utils (`assertCategoriesAreExpense`/`validateAdjustments`/`aggregator`) — **ไม่มี create*↔lifecycle cross-call**
+
+---
+
+## 2. Target Collaborator Services + Seams
+
+แตกเป็น **3 collaborator services + 1 facade** (validate ข้อเสนอตั้งต้นของโจทย์ — ปรับ `previewJe`→Query, ย้าย `update`/`createDraftForRepair` ตามรายละเอียดด้านล่าง):
+
+### 2.1 `ExpenseDocumentQueryService` (READ-only — Phase 1, ปลอดภัยสุด)
+ย้าย 9 เมธอด: `list`, `getSummary`, `getTaxDisallowedSummary`, `getApAging`⚠️, `getDailySummary`, `getCreditNoteCap`, `previewJe`, `getAuditTrail`, `findOne`.
+- **Inject:** `prisma`, `jePreview` (สำหรับ previewJe). ใช้ free-fns `collectJePreviewCodes`, `hasCrossBranchAccess`, `maskPayrollTaxIds` ตรง ๆ (import).
+- **Intra-call:** `getAuditTrail`→`findOne` อยู่ service เดียวกัน → ปลอดภัย.
+- **ไม่มี `$tx`** → ไม่มีทางตัด tx คร่อม seam. นี่คือเหตุผลที่ทำ Phase 1 ก่อน.
+- ~525 LOC.
+
+### 2.2 `ExpenseDocumentLifecycleService` (state machine + posting — Phase 2, เสี่ยงสุด)
+ย้าย: `submitForApproval`, `post`, `executePostBody`(private), `approve`, `voidDocument`, `softDelete`, `notifyApprovers`(private) + private wrappers `readBoolFlag`/`readNumberFlag` (copy verbatim).
+- **Inject:** `prisma`, `transition`, **6 templates** (`sameDay/accrual/creditNote/payroll/settlement/pettyCash` — ทั้งหมด `execute(id, tx)`), `journal`, `notifications?`.
+- ใช้ free-fns ตรง ๆ: `resolvePostPermissionRoles`, `resolveReversePermissionRoles`, `validatePeriodOpen`, `bkkBusinessDate`, `assertUserCanApprove`, `getApprovalRequiredDocTypes`, `getApproversList`, `getReverseReasons`, util `readBoolFlag`.
+- **เหตุผลคลัสเตอร์เดียว:** `executePostBody` ถูกเรียก **ในtx** ของทั้ง `post()` และ `approve()` → ต้องอยู่ service เดียวกันทั้งสาม มิฉะนั้น `$tx` จะคร่อม seam (ผิดกฎเด็ดขาด). `submitForApproval`+`notifyApprovers` และ `voidDocument` ก็โพสต์/แก้ state จึงรวมที่นี่.
+- ~694 LOC.
+
+### 2.3 `ExpenseDocumentCreateService` (create family — Phase 3, เสี่ยง)
+ย้าย: `create`, `update`, `createDraftForRepair`, `createCreditNote`, `createPayroll`, `createSettlement`, `createPettyCash` + private wrapper `readBoolFlag` (copy verbatim).
+- **Inject:** `prisma`, `docNumber`, `aggregator`, `ssoConfig`, `payrollCustom`, `pettyCash`, `transition` (สำหรับ `update.assertCanEdit`).
+- ใช้ free-fns ตรง ๆ: `assertCategoriesAreExpense`, `validateAdjustments`, `ADJUSTMENT_ALLOWLIST`, `maskPayrollTaxIds`, `hasCrossBranchAccess`, util `readBoolFlag`/`readIntFlag`.
+- **ไม่มี create*↔lifecycle cross-call** → seam สะอาด.
+- ⚠️ **~963 LOC — ใหญ่สุด.** ดู §3 hazard H7 (optional further split).
+
+### 2.4 `ExpenseDocumentsService` (facade — คงเดิม)
+- **คง public signature 21 เมธอด** (controller 20 + `createDraftForRepair` ที่ RepairTickets เรียก) → controller/RepairTickets/expense-templates wiring **ไม่เปลี่ยน**.
+- **คง `onModuleInit`** (boot CoA check) — inject `prisma`.
+- **Inject 3 sub-services** + `prisma`; ทุก public method = one-line delegation เช่น `create(dto, u) { return this.create_.create(dto, u); }`, `createDraftForRepair(dto, tx) { return this.create_.createDraftForRepair(dto, tx); }` (tx ไหลผ่าน facade → Create, owner คือ RepairTickets เหมือนเดิม → ไม่มี straddle).
+- ~150–200 LOC.
+
+**สรุป LOC:** 2,475 → facade ~180 + Query ~525 + Lifecycle ~694 + Create ~963 (รวม >2,475 เพราะ boilerplate ของ class/constructor/imports 4 ไฟล์ + delegation).
+
+---
+
+## 3. Hazards & การจัดการ
+
+| ID | Hazard | การจัดการ |
+|----|--------|-----------|
+| **H1** | `executePostBody` ถูกเรียก**ในtx**ของ `post()` + `approve()` | เก็บ `post`+`approve`+`executePostBody` ใน **Lifecycle เดียวกัน** → intra-service call, tx ไม่คร่อม seam |
+| **H2** | `getAuditTrail`→`findOne` | ทั้งคู่ READ → ย้ายเข้า **Query พร้อมกัน** ใน slice เดียว → intra-service |
+| **H3** | `createDraftForRepair` **รับ tx จาก RepairTicketsService** | facade คง signature `createDraftForRepair(dto, tx)` → delegate ไป Create; tx ยัง owned โดย RepairTickets, Create แค่ enlist (เหมือนวันนี้). RepairTickets/its module **ไม่เปลี่ยน** (มัน import `ExpenseDocumentsModule` + เรียก facade) |
+| **H4** | `readBoolFlag`/`readNumberFlag` private wrappers ถูกใช้ทั้ง Create + Lifecycle | copy wrapper **verbatim** เข้าแต่ละ service ที่ใช้ (3–7 บรรทัด, body = delegate ไป util → behavior-identical). `readNumberFlag` เฉพาะ Lifecycle (post ใช้). *Optional* dedup ภายหลัง |
+| **H5** | `onModuleInit` boot-check | คงบน **facade** (NestJS เรียก onModuleInit ของ provider; facade ยังเป็น provider) — รันครั้งเดียวตอน boot เหมือนเดิม |
+| **H6** | `expense-templates.service.ts` ใช้ `forwardRef(() => ExpenseDocumentsService)` เรียก `create/createPayroll/createSettlement` | facade ยัง expose เมธอดเหล่านี้ (delegate ไป Create) → forwardRef **ไม่เปลี่ยน** |
+| **H7** | Create ~963 LOC ยังใหญ่ | *Optional Phase 3b* แยกต่อ (เช่น core `create`/`update`/`createDraftForRepair` vs specialized `createCreditNote`/`createPayroll`/`createSettlement`/`createPettyCash`) — **ไม่มี cross-call** จึงแยกได้. แนะนำ: ทำ 3-service ให้จบก่อน (seam น้อย = เสี่ยงน้อย) แล้วเจ้าของค่อยตัดสิน 3b |
+| **H8** | **$tx-straddle audit** | ทุก WRITE-TX เปิด tx ของตัวเองและเรียก collaborator **ภายใน** tx นั้น (templates/journal/docNumber/utils ทั้งหมดรับ `tx`). หลังแตกแล้ว **ไม่มี tx คร่อม service** — facade delegation เป็น call ธรรมดา (ไม่มี tx ครอบ). ✅ ยืนยันแล้วทุกเมธอด |
+
+### 3.1 กลไก test-construction (หัวใจที่ทำให้ refactor นี้ทำได้)
+412 tests สร้าง **facade** ด้วย mock 15–16 ตัว แล้ว assert บน mock เหล่านั้น (เช่น `expect(docNumberMock.next).toHaveBeenCalled`). เมื่อเมธอดย้ายไป sub-service, mock ต้องไปถึง sub-service. **Slice 0 factory** แก้ปัญหานี้: factory สร้าง sub-services จาก mock เดียวกันแล้วส่งเข้า facade → test เรียก `service.create(...)` เหมือนเดิม, mock instance เดียวกันไหลถึง sub-service → assertion เดิมผ่าน. **factory = construction site เดียวที่เปลี่ยนทุก slice.**
+
+---
+
+## 4. Slice Plan (smallest-safe-first)
+
+> **เลือก strictly-sequential-on-main** (ไม่ stack): แต่ละ slice base = main, merge แล้วค่อย branch ตัวถัดไป. ทุก slice แก้ไฟล์เดียวกัน (`expense-documents.service.ts` + `.module.ts` + ไฟล์ service ใหม่) → stack จะ conflict + เสี่ยง stacked-merge incident ซ้ำรอย. ดู §5 merge order.
+
+### Slice 0 — Test-construction de-risk (no prod behavior change)
+- **เป้า:** เพิ่ม factory `makeExpenseDocumentsService(overrides)` (เช่น `__tests__/support/make-expense-documents-service.ts`) แล้ว migrate **7 ไฟล์ / 16 `new` statements** มาใช้ factory:
+  `expense-documents.service.spec.ts`(**10**), `tax-disallowed`(1), `settlement`(1), `credit-note`(1), `multi-line-create`(1), `payroll`(1), `payroll-user-link`(1).
+  (`expense-documents.controller.spec.ts` ใช้ `useValue` mock — ไม่แตะ.)
+- **เหตุผล:** ปัจจุบัน `as never` cast ซ่อน arg-count/type drift = อันตรายตอนเพิ่ม param. factory รวมเหลือ 1 จุด.
+- factory ต้องรองรับ 2 arg-shape เดิม (15-arg omit notifications: service.spec+tax-disallowed · 16-arg incl `notifications.send`: อีก 5 ไฟล์) และ default `aggregator = new LineAggregatorService()` (REAL — หลาย test พึ่งการ aggregate จริง).
+- **Char-test:** ไม่ย้าย logic → 412 ต้องเขียวเป๊ะ (เปลี่ยนแค่วิธีสร้าง).
+- **Gate:** tsc 0 + 412 green. → PR. **STOP รอ merge.**
+
+### Phase 1 — `ExpenseDocumentQueryService` (READ-only)
+- **Char-test ก่อนย้าย (เติม gap):** read methods ที่ยังไม่ pin โดยตรง — โดยเฉพาะ `getApAging`⚠️ (pin bucket math + labels `0-30/31-60/61-90/90+` + net=total−wht), และเช็ค `getSummary`/`getCreditNoteCap`/`getAuditTrail` มี assertion ตรงหรือไม่ ถ้าไม่มีให้เพิ่ม. (`getDailySummary` 4, `getTaxDisallowedSummary` 7, `findOne` 2, `previewJe`→je-preview.service 8, `list` 5 มีแล้ว.)
+- ย้าย 9 เมธอด **verbatim** เข้า Query (`getApAging` ไม่แตะ labels). facade delegate. factory wire Query จาก mock เดิม.
+- **Gate:** tsc 0 + 412 green. → PR. **STOP รอ merge + เจ้าของ re-confirm ก่อน Phase 2/3.**
+
+### Phase 2 — `ExpenseDocumentLifecycleService` (state machine + posting) — *หลัง Phase 1 + re-confirm*
+แยกย่อย 3 sub-slices (diff เล็ก = review ปลอดภัย):
+
+- **2a — submit/notify/softDelete:** ย้าย `submitForApproval`, `notifyApprovers`, `softDelete` + `readBoolFlag` wrapper → สร้าง Lifecycle service. (ไม่มี JE dispatch; submit = status flip + audit + notify-นอก-tx).
+  - Char: มีแล้ว (submit 4: flag-gate/DRAFT→PENDING flip/non-DRAFT reject/soft-deleted; softDelete 3).
+- **2b — posting core (HIGHEST RISK):** ย้าย `post` + `executePostBody` + `approve` + `readNumberFlag` wrapper (ต้องไปด้วยกัน — shared inner-tx body).
+  - **Char-test ก่อนย้าย (เติม gap ที่ pin ไว้ 0 จุดวันนี้):**
+    (1) `post()` CREDIT_NOTE → `creditNoteTemplate.execute(id, tx)` toHaveBeenCalled
+    (2) `post()` PETTY_CASH_REIMBURSEMENT → `pettyCashTemplate.execute(id, tx)`
+    (5) `executePostBody` type-allowlist `'type X not supported'` reject branch
+    + approve auto-post routing CN/SE/petty (gap เดียวกัน)
+    (ที่ pin แล้ว: sameDay/accrual/settlement/payroll routing, V15, C10 attachment, C12 WHT-formType, C9 period, D1.2.1.2 approval-gate, approver-list, APPROVED/AUTO_POSTED audit — คงเขียวทั้งหมด)
+- **2c — void:** ย้าย `voidDocument` → Lifecycle.
+  - Char: pin แล้วครบ (flipped-Dr/Cr reversal via `journal.createAndPost` + metadata, CAS VOIDED flip, advisory lock, SE→ACCRUAL revert, cascade-block CN/SE, reason/whitelist/future-date guards, C3 audit) — verbatim move.
+- แต่ละ sub-slice: facade delegate + factory wire Lifecycle. **Gate:** tsc 0 + 412 green. → PR ต่อ slice.
+
+### Phase 3 — `ExpenseDocumentCreateService` (create family) — *หลัง Phase 2 + re-confirm*
+- **Char-test ก่อนย้าย (เติม gap):**
+    (3) `createPettyCash` happy-path: pin `expenseDocument.create` args (`documentType=PETTY_CASH_REIMBURSEMENT`, `status=DRAFT`) + เรียก `pettyCash.validate`
+    (4) `update()` happy-path body (DRAFT edit persist lines/totals via `expenseLine.deleteMany`+`expenseDetail.update`+`expenseDocument.update`) — วันนี้ pin แค่ rejection (assertCanEdit)
+    + ยืนยัน `createDraftForRepair` ถูก pin (ผ่าน `repair-tickets.service.spec.ts` หรือเพิ่ม direct test — รับ external tx)
+    (ที่ pin แล้ว: create, createCreditNote, createPayroll, createSettlement guards+DRAFT — verbatim move)
+- ย้าย 7 เมธอด **verbatim** เข้า Create. facade delegate. factory wire Create.
+- **Gate:** tsc 0 + 412 green. → PR.
+- **Optional 3b:** แยก Create ต่อ (H7) — ถามเจ้าของ.
+
+---
+
+## 5. Risk Register + Merge Order
+
+### 5.1 Risk register
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| `$tx` คร่อม seam (JE/state เพี้ยน) | Low | **Critical** | §3 H8 audit ผ่านแล้ว — ทุก tx self-contained ใน service เดียว; executePostBody อยู่กับ post/approve |
+| เพิ่ม ctor param พัง 16 `new` sites | High→**Low** | High | Slice 0 factory ทำก่อน → 1 construction site |
+| JE-dispatch routing เพี้ยนตอนย้าย posting core | Med | **Critical** | 2b char-test เติม gap CN/petty/type-allowlist ก่อน + ย้าย verbatim + pin template.execute args |
+| `getApAging` label/bucket เพี้ยน (TRAP) | Low | High | ย้าย **verbatim**, char-test pin bucket+labels ก่อน, ห้าม unify |
+| main เคลื่อนระหว่างทาง (stacked-merge ซ้ำรอย) | Med | High | strictly-sequential-on-main; re-confirm `origin/main` ก่อนทุก slice; **เจ้าของ verify content landed บน main จริง** (อย่าเชื่อ gh "MERGED") |
+| `createDraftForRepair` external-tx เพี้ยน | Low | High | facade คง signature; tx ไหลผ่าน; RepairTickets unchanged; char-test ก่อนย้าย |
+| 412 → ลดจำนวน (test หาย) | Low | Med | gate นับ test ทุก slice; factory migrate = แก้วิธีสร้าง ไม่ลบ test |
+
+### 5.2 Merge order (เจ้าของ merge — ผมไม่ push main)
+**ลำดับ (1 slice = 1 branch = 1 PR, base=main, sequential):**
+1. `chore/exp-decompose-s0-test-factory` → merge → main
+2. `refactor/exp-decompose-p1-query` (base = main หลัง #1) → merge → **STOP, เจ้าของ re-confirm**
+3. `refactor/exp-decompose-p2a-submit-notify` → merge
+4. `refactor/exp-decompose-p2b-posting-core` → merge
+5. `refactor/exp-decompose-p2c-void` → merge → **STOP, re-confirm**
+6. `refactor/exp-decompose-p3-create` → merge
+7. *(optional)* `refactor/exp-decompose-p3b-create-split`
+
+**ถ้าจำเป็นต้อง stack** (เจ้าของขอ queue): แต่ละ child base = parent branch; **ก่อน merge ต้อง retarget base→main ทีละตัว** + **verify content landed บน main จริง** (git diff origin/main) ก่อนไปตัวถัดไป — กฎจาก stacked-merge incident (#1194/#1195/#1202–1205). **แนะนำ sequential-on-main มากกว่า** (หลีกเลี่ยงปัญหานี้ทั้งหมด).
+
+---
+
+## 6. ขออนุมัติ (STOP)
+
+โปรดยืนยัน/แก้:
+1. **3-service seam** (Query / Lifecycle / Create + facade) ตามนี้ หรือต้องการแยก Create ตั้งแต่แรก (H7 / Phase 3b)?
+2. **Sub-slicing Phase 2** เป็น 2a/2b/2c (แนะนำ) หรือรวมเป็น Lifecycle slice เดียว?
+3. **Sequential-on-main** (แนะนำ) หรือ stack-with-retarget?
+4. ผ่านแล้วจะเริ่มที่ **Slice 0 (test factory)** — implement → spec-review → quality-review → PR → STOP รอ merge.
+
+**ยังไม่เขียน implementation code จนกว่าจะอนุมัติ.**


### PR DESCRIPTION
## Slice 0 — test-construction de-risk (behavior-preserving, test-infra only)

First slice of the **expense-documents transactional-core decompose** epic. **No production code changes.**

Introduces `makeExpenseDocumentsService(overrides)` and collapses **16 positional `new ExpenseDocumentsService(...)` sites across 7 spec files** into one named-object factory — so the later slices (which change the facade constructor to inject extracted sub-services) touch **one** construction site instead of 16. The `as never` positional casts that hid arg-count/type drift are gone.

### What changed
- **New:** `apps/api/src/modules/expense-documents/__tests__/support/make-expense-documents-service.ts` — the single positional construction point; named overrides keyed by constructor param names; `aggregator` defaults to REAL `LineAggregatorService`, `notifications` defaults to `undefined`.
- **Migrated (7 spec files / 16 sites):** `expense-documents.service.spec.ts` (10), `tax-disallowed` / `settlement` / `credit-note` / `multi-line-create` / `payroll` / `payroll-user-link` (1 each). `expense-documents.controller.spec.ts` uses `useValue` — untouched.
- **Docs:** Phase-0 design doc (owner-approved) added under `docs/superpowers/specs/` (separate commit).

### Behavior-preservation (verified)
- `notifications` stays **undefined** in the 2 fifteen-arg files (so `notifyApprovers` early-returns as today); **present** in the 5 sixteen-arg files.
- Per-site mock values preserved (e.g. `payrollCustom.loadWhitelist → Set(['53-1104','53-1105'])`, the void tests' local `journalMock`). Only construction calls + dead imports changed — **no `expect`/mock-setup/test-logic edits**.

### Gates
- `./tools/check-types.sh api` → **0 errors**
- `npm --prefix apps/api run test -- expense-documents` → **412 passed / 34 suites** (baseline 412/34 — unchanged; factory not collected)
- `grep -rc "new ExpenseDocumentsService(" apps/api/src` → **1** (only inside the factory)
- Two-stage review (spec-compliance + code-quality) passed.

### ⚠️ Merge order (sequential-on-main — owner's choice)
- This PR is **base = main**, independent. **Merge this FIRST.**
- Phase 1 (extract `ExpenseDocumentQueryService`) will branch from **updated main** after this lands — NOT stacked.
- Every later slice = its own branch off the freshly-merged main. This avoids the stacked-merge incident class (#1194/#1202–1205): never merge a stacked child without retarget→main + verifying content actually landed on main.

After merge I'll STOP for re-confirm before Phase 1, per plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)