### PR TITLE
Phase 1: extract ExpenseDocumentQueryService (9 read methods, verbatim)

### DIFF
--- a/apps/api/src/modules/expense-documents/__tests__/expense-document-query.service.spec.ts
+++ b/apps/api/src/modules/expense-documents/__tests__/expense-document-query.service.spec.ts
@@ -1,0 +1,361 @@
+/**
+ * Characterization tests for the 9 READ-only methods extracted into
+ * ExpenseDocumentQueryService (Phase 1 of the transactional-core decompose).
+ *
+ * IMPORTANT: every test here drives the FACADE (`service.getApAging(...)` etc.)
+ * via the single construction factory. They were written BEFORE the extraction
+ * to pin the pre-move behavior, and they keep passing after the facade
+ * delegates to QueryService (behavior-identical, same mock instances flow
+ * through the factory). Do NOT change these to test the QueryService directly —
+ * the public contract is the facade.
+ *
+ * Focus: the UNDER-PINNED read methods that lacked dedicated coverage in
+ * expense-documents.service.spec.ts (getApAging, getSummary, getCreditNoteCap,
+ * getAuditTrail, previewJe). `list` / `findOne` / `getDailySummary` are already
+ * covered there, so we only spot-check `list` tab translation here.
+ */
+import { BadRequestException, ForbiddenException, NotFoundException } from '@nestjs/common';
+import { Decimal } from '@prisma/client/runtime/library';
+import { makeExpenseDocumentsService } from './support/make-expense-documents-service';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+describe('ExpenseDocumentQueryService (read methods, via facade)', () => {
+  describe('getApAging (aging-bucket TRAP)', () => {
+    // Deterministic "today" so the BKK calendar-day diff lands rows in stable
+    // buckets. 2026-06-10T03:00:00Z = 2026-06-10 10:00 BKK → BKK date 2026-06-10.
+    beforeEach(() => {
+      jest.useFakeTimers().setSystemTime(new Date('2026-06-10T03:00:00Z'));
+    });
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    function makeWithRows(rows: any[]) {
+      const prisma = {
+        expenseDocument: {
+          findMany: jest.fn().mockResolvedValue(rows),
+        },
+      };
+      return { prisma, service: makeExpenseDocumentsService({ prisma }).service };
+    }
+
+    it('buckets docs into exactly 0-30/31-60/61-90/90+ by BKK calendar-day age, with a TOTAL', async () => {
+      // documentDate is stored at UTC midnight; BKK date = same calendar day.
+      const rows = [
+        // age 0 → 0-30
+        { id: 'd0', number: 'EX-1', vendorName: 'A', vendorTaxId: '1', documentDate: new Date('2026-06-10T00:00:00Z'), totalAmount: new Decimal('100'), withholdingTax: new Decimal('0'), branchId: 'b1' },
+        // age 30 → 0-30 (boundary)
+        { id: 'd30', number: 'EX-2', vendorName: 'A', vendorTaxId: '1', documentDate: new Date('2026-05-11T00:00:00Z'), totalAmount: new Decimal('200'), withholdingTax: new Decimal('0'), branchId: 'b1' },
+        // age 31 → 31-60
+        { id: 'd31', number: 'EX-3', vendorName: 'A', vendorTaxId: '1', documentDate: new Date('2026-05-10T00:00:00Z'), totalAmount: new Decimal('300'), withholdingTax: new Decimal('0'), branchId: 'b1' },
+        // age 61 → 61-90
+        { id: 'd61', number: 'EX-4', vendorName: 'A', vendorTaxId: '1', documentDate: new Date('2026-04-10T00:00:00Z'), totalAmount: new Decimal('400'), withholdingTax: new Decimal('0'), branchId: 'b1' },
+        // age 91 → 90+
+        { id: 'd91', number: 'EX-5', vendorName: 'A', vendorTaxId: '1', documentDate: new Date('2026-03-11T00:00:00Z'), totalAmount: new Decimal('500'), withholdingTax: new Decimal('0'), branchId: 'b1' },
+      ];
+      const { service } = makeWithRows(rows);
+
+      const res = await service.getApAging({});
+
+      // Literal bucket label strings — must remain 0-30/31-60/61-90/90+/TOTAL.
+      expect(Object.keys(res.buckets)).toEqual(['0-30', '31-60', '61-90', '90+', 'TOTAL']);
+      expect(res.buckets['0-30']).toEqual({ count: 2, amount: '300.00' });
+      expect(res.buckets['31-60']).toEqual({ count: 1, amount: '300.00' });
+      expect(res.buckets['61-90']).toEqual({ count: 1, amount: '400.00' });
+      expect(res.buckets['90+']).toEqual({ count: 1, amount: '500.00' });
+      expect(res.buckets.TOTAL).toEqual({ count: 5, amount: '1500.00' });
+
+      // ageDays + per-doc bucket label
+      const d31 = res.docs.find((d) => d.id === 'd31')!;
+      expect(d31.ageDays).toBe(31);
+      expect(d31.bucket).toBe('31-60');
+    });
+
+    it('per-doc netAmount = totalAmount − withholdingTax and bucket amounts use that net', async () => {
+      const rows = [
+        { id: 'd0', number: 'EX-1', vendorName: 'A', vendorTaxId: '1', documentDate: new Date('2026-06-10T00:00:00Z'), totalAmount: new Decimal('1000'), withholdingTax: new Decimal('30'), branchId: 'b1' },
+      ];
+      const { service } = makeWithRows(rows);
+
+      const res = await service.getApAging({});
+
+      expect(res.docs[0].netAmount).toBe('970.00');
+      // Bucket amount uses the net (totalAmount − wht), not gross.
+      expect(res.buckets['0-30'].amount).toBe('970.00');
+      expect(res.buckets.TOTAL.amount).toBe('970.00');
+    });
+
+    it('bucket filter narrows docs but bucket TOTALS still use the full set', async () => {
+      const rows = [
+        { id: 'd0', number: 'EX-1', vendorName: 'A', vendorTaxId: '1', documentDate: new Date('2026-06-10T00:00:00Z'), totalAmount: new Decimal('100'), withholdingTax: new Decimal('0'), branchId: 'b1' },
+        { id: 'd91', number: 'EX-5', vendorName: 'A', vendorTaxId: '1', documentDate: new Date('2026-03-11T00:00:00Z'), totalAmount: new Decimal('500'), withholdingTax: new Decimal('0'), branchId: 'b1' },
+      ];
+      const { service } = makeWithRows(rows);
+
+      const res = await service.getApAging({ bucket: '90+' });
+
+      // docs narrowed to the requested bucket only
+      expect(res.docs.map((d) => d.id)).toEqual(['d91']);
+      // but bucket TOTALS reflect the full unfiltered set
+      expect(res.buckets['0-30']).toEqual({ count: 1, amount: '100.00' });
+      expect(res.buckets['90+']).toEqual({ count: 1, amount: '500.00' });
+      expect(res.buckets.TOTAL).toEqual({ count: 2, amount: '600.00' });
+    });
+
+    it('queries ACCRUAL + unpaid docs and applies vendor/branch filters', async () => {
+      const prisma = {
+        expenseDocument: { findMany: jest.fn().mockResolvedValue([]) },
+      };
+      const service = makeExpenseDocumentsService({ prisma }).service;
+
+      await service.getApAging({ branchId: 'b9', vendor: 'Acme' });
+
+      expect(prisma.expenseDocument.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: {
+            deletedAt: null,
+            status: 'ACCRUAL',
+            paidAt: null,
+            branchId: 'b9',
+            vendorName: { contains: 'Acme', mode: 'insensitive' },
+          },
+          orderBy: { documentDate: 'asc' },
+        }),
+      );
+    });
+  });
+
+  describe('getSummary', () => {
+    it('returns byStatus map + accrualUnpaid count/total (toFixed(2))', async () => {
+      const prisma = {
+        expenseDocument: {
+          count: jest.fn().mockResolvedValue(7),
+          groupBy: jest.fn().mockResolvedValue([
+            { status: 'DRAFT', _count: { _all: 3 } },
+            { status: 'POSTED', _count: { _all: 4 } },
+          ]),
+          aggregate: jest.fn().mockResolvedValue({
+            _count: { _all: 2 },
+            _sum: { totalAmount: new Decimal('1234.5') },
+          }),
+        },
+      };
+      const service = makeExpenseDocumentsService({ prisma }).service;
+
+      const res = await service.getSummary({});
+
+      expect(res.totalCount).toBe(7);
+      expect(res.byStatus).toEqual({ DRAFT: 3, POSTED: 4 });
+      expect(res.accrualUnpaidCount).toBe(2);
+      expect(res.accrualUnpaidTotal).toBe('1234.50');
+    });
+
+    it('defaults accrualUnpaidTotal to "0.00" when sum is null', async () => {
+      const prisma = {
+        expenseDocument: {
+          count: jest.fn().mockResolvedValue(0),
+          groupBy: jest.fn().mockResolvedValue([]),
+          aggregate: jest.fn().mockResolvedValue({
+            _count: { _all: 0 },
+            _sum: { totalAmount: null },
+          }),
+        },
+      };
+      const service = makeExpenseDocumentsService({ prisma }).service;
+
+      const res = await service.getSummary({});
+
+      expect(res.byStatus).toEqual({});
+      expect(res.accrualUnpaidTotal).toBe('0.00');
+    });
+  });
+
+  describe('getCreditNoteCap', () => {
+    it('cap = original.totalAmount − Σ(non-VOIDED CN)', async () => {
+      const prisma = {
+        expenseDocument: {
+          findUniqueOrThrow: jest.fn().mockResolvedValue({
+            id: 'orig',
+            documentType: 'EXPENSE',
+            deletedAt: null,
+            totalAmount: new Decimal('1000'),
+          }),
+          aggregate: jest.fn().mockResolvedValue({ _sum: { totalAmount: new Decimal('300') } }),
+        },
+      };
+      const service = makeExpenseDocumentsService({ prisma }).service;
+
+      const res = await service.getCreditNoteCap('orig');
+
+      expect(res.originalTotal).toBe('1000');
+      expect(res.usedTotal).toBe('300');
+      expect(res.remainingCap).toBe('700');
+      // Confirms it sums only non-VOIDED CNs against this original.
+      expect(prisma.expenseDocument.aggregate).toHaveBeenCalledWith({
+        where: {
+          documentType: 'CREDIT_NOTE',
+          status: { not: 'VOIDED' },
+          deletedAt: null,
+          creditNote: { originalDocumentId: 'orig' },
+        },
+        _sum: { totalAmount: true },
+      });
+    });
+
+    it('throws BadRequestException when original is not an EXPENSE', async () => {
+      const prisma = {
+        expenseDocument: {
+          findUniqueOrThrow: jest.fn().mockResolvedValue({
+            id: 'orig',
+            documentType: 'CREDIT_NOTE',
+            deletedAt: null,
+            totalAmount: new Decimal('1000'),
+          }),
+          aggregate: jest.fn(),
+        },
+      };
+      const service = makeExpenseDocumentsService({ prisma }).service;
+
+      await expect(service.getCreditNoteCap('orig')).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it('throws NotFoundException when original is soft-deleted', async () => {
+      const prisma = {
+        expenseDocument: {
+          findUniqueOrThrow: jest.fn().mockResolvedValue({
+            id: 'orig',
+            documentType: 'EXPENSE',
+            deletedAt: new Date(),
+            totalAmount: new Decimal('1000'),
+          }),
+          aggregate: jest.fn(),
+        },
+      };
+      const service = makeExpenseDocumentsService({ prisma }).service;
+
+      await expect(service.getCreditNoteCap('orig')).rejects.toBeInstanceOf(NotFoundException);
+    });
+  });
+
+  describe('getAuditTrail', () => {
+    function baseFindOneMock(doc: any) {
+      // findOne does two findUniqueOrThrow calls (docType then full doc).
+      const findUniqueOrThrow = jest
+        .fn()
+        .mockResolvedValueOnce({ documentType: doc.documentType ?? 'EXPENSE', deletedAt: null })
+        .mockResolvedValueOnce(doc);
+      return findUniqueOrThrow;
+    }
+
+    it('calls findOne (doc existence) then queries the audit log (both casings, take 50, desc)', async () => {
+      const doc = { id: 'doc-1', documentType: 'EXPENSE', deletedAt: null, branchId: 'b1', payroll: null };
+      const prisma = {
+        expenseDocument: { findUniqueOrThrow: baseFindOneMock(doc) },
+        auditLog: { findMany: jest.fn().mockResolvedValue([{ id: 'log-1' }]) },
+      };
+      const service = makeExpenseDocumentsService({ prisma }).service;
+
+      const res = await service.getAuditTrail('doc-1');
+
+      expect(prisma.expenseDocument.findUniqueOrThrow).toHaveBeenCalled();
+      expect(prisma.auditLog.findMany).toHaveBeenCalledWith({
+        where: {
+          entityId: 'doc-1',
+          entity: { in: ['expense_document', 'ExpenseDocument'] },
+        },
+        orderBy: { createdAt: 'desc' },
+        take: 50,
+        include: {
+          user: { select: { id: true, name: true, email: true } },
+        },
+      });
+      expect(res).toEqual([{ id: 'log-1' }]);
+    });
+
+    it('throws ForbiddenException for a non-cross-branch role reading another branch', async () => {
+      const doc = { id: 'doc-1', documentType: 'EXPENSE', deletedAt: null, branchId: 'b1', payroll: null };
+      const prisma = {
+        expenseDocument: { findUniqueOrThrow: baseFindOneMock(doc) },
+        auditLog: { findMany: jest.fn() },
+      };
+      const service = makeExpenseDocumentsService({ prisma }).service;
+
+      await expect(
+        service.getAuditTrail('doc-1', { role: 'BRANCH_MANAGER', branchId: 'b2' }),
+      ).rejects.toBeInstanceOf(ForbiddenException);
+      expect(prisma.auditLog.findMany).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('previewJe', () => {
+    it('queries chartOfAccount for collected codes and calls jePreview.preview with account-name map', async () => {
+      const prisma = {
+        chartOfAccount: {
+          findMany: jest.fn().mockResolvedValue([
+            { code: '53-1302', name: 'ค่าใช้จ่ายสำนักงาน' },
+          ]),
+        },
+      };
+      const jePreview = { preview: jest.fn().mockReturnValue({ lines: [] }) };
+      const service = makeExpenseDocumentsService({ prisma, jePreview }).service;
+
+      const dto = {
+        branchId: 'b1',
+        documentDate: '2026-06-10',
+        vendorName: 'V',
+        lines: [{ category: '53-1302', amountBeforeVat: 100, vatRate: 0, whtPercent: 0 }],
+      } as any;
+
+      const res = await service.previewJe(dto);
+
+      // chartOfAccount.findMany queried with collected codes + deletedAt: null.
+      const callArg = prisma.chartOfAccount.findMany.mock.calls[0][0];
+      expect(callArg.where.deletedAt).toBeNull();
+      expect(Array.isArray(callArg.where.code.in)).toBe(true);
+      expect(callArg.where.code.in).toContain('53-1302');
+      expect(callArg.select).toEqual({ code: true, name: true });
+
+      // jePreview.preview called with (dto, Map of code→name).
+      expect(jePreview.preview).toHaveBeenCalledTimes(1);
+      const [passedDto, namesMap] = jePreview.preview.mock.calls[0];
+      expect(passedDto).toBe(dto);
+      expect(namesMap).toBeInstanceOf(Map);
+      expect(namesMap.get('53-1302')).toBe('ค่าใช้จ่ายสำนักงาน');
+      expect(res).toEqual({ lines: [] });
+    });
+  });
+
+  describe('list (tab translation spot-check)', () => {
+    function makeForList() {
+      const prisma = {
+        expenseDocument: {
+          findMany: jest.fn().mockResolvedValue([]),
+          count: jest.fn().mockResolvedValue(0),
+        },
+      };
+      return { prisma, service: makeExpenseDocumentsService({ prisma }).service };
+    }
+
+    const cases: Array<[string, any]> = [
+      ['draft', { status: 'DRAFT' }],
+      ['unpaid', { status: 'ACCRUAL' }],
+      ['recorded', { status: { in: ['ACCRUAL', 'POSTED'] } }],
+      ['paid', { paidAt: { not: null } }],
+    ];
+
+    it.each(cases)('tab %s maps to the right where clause', async (tab, expected) => {
+      const { prisma, service } = makeForList();
+      await service.list({ tab } as any, { branchId: 'b1', role: 'BRANCH_MANAGER' });
+      const where = prisma.expenseDocument.findMany.mock.calls[0][0].where;
+      expect(where).toMatchObject(expected);
+    });
+
+    it('default (no tab) excludes VOIDED', async () => {
+      const { prisma, service } = makeForList();
+      await service.list({} as any, { branchId: 'b1', role: 'BRANCH_MANAGER' });
+      const where = prisma.expenseDocument.findMany.mock.calls[0][0].where;
+      expect(where.status).toEqual({ not: 'VOIDED' });
+    });
+  });
+});

--- a/apps/api/src/modules/expense-documents/__tests__/support/make-expense-documents-service.ts
+++ b/apps/api/src/modules/expense-documents/__tests__/support/make-expense-documents-service.ts
@@ -20,6 +20,7 @@
 import { Decimal } from '@prisma/client/runtime/library';
 import { ExpenseDocumentsService } from '../../expense-documents.service';
 import { LineAggregatorService } from '../../services/line-aggregator.service';
+import { ExpenseDocumentQueryService } from '../../services/expense-document-query.service';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -50,6 +51,11 @@ export interface ExpenseDocumentsServiceOverrides {
   pettyCash?: any;
   payrollCustom?: any;
   notifications?: any;
+  // Phase 1 decompose — the read-method sub-service. Defaults to a REAL
+  // ExpenseDocumentQueryService built from the same resolved `prisma` +
+  // `jePreview`, so existing specs' prisma/jePreview mocks flow through the
+  // facade's delegating read methods unchanged.
+  query?: any;
 }
 
 export interface MadeExpenseDocumentsService {
@@ -70,6 +76,7 @@ export interface MadeExpenseDocumentsService {
   pettyCash: any;
   payrollCustom: any;
   notifications: any;
+  query: any;
 }
 
 export function makeExpenseDocumentsService(
@@ -106,8 +113,13 @@ export function makeExpenseDocumentsService(
       validateLine: jest.fn().mockResolvedValue({ taxableBase: new Decimal(0) }),
     };
   // notifications: undefined unless explicitly provided — preserves the
-  // 15-arg early-return behavior of specs that omit it.
+  // early-return behavior of specs that omit it.
   const notifications = overrides.notifications;
+  // Phase 1 decompose — REAL query sub-service by default, built from the SAME
+  // resolved `prisma` + `jePreview` instances so existing specs' mocks flow
+  // through the facade's now-delegating read methods. `jePreview` is no longer
+  // a facade constructor arg (it moved into the query service).
+  const query = overrides.query ?? new ExpenseDocumentQueryService(prisma, jePreview);
 
   // THE single positional construction in the codebase.
   const service = new ExpenseDocumentsService(
@@ -121,11 +133,11 @@ export function makeExpenseDocumentsService(
     settlementTemplate,
     journal,
     aggregator,
-    jePreview,
     ssoConfig,
     pettyCashTemplate,
     pettyCash,
     payrollCustom,
+    query,
     notifications,
   );
 
@@ -147,5 +159,6 @@ export function makeExpenseDocumentsService(
     pettyCash,
     payrollCustom,
     notifications,
+    query,
   };
 }

--- a/apps/api/src/modules/expense-documents/expense-documents.module.ts
+++ b/apps/api/src/modules/expense-documents/expense-documents.module.ts
@@ -15,6 +15,7 @@ import { DocNumberService } from './services/doc-number.service';
 import { StatusTransitionService } from './services/status-transition.service';
 import { LineAggregatorService } from './services/line-aggregator.service';
 import { JePreviewService } from './services/je-preview.service';
+import { ExpenseDocumentQueryService } from './services/expense-document-query.service';
 import { ExpenseVoucherPdfService } from './services/expense-voucher-pdf.service';
 import { PettyCashService } from './services/petty-cash.service';
 import { PayrollCustomService } from './services/payroll-custom.service';
@@ -49,6 +50,7 @@ import { ReversePermissionGuard } from './reverse-permission.guard';
     StatusTransitionService,
     LineAggregatorService,
     JePreviewService,
+    ExpenseDocumentQueryService,
     ExpenseVoucherPdfService,
     PettyCashService,
     PayrollCustomService,

--- a/apps/api/src/modules/expense-documents/expense-documents.service.ts
+++ b/apps/api/src/modules/expense-documents/expense-documents.service.ts
@@ -35,14 +35,13 @@ import { CreatePettyCashDto } from './dto/create-petty-cash.dto';
 import { VoidExpenseDocumentDto } from './dto/void-expense.dto';
 import { hasCrossBranchAccess } from '../auth/branch-access.util';
 import { LineAggregatorService } from './services/line-aggregator.service';
-import { JePreviewService } from './services/je-preview.service';
+import { ExpenseDocumentQueryService } from './services/expense-document-query.service';
 import { SsoConfigService } from '../sso-config/sso-config.service';
 import { NotificationsService } from '../notifications/notifications.service';
 import { PettyCashService } from './services/petty-cash.service';
 import { PayrollCustomService } from './services/payroll-custom.service';
 import { validatePeriodOpen } from '../../utils/period-lock.util';
 import { readBoolFlag, readIntFlag } from '../../utils/config.util';
-import { collectJePreviewCodes } from './je-preview-codes.util';
 import { bkkBusinessDate } from './bkk-business-date.util';
 import {
   assertUserCanApprove,
@@ -95,11 +94,16 @@ export class ExpenseDocumentsService implements OnModuleInit {
     private readonly settlementTemplate: VendorSettlementTemplate,
     private readonly journal: JournalAutoService,
     private readonly aggregator: LineAggregatorService,
-    private readonly jePreview: JePreviewService,
     private readonly ssoConfig: SsoConfigService,
     private readonly pettyCashTemplate: PettyCashTemplate,
     private readonly pettyCash: PettyCashService,
     private readonly payrollCustom: PayrollCustomService,
+    // Phase 1 decompose — the 9 READ-only methods now live in
+    // ExpenseDocumentQueryService; the facade delegates. Owns `jePreview`
+    // (previously a facade param). Placed BEFORE `notifications` so that param
+    // keeps its original trailing-optional `?` form (a required param cannot
+    // follow an optional one) — preserving the exact original DI signature.
+    private readonly query: ExpenseDocumentQueryService,
     // D1.2.1.5 — IN_APP notification fan-out on DRAFT → PENDING_APPROVAL.
     // Optional injection — when the module wires NotificationsService it
     // is used; tests can omit it without breaking submitForApproval.
@@ -1113,140 +1117,22 @@ export class ExpenseDocumentsService implements OnModuleInit {
   }
 
   // ─── List ────────────────────────────────────────────────────────────
+  // Phase 1 decompose — delegates to ExpenseDocumentQueryService.
   async list(
     query: ListExpenseDocumentsQueryDto,
     user: { branchId?: string | null; role?: string },
   ) {
-    const where: Prisma.ExpenseDocumentWhereInput = { deletedAt: null };
-
-    // Branch scoping: cross-branch roles can pass ?branchId or omit it for "all";
-    // non-cross-branch users are PINNED to their assigned branch — the query
-    // param is ignored. If a non-cross-branch user has no branchId assigned
-    // (data corruption), reject rather than fall through to query.branchId.
-    if (hasCrossBranchAccess(user)) {
-      if (query.branchId) where.branchId = query.branchId;
-    } else {
-      if (!user.branchId) {
-        throw new ForbiddenException('ผู้ใช้ไม่มีสาขาที่ได้รับมอบหมาย');
-      }
-      where.branchId = user.branchId;
-    }
-
-    // Tab translation
-    switch (query.tab) {
-      case 'draft':
-        where.status = 'DRAFT';
-        break;
-      case 'unpaid':
-        where.status = 'ACCRUAL';
-        break;
-      case 'recorded':
-        where.status = { in: ['ACCRUAL', 'POSTED'] };
-        break;
-      case 'paid':
-        where.paidAt = { not: null };
-        break;
-      default:
-        where.status = { not: 'VOIDED' };
-    }
-
-    // Explicit status overrides tab
-    if (query.status) where.status = query.status as DocumentStatus;
-    if (query.type) where.documentType = query.type as never;
-
-    // Date range on documentDate
-    if (query.startDate || query.endDate) {
-      where.documentDate = {};
-      if (query.startDate) where.documentDate.gte = new Date(query.startDate);
-      if (query.endDate) {
-        const end = new Date(query.endDate);
-        end.setHours(23, 59, 59, 999);
-        where.documentDate.lte = end;
-      }
-    }
-
-    // Filter by ExpenseLine.category (e.g. CoA code "53-1302")
-    if (query.category) {
-      where.expenseDetail = { lines: { some: { category: query.category } } };
-    }
-
-    if (query.search) {
-      where.OR = [
-        { number: { contains: query.search, mode: 'insensitive' } },
-        { description: { contains: query.search, mode: 'insensitive' } },
-        { vendorName: { contains: query.search, mode: 'insensitive' } },
-        { taxInvoiceNo: { contains: query.search, mode: 'insensitive' } },
-      ];
-    }
-
-    const page = Math.max(1, query.page ?? 1);
-    const limit = Math.min(100, Math.max(1, query.limit ?? 20));
-
-    const [data, total] = await Promise.all([
-      this.prisma.expenseDocument.findMany({
-        where,
-        include: {
-          expenseDetail: { include: { lines: { orderBy: { lineNo: 'asc' } } } },
-          branch: { select: { id: true, name: true } },
-          createdBy: { select: { id: true, name: true } },
-        },
-        orderBy: { documentDate: 'desc' },
-        skip: (page - 1) * limit,
-        take: limit,
-      }),
-      this.prisma.expenseDocument.count({ where }),
-    ]);
-
-    return { data, total, page, limit };
+    return this.query.list(query, user);
   }
 
   // ─── Summary aggregations ────────────────────────────────────────────
+  // Phase 1 decompose — delegates to ExpenseDocumentQueryService.
   async getSummary(filters: {
     branchId?: string;
     startDate?: string;
     endDate?: string;
   }) {
-    const where: Prisma.ExpenseDocumentWhereInput = {
-      deletedAt: null,
-      status: { not: 'VOIDED' },
-    };
-    if (filters.branchId) where.branchId = filters.branchId;
-    if (filters.startDate || filters.endDate) {
-      where.documentDate = {};
-      if (filters.startDate) where.documentDate.gte = new Date(filters.startDate);
-      if (filters.endDate) {
-        const end = new Date(filters.endDate);
-        end.setHours(23, 59, 59, 999);
-        where.documentDate.lte = end;
-      }
-    }
-
-    // Server-side aggregation — does not load full rows into memory.
-    const [totalCount, statusGroups, accrualUnpaid] = await Promise.all([
-      this.prisma.expenseDocument.count({ where }),
-      this.prisma.expenseDocument.groupBy({
-        by: ['status'],
-        where,
-        _count: { _all: true },
-      }),
-      this.prisma.expenseDocument.aggregate({
-        where: { ...where, status: 'ACCRUAL', paidAt: null },
-        _count: { _all: true },
-        _sum: { totalAmount: true },
-      }),
-    ]);
-
-    const byStatus: Record<string, number> = {};
-    for (const g of statusGroups) byStatus[g.status] = g._count._all;
-
-    return {
-      totalCount,
-      byStatus,
-      accrualUnpaidCount: accrualUnpaid._count._all,
-      // Decimal serialized as string ("1234.56") for parity with daily-summary
-      // grandTotal — clients should parse for display rather than trusting JS float.
-      accrualUnpaidTotal: accrualUnpaid._sum.totalAmount?.toFixed(2) ?? '0.00',
-    };
+    return this.query.getSummary(filters);
   }
 
   /**
@@ -1266,61 +1152,15 @@ export class ExpenseDocumentsService implements OnModuleInit {
    * aren't yet on the books. `from` / `to` filter by `documentDate` (BKK).
    * When omitted, scans every POSTED document (use the calling controller's
    * default = current calendar year if you want a "this year" view).
+   *
+   * Phase 1 decompose — delegates to ExpenseDocumentQueryService.
    */
   async getTaxDisallowedSummary(filters: {
     branchId?: string;
     from?: string;
     to?: string;
   }) {
-    const where: Prisma.ExpenseDocumentWhereInput = {
-      deletedAt: null,
-      status: 'POSTED',
-    };
-    if (filters.branchId) where.branchId = filters.branchId;
-    if (filters.from || filters.to) {
-      where.documentDate = {};
-      if (filters.from) where.documentDate.gte = new Date(filters.from);
-      if (filters.to) {
-        const end = new Date(filters.to);
-        end.setHours(23, 59, 59, 999);
-        where.documentDate.lte = end;
-      }
-    }
-
-    // Doc-level: all lines in the doc are disallowed → sum totalAmount.
-    const docLevel = await this.prisma.expenseDocument.aggregate({
-      where: { ...where, taxDisallowed: true },
-      _count: { _all: true },
-      _sum: { totalAmount: true },
-    });
-
-    // Line-level: only count rows where the PARENT doc is NOT already flagged
-    // doc-level (otherwise we'd double-count those lines). Sum `amountBeforeVat`
-    // because tax deductibility is computed on the pre-VAT amount — VAT input
-    // is handled separately on ภ.พ.30, not on ภ.ง.ด.50/51.
-    const lineLevel = await this.prisma.expenseLine.aggregate({
-      where: {
-        taxDisallowed: true,
-        expenseDetail: {
-          document: { ...where, taxDisallowed: false },
-        },
-      },
-      _count: { _all: true },
-      _sum: { amountBeforeVat: true },
-    });
-
-    const docTotal = docLevel._sum.totalAmount ?? new Prisma.Decimal(0);
-    const lineTotal = lineLevel._sum.amountBeforeVat ?? new Prisma.Decimal(0);
-    const grandTotal = docTotal.plus(lineTotal);
-
-    return {
-      docLevelCount: docLevel._count._all,
-      docLevelTotal: docTotal.toFixed(2),
-      lineLevelCount: lineLevel._count._all,
-      lineLevelTotal: lineTotal.toFixed(2),
-      grandTotal: grandTotal.toFixed(2),
-      filters: { from: filters.from ?? null, to: filters.to ?? null },
-    };
+    return this.query.getTaxDisallowedSummary(filters);
   }
 
   /**
@@ -1335,274 +1175,34 @@ export class ExpenseDocumentsService implements OnModuleInit {
    *
    * Age is computed against "today BKK" (start-of-day) so a vendor's row that
    * just crossed midnight in Asia/Bangkok doesn't shift bucket vs server-tz.
+   *
+   * Phase 1 decompose — delegates to ExpenseDocumentQueryService.
    */
   async getApAging(filters: { branchId?: string; vendor?: string; bucket?: '0-30' | '31-60' | '61-90' | '90+' }) {
-    const where: Prisma.ExpenseDocumentWhereInput = {
-      deletedAt: null,
-      status: 'ACCRUAL',
-      paidAt: null,
-    };
-    if (filters.branchId) where.branchId = filters.branchId;
-    if (filters.vendor) {
-      where.vendorName = { contains: filters.vendor, mode: 'insensitive' };
-    }
-
-    // W2 fix — age in calendar days, computed on BKK date strings.
-    // Previous implementation took (todayBkkStart UTC ms − documentDate UTC ms)
-    // / 86_400_000 and floored. Because documentDate stores UTC midnight (00:00Z
-    // = 07:00 BKK same day) while todayBkkStart was UTC minus 7h (=BKK midnight
-    // mapped to 17:00Z previous UTC day), the ms-diff was non-integer around
-    // the boundary, so floor() shifted some rows by ±1 day (e.g. a doc dated
-    // today appeared as 1 day old, pushing it from 0-30 to 31-60 right at
-    // 17:00 BKK / 30 days later). Switch to calendar-day diff on YYYY-MM-DD
-    // strings instead.
-    const toBkkDate = (d: Date): string =>
-      d.toLocaleDateString('en-CA', { timeZone: 'Asia/Bangkok' });
-    const todayBkkStr = toBkkDate(new Date());
-    const daysBetween = (a: string, b: string): number => {
-      // a, b are 'YYYY-MM-DD'. Build UTC midnights and subtract — exact integer
-      // because both sides are at the same UTC hour.
-      const [ay, am, ad] = a.split('-').map(Number);
-      const [by, bm, bd] = b.split('-').map(Number);
-      const aMs = Date.UTC(ay, am - 1, ad);
-      const bMs = Date.UTC(by, bm - 1, bd);
-      return Math.round((bMs - aMs) / (24 * 60 * 60 * 1000));
-    };
-
-    const rows = await this.prisma.expenseDocument.findMany({
-      where,
-      select: {
-        id: true,
-        number: true,
-        vendorName: true,
-        vendorTaxId: true,
-        documentDate: true,
-        totalAmount: true,
-        withholdingTax: true,
-        branchId: true,
-      },
-      orderBy: { documentDate: 'asc' },
-    });
-
-    type Bucket = '0-30' | '31-60' | '61-90' | '90+';
-    const toBucket = (ageDays: number): Bucket => {
-      if (ageDays <= 30) return '0-30';
-      if (ageDays <= 60) return '31-60';
-      if (ageDays <= 90) return '61-90';
-      return '90+';
-    };
-
-    const enriched = rows.map((r) => {
-      const docBkkStr = toBkkDate(new Date(r.documentDate));
-      const ageDays = Math.max(0, daysBetween(docBkkStr, todayBkkStr));
-      return { ...r, ageDays, bucket: toBucket(ageDays) };
-    });
-
-    const filtered = filters.bucket ? enriched.filter((r) => r.bucket === filters.bucket) : enriched;
-
-    const zero = new Prisma.Decimal(0);
-    const totals: Record<Bucket | 'TOTAL', { count: number; amount: Prisma.Decimal }> = {
-      '0-30': { count: 0, amount: new Prisma.Decimal(0) },
-      '31-60': { count: 0, amount: new Prisma.Decimal(0) },
-      '61-90': { count: 0, amount: new Prisma.Decimal(0) },
-      '90+': { count: 0, amount: new Prisma.Decimal(0) },
-      TOTAL: { count: 0, amount: new Prisma.Decimal(0) },
-    };
-    // Bucket totals use the full unfiltered set so the user can see context even
-    // when bucket filter is active.
-    for (const r of enriched) {
-      const amt = new Prisma.Decimal(r.totalAmount.toString()).minus(
-        new Prisma.Decimal(r.withholdingTax?.toString() ?? '0'),
-      );
-      totals[r.bucket].count += 1;
-      totals[r.bucket].amount = totals[r.bucket].amount.plus(amt);
-      totals.TOTAL.count += 1;
-      totals.TOTAL.amount = totals.TOTAL.amount.plus(amt);
-    }
-    void zero;
-
-    return {
-      buckets: {
-        '0-30': { count: totals['0-30'].count, amount: totals['0-30'].amount.toFixed(2) },
-        '31-60': { count: totals['31-60'].count, amount: totals['31-60'].amount.toFixed(2) },
-        '61-90': { count: totals['61-90'].count, amount: totals['61-90'].amount.toFixed(2) },
-        '90+': { count: totals['90+'].count, amount: totals['90+'].amount.toFixed(2) },
-        TOTAL: { count: totals.TOTAL.count, amount: totals.TOTAL.amount.toFixed(2) },
-      },
-      docs: filtered.map((r) => ({
-        id: r.id,
-        number: r.number,
-        vendorName: r.vendorName,
-        vendorTaxId: r.vendorTaxId,
-        documentDate: r.documentDate.toISOString(),
-        ageDays: r.ageDays,
-        bucket: r.bucket,
-        // Net amount = totalAmount − wht (the cash leg pending payment).
-        netAmount: new Prisma.Decimal(r.totalAmount.toString())
-          .minus(new Prisma.Decimal(r.withholdingTax?.toString() ?? '0'))
-          .toFixed(2),
-        branchId: r.branchId,
-      })),
-    };
+    return this.query.getApAging(filters);
   }
 
   // ─── Daily summary (print-ready aggregation) ─────────────────────────
+  // Phase 1 decompose — delegates to ExpenseDocumentQueryService.
   async getDailySummary(
     filters: { date: string; branchId?: string },
     user: { id: string; branchId?: string | null; role?: string | null },
   ) {
-    const branchId = hasCrossBranchAccess(user)
-      ? filters.branchId
-      : (user.branchId ?? filters.branchId);
-    if (!branchId) {
-      throw new BadRequestException('ต้องระบุสาขา');
-    }
-    const start = new Date(filters.date);
-    start.setHours(0, 0, 0, 0);
-    const end = new Date(filters.date);
-    end.setHours(23, 59, 59, 999);
-
-    const documents = await this.prisma.expenseDocument.findMany({
-      where: {
-        branchId,
-        documentDate: { gte: start, lte: end },
-        status: { not: 'VOIDED' },
-        deletedAt: null,
-      },
-      include: {
-        // I4 fix — pull ALL expense lines (not just the first) so the
-        // "by category" aggregation reflects every line's category, weighted
-        // by amountBeforeVat. Previously `take: 1` made multi-line docs all
-        // collapse to their first line's category — a 3-line doc with 1k of
-        // category A and 2x 5k of B would attribute all 11k to A. With this
-        // include the daily summary instead sums per-line amounts into the
-        // right buckets.
-        expenseDetail: { include: { lines: { orderBy: { lineNo: 'asc' } } } },
-        creditNote: true,
-        payroll: true,
-        settlement: true,
-        branch: { select: { id: true, name: true } },
-      },
-      orderBy: { number: 'asc' },
-    });
-
-    // Aggregate
-    const byType: Record<string, { count: number; total: string }> = {};
-    const byPaymentMethod: Record<string, { count: number; total: string }> = {};
-    const byCategory: Record<string, { count: number; total: string }> = {};
-    const cashMovement: Record<string, { out: string; count: number }> = {};
-
-    let grandTotal = new Prisma.Decimal(0);
-
-    for (const d of documents) {
-      const total = new Prisma.Decimal(d.totalAmount.toString());
-      grandTotal = grandTotal.plus(total);
-
-      // By type
-      const tKey = d.documentType;
-      const tBucket = byType[tKey] ?? { count: 0, total: '0' };
-      tBucket.count++;
-      tBucket.total = new Prisma.Decimal(tBucket.total).plus(total).toFixed(2);
-      byType[tKey] = tBucket;
-
-      // By payment method (only if doc has paymentMethod set)
-      if (d.paymentMethod) {
-        const mKey = d.paymentMethod;
-        const mBucket = byPaymentMethod[mKey] ?? { count: 0, total: '0' };
-        mBucket.count++;
-        const netAmt = d.netPayment ? new Prisma.Decimal(d.netPayment.toString()) : total;
-        mBucket.total = new Prisma.Decimal(mBucket.total).plus(netAmt).toFixed(2);
-        byPaymentMethod[mKey] = mBucket;
-      }
-
-      // I4 — By category: sum per-line amounts into category buckets so a
-      // multi-line doc contributes correctly to each category. count uses
-      // 1 per distinct category in the doc (not per line) so a doc with
-      // 3 cleaning lines counts once for "cleaning", not three times.
-      // Defensive: legacy rows without `amountBeforeVat` (data migration
-      // artefacts) fall back to 0 — they still count toward the bucket's
-      // doc count but contribute no value.
-      const lines =
-        (d as { expenseDetail?: { lines?: { category: string; amountBeforeVat?: unknown }[] } | null })
-          .expenseDetail?.lines ?? [];
-      const seenInDoc = new Set<string>();
-      for (const l of lines) {
-        const cat = l.category;
-        const raw = l.amountBeforeVat;
-        const lineAmt = raw != null ? new Prisma.Decimal(raw.toString()) : new Prisma.Decimal(0);
-        const cBucket = byCategory[cat] ?? { count: 0, total: '0' };
-        if (!seenInDoc.has(cat)) {
-          cBucket.count++;
-          seenInDoc.add(cat);
-        }
-        cBucket.total = new Prisma.Decimal(cBucket.total).plus(lineAmt).toFixed(2);
-        byCategory[cat] = cBucket;
-      }
-
-      // Cash movement (only docs with depositAccountCode + paidAt today)
-      if (d.depositAccountCode && d.paidAt && d.paidAt >= start && d.paidAt <= end) {
-        const aKey = d.depositAccountCode;
-        const aBucket = cashMovement[aKey] ?? { out: '0', count: 0 };
-        const netAmt = d.netPayment ? new Prisma.Decimal(d.netPayment.toString()) : total;
-        aBucket.out = new Prisma.Decimal(aBucket.out).plus(netAmt).toFixed(2);
-        aBucket.count++;
-        cashMovement[aKey] = aBucket;
-      }
-    }
-
-    return {
-      date: filters.date,
-      branchId,
-      branchName: documents[0]?.branch?.name ?? null,
-      documents,
-      grandTotal: grandTotal.toFixed(2),
-      byType,
-      byPaymentMethod,
-      byCategory,
-      cashMovement,
-    };
+    return this.query.getDailySummary(filters, user);
   }
 
   // ─── Credit-Note remaining cap ───────────────────────────────────────
   // Returns how much CN can still be issued against this original document.
   // cap = original.totalAmount - Σ (non-VOIDED CNs against this original).
+  // Phase 1 decompose — delegates to ExpenseDocumentQueryService.
   async getCreditNoteCap(originalDocumentId: string) {
-    const original = await this.prisma.expenseDocument.findUniqueOrThrow({
-      where: { id: originalDocumentId },
-    });
-    if (original.deletedAt) {
-      throw new NotFoundException('เอกสารต้นฉบับถูกลบแล้ว');
-    }
-    if (original.documentType !== 'EXPENSE') {
-      throw new BadRequestException('ใบลดหนี้ใช้ลดเอกสารรายจ่ายเท่านั้น');
-    }
-    const priorAgg = await this.prisma.expenseDocument.aggregate({
-      where: {
-        documentType: 'CREDIT_NOTE',
-        status: { not: 'VOIDED' },
-        deletedAt: null,
-        creditNote: { originalDocumentId },
-      },
-      _sum: { totalAmount: true },
-    });
-    const used = new Prisma.Decimal(priorAgg._sum.totalAmount ?? 0);
-    const cap = new Prisma.Decimal(original.totalAmount.toString()).minus(used);
-    return {
-      originalTotal: original.totalAmount.toString(),
-      usedTotal: used.toString(),
-      remainingCap: cap.toString(),
-    };
+    return this.query.getCreditNoteCap(originalDocumentId);
   }
 
   // ─── JE Preview (pure — no DB write) ────────────────────────────────
+  // Phase 1 decompose — delegates to ExpenseDocumentQueryService.
   async previewJe(dto: CreateExpenseDocumentDto) {
-    const codes = collectJePreviewCodes(dto);
-    const rows = await this.prisma.chartOfAccount.findMany({
-      where: { code: { in: [...codes] }, deletedAt: null },
-      select: { code: true, name: true },
-    });
-    const accountNames = new Map(rows.map((r) => [r.code, r.name]));
-    return this.jePreview.preview(dto, accountNames);
+    return this.query.previewJe(dto);
   }
 
   // ─── Audit trail ─────────────────────────────────────────────────────
@@ -1611,34 +1211,12 @@ export class ExpenseDocumentsService implements OnModuleInit {
   // OtherIncomeService.getAuditTrail. Both entity casings are queried for
   // resilience (services write 'expense_document'; defensive include of the
   // PascalCase form in case a future writer / interceptor differs).
+  // Phase 1 decompose — delegates to ExpenseDocumentQueryService.
   async getAuditTrail(
     id: string,
     user?: { branchId?: string | null; role?: string | null },
   ) {
-    // Verify the document exists (throws on unknown / soft-deleted id).
-    const doc = await this.findOne(id);
-    // Branch scoping (mirrors create()/list() guards) — a non-cross-branch role
-    // may only read the audit trail of documents in its OWN branch, so a
-    // BRANCH_MANAGER can't pull another branch's audit history by guessing an id.
-    if (
-      user &&
-      !hasCrossBranchAccess({ role: user.role ?? '' }) &&
-      doc.branchId &&
-      doc.branchId !== user.branchId
-    ) {
-      throw new ForbiddenException('ไม่มีสิทธิ์เข้าถึงเอกสารของสาขาอื่น');
-    }
-    return this.prisma.auditLog.findMany({
-      where: {
-        entityId: id,
-        entity: { in: ['expense_document', 'ExpenseDocument'] },
-      },
-      orderBy: { createdAt: 'desc' },
-      take: 50,
-      include: {
-        user: { select: { id: true, name: true, email: true } },
-      },
-    });
+    return this.query.getAuditTrail(id, user);
   }
 
   // ─── Find one ────────────────────────────────────────────────────────
@@ -1646,53 +1224,9 @@ export class ExpenseDocumentsService implements OnModuleInit {
   // CN view, payroll view, SE view) don't need a follow-up roundtrip. The
   // base includes (expenseDetail / branch / approver) work for every type;
   // creditNote / payroll / settlement detail are added based on documentType.
+  // Phase 1 decompose — delegates to ExpenseDocumentQueryService.
   async findOne(id: string, viewerRole?: string | null) {
-    // First pass to read documentType, then a typed include.
-    const docType = await this.prisma.expenseDocument.findUniqueOrThrow({
-      where: { id },
-      select: { documentType: true, deletedAt: true },
-    });
-    if (docType.deletedAt) throw new NotFoundException('เอกสารถูกลบแล้ว');
-
-    const doc = await this.prisma.expenseDocument.findUniqueOrThrow({
-      where: { id },
-      include: {
-        expenseDetail: { include: { lines: { orderBy: { lineNo: 'asc' } } } },
-        adjustments: { orderBy: { lineNo: 'asc' } },
-        branch: { select: { id: true, name: true } },
-        createdBy: { select: { id: true, name: true } },
-        approvedBy: { select: { id: true, name: true } },
-        // Conditional includes by documentType — Prisma allows boolean here
-        // and noop when the relation row doesn't exist for the type.
-        creditNote: docType.documentType === 'CREDIT_NOTE',
-        payroll:
-          docType.documentType === 'PAYROLL'
-            ? {
-                include: {
-                  lines: {
-                    include: {
-                      customIncome: { orderBy: { createdAt: 'asc' } },
-                      customDeduction: { orderBy: { createdAt: 'asc' } },
-                    },
-                  },
-                },
-              }
-            : false,
-        settlement:
-          docType.documentType === 'VENDOR_SETTLEMENT'
-            ? { include: { settlementLines: true } }
-            : false,
-      },
-    });
-    if (doc.deletedAt) throw new NotFoundException('เอกสารถูกลบแล้ว');
-    // PR-C PII — mask payroll taxIds in the read response. Cast required
-    // because Prisma's conditional-include type for payroll doesn't statically
-    // carry the nested lines shape; the runtime value is correct.
-    maskPayrollTaxIds(
-      doc as { payroll?: { lines: Array<{ employeeTaxId: string | null }> } | null },
-      viewerRole,
-    );
-    return doc;
+    return this.query.findOne(id, viewerRole);
   }
 
   // ─── Update (DRAFT only) ─────────────────────────────────────────────

--- a/apps/api/src/modules/expense-documents/services/expense-document-query.service.ts
+++ b/apps/api/src/modules/expense-documents/services/expense-document-query.service.ts
@@ -1,0 +1,613 @@
+import {
+  Injectable,
+  BadRequestException,
+  NotFoundException,
+  ForbiddenException,
+} from '@nestjs/common';
+import { Prisma, DocumentStatus } from '@prisma/client';
+import { PrismaService } from '../../../prisma/prisma.service';
+import { JePreviewService } from './je-preview.service';
+import { collectJePreviewCodes } from '../je-preview-codes.util';
+import { hasCrossBranchAccess } from '../../auth/branch-access.util';
+import { maskPayrollTaxIds } from '../payroll-pii-mask.util';
+import { CreateExpenseDocumentDto } from '../dto/create.dto';
+import { ListExpenseDocumentsQueryDto } from '../dto/list-query.dto';
+
+/**
+ * Phase 1 of the transactional-core decompose: the 9 READ-only methods of
+ * ExpenseDocumentsService, extracted VERBATIM. The facade delegates to this
+ * service so the public contract (controller + callers) is unchanged.
+ *
+ * Behavior-preserving — method bodies are byte-identical to the pre-extraction
+ * facade; only import paths were adjusted for the deeper directory.
+ */
+@Injectable()
+export class ExpenseDocumentQueryService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly jePreview: JePreviewService,
+  ) {}
+
+  // ─── List ────────────────────────────────────────────────────────────
+  async list(
+    query: ListExpenseDocumentsQueryDto,
+    user: { branchId?: string | null; role?: string },
+  ) {
+    const where: Prisma.ExpenseDocumentWhereInput = { deletedAt: null };
+
+    // Branch scoping: cross-branch roles can pass ?branchId or omit it for "all";
+    // non-cross-branch users are PINNED to their assigned branch — the query
+    // param is ignored. If a non-cross-branch user has no branchId assigned
+    // (data corruption), reject rather than fall through to query.branchId.
+    if (hasCrossBranchAccess(user)) {
+      if (query.branchId) where.branchId = query.branchId;
+    } else {
+      if (!user.branchId) {
+        throw new ForbiddenException('ผู้ใช้ไม่มีสาขาที่ได้รับมอบหมาย');
+      }
+      where.branchId = user.branchId;
+    }
+
+    // Tab translation
+    switch (query.tab) {
+      case 'draft':
+        where.status = 'DRAFT';
+        break;
+      case 'unpaid':
+        where.status = 'ACCRUAL';
+        break;
+      case 'recorded':
+        where.status = { in: ['ACCRUAL', 'POSTED'] };
+        break;
+      case 'paid':
+        where.paidAt = { not: null };
+        break;
+      default:
+        where.status = { not: 'VOIDED' };
+    }
+
+    // Explicit status overrides tab
+    if (query.status) where.status = query.status as DocumentStatus;
+    if (query.type) where.documentType = query.type as never;
+
+    // Date range on documentDate
+    if (query.startDate || query.endDate) {
+      where.documentDate = {};
+      if (query.startDate) where.documentDate.gte = new Date(query.startDate);
+      if (query.endDate) {
+        const end = new Date(query.endDate);
+        end.setHours(23, 59, 59, 999);
+        where.documentDate.lte = end;
+      }
+    }
+
+    // Filter by ExpenseLine.category (e.g. CoA code "53-1302")
+    if (query.category) {
+      where.expenseDetail = { lines: { some: { category: query.category } } };
+    }
+
+    if (query.search) {
+      where.OR = [
+        { number: { contains: query.search, mode: 'insensitive' } },
+        { description: { contains: query.search, mode: 'insensitive' } },
+        { vendorName: { contains: query.search, mode: 'insensitive' } },
+        { taxInvoiceNo: { contains: query.search, mode: 'insensitive' } },
+      ];
+    }
+
+    const page = Math.max(1, query.page ?? 1);
+    const limit = Math.min(100, Math.max(1, query.limit ?? 20));
+
+    const [data, total] = await Promise.all([
+      this.prisma.expenseDocument.findMany({
+        where,
+        include: {
+          expenseDetail: { include: { lines: { orderBy: { lineNo: 'asc' } } } },
+          branch: { select: { id: true, name: true } },
+          createdBy: { select: { id: true, name: true } },
+        },
+        orderBy: { documentDate: 'desc' },
+        skip: (page - 1) * limit,
+        take: limit,
+      }),
+      this.prisma.expenseDocument.count({ where }),
+    ]);
+
+    return { data, total, page, limit };
+  }
+
+  // ─── Summary aggregations ────────────────────────────────────────────
+  async getSummary(filters: {
+    branchId?: string;
+    startDate?: string;
+    endDate?: string;
+  }) {
+    const where: Prisma.ExpenseDocumentWhereInput = {
+      deletedAt: null,
+      status: { not: 'VOIDED' },
+    };
+    if (filters.branchId) where.branchId = filters.branchId;
+    if (filters.startDate || filters.endDate) {
+      where.documentDate = {};
+      if (filters.startDate) where.documentDate.gte = new Date(filters.startDate);
+      if (filters.endDate) {
+        const end = new Date(filters.endDate);
+        end.setHours(23, 59, 59, 999);
+        where.documentDate.lte = end;
+      }
+    }
+
+    // Server-side aggregation — does not load full rows into memory.
+    const [totalCount, statusGroups, accrualUnpaid] = await Promise.all([
+      this.prisma.expenseDocument.count({ where }),
+      this.prisma.expenseDocument.groupBy({
+        by: ['status'],
+        where,
+        _count: { _all: true },
+      }),
+      this.prisma.expenseDocument.aggregate({
+        where: { ...where, status: 'ACCRUAL', paidAt: null },
+        _count: { _all: true },
+        _sum: { totalAmount: true },
+      }),
+    ]);
+
+    const byStatus: Record<string, number> = {};
+    for (const g of statusGroups) byStatus[g.status] = g._count._all;
+
+    return {
+      totalCount,
+      byStatus,
+      accrualUnpaidCount: accrualUnpaid._count._all,
+      // Decimal serialized as string ("1234.56") for parity with daily-summary
+      // grandTotal — clients should parse for display rather than trusting JS float.
+      accrualUnpaidTotal: accrualUnpaid._sum.totalAmount?.toFixed(2) ?? '0.00',
+    };
+  }
+
+  /**
+   * Phase A.5 — Tax-disallowed summary for ภ.ง.ด.50/51 prep.
+   *
+   * Returns the total amount of expense documents flagged as tax-disallowed
+   * (ม.65 ตรี ป.รัษฎากร) over a date range. Used by the accountant at year-
+   * end to exclude these from the deductible-expense total on the corporate
+   * income-tax filing.
+   *
+   * Two roll-ups:
+   *   - `docLevelTotal`: sum(totalAmount) of POSTED docs with doc-level flag
+   *   - `lineLevelTotal`: sum(amountBeforeVat) of line-level overrides on
+   *      docs NOT already disallowed at doc-level (avoid double-count)
+   *
+   * Both are POSTED-only — DRAFT / ACCRUAL / VOIDED are excluded since they
+   * aren't yet on the books. `from` / `to` filter by `documentDate` (BKK).
+   * When omitted, scans every POSTED document (use the calling controller's
+   * default = current calendar year if you want a "this year" view).
+   */
+  async getTaxDisallowedSummary(filters: {
+    branchId?: string;
+    from?: string;
+    to?: string;
+  }) {
+    const where: Prisma.ExpenseDocumentWhereInput = {
+      deletedAt: null,
+      status: 'POSTED',
+    };
+    if (filters.branchId) where.branchId = filters.branchId;
+    if (filters.from || filters.to) {
+      where.documentDate = {};
+      if (filters.from) where.documentDate.gte = new Date(filters.from);
+      if (filters.to) {
+        const end = new Date(filters.to);
+        end.setHours(23, 59, 59, 999);
+        where.documentDate.lte = end;
+      }
+    }
+
+    // Doc-level: all lines in the doc are disallowed → sum totalAmount.
+    const docLevel = await this.prisma.expenseDocument.aggregate({
+      where: { ...where, taxDisallowed: true },
+      _count: { _all: true },
+      _sum: { totalAmount: true },
+    });
+
+    // Line-level: only count rows where the PARENT doc is NOT already flagged
+    // doc-level (otherwise we'd double-count those lines). Sum `amountBeforeVat`
+    // because tax deductibility is computed on the pre-VAT amount — VAT input
+    // is handled separately on ภ.พ.30, not on ภ.ง.ด.50/51.
+    const lineLevel = await this.prisma.expenseLine.aggregate({
+      where: {
+        taxDisallowed: true,
+        expenseDetail: {
+          document: { ...where, taxDisallowed: false },
+        },
+      },
+      _count: { _all: true },
+      _sum: { amountBeforeVat: true },
+    });
+
+    const docTotal = docLevel._sum.totalAmount ?? new Prisma.Decimal(0);
+    const lineTotal = lineLevel._sum.amountBeforeVat ?? new Prisma.Decimal(0);
+    const grandTotal = docTotal.plus(lineTotal);
+
+    return {
+      docLevelCount: docLevel._count._all,
+      docLevelTotal: docTotal.toFixed(2),
+      lineLevelCount: lineLevel._count._all,
+      lineLevelTotal: lineTotal.toFixed(2),
+      grandTotal: grandTotal.toFixed(2),
+      filters: { from: filters.from ?? null, to: filters.to ?? null },
+    };
+  }
+
+  /**
+   * AP Aging — Fix Report P1-1.
+   *
+   * Returns ACCRUAL (unpaid) expenses bucketed by age since `documentDate`,
+   * plus their per-bucket sums. Used by the APAgingPage with optional vendor /
+   * bucket filters.
+   *
+   * Buckets (per Fix Report §1.3 P1-1):
+   *   0-30 / 31-60 / 61-90 / 90+ days overdue
+   *
+   * Age is computed against "today BKK" (start-of-day) so a vendor's row that
+   * just crossed midnight in Asia/Bangkok doesn't shift bucket vs server-tz.
+   */
+  async getApAging(filters: { branchId?: string; vendor?: string; bucket?: '0-30' | '31-60' | '61-90' | '90+' }) {
+    const where: Prisma.ExpenseDocumentWhereInput = {
+      deletedAt: null,
+      status: 'ACCRUAL',
+      paidAt: null,
+    };
+    if (filters.branchId) where.branchId = filters.branchId;
+    if (filters.vendor) {
+      where.vendorName = { contains: filters.vendor, mode: 'insensitive' };
+    }
+
+    // W2 fix — age in calendar days, computed on BKK date strings.
+    // Previous implementation took (todayBkkStart UTC ms − documentDate UTC ms)
+    // / 86_400_000 and floored. Because documentDate stores UTC midnight (00:00Z
+    // = 07:00 BKK same day) while todayBkkStart was UTC minus 7h (=BKK midnight
+    // mapped to 17:00Z previous UTC day), the ms-diff was non-integer around
+    // the boundary, so floor() shifted some rows by ±1 day (e.g. a doc dated
+    // today appeared as 1 day old, pushing it from 0-30 to 31-60 right at
+    // 17:00 BKK / 30 days later). Switch to calendar-day diff on YYYY-MM-DD
+    // strings instead.
+    const toBkkDate = (d: Date): string =>
+      d.toLocaleDateString('en-CA', { timeZone: 'Asia/Bangkok' });
+    const todayBkkStr = toBkkDate(new Date());
+    const daysBetween = (a: string, b: string): number => {
+      // a, b are 'YYYY-MM-DD'. Build UTC midnights and subtract — exact integer
+      // because both sides are at the same UTC hour.
+      const [ay, am, ad] = a.split('-').map(Number);
+      const [by, bm, bd] = b.split('-').map(Number);
+      const aMs = Date.UTC(ay, am - 1, ad);
+      const bMs = Date.UTC(by, bm - 1, bd);
+      return Math.round((bMs - aMs) / (24 * 60 * 60 * 1000));
+    };
+
+    const rows = await this.prisma.expenseDocument.findMany({
+      where,
+      select: {
+        id: true,
+        number: true,
+        vendorName: true,
+        vendorTaxId: true,
+        documentDate: true,
+        totalAmount: true,
+        withholdingTax: true,
+        branchId: true,
+      },
+      orderBy: { documentDate: 'asc' },
+    });
+
+    type Bucket = '0-30' | '31-60' | '61-90' | '90+';
+    const toBucket = (ageDays: number): Bucket => {
+      if (ageDays <= 30) return '0-30';
+      if (ageDays <= 60) return '31-60';
+      if (ageDays <= 90) return '61-90';
+      return '90+';
+    };
+
+    const enriched = rows.map((r) => {
+      const docBkkStr = toBkkDate(new Date(r.documentDate));
+      const ageDays = Math.max(0, daysBetween(docBkkStr, todayBkkStr));
+      return { ...r, ageDays, bucket: toBucket(ageDays) };
+    });
+
+    const filtered = filters.bucket ? enriched.filter((r) => r.bucket === filters.bucket) : enriched;
+
+    const zero = new Prisma.Decimal(0);
+    const totals: Record<Bucket | 'TOTAL', { count: number; amount: Prisma.Decimal }> = {
+      '0-30': { count: 0, amount: new Prisma.Decimal(0) },
+      '31-60': { count: 0, amount: new Prisma.Decimal(0) },
+      '61-90': { count: 0, amount: new Prisma.Decimal(0) },
+      '90+': { count: 0, amount: new Prisma.Decimal(0) },
+      TOTAL: { count: 0, amount: new Prisma.Decimal(0) },
+    };
+    // Bucket totals use the full unfiltered set so the user can see context even
+    // when bucket filter is active.
+    for (const r of enriched) {
+      const amt = new Prisma.Decimal(r.totalAmount.toString()).minus(
+        new Prisma.Decimal(r.withholdingTax?.toString() ?? '0'),
+      );
+      totals[r.bucket].count += 1;
+      totals[r.bucket].amount = totals[r.bucket].amount.plus(amt);
+      totals.TOTAL.count += 1;
+      totals.TOTAL.amount = totals.TOTAL.amount.plus(amt);
+    }
+    void zero;
+
+    return {
+      buckets: {
+        '0-30': { count: totals['0-30'].count, amount: totals['0-30'].amount.toFixed(2) },
+        '31-60': { count: totals['31-60'].count, amount: totals['31-60'].amount.toFixed(2) },
+        '61-90': { count: totals['61-90'].count, amount: totals['61-90'].amount.toFixed(2) },
+        '90+': { count: totals['90+'].count, amount: totals['90+'].amount.toFixed(2) },
+        TOTAL: { count: totals.TOTAL.count, amount: totals.TOTAL.amount.toFixed(2) },
+      },
+      docs: filtered.map((r) => ({
+        id: r.id,
+        number: r.number,
+        vendorName: r.vendorName,
+        vendorTaxId: r.vendorTaxId,
+        documentDate: r.documentDate.toISOString(),
+        ageDays: r.ageDays,
+        bucket: r.bucket,
+        // Net amount = totalAmount − wht (the cash leg pending payment).
+        netAmount: new Prisma.Decimal(r.totalAmount.toString())
+          .minus(new Prisma.Decimal(r.withholdingTax?.toString() ?? '0'))
+          .toFixed(2),
+        branchId: r.branchId,
+      })),
+    };
+  }
+
+  // ─── Daily summary (print-ready aggregation) ─────────────────────────
+  async getDailySummary(
+    filters: { date: string; branchId?: string },
+    user: { id: string; branchId?: string | null; role?: string | null },
+  ) {
+    const branchId = hasCrossBranchAccess(user)
+      ? filters.branchId
+      : (user.branchId ?? filters.branchId);
+    if (!branchId) {
+      throw new BadRequestException('ต้องระบุสาขา');
+    }
+    const start = new Date(filters.date);
+    start.setHours(0, 0, 0, 0);
+    const end = new Date(filters.date);
+    end.setHours(23, 59, 59, 999);
+
+    const documents = await this.prisma.expenseDocument.findMany({
+      where: {
+        branchId,
+        documentDate: { gte: start, lte: end },
+        status: { not: 'VOIDED' },
+        deletedAt: null,
+      },
+      include: {
+        // I4 fix — pull ALL expense lines (not just the first) so the
+        // "by category" aggregation reflects every line's category, weighted
+        // by amountBeforeVat. Previously `take: 1` made multi-line docs all
+        // collapse to their first line's category — a 3-line doc with 1k of
+        // category A and 2x 5k of B would attribute all 11k to A. With this
+        // include the daily summary instead sums per-line amounts into the
+        // right buckets.
+        expenseDetail: { include: { lines: { orderBy: { lineNo: 'asc' } } } },
+        creditNote: true,
+        payroll: true,
+        settlement: true,
+        branch: { select: { id: true, name: true } },
+      },
+      orderBy: { number: 'asc' },
+    });
+
+    // Aggregate
+    const byType: Record<string, { count: number; total: string }> = {};
+    const byPaymentMethod: Record<string, { count: number; total: string }> = {};
+    const byCategory: Record<string, { count: number; total: string }> = {};
+    const cashMovement: Record<string, { out: string; count: number }> = {};
+
+    let grandTotal = new Prisma.Decimal(0);
+
+    for (const d of documents) {
+      const total = new Prisma.Decimal(d.totalAmount.toString());
+      grandTotal = grandTotal.plus(total);
+
+      // By type
+      const tKey = d.documentType;
+      const tBucket = byType[tKey] ?? { count: 0, total: '0' };
+      tBucket.count++;
+      tBucket.total = new Prisma.Decimal(tBucket.total).plus(total).toFixed(2);
+      byType[tKey] = tBucket;
+
+      // By payment method (only if doc has paymentMethod set)
+      if (d.paymentMethod) {
+        const mKey = d.paymentMethod;
+        const mBucket = byPaymentMethod[mKey] ?? { count: 0, total: '0' };
+        mBucket.count++;
+        const netAmt = d.netPayment ? new Prisma.Decimal(d.netPayment.toString()) : total;
+        mBucket.total = new Prisma.Decimal(mBucket.total).plus(netAmt).toFixed(2);
+        byPaymentMethod[mKey] = mBucket;
+      }
+
+      // I4 — By category: sum per-line amounts into category buckets so a
+      // multi-line doc contributes correctly to each category. count uses
+      // 1 per distinct category in the doc (not per line) so a doc with
+      // 3 cleaning lines counts once for "cleaning", not three times.
+      // Defensive: legacy rows without `amountBeforeVat` (data migration
+      // artefacts) fall back to 0 — they still count toward the bucket's
+      // doc count but contribute no value.
+      const lines =
+        (d as { expenseDetail?: { lines?: { category: string; amountBeforeVat?: unknown }[] } | null })
+          .expenseDetail?.lines ?? [];
+      const seenInDoc = new Set<string>();
+      for (const l of lines) {
+        const cat = l.category;
+        const raw = l.amountBeforeVat;
+        const lineAmt = raw != null ? new Prisma.Decimal(raw.toString()) : new Prisma.Decimal(0);
+        const cBucket = byCategory[cat] ?? { count: 0, total: '0' };
+        if (!seenInDoc.has(cat)) {
+          cBucket.count++;
+          seenInDoc.add(cat);
+        }
+        cBucket.total = new Prisma.Decimal(cBucket.total).plus(lineAmt).toFixed(2);
+        byCategory[cat] = cBucket;
+      }
+
+      // Cash movement (only docs with depositAccountCode + paidAt today)
+      if (d.depositAccountCode && d.paidAt && d.paidAt >= start && d.paidAt <= end) {
+        const aKey = d.depositAccountCode;
+        const aBucket = cashMovement[aKey] ?? { out: '0', count: 0 };
+        const netAmt = d.netPayment ? new Prisma.Decimal(d.netPayment.toString()) : total;
+        aBucket.out = new Prisma.Decimal(aBucket.out).plus(netAmt).toFixed(2);
+        aBucket.count++;
+        cashMovement[aKey] = aBucket;
+      }
+    }
+
+    return {
+      date: filters.date,
+      branchId,
+      branchName: documents[0]?.branch?.name ?? null,
+      documents,
+      grandTotal: grandTotal.toFixed(2),
+      byType,
+      byPaymentMethod,
+      byCategory,
+      cashMovement,
+    };
+  }
+
+  // ─── Credit-Note remaining cap ───────────────────────────────────────
+  // Returns how much CN can still be issued against this original document.
+  // cap = original.totalAmount - Σ (non-VOIDED CNs against this original).
+  async getCreditNoteCap(originalDocumentId: string) {
+    const original = await this.prisma.expenseDocument.findUniqueOrThrow({
+      where: { id: originalDocumentId },
+    });
+    if (original.deletedAt) {
+      throw new NotFoundException('เอกสารต้นฉบับถูกลบแล้ว');
+    }
+    if (original.documentType !== 'EXPENSE') {
+      throw new BadRequestException('ใบลดหนี้ใช้ลดเอกสารรายจ่ายเท่านั้น');
+    }
+    const priorAgg = await this.prisma.expenseDocument.aggregate({
+      where: {
+        documentType: 'CREDIT_NOTE',
+        status: { not: 'VOIDED' },
+        deletedAt: null,
+        creditNote: { originalDocumentId },
+      },
+      _sum: { totalAmount: true },
+    });
+    const used = new Prisma.Decimal(priorAgg._sum.totalAmount ?? 0);
+    const cap = new Prisma.Decimal(original.totalAmount.toString()).minus(used);
+    return {
+      originalTotal: original.totalAmount.toString(),
+      usedTotal: used.toString(),
+      remainingCap: cap.toString(),
+    };
+  }
+
+  // ─── JE Preview (pure — no DB write) ────────────────────────────────
+  async previewJe(dto: CreateExpenseDocumentDto) {
+    const codes = collectJePreviewCodes(dto);
+    const rows = await this.prisma.chartOfAccount.findMany({
+      where: { code: { in: [...codes] }, deletedAt: null },
+      select: { code: true, name: true },
+    });
+    const accountNames = new Map(rows.map((r) => [r.code, r.name]));
+    return this.jePreview.preview(dto, accountNames);
+  }
+
+  // ─── Audit trail ─────────────────────────────────────────────────────
+  // Immutable event timeline for one expense document, consumed by the shared
+  // InternalControlActionBar audit timeline on the ExpenseDetailPage. Mirrors
+  // OtherIncomeService.getAuditTrail. Both entity casings are queried for
+  // resilience (services write 'expense_document'; defensive include of the
+  // PascalCase form in case a future writer / interceptor differs).
+  async getAuditTrail(
+    id: string,
+    user?: { branchId?: string | null; role?: string | null },
+  ) {
+    // Verify the document exists (throws on unknown / soft-deleted id).
+    const doc = await this.findOne(id);
+    // Branch scoping (mirrors create()/list() guards) — a non-cross-branch role
+    // may only read the audit trail of documents in its OWN branch, so a
+    // BRANCH_MANAGER can't pull another branch's audit history by guessing an id.
+    if (
+      user &&
+      !hasCrossBranchAccess({ role: user.role ?? '' }) &&
+      doc.branchId &&
+      doc.branchId !== user.branchId
+    ) {
+      throw new ForbiddenException('ไม่มีสิทธิ์เข้าถึงเอกสารของสาขาอื่น');
+    }
+    return this.prisma.auditLog.findMany({
+      where: {
+        entityId: id,
+        entity: { in: ['expense_document', 'ExpenseDocument'] },
+      },
+      orderBy: { createdAt: 'desc' },
+      take: 50,
+      include: {
+        user: { select: { id: true, name: true, email: true } },
+      },
+    });
+  }
+
+  // ─── Find one ────────────────────────────────────────────────────────
+  // I5 — include type-specific detail so single-doc views (PaymentVoucher,
+  // CN view, payroll view, SE view) don't need a follow-up roundtrip. The
+  // base includes (expenseDetail / branch / approver) work for every type;
+  // creditNote / payroll / settlement detail are added based on documentType.
+  async findOne(id: string, viewerRole?: string | null) {
+    // First pass to read documentType, then a typed include.
+    const docType = await this.prisma.expenseDocument.findUniqueOrThrow({
+      where: { id },
+      select: { documentType: true, deletedAt: true },
+    });
+    if (docType.deletedAt) throw new NotFoundException('เอกสารถูกลบแล้ว');
+
+    const doc = await this.prisma.expenseDocument.findUniqueOrThrow({
+      where: { id },
+      include: {
+        expenseDetail: { include: { lines: { orderBy: { lineNo: 'asc' } } } },
+        adjustments: { orderBy: { lineNo: 'asc' } },
+        branch: { select: { id: true, name: true } },
+        createdBy: { select: { id: true, name: true } },
+        approvedBy: { select: { id: true, name: true } },
+        // Conditional includes by documentType — Prisma allows boolean here
+        // and noop when the relation row doesn't exist for the type.
+        creditNote: docType.documentType === 'CREDIT_NOTE',
+        payroll:
+          docType.documentType === 'PAYROLL'
+            ? {
+                include: {
+                  lines: {
+                    include: {
+                      customIncome: { orderBy: { createdAt: 'asc' } },
+                      customDeduction: { orderBy: { createdAt: 'asc' } },
+                    },
+                  },
+                },
+              }
+            : false,
+        settlement:
+          docType.documentType === 'VENDOR_SETTLEMENT'
+            ? { include: { settlementLines: true } }
+            : false,
+      },
+    });
+    if (doc.deletedAt) throw new NotFoundException('เอกสารถูกลบแล้ว');
+    // PR-C PII — mask payroll taxIds in the read response. Cast required
+    // because Prisma's conditional-include type for payroll doesn't statically
+    // carry the nested lines shape; the runtime value is correct.
+    maskPayrollTaxIds(
+      doc as { payroll?: { lines: Array<{ employeeTaxId: string | null }> } | null },
+      viewerRole,
+    );
+    return doc;
+  }
+}


### PR DESCRIPTION
## Phase 1 — extract ExpenseDocumentQueryService (behavior-preserving)

Second slice of the **expense-documents transactional-core decompose** epic (design: `docs/superpowers/specs/2026-06-10-...md`; Slice 0 = #1215, merged). Branch is off the post-#1215 main.

Moves the **9 READ-only methods VERBATIM** out of the `ExpenseDocumentsService` facade into a new `ExpenseDocumentQueryService`; facade delegates, signatures unchanged. No `$transaction`, no JE, no state change — read-only.

### What changed
- **New** `services/expense-document-query.service.ts` — `list`, `getSummary`, `getTaxDisallowedSummary`, `getApAging`⚠️, `getDailySummary`, `getCreditNoteCap`, `previewJe`, `getAuditTrail`, `findOne` (bodies byte-identical to main; only import paths adjusted). Ctor `(prisma, jePreview)`. `getAuditTrail→findOne` stays intra-service.
- **Facade** delegates all 9 (exact signatures kept); `jePreview` dropped from ctor (now owned by QueryService); `query` injected as required param **before** the unchanged optional `notifications?` (so the original NestJS DI signature is preserved byte-for-byte). Facade 2475 → 2009 LOC.
- **Module** registers `ExpenseDocumentQueryService` provider.
- **Factory** builds QueryService from the same resolved `prisma`+`jePreview` mocks and routes it into the facade — the single positional construction site (the pattern later slices reuse).
- **+17 characterization tests** (`__tests__/expense-document-query.service.spec.ts`, through the facade) pinning getApAging (TRAP: literal labels `0-30/31-60/61-90/90+`, `<=` bucket edges via fake-timer determinism, net=total−wht, filter-vs-totals), getSummary, getCreditNoteCap, getAuditTrail, previewJe.

### ⚠️ getApAging TRAP
Moved 100% verbatim. Bucket labels `0-30/31-60/61-90/90+` **untouched** (owner-pending canonicalization). Verified byte-identical + pinned by the new test.

### Gates
- `./tools/check-types.sh api` → **0 errors**
- `npm --prefix apps/api run test -- expense-documents` → **429 passed / 35 suites** (412 existing UNCHANGED + 17 new)
- `grep -rc "new ExpenseDocumentsService(" apps/api/src` → **1** (factory only) · `grep this.jePreview` in facade → **0**
- Two-stage review (spec-compliance + code-quality) passed; all 9 bodies independently confirmed byte-identical to main.

### ⚠️ Merge order (sequential-on-main)
- Base = main (post-#1215), independent. **Merge after #1215** (already merged).
- After this lands I **STOP for owner re-confirm** before Phase 2 (Lifecycle 2a/2b/2c) per the approved plan. Phase 2a will branch off freshly-merged main — NOT stacked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)