### PR TITLE
Phase 2a: extract ExpenseDocumentLifecycleService (submit/notify/softDelete, verbatim)

### DIFF
--- a/apps/api/src/modules/expense-documents/__tests__/expense-document-lifecycle.service.spec.ts
+++ b/apps/api/src/modules/expense-documents/__tests__/expense-document-lifecycle.service.spec.ts
@@ -1,0 +1,127 @@
+import { Decimal } from '@prisma/client/runtime/library';
+import { makeExpenseDocumentsService } from './support/make-expense-documents-service';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+/**
+ * Characterization for the private `notifyApprovers` fan-out, pinned THROUGH
+ * THE FACADE (`service.submitForApproval` → lifecycle.submitForApproval →
+ * lifecycle.notifyApprovers). These branches were NOT covered by the existing
+ * submitForApproval specs (which all omit `notifications`, so they only exercise
+ * the undefined-early-return path implicitly).
+ *
+ * Phase 2a decompose — added BEFORE the move and kept GREEN after, so the
+ * extracted ExpenseDocumentLifecycleService is byte-behavior-identical to the
+ * pre-extraction facade. Asserts on the injected notifications.send mock.
+ *
+ * Branches pinned:
+ *   (a) notification_on_pending=false → early return (no send)
+ *   (b) notifications undefined        → early return (no throw)
+ *   (c) empty approvers_list           → OWNER fallback (send to owners)
+ *   (d) Promise.allSettled             → one failed recipient is swallowed;
+ *                                        the others still receive + no rethrow
+ */
+describe('ExpenseDocumentLifecycleService — notifyApprovers fan-out (via facade)', () => {
+  /**
+   * Build a prisma double whose systemConfig.findFirst is driven by a per-key
+   * map and whose user.findMany is configurable. `approval_enabled` defaults to
+   * true so submitForApproval reaches the notify step.
+   */
+  function makePrisma(opts: {
+    configValues?: Record<string, string>;
+    users?: Array<{ id: string }>;
+  } = {}) {
+    const configValues: Record<string, string> = {
+      approval_enabled: 'true',
+      ...(opts.configValues ?? {}),
+    };
+    const prisma: any = {
+      $transaction: jest.fn(async (cb: any) => cb(prisma)),
+      $executeRawUnsafe: jest.fn().mockResolvedValue(1),
+      expenseDocument: {
+        findUniqueOrThrow: jest
+          .fn()
+          .mockResolvedValue({ id: 'doc-1', status: 'DRAFT', deletedAt: null }),
+        update: jest.fn().mockResolvedValue({
+          id: 'doc-1',
+          number: 'EX-20260610-0001',
+          documentType: 'EXPENSE',
+          totalAmount: new Decimal('1234.56'),
+          status: 'PENDING_APPROVAL',
+          deletedAt: null,
+        }),
+      },
+      auditLog: { create: jest.fn().mockResolvedValue({}) },
+      systemConfig: {
+        findFirst: jest.fn().mockImplementation((args: { where: { key: string } }) => {
+          const v = configValues[args.where.key];
+          return Promise.resolve(v === undefined ? null : { value: v });
+        }),
+      },
+      user: {
+        findMany: jest.fn().mockResolvedValue(opts.users ?? []),
+      },
+    };
+    return prisma;
+  }
+
+  it('(a) notification_on_pending=false → does NOT send', async () => {
+    const send = jest.fn().mockResolvedValue(undefined);
+    const prisma = makePrisma({
+      configValues: { notification_on_pending: 'false' },
+      users: [{ id: 'owner-1' }],
+    });
+    const { service } = makeExpenseDocumentsService({ prisma, notifications: { send } });
+
+    await service.submitForApproval('doc-1', 'user-1');
+
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it('(b) notifications undefined → submit still succeeds, no throw', async () => {
+    const prisma = makePrisma({ users: [{ id: 'owner-1' }] });
+    // notifications omitted → factory default undefined.
+    const { service } = makeExpenseDocumentsService({ prisma });
+
+    const result = await service.submitForApproval('doc-1', 'user-1');
+
+    expect(result.status).toBe('PENDING_APPROVAL');
+  });
+
+  it('(c) empty approvers_list → falls back to OWNER users', async () => {
+    const send = jest.fn().mockResolvedValue(undefined);
+    // No approvers_list config row → getApproversList returns [] → OWNER fallback.
+    const prisma = makePrisma({ users: [{ id: 'owner-1' }, { id: 'owner-2' }] });
+    const { service } = makeExpenseDocumentsService({ prisma, notifications: { send } });
+
+    await service.submitForApproval('doc-1', 'user-1');
+
+    expect(prisma.user.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ role: 'OWNER', isActive: true, deletedAt: null }),
+      }),
+    );
+    expect(send).toHaveBeenCalledTimes(2);
+    expect(send).toHaveBeenCalledWith(
+      expect.objectContaining({ channel: 'IN_APP', recipient: 'owner-1' }),
+    );
+    expect(send).toHaveBeenCalledWith(
+      expect.objectContaining({ channel: 'IN_APP', recipient: 'owner-2' }),
+    );
+  });
+
+  it('(d) one failed recipient is swallowed (allSettled); others still notified; no rethrow', async () => {
+    const send = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('recipient blew up'))
+      .mockResolvedValue(undefined);
+    const prisma = makePrisma({ users: [{ id: 'owner-1' }, { id: 'owner-2' }] });
+    const { service } = makeExpenseDocumentsService({ prisma, notifications: { send } });
+
+    // Must resolve (not reject) even though the first send rejects.
+    const result = await service.submitForApproval('doc-1', 'user-1');
+
+    expect(result.status).toBe('PENDING_APPROVAL');
+    expect(send).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/api/src/modules/expense-documents/__tests__/support/make-expense-documents-service.ts
+++ b/apps/api/src/modules/expense-documents/__tests__/support/make-expense-documents-service.ts
@@ -21,6 +21,7 @@ import { Decimal } from '@prisma/client/runtime/library';
 import { ExpenseDocumentsService } from '../../expense-documents.service';
 import { LineAggregatorService } from '../../services/line-aggregator.service';
 import { ExpenseDocumentQueryService } from '../../services/expense-document-query.service';
+import { ExpenseDocumentLifecycleService } from '../../services/expense-document-lifecycle.service';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -56,6 +57,12 @@ export interface ExpenseDocumentsServiceOverrides {
   // `jePreview`, so existing specs' prisma/jePreview mocks flow through the
   // facade's delegating read methods unchanged.
   query?: any;
+  // Phase 2a decompose — the lifecycle sub-service (submitForApproval /
+  // softDelete + the private notifyApprovers fan-out). Defaults to a REAL
+  // ExpenseDocumentLifecycleService built from the SAME resolved `prisma` +
+  // `notifications`, so existing specs' prisma/notifications mocks flow through
+  // the facade's delegating lifecycle methods unchanged.
+  lifecycle?: any;
 }
 
 export interface MadeExpenseDocumentsService {
@@ -77,6 +84,7 @@ export interface MadeExpenseDocumentsService {
   payrollCustom: any;
   notifications: any;
   query: any;
+  lifecycle: any;
 }
 
 export function makeExpenseDocumentsService(
@@ -120,6 +128,12 @@ export function makeExpenseDocumentsService(
   // through the facade's now-delegating read methods. `jePreview` is no longer
   // a facade constructor arg (it moved into the query service).
   const query = overrides.query ?? new ExpenseDocumentQueryService(prisma, jePreview);
+  // Phase 2a decompose — REAL lifecycle sub-service by default, built from the
+  // SAME resolved `prisma` + `notifications` instances so existing specs' mocks
+  // flow through the facade's now-delegating lifecycle methods. `notifications`
+  // is no longer a facade constructor arg (it moved into the lifecycle service).
+  const lifecycle =
+    overrides.lifecycle ?? new ExpenseDocumentLifecycleService(prisma, notifications);
 
   // THE single positional construction in the codebase.
   const service = new ExpenseDocumentsService(
@@ -138,7 +152,7 @@ export function makeExpenseDocumentsService(
     pettyCash,
     payrollCustom,
     query,
-    notifications,
+    lifecycle,
   );
 
   return {
@@ -160,5 +174,6 @@ export function makeExpenseDocumentsService(
     payrollCustom,
     notifications,
     query,
+    lifecycle,
   };
 }

--- a/apps/api/src/modules/expense-documents/expense-documents.module.ts
+++ b/apps/api/src/modules/expense-documents/expense-documents.module.ts
@@ -16,6 +16,7 @@ import { StatusTransitionService } from './services/status-transition.service';
 import { LineAggregatorService } from './services/line-aggregator.service';
 import { JePreviewService } from './services/je-preview.service';
 import { ExpenseDocumentQueryService } from './services/expense-document-query.service';
+import { ExpenseDocumentLifecycleService } from './services/expense-document-lifecycle.service';
 import { ExpenseVoucherPdfService } from './services/expense-voucher-pdf.service';
 import { PettyCashService } from './services/petty-cash.service';
 import { PayrollCustomService } from './services/payroll-custom.service';
@@ -51,6 +52,7 @@ import { ReversePermissionGuard } from './reverse-permission.guard';
     LineAggregatorService,
     JePreviewService,
     ExpenseDocumentQueryService,
+    ExpenseDocumentLifecycleService,
     ExpenseVoucherPdfService,
     PettyCashService,
     PayrollCustomService,

--- a/apps/api/src/modules/expense-documents/expense-documents.service.ts
+++ b/apps/api/src/modules/expense-documents/expense-documents.service.ts
@@ -36,8 +36,8 @@ import { VoidExpenseDocumentDto } from './dto/void-expense.dto';
 import { hasCrossBranchAccess } from '../auth/branch-access.util';
 import { LineAggregatorService } from './services/line-aggregator.service';
 import { ExpenseDocumentQueryService } from './services/expense-document-query.service';
+import { ExpenseDocumentLifecycleService } from './services/expense-document-lifecycle.service';
 import { SsoConfigService } from '../sso-config/sso-config.service';
-import { NotificationsService } from '../notifications/notifications.service';
 import { PettyCashService } from './services/petty-cash.service';
 import { PayrollCustomService } from './services/payroll-custom.service';
 import { validatePeriodOpen } from '../../utils/period-lock.util';
@@ -46,7 +46,6 @@ import { bkkBusinessDate } from './bkk-business-date.util';
 import {
   assertUserCanApprove,
   getApprovalRequiredDocTypes,
-  getApproversList,
   getReverseReasons,
 } from './approval-config.util';
 
@@ -100,77 +99,14 @@ export class ExpenseDocumentsService implements OnModuleInit {
     private readonly payrollCustom: PayrollCustomService,
     // Phase 1 decompose — the 9 READ-only methods now live in
     // ExpenseDocumentQueryService; the facade delegates. Owns `jePreview`
-    // (previously a facade param). Placed BEFORE `notifications` so that param
-    // keeps its original trailing-optional `?` form (a required param cannot
-    // follow an optional one) — preserving the exact original DI signature.
+    // (previously a facade param).
     private readonly query: ExpenseDocumentQueryService,
-    // D1.2.1.5 — IN_APP notification fan-out on DRAFT → PENDING_APPROVAL.
-    // Optional injection — when the module wires NotificationsService it
-    // is used; tests can omit it without breaking submitForApproval.
-    private readonly notifications?: NotificationsService,
+    // Phase 2a decompose — submitForApproval / softDelete (+ the private
+    // notifyApprovers fan-out) now live in ExpenseDocumentLifecycleService;
+    // the facade delegates. The lifecycle service OWNS the NotificationsService
+    // dependency (the facade no longer references it directly).
+    private readonly lifecycle: ExpenseDocumentLifecycleService,
   ) {}
-
-  /**
-   * D1.2.1.5 — Fan out IN_APP notifications to configured approvers when
-   * a doc enters PENDING_APPROVAL. Runs OUTSIDE the parent transaction —
-   * a notification failure NEVER rolls back the status flip.
-   *
-   * - Reads `notification_on_pending` (default true) — opt-out per OWNER.
-   * - Reads + validates `approvers_list` against the User table.
-   * - Falls back to OWNER users when the list is empty (root-of-trust).
-   * - Uses `Promise.allSettled` so one bad recipient never blocks the rest.
-   * - Errors are logged + swallowed (no rethrow).
-   */
-  private async notifyApprovers(doc: {
-    id: string;
-    documentNumber: string;
-    documentType: string;
-    totalAmount: Prisma.Decimal | string | number;
-  }): Promise<void> {
-    try {
-      const enabled = await this.readBoolFlag(
-        this.prisma,
-        'notification_on_pending',
-        true,
-      );
-      if (!enabled) return;
-      if (!this.notifications) return;
-
-      // Resolve recipients: approvers_list → fallback to OWNER users.
-      let recipients = await getApproversList(this.prisma);
-      if (recipients.length === 0) {
-        const owners = await this.prisma.user.findMany({
-          where: { role: 'OWNER', isActive: true, deletedAt: null },
-          select: { id: true },
-        });
-        recipients = owners.map((u) => u.id);
-      }
-      if (recipients.length === 0) return;
-
-      const totalStr = new Prisma.Decimal(doc.totalAmount.toString()).toFixed(2);
-      const message =
-        `เอกสาร ${doc.documentNumber} (${doc.documentType}) ` +
-        `ยอด ${totalStr} บาท รออนุมัติ`;
-
-      await Promise.allSettled(
-        recipients.map((userId) =>
-          this.notifications!.send({
-            channel: 'IN_APP',
-            recipient: userId,
-            subject: 'มีเอกสารรออนุมัติ',
-            message,
-            relatedId: doc.id,
-          }),
-        ),
-      );
-    } catch (err) {
-      // Log and swallow — notification failure must NOT roll back the
-      // status flip already persisted in the parent transaction.
-      this.logger.warn(
-        `notifyApprovers(${doc.id}) failed: ${(err as Error).message}`,
-      );
-    }
-  }
 
   // ─── D1.* — Service-side SystemConfig flag readers ─────────────────────
   // Delegates to shared `readBoolFlag` in utils/config.util
@@ -1325,73 +1261,11 @@ export class ExpenseDocumentsService implements OnModuleInit {
   }
 
   // ─── Submit for approval (DRAFT → PENDING_APPROVAL) ─────────────────
-  // D1.2.1.1 — entry point of the Approval Workflow. Only callable when
-  // SystemConfig `approval_enabled` is true. Without that flag set the
-  // legacy lifecycle (DRAFT → POSTED) applies and there's no reason to
-  // visit PENDING_APPROVAL.
-  //
-  // NOTE: this references the new enum values `PENDING_APPROVAL` and
-  // `APPROVED` which land on the schema in D1.2.1.6 (sibling PR). Until
-  // that migrates, this PR uses `as unknown as DocumentStatus` casts. At
-  // merge time accept the conflict on `schema.prisma` from 1.6.
+  // D1.2.1.1 — entry point of the Approval Workflow. Phase 2a decompose:
+  // delegated to ExpenseDocumentLifecycleService (which owns the notification
+  // fan-out). Signature + behavior unchanged.
   async submitForApproval(id: string, userId: string) {
-    const updated = await this.prisma.$transaction(async (tx) => {
-      await tx.$executeRawUnsafe(`SELECT pg_advisory_xact_lock(hashtext($1))`, `post:${id}`);
-
-      const approvalEnabled = await this.readBoolFlag(tx, 'approval_enabled', false);
-      if (!approvalEnabled) {
-        throw new BadRequestException(
-          'ฟีเจอร์ขออนุมัติยังไม่เปิดใช้งาน — กรุณาเปิด SystemConfig `approval_enabled` ก่อน',
-        );
-      }
-
-      const doc = await tx.expenseDocument.findUniqueOrThrow({ where: { id } });
-      if (doc.deletedAt) throw new NotFoundException('เอกสารถูกลบแล้ว');
-      if (doc.status !== 'DRAFT') {
-        throw new BadRequestException(
-          `ส่งขออนุมัติได้เฉพาะเอกสาร DRAFT — สถานะปัจจุบัน ${doc.status}`,
-        );
-      }
-
-      const PENDING_APPROVAL = 'PENDING_APPROVAL' as unknown as DocumentStatus;
-      const result = await tx.expenseDocument.update({
-        where: { id },
-        data: { status: PENDING_APPROVAL },
-      });
-
-      // D1.2.1.5 — APPROVAL_REQUESTED audit log. Atomic with the status flip.
-      // PII-safe payload: documentNumber + totalAmount + documentType only.
-      // Salary lines, employee tax IDs, etc. NEVER captured here per PDPA.
-      await tx.auditLog.create({
-        data: {
-          action: 'APPROVAL_REQUESTED',
-          entity: 'expense_document',
-          entityId: id,
-          userId,
-          oldValue: { status: 'DRAFT' },
-          newValue: {
-            status: 'PENDING_APPROVAL',
-            documentNumber: result.number,
-            documentType: result.documentType,
-            totalAmount: result.totalAmount.toString(),
-            requesterUserId: userId,
-          },
-        },
-      });
-
-      return result;
-    });
-
-    // D1.2.1.5 — fan out notifications OUTSIDE the tx. A notification failure
-    // must never roll back the status flip already persisted.
-    await this.notifyApprovers({
-      id: updated.id,
-      documentNumber: updated.number,
-      documentType: updated.documentType,
-      totalAmount: updated.totalAmount,
-    });
-
-    return updated;
+    return this.lifecycle.submitForApproval(id, userId);
   }
 
   // ─── Post (DRAFT → ACCRUAL or POSTED) ────────────────────────────────
@@ -1993,17 +1867,9 @@ export class ExpenseDocumentsService implements OnModuleInit {
   }
 
   // ─── Soft delete (DRAFT only) ────────────────────────────────────────
+  // Phase 2a decompose: delegated to ExpenseDocumentLifecycleService.
+  // Signature + behavior unchanged.
   async softDelete(id: string, _userId: string) {
-    const existing = await this.prisma.expenseDocument.findUniqueOrThrow({ where: { id } });
-    if (existing.status !== 'DRAFT') {
-      throw new BadRequestException('ลบได้เฉพาะเอกสาร DRAFT — เอกสารที่ post ไปแล้ว ใช้ void แทน');
-    }
-    if (existing.deletedAt) {
-      throw new BadRequestException('เอกสารถูกลบไปแล้ว');
-    }
-    return this.prisma.expenseDocument.update({
-      where: { id },
-      data: { deletedAt: new Date() },
-    });
+    return this.lifecycle.softDelete(id, _userId);
   }
 }

--- a/apps/api/src/modules/expense-documents/services/expense-document-lifecycle.service.ts
+++ b/apps/api/src/modules/expense-documents/services/expense-document-lifecycle.service.ts
@@ -1,0 +1,199 @@
+import {
+  Injectable,
+  BadRequestException,
+  NotFoundException,
+  Logger,
+} from '@nestjs/common';
+import { Prisma, DocumentStatus } from '@prisma/client';
+import { PrismaService } from '../../../prisma/prisma.service';
+import { NotificationsService } from '../../notifications/notifications.service';
+import { getApproversList } from '../approval-config.util';
+import { readBoolFlag } from '../../../utils/config.util';
+
+/**
+ * Phase 2 of the transactional-core decompose: the document LIFECYCLE methods of
+ * ExpenseDocumentsService, extracted VERBATIM. The facade delegates to this
+ * service so the public contract (controller + callers) is unchanged.
+ *
+ * Phase 2a (this slice) moves the 3 lowest-risk members: submitForApproval,
+ * notifyApprovers (private), softDelete — plus a verbatim COPY of the private
+ * readBoolFlag wrapper they need. Later slices 2b/2c ADD post/approve/
+ * executePostBody/voidDocument to THIS service.
+ *
+ * This service OWNS the notifications dependency (the facade sheds it) — the
+ * trailing-optional `notifications?` ctor param preserves notifyApprovers'
+ * early-return behavior when notifications is not wired (tests can omit it).
+ *
+ * Behavior-preserving — method bodies are byte-identical to the pre-extraction
+ * facade; only import paths were adjusted for the deeper directory.
+ */
+@Injectable()
+export class ExpenseDocumentLifecycleService {
+  private readonly logger = new Logger(ExpenseDocumentLifecycleService.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly notifications?: NotificationsService,
+  ) {}
+
+  // ─── Submit for approval (DRAFT → PENDING_APPROVAL) ─────────────────
+  // D1.2.1.1 — entry point of the Approval Workflow. Only callable when
+  // SystemConfig `approval_enabled` is true. Without that flag set the
+  // legacy lifecycle (DRAFT → POSTED) applies and there's no reason to
+  // visit PENDING_APPROVAL.
+  //
+  // NOTE: this references the new enum values `PENDING_APPROVAL` and
+  // `APPROVED` which land on the schema in D1.2.1.6 (sibling PR). Until
+  // that migrates, this PR uses `as unknown as DocumentStatus` casts. At
+  // merge time accept the conflict on `schema.prisma` from 1.6.
+  async submitForApproval(id: string, userId: string) {
+    const updated = await this.prisma.$transaction(async (tx) => {
+      await tx.$executeRawUnsafe(`SELECT pg_advisory_xact_lock(hashtext($1))`, `post:${id}`);
+
+      const approvalEnabled = await this.readBoolFlag(tx, 'approval_enabled', false);
+      if (!approvalEnabled) {
+        throw new BadRequestException(
+          'ฟีเจอร์ขออนุมัติยังไม่เปิดใช้งาน — กรุณาเปิด SystemConfig `approval_enabled` ก่อน',
+        );
+      }
+
+      const doc = await tx.expenseDocument.findUniqueOrThrow({ where: { id } });
+      if (doc.deletedAt) throw new NotFoundException('เอกสารถูกลบแล้ว');
+      if (doc.status !== 'DRAFT') {
+        throw new BadRequestException(
+          `ส่งขออนุมัติได้เฉพาะเอกสาร DRAFT — สถานะปัจจุบัน ${doc.status}`,
+        );
+      }
+
+      const PENDING_APPROVAL = 'PENDING_APPROVAL' as unknown as DocumentStatus;
+      const result = await tx.expenseDocument.update({
+        where: { id },
+        data: { status: PENDING_APPROVAL },
+      });
+
+      // D1.2.1.5 — APPROVAL_REQUESTED audit log. Atomic with the status flip.
+      // PII-safe payload: documentNumber + totalAmount + documentType only.
+      // Salary lines, employee tax IDs, etc. NEVER captured here per PDPA.
+      await tx.auditLog.create({
+        data: {
+          action: 'APPROVAL_REQUESTED',
+          entity: 'expense_document',
+          entityId: id,
+          userId,
+          oldValue: { status: 'DRAFT' },
+          newValue: {
+            status: 'PENDING_APPROVAL',
+            documentNumber: result.number,
+            documentType: result.documentType,
+            totalAmount: result.totalAmount.toString(),
+            requesterUserId: userId,
+          },
+        },
+      });
+
+      return result;
+    });
+
+    // D1.2.1.5 — fan out notifications OUTSIDE the tx. A notification failure
+    // must never roll back the status flip already persisted.
+    await this.notifyApprovers({
+      id: updated.id,
+      documentNumber: updated.number,
+      documentType: updated.documentType,
+      totalAmount: updated.totalAmount,
+    });
+
+    return updated;
+  }
+
+  /**
+   * D1.2.1.5 — Fan out IN_APP notifications to configured approvers when
+   * a doc enters PENDING_APPROVAL. Runs OUTSIDE the parent transaction —
+   * a notification failure NEVER rolls back the status flip.
+   *
+   * - Reads `notification_on_pending` (default true) — opt-out per OWNER.
+   * - Reads + validates `approvers_list` against the User table.
+   * - Falls back to OWNER users when the list is empty (root-of-trust).
+   * - Uses `Promise.allSettled` so one bad recipient never blocks the rest.
+   * - Errors are logged + swallowed (no rethrow).
+   */
+  private async notifyApprovers(doc: {
+    id: string;
+    documentNumber: string;
+    documentType: string;
+    totalAmount: Prisma.Decimal | string | number;
+  }): Promise<void> {
+    try {
+      const enabled = await this.readBoolFlag(
+        this.prisma,
+        'notification_on_pending',
+        true,
+      );
+      if (!enabled) return;
+      if (!this.notifications) return;
+
+      // Resolve recipients: approvers_list → fallback to OWNER users.
+      let recipients = await getApproversList(this.prisma);
+      if (recipients.length === 0) {
+        const owners = await this.prisma.user.findMany({
+          where: { role: 'OWNER', isActive: true, deletedAt: null },
+          select: { id: true },
+        });
+        recipients = owners.map((u) => u.id);
+      }
+      if (recipients.length === 0) return;
+
+      const totalStr = new Prisma.Decimal(doc.totalAmount.toString()).toFixed(2);
+      const message =
+        `เอกสาร ${doc.documentNumber} (${doc.documentType}) ` +
+        `ยอด ${totalStr} บาท รออนุมัติ`;
+
+      await Promise.allSettled(
+        recipients.map((userId) =>
+          this.notifications!.send({
+            channel: 'IN_APP',
+            recipient: userId,
+            subject: 'มีเอกสารรออนุมัติ',
+            message,
+            relatedId: doc.id,
+          }),
+        ),
+      );
+    } catch (err) {
+      // Log and swallow — notification failure must NOT roll back the
+      // status flip already persisted in the parent transaction.
+      this.logger.warn(
+        `notifyApprovers(${doc.id}) failed: ${(err as Error).message}`,
+      );
+    }
+  }
+
+  // ─── Soft delete (DRAFT only) ────────────────────────────────────────
+  async softDelete(id: string, _userId: string) {
+    const existing = await this.prisma.expenseDocument.findUniqueOrThrow({ where: { id } });
+    if (existing.status !== 'DRAFT') {
+      throw new BadRequestException('ลบได้เฉพาะเอกสาร DRAFT — เอกสารที่ post ไปแล้ว ใช้ void แทน');
+    }
+    if (existing.deletedAt) {
+      throw new BadRequestException('เอกสารถูกลบไปแล้ว');
+    }
+    return this.prisma.expenseDocument.update({
+      where: { id },
+      data: { deletedAt: new Date() },
+    });
+  }
+
+  // ─── D1.* — Service-side SystemConfig flag readers ─────────────────────
+  // Delegates to shared `readBoolFlag` in utils/config.util
+  // so every service uses identical parsing + defensive try/catch semantics.
+  // Kept as private wrappers for ergonomic (this.readBoolFlag) call sites.
+  // Spec-defined defaults flow through `fallback` and preserve first-boot
+  // behaviour when the SystemConfig row is missing.
+  private async readBoolFlag(
+    tx: Prisma.TransactionClient | PrismaService,
+    key: string,
+    fallback: boolean,
+  ): Promise<boolean> {
+    return readBoolFlag(tx, key, fallback);
+  }
+}


### PR DESCRIPTION
## Phase 2a — ExpenseDocumentLifecycleService (submit/notify/softDelete)

Third code slice of the expense-documents transactional-core decompose (Slice 0 #1215, Phase 1 #1216 — both merged). Off post-#1216 main.

Moves the 3 lowest-risk lifecycle members **VERBATIM** into a new `ExpenseDocumentLifecycleService` (the future home for post/approve/executePostBody in 2b + voidDocument in 2c). Behavior byte-identical.

### What changed
- **New** `services/expense-document-lifecycle.service.ts` — `submitForApproval` (full `$transaction` + advisory lock verbatim), `notifyApprovers` (private), `softDelete`, + a verbatim copy of the `readBoolFlag` wrapper + own `logger`. Ctor `(prisma, notifications?)`.
- **Facade** delegates submitForApproval + softDelete (exact sigs); `notifyApprovers` removed; **`notifications` dep shed entirely** (now owned by lifecycle — facade ctor ends `…, query, lifecycle`). Facade −149 LOC.
- **Module** registers the provider. **Factory** builds lifecycle from the same resolved prisma+notifications mocks and routes it into the facade.
- **+4 characterization tests** pinning `notifyApprovers` branches (opt-out flag → no send; notifications undefined → no throw; empty approvers_list → OWNER fallback; `allSettled` swallows a rejected recipient) through the facade.

### Gates
- tsc 0 · `npm --prefix apps/api run test -- expense-documents` → **433 passed / 36 suites** (429 existing UNCHANGED + 4 new)
- `new ExpenseDocumentsService(` = 1 (factory) · `this.notifications` in facade = 0
- Two-stage review passed (submitForApproval `$tx` confirmed byte-identical; restored the original `D1.2.1.1` leading comment that was mis-copied).

### Merge order (sequential-on-main)
Base = current main. 2b (posting core) branches off this once merged — NOT stacked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)