### PR TITLE
Phase 2b: extract JE-posting core into LifecycleService (post/executePostBody/approve, verbatim)

### DIFF
--- a/apps/api/src/modules/expense-documents/__tests__/expense-document-lifecycle-posting.service.spec.ts
+++ b/apps/api/src/modules/expense-documents/__tests__/expense-document-lifecycle-posting.service.spec.ts
@@ -1,0 +1,169 @@
+import { BadRequestException } from '@nestjs/common';
+import { Decimal } from '@prisma/client/runtime/library';
+import {
+  makeExpenseDocumentsService,
+  MadeExpenseDocumentsService,
+} from './support/make-expense-documents-service';
+
+/**
+ * Phase 2b CHARACTERIZATION spec — pins the CURRENT behavior of the JE-posting
+ * core (post / executePostBody / approve) THROUGH THE FACADE before that core
+ * is moved VERBATIM into ExpenseDocumentLifecycleService. These tests must stay
+ * green identically before AND after the move (the facade delegates to lifecycle
+ * which holds the SAME template mocks via the factory).
+ *
+ * Gaps pinned here (not covered by the existing post/approve specs):
+ *   1. post() routes a CREDIT_NOTE doc to creditNoteTemplate.execute(id, tx).
+ *   2. post() of a PETTY_CASH_REIMBURSEMENT doc THROWS
+ *      `type PETTY_CASH_REIMBURSEMENT not supported` and NEVER reaches
+ *      pettyCashTemplate.execute — pins the allow-list quirk: PETTY_CASH is
+ *      NOT in executePostBody's allow-list, so the later (unreachable)
+ *      `if (doc.documentType === 'PETTY_CASH_REIMBURSEMENT')` branch is dead.
+ *   3. approve() with auto_post_on_approve=true of a CREDIT_NOTE doc routes the
+ *      auto-post chain to creditNoteTemplate.execute + writes AUTO_POSTED audit.
+ *
+ * Harness mirrors expense-documents.service.spec.ts: prisma.$transaction runs
+ * the callback synchronously against the same prisma mock; advisory locks,
+ * companyInfo (SHOP), accountingPeriod (OPEN), systemConfig, auditLog all
+ * stubbed so the posting body flows to the JE-template dispatch unobstructed.
+ */
+describe('ExpenseDocuments posting core (Phase 2b characterization)', () => {
+  let made: MadeExpenseDocumentsService;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+
+  beforeEach(() => {
+    prisma = {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      $transaction: jest.fn(async (cb: any) => cb(prisma)),
+      $executeRawUnsafe: jest.fn().mockResolvedValue(1),
+      expenseDocument: {
+        findUniqueOrThrow: jest.fn(),
+        update: jest.fn().mockResolvedValue({}),
+        count: jest.fn().mockResolvedValue(0),
+      },
+      expenseDetail: {
+        findUnique: jest.fn().mockResolvedValue({ lines: [] }),
+      },
+      // C10 attachment-threshold check reads ATTACHMENT_REQUIRED_ABOVE_AMOUNT.
+      // Default null → threshold defaults to 0 → never enforced.
+      systemConfig: {
+        findUnique: jest.fn().mockResolvedValue(null),
+        // approval_enabled / auto_post_on_approve etc. → null = defaults
+        findFirst: jest.fn().mockResolvedValue(null),
+      },
+      // post/approve resolve SHOP companyId for the validatePeriodOpen call.
+      companyInfo: {
+        findFirst: jest.fn().mockResolvedValue({ id: 'shop-co-id' }),
+      },
+      // validatePeriodOpen reads accountingPeriod — null = OPEN.
+      accountingPeriod: {
+        findUnique: jest.fn().mockResolvedValue(null),
+      },
+      auditLog: {
+        create: jest.fn().mockResolvedValue({}),
+      },
+      user: {
+        findMany: jest.fn().mockResolvedValue([]),
+      },
+    };
+
+    made = makeExpenseDocumentsService({
+      prisma,
+      transition: {
+        // assertCanPost / assertCanApprove no-op so the posting body runs.
+        assertCanPost: jest.fn(),
+        assertCanApprove: jest.fn(),
+        assertCanVoid: jest.fn(),
+        assertCanEdit: jest.fn(),
+        resolveTargetStatus: jest.fn().mockReturnValue('POSTED'),
+      },
+      creditNoteTemplate: { execute: jest.fn().mockResolvedValue({ entryNo: 'JE-CN' }) },
+      pettyCashTemplate: { execute: jest.fn().mockResolvedValue({ entryNo: 'JE-PC' }) },
+      sameDayTemplate: { execute: jest.fn().mockResolvedValue({ entryNo: 'JE-SD' }) },
+      accrualTemplate: { execute: jest.fn().mockResolvedValue({ entryNo: 'JE-AC' }) },
+      payrollTemplate: { execute: jest.fn().mockResolvedValue({ entryNo: 'JE-PR' }) },
+      settlementTemplate: { execute: jest.fn().mockResolvedValue({ entryNo: 'JE-SE' }) },
+    });
+  });
+
+  // GAP #1 — CREDIT_NOTE is in the allow-list + has a reachable branch.
+  it('post() routes a CREDIT_NOTE doc to creditNoteTemplate.execute(id, tx)', async () => {
+    prisma.expenseDocument.findUniqueOrThrow.mockResolvedValue({
+      id: 'cn-1',
+      status: 'DRAFT',
+      documentType: 'CREDIT_NOTE',
+      paymentMethod: null,
+      depositAccountCode: null,
+      totalAmount: new Decimal('500.00'),
+      withholdingTax: new Decimal('0'),
+      whtFormType: null,
+      receiptImageUrl: null,
+      documentDate: new Date('2026-05-10'),
+      deletedAt: null,
+    });
+
+    await made.service.post('cn-1', 'user-1');
+
+    expect(made.creditNoteTemplate.execute).toHaveBeenCalledWith('cn-1', expect.anything());
+    // Routed via the CREDIT_NOTE branch — NOT the generic same-day/accrual path.
+    expect(made.sameDayTemplate.execute).not.toHaveBeenCalled();
+    expect(made.accrualTemplate.execute).not.toHaveBeenCalled();
+  });
+
+  // GAP #2 + #5 — PETTY_CASH allow-list quirk: NOT in the allow-list, so
+  // executePostBody throws `type ... not supported` BEFORE the (dead) petty-cash
+  // branch is ever reached. Pin the THROW; pettyCashTemplate must NOT run.
+  it('post() of a PETTY_CASH_REIMBURSEMENT doc THROWS not-supported and never calls pettyCashTemplate', async () => {
+    prisma.expenseDocument.findUniqueOrThrow.mockResolvedValue({
+      id: 'pc-1',
+      status: 'DRAFT',
+      documentType: 'PETTY_CASH_REIMBURSEMENT',
+      paymentMethod: null,
+      depositAccountCode: null,
+      totalAmount: new Decimal('500.00'),
+      withholdingTax: new Decimal('0'),
+      whtFormType: null,
+      receiptImageUrl: null,
+      documentDate: new Date('2026-05-10'),
+      deletedAt: null,
+    });
+
+    await expect(made.service.post('pc-1', 'user-1')).rejects.toThrow(BadRequestException);
+    await expect(made.service.post('pc-1', 'user-1')).rejects.toThrow(
+      'type PETTY_CASH_REIMBURSEMENT not supported',
+    );
+    expect(made.pettyCashTemplate.execute).not.toHaveBeenCalled();
+  });
+
+  // GAP #3 — approve() auto-post chain on a CREDIT_NOTE doc routes to
+  // creditNoteTemplate.execute and writes the AUTO_POSTED audit log.
+  it('approve() auto-post (auto_post_on_approve=true) of a CREDIT_NOTE routes to creditNoteTemplate + writes AUTO_POSTED audit', async () => {
+    prisma.expenseDocument.findUniqueOrThrow.mockResolvedValue({
+      id: 'cn-app',
+      status: 'PENDING_APPROVAL',
+      documentType: 'CREDIT_NOTE',
+      paymentMethod: null,
+      depositAccountCode: null,
+      totalAmount: new Decimal('500.00'),
+      withholdingTax: new Decimal('0'),
+      whtFormType: null,
+      receiptImageUrl: null,
+      documentDate: new Date('2026-05-10'),
+      deletedAt: null,
+    });
+    // systemConfig.findFirst defaults to null → auto_post_on_approve defaults true.
+
+    await made.service.approve('cn-app', 'user-1', 'OWNER');
+
+    // Auto-post chain routed to the CREDIT_NOTE template.
+    expect(made.creditNoteTemplate.execute).toHaveBeenCalledWith('cn-app', expect.anything());
+
+    // Both APPROVED + AUTO_POSTED audit logs written in the same tx.
+    const actions = prisma.auditLog.create.mock.calls.map(
+      (c: unknown[]) => (c[0] as { data?: { action?: string } })?.data?.action,
+    );
+    expect(actions).toContain('APPROVED');
+    expect(actions).toContain('AUTO_POSTED');
+  });
+});

--- a/apps/api/src/modules/expense-documents/__tests__/support/make-expense-documents-service.ts
+++ b/apps/api/src/modules/expense-documents/__tests__/support/make-expense-documents-service.ts
@@ -128,27 +128,35 @@ export function makeExpenseDocumentsService(
   // through the facade's now-delegating read methods. `jePreview` is no longer
   // a facade constructor arg (it moved into the query service).
   const query = overrides.query ?? new ExpenseDocumentQueryService(prisma, jePreview);
-  // Phase 2a decompose — REAL lifecycle sub-service by default, built from the
-  // SAME resolved `prisma` + `notifications` instances so existing specs' mocks
-  // flow through the facade's now-delegating lifecycle methods. `notifications`
-  // is no longer a facade constructor arg (it moved into the lifecycle service).
+  // Phase 2a/2b decompose — REAL lifecycle sub-service by default. Phase 2b
+  // moved the JE-posting core (post / executePostBody / approve) here, so the
+  // lifecycle ctor now also takes `transition` + the 6 JE templates. They are
+  // built from the SAME resolved mock instances the facade specs assert on
+  // (e.g. `sameDayTemplate.execute`), so the facade's delegating post/approve
+  // reach the same mocks. `notifications` stays the trailing-optional param.
   const lifecycle =
-    overrides.lifecycle ?? new ExpenseDocumentLifecycleService(prisma, notifications);
+    overrides.lifecycle ??
+    new ExpenseDocumentLifecycleService(
+      prisma,
+      transition,
+      sameDayTemplate,
+      accrualTemplate,
+      creditNoteTemplate,
+      payrollTemplate,
+      settlementTemplate,
+      pettyCashTemplate,
+      notifications,
+    );
 
-  // THE single positional construction in the codebase.
+  // THE single positional construction in the codebase. Phase 2b removed the 6
+  // JE-template args from the facade ctor (they now feed the lifecycle service).
   const service = new ExpenseDocumentsService(
     prisma,
     docNumber,
     transition,
-    sameDayTemplate,
-    accrualTemplate,
-    creditNoteTemplate,
-    payrollTemplate,
-    settlementTemplate,
     journal,
     aggregator,
     ssoConfig,
-    pettyCashTemplate,
     pettyCash,
     payrollCustom,
     query,

--- a/apps/api/src/modules/expense-documents/expense-documents.service.ts
+++ b/apps/api/src/modules/expense-documents/expense-documents.service.ts
@@ -6,10 +6,9 @@ import {
   Logger,
   OnModuleInit,
 } from '@nestjs/common';
-import { Prisma, DocumentStatus } from '@prisma/client';
+import { Prisma } from '@prisma/client';
 import { PrismaService } from '../../prisma/prisma.service';
 import { JournalAutoService } from '../journal/journal-auto.service';
-import { resolvePostPermissionRoles } from './post-permission.guard';
 import { resolveReversePermissionRoles } from './reverse-permission.guard';
 import { maskPayrollTaxIds } from './payroll-pii-mask.util';
 import {
@@ -19,12 +18,6 @@ import {
 } from './expense-validators.util';
 import { DocNumberService } from './services/doc-number.service';
 import { StatusTransitionService } from './services/status-transition.service';
-import { ExpenseSameDayTemplate } from '../journal/cpa-templates/expense-same-day.template';
-import { ExpenseAccrualTemplate } from '../journal/cpa-templates/expense-accrual.template';
-import { CreditNoteTemplate } from '../journal/cpa-templates/credit-note.template';
-import { PayrollTemplate } from '../journal/cpa-templates/payroll.template';
-import { VendorSettlementTemplate } from '../journal/cpa-templates/vendor-settlement.template';
-import { PettyCashTemplate } from '../journal/cpa-templates/petty-cash.template';
 import { CreateExpenseDocumentDto } from './dto/create.dto';
 import { UpdateExpenseDocumentDto } from './dto/update.dto';
 import { ListExpenseDocumentsQueryDto } from './dto/list-query.dto';
@@ -43,11 +36,7 @@ import { PayrollCustomService } from './services/payroll-custom.service';
 import { validatePeriodOpen } from '../../utils/period-lock.util';
 import { readBoolFlag, readIntFlag } from '../../utils/config.util';
 import { bkkBusinessDate } from './bkk-business-date.util';
-import {
-  assertUserCanApprove,
-  getApprovalRequiredDocTypes,
-  getReverseReasons,
-} from './approval-config.util';
+import { getReverseReasons } from './approval-config.util';
 
 @Injectable()
 export class ExpenseDocumentsService implements OnModuleInit {
@@ -86,15 +75,9 @@ export class ExpenseDocumentsService implements OnModuleInit {
     private readonly prisma: PrismaService,
     private readonly docNumber: DocNumberService,
     private readonly transition: StatusTransitionService,
-    private readonly sameDayTemplate: ExpenseSameDayTemplate,
-    private readonly accrualTemplate: ExpenseAccrualTemplate,
-    private readonly creditNoteTemplate: CreditNoteTemplate,
-    private readonly payrollTemplate: PayrollTemplate,
-    private readonly settlementTemplate: VendorSettlementTemplate,
     private readonly journal: JournalAutoService,
     private readonly aggregator: LineAggregatorService,
     private readonly ssoConfig: SsoConfigService,
-    private readonly pettyCashTemplate: PettyCashTemplate,
     private readonly pettyCash: PettyCashService,
     private readonly payrollCustom: PayrollCustomService,
     // Phase 1 decompose — the 9 READ-only methods now live in
@@ -120,38 +103,6 @@ export class ExpenseDocumentsService implements OnModuleInit {
     fallback: boolean,
   ): Promise<boolean> {
     return readBoolFlag(tx, key, fallback);
-  }
-
-  /**
-   * D1.2.1.2 — Numeric SystemConfig reader. Returns the stored Decimal as a
-   * Prisma.Decimal, clamped to ≥ 0 (negatives become 0). On missing or
-   * unparseable values returns the fallback. Used by the approval-threshold
-   * gate where negatives would yield bizarre "every doc requires approval"
-   * behaviour.
-   *
-   * Intentionally NOT consolidated onto config.util.readNumberFlag — that returns
-   * a plain number with no clamp; this returns Prisma.Decimal clamped to ≥ 0.
-   * Do not dedup without preserving the Decimal return + clamp.
-   */
-  private async readNumberFlag(
-    tx: Prisma.TransactionClient | PrismaService,
-    key: string,
-    fallback: number,
-  ): Promise<Prisma.Decimal> {
-    try {
-      const row = await tx.systemConfig.findFirst({
-        where: { key, deletedAt: null },
-        select: { value: true },
-      });
-      const raw = row?.value;
-      if (!raw) return new Prisma.Decimal(fallback);
-      const parsed = Number(raw);
-      if (!Number.isFinite(parsed)) return new Prisma.Decimal(fallback);
-      const clamped = parsed < 0 ? 0 : parsed;
-      return new Prisma.Decimal(clamped);
-    } catch {
-      return new Prisma.Decimal(fallback);
-    }
   }
 
 
@@ -1269,350 +1220,19 @@ export class ExpenseDocumentsService implements OnModuleInit {
   }
 
   // ─── Post (DRAFT → ACCRUAL or POSTED) ────────────────────────────────
-  // D1.2.1.1 — when `approval_enabled` is true, DRAFT documents must first
-  // be submitted via `submitForApproval()`. Posting straight from DRAFT is
-  // rejected so the approval signature is never bypassed. When false, the
-  // legacy DRAFT → POSTED path is preserved.
-  // D1.2.1.6 — also accepts APPROVED → POSTED (when approval_enabled is on
-  // AND auto_post_on_approve is false, OWNER manually calls post() on an
-  // APPROVED doc; assertCanPost permits both DRAFT + APPROVED).
+  // Phase 2b decompose — the JE-posting core (post + the shared inner-tx body
+  // executePostBody + approve) now lives in ExpenseDocumentLifecycleService.
+  // The facade delegates so the public contract (controller + callers) is
+  // unchanged. executePostBody is private to the lifecycle service (shared by
+  // post + approve inside their own $transaction).
   async post(id: string, _userId: string, userRole?: string) {
-    // D1.3.2.3 (S3 defense-in-depth) — mirror the PostPermissionGuard
-    // check at the service boundary. Skipped when userRole is undefined
-    // (system-internal / unit-test paths).
-    if (userRole !== undefined) {
-      const allowed = await resolvePostPermissionRoles(this.prisma);
-      if (!allowed.has(userRole)) {
-        throw new ForbiddenException(
-          `ไม่มีสิทธิ์โพสต์เอกสาร (role ปัจจุบัน: ${userRole})`,
-        );
-      }
-    }
-    return this.prisma.$transaction(async (tx) => {
-      // Per-doc advisory lock — serializes concurrent post calls on the same id.
-      // Without this, two callers could both read DRAFT, both pass assertCanPost,
-      // and both run the JE template → two journal entries for one document
-      // (same race class as voidDocument).
-      await tx.$executeRawUnsafe(`SELECT pg_advisory_xact_lock(hashtext($1))`, `post:${id}`);
-
-      const doc = await tx.expenseDocument.findUniqueOrThrow({ where: { id } });
-      if (doc.deletedAt) throw new NotFoundException('เอกสารถูกลบแล้ว');
-
-      // D1.2.1.2 — approval gate (threshold OR doctype filter).
-      //
-      // The gate fires when SystemConfig `approval_enabled` is true (sibling
-      // PR D1.2.1.1) AND the doc is DRAFT AND EITHER of:
-      //   (a) doc.totalAmount >= SystemConfig `approval_threshold`
-      //       (default 50,000 ฿; negatives clamp to 0 so a malformed config
-      //       can never accidentally short-circuit the gate to "always on")
-      //   (b) doc.documentType is in SystemConfig `approval_required_doc_types`
-      //       (default `['PAYROLL']` — hardcoded here; once #932 merges the
-      //       SystemConfig value takes over for the same OR-composed gate)
-      //
-      // OR semantics ensure low-value payroll still requires approval, and a
-      // high-value EX still gets gated even if not in the doctype list.
-      //
-      // Source-status check (`DRAFT`) keeps APPROVED docs flowing through —
-      // a doc that has already passed approval should not be re-checked here.
-      const approvalEnabled = await this.readBoolFlag(tx, 'approval_enabled', false);
-      if (approvalEnabled && doc.status === 'DRAFT') {
-        const threshold = await this.readNumberFlag(tx, 'approval_threshold', 50000);
-        const docTotal = new Prisma.Decimal(doc.totalAmount.toString());
-        const overThreshold = docTotal.gte(threshold);
-
-        // D1.2.1.4 — doc-type filter via `getApprovalRequiredDocTypes` helper.
-        // Reads SystemConfig key `approval_required_doc_types` (JSON array),
-        // filters to valid DocumentType enum values, defaults to ['PAYROLL']
-        // on missing/malformed rows.
-        const requiredDocTypes = await getApprovalRequiredDocTypes(tx);
-        const isRequiredType = requiredDocTypes.includes(doc.documentType);
-
-        if (overThreshold || isRequiredType) {
-          throw new BadRequestException(
-            'เอกสารต้องผ่านการอนุมัติก่อน — กรุณากด "ส่งขออนุมัติ"',
-          );
-        }
-      }
-
-      this.transition.assertCanPost({
-        type: doc.documentType,
-        from: doc.status,
-        hasPaymentMethod: !!doc.paymentMethod && !!doc.depositAccountCode,
-        totalAmount: doc.totalAmount.toString(),
-      });
-
-      return this.executePostBody(doc, tx);
-    });
-  }
-
-  /**
-   * Shared post body — period guard, attachment threshold, WHT routing,
-   * JE template dispatch. Called from both post() (after assertCanPost) and
-   * approve() (after assertCanApprove + status flip to APPROVED, when
-   * auto_post_on_approve is true).
-   *
-   * Pure refactor extracted to eliminate ~150 LOC of drift-prone duplication
-   * (see deep-review finding Group 3 #1). Behaviour is identical to the inline
-   * blocks it replaces — caller is responsible for:
-   *   • advisory lock acquisition
-   *   • doc load + deletedAt check
-   *   • transition assertion (assertCanPost / assertCanApprove)
-   *   • status flip + APPROVED audit (approve path only)
-   *   • AUTO_POSTED audit after success (approve path only)
-   *
-   * Returns the JE template result (`{ journalEntryId, ... }` shape varies
-   * by template) so the caller can propagate it.
-   */
-  private async executePostBody(
-    // eslint-disable-next-line @typescript-eslint/no-empty-object-type
-    doc: Prisma.ExpenseDocumentGetPayload<{}>,
-    tx: Prisma.TransactionClient,
-  ): Promise<unknown> {
-    const id = doc.id;
-
-    // Fix #C9 (Round 2 — moved from journal-auto.service.createAndPost):
-    // Period-open guard at the module boundary. Previously the guard lived
-    // inside createAndPost, which broke payment + contract atomicity (it
-    // would reject mid-tx JE writes and roll back the Payment record).
-    // The guard belongs HERE because:
-    //   1. We know the canonical posting date — doc.documentDate, not
-    //      "now" (which would let a backdated post slip through if the
-    //      clock crossed midnight between create + post).
-    //   2. We know the canonical companyId — SHOP (all expense flows post
-    //      SHOP-side per accounting.md §VAT Policy; expense template
-    //      resolves SHOP later, this guard mirrors that).
-    // Resolve SHOP companyId once via tx + cache; re-using the same
-    // pattern as expense templates' getShopCompanyId.
-    const shopForPeriod = await tx.companyInfo.findFirst({
-      where: { companyCode: 'SHOP', deletedAt: null },
-      select: { id: true },
-    });
-    if (!shopForPeriod) {
-      throw new NotFoundException(
-        'CompanyInfo with companyCode=SHOP not found — seed accounting data first',
-      );
-    }
-    // documentDate is required on the schema but defend against legacy
-    // rows with NULL via fallback to "now" (matches receipts.service +
-    // payments.service behavior — neither has a per-row date column on
-    // the doc, both pass new Date()).
-    const periodDate = doc.documentDate ?? new Date();
-    await validatePeriodOpen(tx, periodDate, shopForPeriod.id);
-
-    // Fix #C10 — attachment threshold enforced server-side.
-    // ATTACHMENT_REQUIRED_ABOVE_AMOUNT is set in /settings#attachment but
-    // was previously only enforced by the frontend submit button. A direct
-    // API call could POST a 500k expense with no receiptImageUrl → tax-audit
-    // risk. Defense in depth: re-check at post() before any JE is written.
-    const thresholdCfg = await tx.systemConfig.findUnique({
-      where: { key: 'ATTACHMENT_REQUIRED_ABOVE_AMOUNT' },
-    });
-    const rawThreshold = thresholdCfg?.value ?? '0';
-    const threshold = new Prisma.Decimal(
-      Number.isFinite(Number(rawThreshold)) ? rawThreshold : '0',
-    );
-    const docTotal = new Prisma.Decimal(doc.totalAmount.toString());
-    if (threshold.gt(0) && docTotal.gte(threshold) && !doc.receiptImageUrl) {
-      throw new BadRequestException(
-        `เอกสารยอด ${docTotal.toFixed(2)} บาท ต้องแนบไฟล์ประกอบ (เกณฑ์ ${threshold.toFixed(2)} บาท)`,
-      );
-    }
-
-    // EXPENSE + CREDIT_NOTE + PAYROLL + VENDOR_SETTLEMENT + REPAIR_SERVICE supported
-    if (
-      !['EXPENSE', 'CREDIT_NOTE', 'PAYROLL', 'VENDOR_SETTLEMENT', 'REPAIR_SERVICE'].includes(
-        doc.documentType,
-      )
-    ) {
-      throw new BadRequestException(`type ${doc.documentType} not supported`);
-    }
-
-    // Fix #C12 — WHT routing invariant. When the doc has WHT > 0, doc.whtFormType
-    // MUST be non-null (and a recognised form). Previously the JE template silently
-    // defaulted to PND3 → routed to 21-3102, misfiling juristic-vendor WHT under
-    // ภ.ง.ด.3 instead of ภ.ง.ด.53 (government compliance bug).
-    //
-    // C12-symmetry: mirror the guard across all 4 doc types so any
-    // future bypass surfaces at post() instead of being silently misrouted by
-    // the template. Each doc type carries WHT differently:
-    //   - EXPENSE: doc.whtFormType OR every ExpenseLine.whtFormType is set
-    //     (per-line routing — P2-4)
-    //   - PAYROLL: doc.withholdingTax > 0 → always Cr 21-3101 (ภ.ง.ด.1) —
-    //     payroll WHT is employee income tax, NOT PND3/PND53, so no formType
-    //     enforcement here (BUT we still require it to be null since the field
-    //     is meaningless for payroll)
-    //   - VENDOR_SETTLEMENT: single-vendor invariant means doc-level form type
-    //     applies (intentionally no per-line routing per accounting.md)
-    //   - CREDIT_NOTE: createCreditNote already blocks original-with-WHT
-    //     (so CN itself ideally has no WHT), but if the original had WHT and
-    //     this branch is reached, we still need doc-level formType
-    const wht = new Prisma.Decimal(doc.withholdingTax?.toString() ?? '0');
-    if (wht.gt(0)) {
-      if (doc.documentType === 'EXPENSE') {
-        if (!doc.whtFormType) {
-          // Check if every WHT-bearing line has its own form type → fall through to
-          // per-line routing in the template. Otherwise the doc-level is mandatory.
-          const detail = await tx.expenseDetail.findUnique({
-            where: { documentId: id },
-            include: { lines: true },
-          });
-          const whtLines = (detail?.lines ?? []).filter(
-            (l) => l.whtAmount && new Prisma.Decimal(l.whtAmount.toString()).gt(0),
-          );
-          const allLinesHaveFormType =
-            whtLines.length > 0 && whtLines.every((l) => !!l.whtFormType);
-          if (!allLinesHaveFormType) {
-            throw new BadRequestException(
-              'whtFormType ต้องระบุเมื่อมี WHT — เลือก PND3 หรือ PND53',
-            );
-          }
-          // If every line has a form type, validate each is PND3/PND53 (no other strings)
-          for (const l of whtLines) {
-            if (l.whtFormType !== 'PND3' && l.whtFormType !== 'PND53') {
-              throw new BadRequestException(
-                `whtFormType ของบรรทัด ${(l as { lineNo?: number }).lineNo ?? '?'} ` +
-                  `ต้องเป็น PND3 หรือ PND53 (พบ ${l.whtFormType ?? 'null'})`,
-              );
-            }
-          }
-        } else if (doc.whtFormType !== 'PND3' && doc.whtFormType !== 'PND53') {
-          throw new BadRequestException(
-            `whtFormType ต้องเป็น PND3 หรือ PND53 (พบ ${doc.whtFormType})`,
-          );
-        }
-      } else if (doc.documentType === 'VENDOR_SETTLEMENT' || doc.documentType === 'CREDIT_NOTE') {
-        // Per-line routing intentionally NOT supported for SE (single-vendor
-        // invariant per accounting.md) and CN (template routes by original.whtFormType
-        // since CN itself carries no WHT — but defense in depth).
-        if (!doc.whtFormType) {
-          throw new BadRequestException(
-            'whtFormType ต้องระบุเมื่อมี WHT — เลือก PND3 หรือ PND53',
-          );
-        }
-        if (doc.whtFormType !== 'PND3' && doc.whtFormType !== 'PND53') {
-          throw new BadRequestException(
-            `whtFormType ต้องเป็น PND3 หรือ PND53 (พบ ${doc.whtFormType})`,
-          );
-        }
-      }
-      // PAYROLL: doc.whtFormType is meaningless (employee income tax always
-      // routes to 21-3101 / ภ.ง.ด.1). No enforcement — payroll.template
-      // posts to 21-3101 unconditionally when sumWht > 0.
-    }
-
-    if (doc.documentType === 'CREDIT_NOTE') {
-      return this.creditNoteTemplate.execute(id, tx);
-    }
-    if (doc.documentType === 'PAYROLL') {
-      return this.payrollTemplate.execute(id, tx);
-    }
-    if (doc.documentType === 'VENDOR_SETTLEMENT') {
-      return this.settlementTemplate.execute(id, tx);
-    }
-    if (doc.documentType === 'PETTY_CASH_REIMBURSEMENT') {
-      return this.pettyCashTemplate.execute(id, tx);
-    }
-    const target = this.transition.resolveTargetStatus(
-      doc.documentType,
-      !!doc.paymentMethod && !!doc.depositAccountCode,
-    );
-    if (target === 'POSTED') {
-      return this.sameDayTemplate.execute(id, tx);
-    } else {
-      // V15 — ACCRUAL ห้ามมี WHT (ม.50 ป.รัษฎากร).
-      // WHT เกิด "ขณะที่จ่ายเงินได้" → ACCRUAL is the accrual leg before
-      // payment, so WHT must defer to the SETTLEMENT step. Booking WHT now
-      // would put it in the wrong tax period and cause ภงด.53 misfile.
-      // Fix Report P0-2.
-      if (doc.withholdingTax && doc.withholdingTax.gt(0)) {
-        throw new BadRequestException(
-          'V15: เอกสารตั้งหนี้ (ACCRUAL) ห้ามมี WHT (มาตรา 50 ป.รัษฎากร) — ' +
-            'WHT จะถูกบันทึกตอน Settlement เมื่อจ่ายเงินจริง',
-        );
-      }
-      return this.accrualTemplate.execute(id, tx);
-    }
+    return this.lifecycle.post(id, _userId, userRole);
   }
 
   // ─── Approve (PENDING_APPROVAL → APPROVED → optionally POSTED) ────────
-  // D1.2.1.6 — second leg of the Approval Workflow. The DRAFT →
-  // PENDING_APPROVAL gate is wired in D1.2.1.1 (approval_enabled flag).
-  //
-  // Behaviour:
-  //  - Loads the doc under the same `post:` advisory lock so a concurrent
-  //    approve+post cannot double-post a JE.
-  //  - Asserts the source status is PENDING_APPROVAL.
-  //  - Flips status → APPROVED.
-  //  - Reads SystemConfig `auto_post_on_approve` (default true). When true,
-  //    chains to post() in the same transaction so APPROVED never persists
-  //    visibly. When false, returns the APPROVED doc and OWNER posts later
-  //    by calling /expenses/:id/post (which now also accepts APPROVED via
-  //    StatusTransitionService.assertCanPost).
-  //
-  // userId is captured for audit logs (APPROVED + AUTO_POSTED actions written
-  // inside the same tx). Signature parity with post() / voidDocument().
+  // Phase 2b decompose — delegates to ExpenseDocumentLifecycleService.approve.
   async approve(id: string, userId: string, userRole?: string) {
-    return this.prisma.$transaction(async (tx) => {
-      // Re-use the `post:` lock key — approve always either becomes the JE
-      // post (auto path) or precedes a future post(), so serializing on the
-      // same lock is correct.
-      await tx.$executeRawUnsafe(`SELECT pg_advisory_xact_lock(hashtext($1))`, `post:${id}`);
-
-      // D1.2.1.3 — approver membership check. OWNER always passes; everyone
-      // else must appear in SystemConfig `approvers_list`.
-      await assertUserCanApprove(tx, userId, userRole);
-
-      const doc = await tx.expenseDocument.findUniqueOrThrow({ where: { id } });
-      if (doc.deletedAt) throw new NotFoundException('เอกสารถูกลบแล้ว');
-      this.transition.assertCanApprove({ from: doc.status });
-
-      // Stamp APPROVED first so the auto-post branch starts from a clean
-      // APPROVED row (assertCanPost permits APPROVED). When auto-post is off
-      // the APPROVED state persists and downstream post() will pick it up.
-      await tx.expenseDocument.update({
-        where: { id },
-        data: { status: 'APPROVED' as DocumentStatus },
-      });
-
-      // D1.2.1.6 — APPROVED audit log (always written, regardless of auto-post).
-      await tx.auditLog.create({
-        data: {
-          action: 'APPROVED',
-          entity: 'expense_document',
-          entityId: id,
-          userId,
-          oldValue: { status: 'PENDING_APPROVAL' },
-          newValue: { status: 'APPROVED' },
-        },
-      });
-
-      const autoPost = await this.readBoolFlag(tx, 'auto_post_on_approve', true);
-      if (!autoPost) {
-        return tx.expenseDocument.findUniqueOrThrow({ where: { id } });
-      }
-
-      // Auto-post chain — delegated to executePostBody() shared helper.
-      // Skips the lock (already held) and the from-DRAFT assertCanPost (we
-      // just set APPROVED, which assertCanPost permits per D1.2.1.6). All
-      // integrity guards (period open, attachment threshold, WHT routing,
-      // V15 ACCRUAL-no-WHT, type allow-list) run via the helper so any
-      // future change to those guards lands in both paths automatically.
-      const result = await this.executePostBody(doc, tx);
-
-      // D1.2.1.6 — AUTO_POSTED audit log (only when auto_post_on_approve=true
-      // and the auto-post chain completed without throwing).
-      await tx.auditLog.create({
-        data: {
-          action: 'AUTO_POSTED',
-          entity: 'expense_document',
-          entityId: id,
-          userId,
-          newValue: { status: 'POSTED', autoPostedFromApproval: true },
-        },
-      });
-
-      return result;
-    });
+    return this.lifecycle.approve(id, userId, userRole);
   }
 
   // ─── Void (any non-VOIDED → VOIDED) ──────────────────────────────────

--- a/apps/api/src/modules/expense-documents/services/expense-document-lifecycle.service.ts
+++ b/apps/api/src/modules/expense-documents/services/expense-document-lifecycle.service.ts
@@ -2,13 +2,27 @@ import {
   Injectable,
   BadRequestException,
   NotFoundException,
+  ForbiddenException,
   Logger,
 } from '@nestjs/common';
 import { Prisma, DocumentStatus } from '@prisma/client';
 import { PrismaService } from '../../../prisma/prisma.service';
 import { NotificationsService } from '../../notifications/notifications.service';
-import { getApproversList } from '../approval-config.util';
+import {
+  getApproversList,
+  assertUserCanApprove,
+  getApprovalRequiredDocTypes,
+} from '../approval-config.util';
+import { resolvePostPermissionRoles } from '../post-permission.guard';
+import { validatePeriodOpen } from '../../../utils/period-lock.util';
 import { readBoolFlag } from '../../../utils/config.util';
+import { StatusTransitionService } from './status-transition.service';
+import { ExpenseSameDayTemplate } from '../../journal/cpa-templates/expense-same-day.template';
+import { ExpenseAccrualTemplate } from '../../journal/cpa-templates/expense-accrual.template';
+import { CreditNoteTemplate } from '../../journal/cpa-templates/credit-note.template';
+import { PayrollTemplate } from '../../journal/cpa-templates/payroll.template';
+import { VendorSettlementTemplate } from '../../journal/cpa-templates/vendor-settlement.template';
+import { PettyCashTemplate } from '../../journal/cpa-templates/petty-cash.template';
 
 /**
  * Phase 2 of the transactional-core decompose: the document LIFECYCLE methods of
@@ -33,6 +47,15 @@ export class ExpenseDocumentLifecycleService {
 
   constructor(
     private readonly prisma: PrismaService,
+    // Phase 2b — the StatusTransitionService + 6 JE templates needed by the
+    // posting core (post / executePostBody / approve) that moved here verbatim.
+    private readonly transition: StatusTransitionService,
+    private readonly sameDayTemplate: ExpenseSameDayTemplate,
+    private readonly accrualTemplate: ExpenseAccrualTemplate,
+    private readonly creditNoteTemplate: CreditNoteTemplate,
+    private readonly payrollTemplate: PayrollTemplate,
+    private readonly settlementTemplate: VendorSettlementTemplate,
+    private readonly pettyCashTemplate: PettyCashTemplate,
     private readonly notifications?: NotificationsService,
   ) {}
 
@@ -183,6 +206,353 @@ export class ExpenseDocumentLifecycleService {
     });
   }
 
+  // ─── Post (DRAFT → ACCRUAL or POSTED) ────────────────────────────────
+  // D1.2.1.1 — when `approval_enabled` is true, DRAFT documents must first
+  // be submitted via `submitForApproval()`. Posting straight from DRAFT is
+  // rejected so the approval signature is never bypassed. When false, the
+  // legacy DRAFT → POSTED path is preserved.
+  // D1.2.1.6 — also accepts APPROVED → POSTED (when approval_enabled is on
+  // AND auto_post_on_approve is false, OWNER manually calls post() on an
+  // APPROVED doc; assertCanPost permits both DRAFT + APPROVED).
+  async post(id: string, _userId: string, userRole?: string) {
+    // D1.3.2.3 (S3 defense-in-depth) — mirror the PostPermissionGuard
+    // check at the service boundary. Skipped when userRole is undefined
+    // (system-internal / unit-test paths).
+    if (userRole !== undefined) {
+      const allowed = await resolvePostPermissionRoles(this.prisma);
+      if (!allowed.has(userRole)) {
+        throw new ForbiddenException(
+          `ไม่มีสิทธิ์โพสต์เอกสาร (role ปัจจุบัน: ${userRole})`,
+        );
+      }
+    }
+    return this.prisma.$transaction(async (tx) => {
+      // Per-doc advisory lock — serializes concurrent post calls on the same id.
+      // Without this, two callers could both read DRAFT, both pass assertCanPost,
+      // and both run the JE template → two journal entries for one document
+      // (same race class as voidDocument).
+      await tx.$executeRawUnsafe(`SELECT pg_advisory_xact_lock(hashtext($1))`, `post:${id}`);
+
+      const doc = await tx.expenseDocument.findUniqueOrThrow({ where: { id } });
+      if (doc.deletedAt) throw new NotFoundException('เอกสารถูกลบแล้ว');
+
+      // D1.2.1.2 — approval gate (threshold OR doctype filter).
+      //
+      // The gate fires when SystemConfig `approval_enabled` is true (sibling
+      // PR D1.2.1.1) AND the doc is DRAFT AND EITHER of:
+      //   (a) doc.totalAmount >= SystemConfig `approval_threshold`
+      //       (default 50,000 ฿; negatives clamp to 0 so a malformed config
+      //       can never accidentally short-circuit the gate to "always on")
+      //   (b) doc.documentType is in SystemConfig `approval_required_doc_types`
+      //       (default `['PAYROLL']` — hardcoded here; once #932 merges the
+      //       SystemConfig value takes over for the same OR-composed gate)
+      //
+      // OR semantics ensure low-value payroll still requires approval, and a
+      // high-value EX still gets gated even if not in the doctype list.
+      //
+      // Source-status check (`DRAFT`) keeps APPROVED docs flowing through —
+      // a doc that has already passed approval should not be re-checked here.
+      const approvalEnabled = await this.readBoolFlag(tx, 'approval_enabled', false);
+      if (approvalEnabled && doc.status === 'DRAFT') {
+        const threshold = await this.readNumberFlag(tx, 'approval_threshold', 50000);
+        const docTotal = new Prisma.Decimal(doc.totalAmount.toString());
+        const overThreshold = docTotal.gte(threshold);
+
+        // D1.2.1.4 — doc-type filter via `getApprovalRequiredDocTypes` helper.
+        // Reads SystemConfig key `approval_required_doc_types` (JSON array),
+        // filters to valid DocumentType enum values, defaults to ['PAYROLL']
+        // on missing/malformed rows.
+        const requiredDocTypes = await getApprovalRequiredDocTypes(tx);
+        const isRequiredType = requiredDocTypes.includes(doc.documentType);
+
+        if (overThreshold || isRequiredType) {
+          throw new BadRequestException(
+            'เอกสารต้องผ่านการอนุมัติก่อน — กรุณากด "ส่งขออนุมัติ"',
+          );
+        }
+      }
+
+      this.transition.assertCanPost({
+        type: doc.documentType,
+        from: doc.status,
+        hasPaymentMethod: !!doc.paymentMethod && !!doc.depositAccountCode,
+        totalAmount: doc.totalAmount.toString(),
+      });
+
+      return this.executePostBody(doc, tx);
+    });
+  }
+
+  /**
+   * Shared post body — period guard, attachment threshold, WHT routing,
+   * JE template dispatch. Called from both post() (after assertCanPost) and
+   * approve() (after assertCanApprove + status flip to APPROVED, when
+   * auto_post_on_approve is true).
+   *
+   * Pure refactor extracted to eliminate ~150 LOC of drift-prone duplication
+   * (see deep-review finding Group 3 #1). Behaviour is identical to the inline
+   * blocks it replaces — caller is responsible for:
+   *   • advisory lock acquisition
+   *   • doc load + deletedAt check
+   *   • transition assertion (assertCanPost / assertCanApprove)
+   *   • status flip + APPROVED audit (approve path only)
+   *   • AUTO_POSTED audit after success (approve path only)
+   *
+   * Returns the JE template result (`{ journalEntryId, ... }` shape varies
+   * by template) so the caller can propagate it.
+   */
+  private async executePostBody(
+    // eslint-disable-next-line @typescript-eslint/no-empty-object-type
+    doc: Prisma.ExpenseDocumentGetPayload<{}>,
+    tx: Prisma.TransactionClient,
+  ): Promise<unknown> {
+    const id = doc.id;
+
+    // Fix #C9 (Round 2 — moved from journal-auto.service.createAndPost):
+    // Period-open guard at the module boundary. Previously the guard lived
+    // inside createAndPost, which broke payment + contract atomicity (it
+    // would reject mid-tx JE writes and roll back the Payment record).
+    // The guard belongs HERE because:
+    //   1. We know the canonical posting date — doc.documentDate, not
+    //      "now" (which would let a backdated post slip through if the
+    //      clock crossed midnight between create + post).
+    //   2. We know the canonical companyId — SHOP (all expense flows post
+    //      SHOP-side per accounting.md §VAT Policy; expense template
+    //      resolves SHOP later, this guard mirrors that).
+    // Resolve SHOP companyId once via tx + cache; re-using the same
+    // pattern as expense templates' getShopCompanyId.
+    const shopForPeriod = await tx.companyInfo.findFirst({
+      where: { companyCode: 'SHOP', deletedAt: null },
+      select: { id: true },
+    });
+    if (!shopForPeriod) {
+      throw new NotFoundException(
+        'CompanyInfo with companyCode=SHOP not found — seed accounting data first',
+      );
+    }
+    // documentDate is required on the schema but defend against legacy
+    // rows with NULL via fallback to "now" (matches receipts.service +
+    // payments.service behavior — neither has a per-row date column on
+    // the doc, both pass new Date()).
+    const periodDate = doc.documentDate ?? new Date();
+    await validatePeriodOpen(tx, periodDate, shopForPeriod.id);
+
+    // Fix #C10 — attachment threshold enforced server-side.
+    // ATTACHMENT_REQUIRED_ABOVE_AMOUNT is set in /settings#attachment but
+    // was previously only enforced by the frontend submit button. A direct
+    // API call could POST a 500k expense with no receiptImageUrl → tax-audit
+    // risk. Defense in depth: re-check at post() before any JE is written.
+    const thresholdCfg = await tx.systemConfig.findUnique({
+      where: { key: 'ATTACHMENT_REQUIRED_ABOVE_AMOUNT' },
+    });
+    const rawThreshold = thresholdCfg?.value ?? '0';
+    const threshold = new Prisma.Decimal(
+      Number.isFinite(Number(rawThreshold)) ? rawThreshold : '0',
+    );
+    const docTotal = new Prisma.Decimal(doc.totalAmount.toString());
+    if (threshold.gt(0) && docTotal.gte(threshold) && !doc.receiptImageUrl) {
+      throw new BadRequestException(
+        `เอกสารยอด ${docTotal.toFixed(2)} บาท ต้องแนบไฟล์ประกอบ (เกณฑ์ ${threshold.toFixed(2)} บาท)`,
+      );
+    }
+
+    // EXPENSE + CREDIT_NOTE + PAYROLL + VENDOR_SETTLEMENT + REPAIR_SERVICE supported
+    if (
+      !['EXPENSE', 'CREDIT_NOTE', 'PAYROLL', 'VENDOR_SETTLEMENT', 'REPAIR_SERVICE'].includes(
+        doc.documentType,
+      )
+    ) {
+      throw new BadRequestException(`type ${doc.documentType} not supported`);
+    }
+
+    // Fix #C12 — WHT routing invariant. When the doc has WHT > 0, doc.whtFormType
+    // MUST be non-null (and a recognised form). Previously the JE template silently
+    // defaulted to PND3 → routed to 21-3102, misfiling juristic-vendor WHT under
+    // ภ.ง.ด.3 instead of ภ.ง.ด.53 (government compliance bug).
+    //
+    // C12-symmetry: mirror the guard across all 4 doc types so any
+    // future bypass surfaces at post() instead of being silently misrouted by
+    // the template. Each doc type carries WHT differently:
+    //   - EXPENSE: doc.whtFormType OR every ExpenseLine.whtFormType is set
+    //     (per-line routing — P2-4)
+    //   - PAYROLL: doc.withholdingTax > 0 → always Cr 21-3101 (ภ.ง.ด.1) —
+    //     payroll WHT is employee income tax, NOT PND3/PND53, so no formType
+    //     enforcement here (BUT we still require it to be null since the field
+    //     is meaningless for payroll)
+    //   - VENDOR_SETTLEMENT: single-vendor invariant means doc-level form type
+    //     applies (intentionally no per-line routing per accounting.md)
+    //   - CREDIT_NOTE: createCreditNote already blocks original-with-WHT
+    //     (so CN itself ideally has no WHT), but if the original had WHT and
+    //     this branch is reached, we still need doc-level formType
+    const wht = new Prisma.Decimal(doc.withholdingTax?.toString() ?? '0');
+    if (wht.gt(0)) {
+      if (doc.documentType === 'EXPENSE') {
+        if (!doc.whtFormType) {
+          // Check if every WHT-bearing line has its own form type → fall through to
+          // per-line routing in the template. Otherwise the doc-level is mandatory.
+          const detail = await tx.expenseDetail.findUnique({
+            where: { documentId: id },
+            include: { lines: true },
+          });
+          const whtLines = (detail?.lines ?? []).filter(
+            (l) => l.whtAmount && new Prisma.Decimal(l.whtAmount.toString()).gt(0),
+          );
+          const allLinesHaveFormType =
+            whtLines.length > 0 && whtLines.every((l) => !!l.whtFormType);
+          if (!allLinesHaveFormType) {
+            throw new BadRequestException(
+              'whtFormType ต้องระบุเมื่อมี WHT — เลือก PND3 หรือ PND53',
+            );
+          }
+          // If every line has a form type, validate each is PND3/PND53 (no other strings)
+          for (const l of whtLines) {
+            if (l.whtFormType !== 'PND3' && l.whtFormType !== 'PND53') {
+              throw new BadRequestException(
+                `whtFormType ของบรรทัด ${(l as { lineNo?: number }).lineNo ?? '?'} ` +
+                  `ต้องเป็น PND3 หรือ PND53 (พบ ${l.whtFormType ?? 'null'})`,
+              );
+            }
+          }
+        } else if (doc.whtFormType !== 'PND3' && doc.whtFormType !== 'PND53') {
+          throw new BadRequestException(
+            `whtFormType ต้องเป็น PND3 หรือ PND53 (พบ ${doc.whtFormType})`,
+          );
+        }
+      } else if (doc.documentType === 'VENDOR_SETTLEMENT' || doc.documentType === 'CREDIT_NOTE') {
+        // Per-line routing intentionally NOT supported for SE (single-vendor
+        // invariant per accounting.md) and CN (template routes by original.whtFormType
+        // since CN itself carries no WHT — but defense in depth).
+        if (!doc.whtFormType) {
+          throw new BadRequestException(
+            'whtFormType ต้องระบุเมื่อมี WHT — เลือก PND3 หรือ PND53',
+          );
+        }
+        if (doc.whtFormType !== 'PND3' && doc.whtFormType !== 'PND53') {
+          throw new BadRequestException(
+            `whtFormType ต้องเป็น PND3 หรือ PND53 (พบ ${doc.whtFormType})`,
+          );
+        }
+      }
+      // PAYROLL: doc.whtFormType is meaningless (employee income tax always
+      // routes to 21-3101 / ภ.ง.ด.1). No enforcement — payroll.template
+      // posts to 21-3101 unconditionally when sumWht > 0.
+    }
+
+    if (doc.documentType === 'CREDIT_NOTE') {
+      return this.creditNoteTemplate.execute(id, tx);
+    }
+    if (doc.documentType === 'PAYROLL') {
+      return this.payrollTemplate.execute(id, tx);
+    }
+    if (doc.documentType === 'VENDOR_SETTLEMENT') {
+      return this.settlementTemplate.execute(id, tx);
+    }
+    if (doc.documentType === 'PETTY_CASH_REIMBURSEMENT') {
+      return this.pettyCashTemplate.execute(id, tx);
+    }
+    const target = this.transition.resolveTargetStatus(
+      doc.documentType,
+      !!doc.paymentMethod && !!doc.depositAccountCode,
+    );
+    if (target === 'POSTED') {
+      return this.sameDayTemplate.execute(id, tx);
+    } else {
+      // V15 — ACCRUAL ห้ามมี WHT (ม.50 ป.รัษฎากร).
+      // WHT เกิด "ขณะที่จ่ายเงินได้" → ACCRUAL is the accrual leg before
+      // payment, so WHT must defer to the SETTLEMENT step. Booking WHT now
+      // would put it in the wrong tax period and cause ภงด.53 misfile.
+      // Fix Report P0-2.
+      if (doc.withholdingTax && doc.withholdingTax.gt(0)) {
+        throw new BadRequestException(
+          'V15: เอกสารตั้งหนี้ (ACCRUAL) ห้ามมี WHT (มาตรา 50 ป.รัษฎากร) — ' +
+            'WHT จะถูกบันทึกตอน Settlement เมื่อจ่ายเงินจริง',
+        );
+      }
+      return this.accrualTemplate.execute(id, tx);
+    }
+  }
+
+  // ─── Approve (PENDING_APPROVAL → APPROVED → optionally POSTED) ────────
+  // D1.2.1.6 — second leg of the Approval Workflow. The DRAFT →
+  // PENDING_APPROVAL gate is wired in D1.2.1.1 (approval_enabled flag).
+  //
+  // Behaviour:
+  //  - Loads the doc under the same `post:` advisory lock so a concurrent
+  //    approve+post cannot double-post a JE.
+  //  - Asserts the source status is PENDING_APPROVAL.
+  //  - Flips status → APPROVED.
+  //  - Reads SystemConfig `auto_post_on_approve` (default true). When true,
+  //    chains to post() in the same transaction so APPROVED never persists
+  //    visibly. When false, returns the APPROVED doc and OWNER posts later
+  //    by calling /expenses/:id/post (which now also accepts APPROVED via
+  //    StatusTransitionService.assertCanPost).
+  //
+  // userId is captured for audit logs (APPROVED + AUTO_POSTED actions written
+  // inside the same tx). Signature parity with post() / voidDocument().
+  async approve(id: string, userId: string, userRole?: string) {
+    return this.prisma.$transaction(async (tx) => {
+      // Re-use the `post:` lock key — approve always either becomes the JE
+      // post (auto path) or precedes a future post(), so serializing on the
+      // same lock is correct.
+      await tx.$executeRawUnsafe(`SELECT pg_advisory_xact_lock(hashtext($1))`, `post:${id}`);
+
+      // D1.2.1.3 — approver membership check. OWNER always passes; everyone
+      // else must appear in SystemConfig `approvers_list`.
+      await assertUserCanApprove(tx, userId, userRole);
+
+      const doc = await tx.expenseDocument.findUniqueOrThrow({ where: { id } });
+      if (doc.deletedAt) throw new NotFoundException('เอกสารถูกลบแล้ว');
+      this.transition.assertCanApprove({ from: doc.status });
+
+      // Stamp APPROVED first so the auto-post branch starts from a clean
+      // APPROVED row (assertCanPost permits APPROVED). When auto-post is off
+      // the APPROVED state persists and downstream post() will pick it up.
+      await tx.expenseDocument.update({
+        where: { id },
+        data: { status: 'APPROVED' as DocumentStatus },
+      });
+
+      // D1.2.1.6 — APPROVED audit log (always written, regardless of auto-post).
+      await tx.auditLog.create({
+        data: {
+          action: 'APPROVED',
+          entity: 'expense_document',
+          entityId: id,
+          userId,
+          oldValue: { status: 'PENDING_APPROVAL' },
+          newValue: { status: 'APPROVED' },
+        },
+      });
+
+      const autoPost = await this.readBoolFlag(tx, 'auto_post_on_approve', true);
+      if (!autoPost) {
+        return tx.expenseDocument.findUniqueOrThrow({ where: { id } });
+      }
+
+      // Auto-post chain — delegated to executePostBody() shared helper.
+      // Skips the lock (already held) and the from-DRAFT assertCanPost (we
+      // just set APPROVED, which assertCanPost permits per D1.2.1.6). All
+      // integrity guards (period open, attachment threshold, WHT routing,
+      // V15 ACCRUAL-no-WHT, type allow-list) run via the helper so any
+      // future change to those guards lands in both paths automatically.
+      const result = await this.executePostBody(doc, tx);
+
+      // D1.2.1.6 — AUTO_POSTED audit log (only when auto_post_on_approve=true
+      // and the auto-post chain completed without throwing).
+      await tx.auditLog.create({
+        data: {
+          action: 'AUTO_POSTED',
+          entity: 'expense_document',
+          entityId: id,
+          userId,
+          newValue: { status: 'POSTED', autoPostedFromApproval: true },
+        },
+      });
+
+      return result;
+    });
+  }
+
   // ─── D1.* — Service-side SystemConfig flag readers ─────────────────────
   // Delegates to shared `readBoolFlag` in utils/config.util
   // so every service uses identical parsing + defensive try/catch semantics.
@@ -195,5 +565,37 @@ export class ExpenseDocumentLifecycleService {
     fallback: boolean,
   ): Promise<boolean> {
     return readBoolFlag(tx, key, fallback);
+  }
+
+  /**
+   * D1.2.1.2 — Numeric SystemConfig reader. Returns the stored Decimal as a
+   * Prisma.Decimal, clamped to ≥ 0 (negatives become 0). On missing or
+   * unparseable values returns the fallback. Used by the approval-threshold
+   * gate where negatives would yield bizarre "every doc requires approval"
+   * behaviour.
+   *
+   * Intentionally NOT consolidated onto config.util.readNumberFlag — that returns
+   * a plain number with no clamp; this returns Prisma.Decimal clamped to ≥ 0.
+   * Do not dedup without preserving the Decimal return + clamp.
+   */
+  private async readNumberFlag(
+    tx: Prisma.TransactionClient | PrismaService,
+    key: string,
+    fallback: number,
+  ): Promise<Prisma.Decimal> {
+    try {
+      const row = await tx.systemConfig.findFirst({
+        where: { key, deletedAt: null },
+        select: { value: true },
+      });
+      const raw = row?.value;
+      if (!raw) return new Prisma.Decimal(fallback);
+      const parsed = Number(raw);
+      if (!Number.isFinite(parsed)) return new Prisma.Decimal(fallback);
+      const clamped = parsed < 0 ? 0 : parsed;
+      return new Prisma.Decimal(clamped);
+    } catch {
+      return new Prisma.Decimal(fallback);
+    }
   }
 }


### PR DESCRIPTION
## Phase 2b — JE-posting core (post / executePostBody / approve) — HIGH RISK, verified byte-identical

Slice of the expense-documents transactional-core decompose (Slice 0 #1215, P1 #1216, P2a #1217 — all merged). Off post-#1217 main.

Moves the regulated JE-posting core **VERBATIM** into `ExpenseDocumentLifecycleService` (created in 2a). `post()` + `approve()` each call `executePostBody` inside their own `$transaction`, so all three move together (executePostBody = shared inner-tx body, now private in lifecycle). **JE dispatch + document state transitions are byte-identical to main** — confirmed by `diff` of all 3 methods vs `ac45d4db` (zero differences).

### What changed
- **Lifecycle service** gains `post`, `executePostBody` (private), `approve` (verbatim) + `readNumberFlag` wrapper; ctor grows to `(prisma, transition, sameDayTemplate, accrualTemplate, creditNoteTemplate, payrollTemplate, settlementTemplate, pettyCashTemplate, notifications?)`.
- **Facade** delegates `post`/`approve`; `executePostBody` removed; **sheds the 6 JE templates + `readNumberFlag` + post/approve-only free-fn imports**. Facade −400 LOC (now ~1600).
- **Factory** builds lifecycle with the new 9-arg ctor from the same resolved template/transition mocks (so existing post/approve specs that assert on `sameDay.execute` etc. still pass via delegation).
- **+3 characterization tests**: CREDIT_NOTE post → `creditNoteTemplate.execute`; **PETTY_CASH post → THROWS `type PETTY_CASH_REIMBURSEMENT not supported`** (pins the existing allow-list quirk — PETTY_CASH is not in the allow-list, so the later petty-cash branch is dead; documented so nobody "fixes" it); CREDIT_NOTE auto-post → `creditNoteTemplate.execute` + APPROVED/AUTO_POSTED audits.

### Gates
- tsc 0 · `npm --prefix apps/api run test -- expense-documents` → **436 passed / 37 suites** (433 existing UNCHANGED + 3 new) · lint exit 0
- `new ExpenseDocumentsService(`=1 · facade: 6-templates / readNumberFlag / transition.assertCanPost greps all 0; readBoolFlag + transition.assertCanEdit/assertCanVoid KEPT (create/update/void)
- Two-stage review passed; **post/executePostBody/approve confirmed byte-identical to main**.

### Merge order (sequential-on-main)
Base = current main. 2c (voidDocument — last lifecycle slice) branches off this once merged; then STOP for owner re-confirm before Phase 3 (Create).

🤖 Generated with [Claude Code](https://claude.com/claude-code)