### PR TITLE
Phase 2c: extract voidDocument into LifecycleService (verbatim) — lifecycle complete

### DIFF
--- a/apps/api/src/modules/expense-documents/__tests__/support/make-expense-documents-service.ts
+++ b/apps/api/src/modules/expense-documents/__tests__/support/make-expense-documents-service.ts
@@ -128,12 +128,14 @@ export function makeExpenseDocumentsService(
   // through the facade's now-delegating read methods. `jePreview` is no longer
   // a facade constructor arg (it moved into the query service).
   const query = overrides.query ?? new ExpenseDocumentQueryService(prisma, jePreview);
-  // Phase 2a/2b decompose — REAL lifecycle sub-service by default. Phase 2b
+  // Phase 2a/2b/2c decompose — REAL lifecycle sub-service by default. Phase 2b
   // moved the JE-posting core (post / executePostBody / approve) here, so the
-  // lifecycle ctor now also takes `transition` + the 6 JE templates. They are
-  // built from the SAME resolved mock instances the facade specs assert on
-  // (e.g. `sameDayTemplate.execute`), so the facade's delegating post/approve
-  // reach the same mocks. `notifications` stays the trailing-optional param.
+  // lifecycle ctor takes `transition` + the 6 JE templates. Phase 2c moved
+  // voidDocument here too, adding `journal` (before the trailing-optional
+  // notifications). All are built from the SAME resolved mock instances the
+  // facade specs assert on (e.g. `sameDayTemplate.execute`, `journal.createAndPost`),
+  // so the facade's delegating post/approve/void reach the same mocks.
+  // `notifications` stays the trailing-optional param.
   const lifecycle =
     overrides.lifecycle ??
     new ExpenseDocumentLifecycleService(
@@ -145,16 +147,17 @@ export function makeExpenseDocumentsService(
       payrollTemplate,
       settlementTemplate,
       pettyCashTemplate,
+      journal,
       notifications,
     );
 
   // THE single positional construction in the codebase. Phase 2b removed the 6
-  // JE-template args from the facade ctor (they now feed the lifecycle service).
+  // JE-template args; Phase 2c removed `journal` (it now feeds the lifecycle
+  // service) from the facade ctor.
   const service = new ExpenseDocumentsService(
     prisma,
     docNumber,
     transition,
-    journal,
     aggregator,
     ssoConfig,
     pettyCash,

--- a/apps/api/src/modules/expense-documents/expense-documents.service.ts
+++ b/apps/api/src/modules/expense-documents/expense-documents.service.ts
@@ -8,8 +8,6 @@ import {
 } from '@nestjs/common';
 import { Prisma } from '@prisma/client';
 import { PrismaService } from '../../prisma/prisma.service';
-import { JournalAutoService } from '../journal/journal-auto.service';
-import { resolveReversePermissionRoles } from './reverse-permission.guard';
 import { maskPayrollTaxIds } from './payroll-pii-mask.util';
 import {
   ADJUSTMENT_ALLOWLIST,
@@ -33,10 +31,7 @@ import { ExpenseDocumentLifecycleService } from './services/expense-document-lif
 import { SsoConfigService } from '../sso-config/sso-config.service';
 import { PettyCashService } from './services/petty-cash.service';
 import { PayrollCustomService } from './services/payroll-custom.service';
-import { validatePeriodOpen } from '../../utils/period-lock.util';
 import { readBoolFlag, readIntFlag } from '../../utils/config.util';
-import { bkkBusinessDate } from './bkk-business-date.util';
-import { getReverseReasons } from './approval-config.util';
 
 @Injectable()
 export class ExpenseDocumentsService implements OnModuleInit {
@@ -75,7 +70,6 @@ export class ExpenseDocumentsService implements OnModuleInit {
     private readonly prisma: PrismaService,
     private readonly docNumber: DocNumberService,
     private readonly transition: StatusTransitionService,
-    private readonly journal: JournalAutoService,
     private readonly aggregator: LineAggregatorService,
     private readonly ssoConfig: SsoConfigService,
     private readonly pettyCash: PettyCashService,
@@ -1236,254 +1230,15 @@ export class ExpenseDocumentsService implements OnModuleInit {
   }
 
   // ─── Void (any non-VOIDED → VOIDED) ──────────────────────────────────
-  // Posts a reversal JE (flipped Dr/Cr) when the doc had a journal entry,
-  // and for VENDOR_SETTLEMENT also reverts each cleared EX back to ACCRUAL.
-  // C3 — Optionally accepts reasonCode + reasonDetail + reverseDate (caller-chosen
-  // posting date for the reversal JE). All optional → existing parameterless
-  // void path still works (back-compat).
+  // Phase 2c decompose: delegated to ExpenseDocumentLifecycleService.
+  // Signature + behavior unchanged.
   async voidDocument(
     id: string,
     userId: string,
     dto: VoidExpenseDocumentDto = {},
     userRole?: string,
   ) {
-    // D1.3.2.4 (S3 defense-in-depth) — mirror the ReversePermissionGuard
-    // check at the service boundary. Skipped when userRole is undefined
-    // (system-internal / unit-test paths).
-    if (userRole !== undefined) {
-      const allowed = await resolveReversePermissionRoles(this.prisma);
-      if (!allowed.has(userRole)) {
-        throw new ForbiddenException(
-          `ไม่มีสิทธิ์กลับรายการเอกสาร (role ปัจจุบัน: ${userRole})`,
-        );
-      }
-    }
-    return this.prisma.$transaction(async (tx) => {
-      // Per-doc advisory lock — serializes concurrent voids on the same id so
-      // two callers cannot both pass assertCanVoid and double-post a reversal JE.
-      // (PG REPEATABLE READ does not prevent this write skew on its own.)
-      await tx.$executeRawUnsafe(`SELECT pg_advisory_xact_lock(hashtext($1))`, `void:${id}`);
-
-      const doc = await tx.expenseDocument.findUniqueOrThrow({
-        where: { id },
-        include: { settlement: { include: { settlementLines: true } } },
-      });
-      if (doc.deletedAt) throw new NotFoundException('เอกสารถูกลบแล้ว');
-
-      // D1.2.7.4 — `reverse_block_cascaded` (default true). OWNER may disable
-      // via SystemConfig to allow voiding upstream docs even when downstream CN/SE
-      // exist. Default-on preserves the strict safety from C3.4. If owner
-      // disables, downstream consumers will become orphaned — UI must surface
-      // this risk separately (out of scope here).
-      const cascadeBlockEnabled = await this.readBoolFlag(tx, 'reverse_block_cascaded', true);
-
-      const pendingCn = await tx.expenseDocument.count({
-        where: {
-          documentType: 'CREDIT_NOTE',
-          status: { not: 'VOIDED' },
-          deletedAt: null,
-          creditNote: { originalDocumentId: id },
-        },
-      });
-      if (cascadeBlockEnabled && pendingCn > 0) {
-        throw new BadRequestException('มีใบลดหนี้ที่ยังไม่ถูกยกเลิก ไม่สามารถยกเลิกเอกสารต้นฉบับได้');
-      }
-
-      // C3.4 — Cascade check: also block void when an active SETTLEMENT
-      // clears this doc. (Settlement-on-void of the SE itself separately
-      // reverts cleared docs back to ACCRUAL — that's the SE-being-voided
-      // path, not this one.) Gated by the same `reverse_block_cascaded` flag.
-      const pendingSe = await tx.expenseDocument.count({
-        where: {
-          documentType: 'VENDOR_SETTLEMENT',
-          status: { not: 'VOIDED' },
-          deletedAt: null,
-          settlement: { settlementLines: { some: { clearedDocumentId: id } } },
-        },
-      });
-      if (cascadeBlockEnabled && pendingSe > 0) {
-        throw new BadRequestException(
-          'มีใบจ่ายเจ้าหนี้ (SE) ที่ยังไม่ถูกยกเลิกอ้างถึงเอกสารนี้อยู่ — ' +
-            'กรุณายกเลิก SE ก่อน',
-        );
-      }
-
-      // D1.2.7.1 — `reverse_reason_required` (default true). When enabled,
-      // server enforces that `dto.reasonCode` is present + non-empty. UI
-      // already enforces via canSubmit, but the server gate prevents a
-      // bypass (e.g. direct curl without going through ReverseDialog).
-      const reasonRequired = await this.readBoolFlag(tx, 'reverse_reason_required', true);
-      if (reasonRequired && !dto.reasonCode?.trim()) {
-        throw new BadRequestException('กรุณาระบุเหตุผลในการยกเลิกเอกสาร');
-      }
-
-      // D1.2.7.2 — `reverse_reasons` SystemConfig (default = 6 canonical
-      // codes). Validate dto.reasonCode against the configured whitelist
-      // when present. OWNER can extend/override the list via SettingsService.
-      if (dto.reasonCode?.trim()) {
-        const reasons = await getReverseReasons(tx);
-        const allowed = new Set(reasons.map((r) => r.code));
-        if (!allowed.has(dto.reasonCode)) {
-          throw new BadRequestException(
-            `เหตุผล "${dto.reasonCode}" ไม่อยู่ในรายการที่ตั้งค่าไว้`,
-          );
-        }
-      }
-
-      // D1.2.6.4 — `payment_date_allow_future` (default true). When OWNER
-      // disables, reject future-dated reverseDate. UI also shows warning.
-      if (dto.reverseDate) {
-        const allowFuture = await this.readBoolFlag(tx, 'payment_date_allow_future', true);
-        if (!allowFuture) {
-          const dateUtc = new Date(dto.reverseDate);
-          const todayBkk = new Date();
-          // Strip time so the check is calendar-day comparison.
-          if (dateUtc.getTime() > todayBkk.getTime()) {
-            throw new BadRequestException(
-              'ไม่อนุญาตให้ระบุวันที่ในอนาคต — กรุณาเลือกวันที่ไม่เกินวันนี้',
-            );
-          }
-        }
-      }
-
-      this.transition.assertCanVoid({ from: doc.status });
-
-      // Fix #C9 (Round 2 — moved from journal-auto.service.createAndPost):
-      // Period-open guard at the module boundary. C3.1 — when caller passes
-      // `reverseDate`, the reversal JE postedAt uses it (still V19-gated); else
-      // the legacy behavior (today BKK noon).
-      const reverseAt = dto.reverseDate
-        ? bkkBusinessDate(new Date(dto.reverseDate))
-        : bkkBusinessDate(new Date());
-      const shopForVoidPeriod = await tx.companyInfo.findFirst({
-        where: { companyCode: 'SHOP', deletedAt: null },
-        select: { id: true },
-      });
-      if (!shopForVoidPeriod) {
-        throw new NotFoundException(
-          'CompanyInfo with companyCode=SHOP not found — seed accounting data first',
-        );
-      }
-      await validatePeriodOpen(tx, reverseAt, shopForVoidPeriod.id);
-
-      // Post reversal JE (flipped Dr/Cr) if doc had one. The original JE stays
-      // intact; the reversal lives as a separate POSTED entry tagged via metadata.
-      // Reversal postedAt is BKK noon "today" — keeps the entry inside the
-      // intended Thai accounting day regardless of UTC server clock.
-      let reverseJournalEntryId: string | null = null;
-      if (doc.journalEntryId) {
-        const original = await tx.journalEntry.findUniqueOrThrow({
-          where: { id: doc.journalEntryId },
-          include: { lines: true },
-        });
-        // W6 fix — fall back to SHOP company id when legacy JE rows lack
-        // companyId (pre-A.1b migration). Without this, voiding an old EX
-        // throws "companyId required" from journal-auto.service. SHOP is the
-        // canonical home for expense-side flows per accounting.md.
-        let companyId = original.companyId;
-        if (!companyId) {
-          const shop = await tx.companyInfo.findFirst({
-            where: { companyCode: 'SHOP', deletedAt: null },
-            select: { id: true },
-          });
-          if (!shop) {
-            // W6 (Round 2) — replace bare Error with NestJS exception so the
-            // response is a clean 404 instead of a 500 with stack trace. Same
-            // wording shape as the post()/voidDocument() period-guard SHOP
-            // fallback and the FINANCE fallback in resolveFinanceCompanyId.
-            throw new NotFoundException(
-              'CompanyInfo with companyCode=SHOP not found — seed accounting data first',
-            );
-          }
-          companyId = shop.id;
-        }
-        const reverseEntry = await this.journal.createAndPost(
-          {
-            description: `กลับรายการ ${doc.number}`,
-            reference: doc.id,
-            metadata: {
-              tag: 'EXPENSE_VOID_REVERSAL',
-              documentId: doc.id,
-              documentNumber: doc.number,
-              documentType: doc.documentType,
-              originalJournalEntryId: original.id,
-              flow: `expense-${doc.documentType.toLowerCase()}-void`,
-              // C3 — reason metadata embedded so JE-side audits can grep
-              // by reasonCode without joining audit_logs.
-              reverseReasonCode: dto.reasonCode ?? null,
-              reverseReasonDetail: dto.reasonDetail ?? null,
-            },
-            postedAt: reverseAt,
-            companyId,
-            lines: original.lines.map((l) => ({
-              accountCode: l.accountCode,
-              dr: new Prisma.Decimal(l.credit.toString()),
-              cr: new Prisma.Decimal(l.debit.toString()),
-              description: l.description ? `[กลับรายการ] ${l.description}` : '[กลับรายการ]',
-            })),
-          },
-          tx,
-        );
-        reverseJournalEntryId = reverseEntry.id;
-      }
-
-      // VENDOR_SETTLEMENT side-effect: revert each cleared EX back to ACCRUAL.
-      // The SE was the only thing that flipped them to POSTED + paidAt; voiding
-      // the SE must undo that, otherwise the EXs stay POSTED with no payment.
-      // updateMany with deletedAt:null guard so a soft-deleted EX is not
-      // resurrected — if it was already deleted, we simply skip + log.
-      if (doc.documentType === 'VENDOR_SETTLEMENT' && doc.settlement) {
-        for (const line of doc.settlement.settlementLines) {
-          const result = await tx.expenseDocument.updateMany({
-            where: { id: line.clearedDocumentId, deletedAt: null },
-            data: { status: 'ACCRUAL', paidAt: null },
-          });
-          if (result.count === 0) {
-            this.logger.warn(
-              `Void SE ${doc.number}: cleared EX ${line.clearedDocumentId} was soft-deleted — skipped revert`,
-            );
-          }
-        }
-      }
-
-      // Compare-and-swap on status — second concurrent caller (if it somehow
-      // bypassed the advisory lock) sees count=0 and aborts. Belt-and-braces.
-      const flip = await tx.expenseDocument.updateMany({
-        where: { id, status: { not: 'VOIDED' } },
-        data: { status: 'VOIDED' },
-      });
-      if (flip.count === 0) {
-        throw new BadRequestException('เอกสารถูกยกเลิกไปแล้ว');
-      }
-
-      // C3.3 — Audit trail with reason + reverse JE pointer. Stuffed into
-      // `newValue` JSON rather than adding columns (AuditLog has a Merkle hash
-      // chain — adding columns would break the verification path on existing rows).
-      await tx.auditLog.create({
-        data: {
-          action: 'EXPENSE_VOIDED',
-          entity: 'expense_document',
-          entityId: id,
-          userId,
-          oldValue: { status: doc.status, journalEntryId: doc.journalEntryId },
-          newValue: {
-            status: 'VOIDED',
-            reverseJournalEntryId,
-            reverseDate: reverseAt.toISOString(),
-            reasonCode: dto.reasonCode ?? null,
-            reasonDetail: dto.reasonDetail ?? null,
-            // Structured reverse reason — read by the shared timeline's
-            // mapAuditEvents (parity with other-income / asset modules).
-            reverseReasonLabel: dto.reasonLabel ?? null,
-            reverseNote: dto.note ?? null,
-            documentNumber: doc.number,
-            documentType: doc.documentType,
-          },
-        },
-      });
-
-      return tx.expenseDocument.findUniqueOrThrow({ where: { id } });
-    });
+    return this.lifecycle.voidDocument(id, userId, dto, userRole);
   }
 
   // ─── Soft delete (DRAFT only) ────────────────────────────────────────

--- a/apps/api/src/modules/expense-documents/services/expense-document-lifecycle.service.ts
+++ b/apps/api/src/modules/expense-documents/services/expense-document-lifecycle.service.ts
@@ -12,27 +12,32 @@ import {
   getApproversList,
   assertUserCanApprove,
   getApprovalRequiredDocTypes,
+  getReverseReasons,
 } from '../approval-config.util';
 import { resolvePostPermissionRoles } from '../post-permission.guard';
+import { resolveReversePermissionRoles } from '../reverse-permission.guard';
+import { bkkBusinessDate } from '../bkk-business-date.util';
 import { validatePeriodOpen } from '../../../utils/period-lock.util';
 import { readBoolFlag } from '../../../utils/config.util';
 import { StatusTransitionService } from './status-transition.service';
+import { JournalAutoService } from '../../journal/journal-auto.service';
 import { ExpenseSameDayTemplate } from '../../journal/cpa-templates/expense-same-day.template';
 import { ExpenseAccrualTemplate } from '../../journal/cpa-templates/expense-accrual.template';
 import { CreditNoteTemplate } from '../../journal/cpa-templates/credit-note.template';
 import { PayrollTemplate } from '../../journal/cpa-templates/payroll.template';
 import { VendorSettlementTemplate } from '../../journal/cpa-templates/vendor-settlement.template';
 import { PettyCashTemplate } from '../../journal/cpa-templates/petty-cash.template';
+import { VoidExpenseDocumentDto } from '../dto/void-expense.dto';
 
 /**
  * Phase 2 of the transactional-core decompose: the document LIFECYCLE methods of
  * ExpenseDocumentsService, extracted VERBATIM. The facade delegates to this
  * service so the public contract (controller + callers) is unchanged.
  *
- * Phase 2a (this slice) moves the 3 lowest-risk members: submitForApproval,
- * notifyApprovers (private), softDelete — plus a verbatim COPY of the private
- * readBoolFlag wrapper they need. Later slices 2b/2c ADD post/approve/
- * executePostBody/voidDocument to THIS service.
+ * Complete (Phases 2a/2b/2c): the full document state machine lives here —
+ * submitForApproval, notifyApprovers (private), softDelete (2a); post,
+ * executePostBody (private), approve (2b); voidDocument (2c) — plus verbatim
+ * copies of the private readBoolFlag / readNumberFlag config-flag wrappers.
  *
  * This service OWNS the notifications dependency (the facade sheds it) — the
  * trailing-optional `notifications?` ctor param preserves notifyApprovers'
@@ -56,6 +61,10 @@ export class ExpenseDocumentLifecycleService {
     private readonly payrollTemplate: PayrollTemplate,
     private readonly settlementTemplate: VendorSettlementTemplate,
     private readonly pettyCashTemplate: PettyCashTemplate,
+    // Phase 2c — the JournalAutoService used by voidDocument's reversal-JE
+    // post (this.journal.createAndPost). Placed before the trailing-optional
+    // notifications? so the existing param contract stays positional-stable.
+    private readonly journal: JournalAutoService,
     private readonly notifications?: NotificationsService,
   ) {}
 
@@ -550,6 +559,251 @@ export class ExpenseDocumentLifecycleService {
       });
 
       return result;
+    });
+  }
+
+  async voidDocument(
+    id: string,
+    userId: string,
+    dto: VoidExpenseDocumentDto = {},
+    userRole?: string,
+  ) {
+    // D1.3.2.4 (S3 defense-in-depth) — mirror the ReversePermissionGuard
+    // check at the service boundary. Skipped when userRole is undefined
+    // (system-internal / unit-test paths).
+    if (userRole !== undefined) {
+      const allowed = await resolveReversePermissionRoles(this.prisma);
+      if (!allowed.has(userRole)) {
+        throw new ForbiddenException(
+          `ไม่มีสิทธิ์กลับรายการเอกสาร (role ปัจจุบัน: ${userRole})`,
+        );
+      }
+    }
+    return this.prisma.$transaction(async (tx) => {
+      // Per-doc advisory lock — serializes concurrent voids on the same id so
+      // two callers cannot both pass assertCanVoid and double-post a reversal JE.
+      // (PG REPEATABLE READ does not prevent this write skew on its own.)
+      await tx.$executeRawUnsafe(`SELECT pg_advisory_xact_lock(hashtext($1))`, `void:${id}`);
+
+      const doc = await tx.expenseDocument.findUniqueOrThrow({
+        where: { id },
+        include: { settlement: { include: { settlementLines: true } } },
+      });
+      if (doc.deletedAt) throw new NotFoundException('เอกสารถูกลบแล้ว');
+
+      // D1.2.7.4 — `reverse_block_cascaded` (default true). OWNER may disable
+      // via SystemConfig to allow voiding upstream docs even when downstream CN/SE
+      // exist. Default-on preserves the strict safety from C3.4. If owner
+      // disables, downstream consumers will become orphaned — UI must surface
+      // this risk separately (out of scope here).
+      const cascadeBlockEnabled = await this.readBoolFlag(tx, 'reverse_block_cascaded', true);
+
+      const pendingCn = await tx.expenseDocument.count({
+        where: {
+          documentType: 'CREDIT_NOTE',
+          status: { not: 'VOIDED' },
+          deletedAt: null,
+          creditNote: { originalDocumentId: id },
+        },
+      });
+      if (cascadeBlockEnabled && pendingCn > 0) {
+        throw new BadRequestException('มีใบลดหนี้ที่ยังไม่ถูกยกเลิก ไม่สามารถยกเลิกเอกสารต้นฉบับได้');
+      }
+
+      // C3.4 — Cascade check: also block void when an active SETTLEMENT
+      // clears this doc. (Settlement-on-void of the SE itself separately
+      // reverts cleared docs back to ACCRUAL — that's the SE-being-voided
+      // path, not this one.) Gated by the same `reverse_block_cascaded` flag.
+      const pendingSe = await tx.expenseDocument.count({
+        where: {
+          documentType: 'VENDOR_SETTLEMENT',
+          status: { not: 'VOIDED' },
+          deletedAt: null,
+          settlement: { settlementLines: { some: { clearedDocumentId: id } } },
+        },
+      });
+      if (cascadeBlockEnabled && pendingSe > 0) {
+        throw new BadRequestException(
+          'มีใบจ่ายเจ้าหนี้ (SE) ที่ยังไม่ถูกยกเลิกอ้างถึงเอกสารนี้อยู่ — ' +
+            'กรุณายกเลิก SE ก่อน',
+        );
+      }
+
+      // D1.2.7.1 — `reverse_reason_required` (default true). When enabled,
+      // server enforces that `dto.reasonCode` is present + non-empty. UI
+      // already enforces via canSubmit, but the server gate prevents a
+      // bypass (e.g. direct curl without going through ReverseDialog).
+      const reasonRequired = await this.readBoolFlag(tx, 'reverse_reason_required', true);
+      if (reasonRequired && !dto.reasonCode?.trim()) {
+        throw new BadRequestException('กรุณาระบุเหตุผลในการยกเลิกเอกสาร');
+      }
+
+      // D1.2.7.2 — `reverse_reasons` SystemConfig (default = 6 canonical
+      // codes). Validate dto.reasonCode against the configured whitelist
+      // when present. OWNER can extend/override the list via SettingsService.
+      if (dto.reasonCode?.trim()) {
+        const reasons = await getReverseReasons(tx);
+        const allowed = new Set(reasons.map((r) => r.code));
+        if (!allowed.has(dto.reasonCode)) {
+          throw new BadRequestException(
+            `เหตุผล "${dto.reasonCode}" ไม่อยู่ในรายการที่ตั้งค่าไว้`,
+          );
+        }
+      }
+
+      // D1.2.6.4 — `payment_date_allow_future` (default true). When OWNER
+      // disables, reject future-dated reverseDate. UI also shows warning.
+      if (dto.reverseDate) {
+        const allowFuture = await this.readBoolFlag(tx, 'payment_date_allow_future', true);
+        if (!allowFuture) {
+          const dateUtc = new Date(dto.reverseDate);
+          const todayBkk = new Date();
+          // Strip time so the check is calendar-day comparison.
+          if (dateUtc.getTime() > todayBkk.getTime()) {
+            throw new BadRequestException(
+              'ไม่อนุญาตให้ระบุวันที่ในอนาคต — กรุณาเลือกวันที่ไม่เกินวันนี้',
+            );
+          }
+        }
+      }
+
+      this.transition.assertCanVoid({ from: doc.status });
+
+      // Fix #C9 (Round 2 — moved from journal-auto.service.createAndPost):
+      // Period-open guard at the module boundary. C3.1 — when caller passes
+      // `reverseDate`, the reversal JE postedAt uses it (still V19-gated); else
+      // the legacy behavior (today BKK noon).
+      const reverseAt = dto.reverseDate
+        ? bkkBusinessDate(new Date(dto.reverseDate))
+        : bkkBusinessDate(new Date());
+      const shopForVoidPeriod = await tx.companyInfo.findFirst({
+        where: { companyCode: 'SHOP', deletedAt: null },
+        select: { id: true },
+      });
+      if (!shopForVoidPeriod) {
+        throw new NotFoundException(
+          'CompanyInfo with companyCode=SHOP not found — seed accounting data first',
+        );
+      }
+      await validatePeriodOpen(tx, reverseAt, shopForVoidPeriod.id);
+
+      // Post reversal JE (flipped Dr/Cr) if doc had one. The original JE stays
+      // intact; the reversal lives as a separate POSTED entry tagged via metadata.
+      // Reversal postedAt is BKK noon "today" — keeps the entry inside the
+      // intended Thai accounting day regardless of UTC server clock.
+      let reverseJournalEntryId: string | null = null;
+      if (doc.journalEntryId) {
+        const original = await tx.journalEntry.findUniqueOrThrow({
+          where: { id: doc.journalEntryId },
+          include: { lines: true },
+        });
+        // W6 fix — fall back to SHOP company id when legacy JE rows lack
+        // companyId (pre-A.1b migration). Without this, voiding an old EX
+        // throws "companyId required" from journal-auto.service. SHOP is the
+        // canonical home for expense-side flows per accounting.md.
+        let companyId = original.companyId;
+        if (!companyId) {
+          const shop = await tx.companyInfo.findFirst({
+            where: { companyCode: 'SHOP', deletedAt: null },
+            select: { id: true },
+          });
+          if (!shop) {
+            // W6 (Round 2) — replace bare Error with NestJS exception so the
+            // response is a clean 404 instead of a 500 with stack trace. Same
+            // wording shape as the post()/voidDocument() period-guard SHOP
+            // fallback and the FINANCE fallback in resolveFinanceCompanyId.
+            throw new NotFoundException(
+              'CompanyInfo with companyCode=SHOP not found — seed accounting data first',
+            );
+          }
+          companyId = shop.id;
+        }
+        const reverseEntry = await this.journal.createAndPost(
+          {
+            description: `กลับรายการ ${doc.number}`,
+            reference: doc.id,
+            metadata: {
+              tag: 'EXPENSE_VOID_REVERSAL',
+              documentId: doc.id,
+              documentNumber: doc.number,
+              documentType: doc.documentType,
+              originalJournalEntryId: original.id,
+              flow: `expense-${doc.documentType.toLowerCase()}-void`,
+              // C3 — reason metadata embedded so JE-side audits can grep
+              // by reasonCode without joining audit_logs.
+              reverseReasonCode: dto.reasonCode ?? null,
+              reverseReasonDetail: dto.reasonDetail ?? null,
+            },
+            postedAt: reverseAt,
+            companyId,
+            lines: original.lines.map((l) => ({
+              accountCode: l.accountCode,
+              dr: new Prisma.Decimal(l.credit.toString()),
+              cr: new Prisma.Decimal(l.debit.toString()),
+              description: l.description ? `[กลับรายการ] ${l.description}` : '[กลับรายการ]',
+            })),
+          },
+          tx,
+        );
+        reverseJournalEntryId = reverseEntry.id;
+      }
+
+      // VENDOR_SETTLEMENT side-effect: revert each cleared EX back to ACCRUAL.
+      // The SE was the only thing that flipped them to POSTED + paidAt; voiding
+      // the SE must undo that, otherwise the EXs stay POSTED with no payment.
+      // updateMany with deletedAt:null guard so a soft-deleted EX is not
+      // resurrected — if it was already deleted, we simply skip + log.
+      if (doc.documentType === 'VENDOR_SETTLEMENT' && doc.settlement) {
+        for (const line of doc.settlement.settlementLines) {
+          const result = await tx.expenseDocument.updateMany({
+            where: { id: line.clearedDocumentId, deletedAt: null },
+            data: { status: 'ACCRUAL', paidAt: null },
+          });
+          if (result.count === 0) {
+            this.logger.warn(
+              `Void SE ${doc.number}: cleared EX ${line.clearedDocumentId} was soft-deleted — skipped revert`,
+            );
+          }
+        }
+      }
+
+      // Compare-and-swap on status — second concurrent caller (if it somehow
+      // bypassed the advisory lock) sees count=0 and aborts. Belt-and-braces.
+      const flip = await tx.expenseDocument.updateMany({
+        where: { id, status: { not: 'VOIDED' } },
+        data: { status: 'VOIDED' },
+      });
+      if (flip.count === 0) {
+        throw new BadRequestException('เอกสารถูกยกเลิกไปแล้ว');
+      }
+
+      // C3.3 — Audit trail with reason + reverse JE pointer. Stuffed into
+      // `newValue` JSON rather than adding columns (AuditLog has a Merkle hash
+      // chain — adding columns would break the verification path on existing rows).
+      await tx.auditLog.create({
+        data: {
+          action: 'EXPENSE_VOIDED',
+          entity: 'expense_document',
+          entityId: id,
+          userId,
+          oldValue: { status: doc.status, journalEntryId: doc.journalEntryId },
+          newValue: {
+            status: 'VOIDED',
+            reverseJournalEntryId,
+            reverseDate: reverseAt.toISOString(),
+            reasonCode: dto.reasonCode ?? null,
+            reasonDetail: dto.reasonDetail ?? null,
+            // Structured reverse reason — read by the shared timeline's
+            // mapAuditEvents (parity with other-income / asset modules).
+            reverseReasonLabel: dto.reasonLabel ?? null,
+            reverseNote: dto.note ?? null,
+            documentNumber: doc.number,
+            documentType: doc.documentType,
+          },
+        },
+      });
+
+      return tx.expenseDocument.findUniqueOrThrow({ where: { id } });
     });
   }
 


### PR DESCRIPTION
## Phase 2c — voidDocument (final lifecycle slice), verified byte-identical

Last lifecycle slice of the expense-documents transactional-core decompose (Slice 0 #1215, P1 #1216, P2a #1217, P2b #1218 — all merged). Off post-#1218 main.

Moves `voidDocument` **VERBATIM** into `ExpenseDocumentLifecycleService`, completing the lifecycle service (submit/notify/softDelete + post/executePostBody/approve + void). **Reversal JE (flipped Dr/Cr) + state transitions byte-identical to main** — confirmed by `diff` (244 lines, zero differences) and the ~28 existing void tests passing UNCHANGED via the delegated path.

### What changed
- **Lifecycle service** gains `voidDocument` (verbatim, whole `$transaction`: reversal JE via `journal.createAndPost`, CAS VOIDED flip, SE→ACCRUAL revert, cascade-block, reason/whitelist/future-date guards, period guard, C3 audit) + `journal` ctor param (now `(prisma, transition, 6 templates, journal, notifications?)`).
- **Facade** delegates `voidDocument`; **sheds the `journal` dep** + 4 void-only imports. Facade now ~1250 LOC (from 2475) — holds only create-family + `update` real bodies + delegations.
- **Factory** builds lifecycle with `journal` from the same resolved mock.
- **No new tests** — voidDocument was already pinned by ~28 existing tests, which now exercise the delegated path (real lifecycle body + same mocks).

### Gates
- tsc 0 · `npm --prefix apps/api run test -- expense-documents` → **436 passed / 37 suites** (UNCHANGED) · lint exit 0
- `new ExpenseDocumentsService(`=1 · facade `this.journal`=0; `readBoolFlag` + `transition.assertCanEdit` KEPT (create/update)
- Two-stage review passed; voidDocument confirmed byte-identical; 2 cosmetic doc-comment nits fixed.

### Decompose status after this merge
`ExpenseDocumentsService` facade: 2475 → ~1250 LOC. Extracted: `ExpenseDocumentQueryService` (9 read) + `ExpenseDocumentLifecycleService` (submit/post/approve/void/softDelete/notify). **Remaining = Phase 3** (create-family + update → `ExpenseDocumentCreateService`) — branches off this once merged, after owner re-confirm (plan gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)