### PR TITLE
refactor(line-oa): thin LineOaPaymentController — extract logic to PaymentEvidenceService (900->230 LOC)

### DIFF
--- a/apps/api/src/modules/line-oa/line-oa-payment.controller.spec.ts
+++ b/apps/api/src/modules/line-oa/line-oa-payment.controller.spec.ts
@@ -1,0 +1,1171 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import { Request, Response } from 'express';
+import { LineOaPaymentController } from './line-oa-payment.controller';
+import { LineOaService } from './line-oa.service';
+import { PrismaService } from '../../prisma/prisma.service';
+import { PromptPayQrService } from './promptpay/promptpay-qr.service';
+import { PaymentLinkService } from './payment-links/payment-link.service';
+import { PaymentEvidenceService } from './services/payment-evidence.service';
+import { StorageService } from '../storage/storage.service';
+import { FlexTemplatesService } from './flex-templates.service';
+import { LineFinanceClientService } from '../chatbot-finance/services/line-finance-client.service';
+import { ConfigService } from '@nestjs/config';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+
+// ── helpers ──────────────────────────────────────────────
+function mockReq(userId?: string): Request {
+  return { user: userId ? { id: userId } : undefined } as unknown as Request;
+}
+
+function dec(n: number | string): Prisma.Decimal {
+  return new Prisma.Decimal(n);
+}
+
+describe('LineOaPaymentController (characterization)', () => {
+  let controller: LineOaPaymentController;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let lineOa: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let promptPay: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let paymentLink: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let storage: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let flexTemplates: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let lineFinance: any;
+
+  beforeEach(async () => {
+    prisma = {
+      paymentEvidence: {
+        count: jest.fn(),
+        aggregate: jest.fn(),
+        findMany: jest.fn(),
+        findUnique: jest.fn(),
+        update: jest.fn(),
+        create: jest.fn(),
+      },
+      paymentLink: {
+        findUnique: jest.fn(),
+        update: jest.fn(),
+      },
+      contract: { findFirst: jest.fn() },
+      payment: { count: jest.fn() },
+      chatRoom: { findFirst: jest.fn(), update: jest.fn() },
+      chatMessage: { create: jest.fn() },
+      notificationLog: { create: jest.fn() },
+      $transaction: jest.fn(),
+    };
+
+    lineOa = {
+      buildPaymentSuccess: jest.fn().mockReturnValue({ type: 'flex' }),
+      sendFlexMessage: jest.fn().mockResolvedValue(undefined),
+      pushMessage: jest.fn().mockResolvedValue(undefined),
+    };
+
+    promptPay = {
+      generateQrBuffer: jest.fn(),
+      generateQrDataUrl: jest.fn(),
+      getAccountName: jest.fn().mockReturnValue('สมชาย'),
+      getMaskedPromptPayId: jest.fn().mockReturnValue('xxx-xxx-1234'),
+    };
+
+    storage = {
+      configured: false,
+      upload: jest.fn().mockResolvedValue(undefined),
+      getSignedDownloadUrl: jest.fn(),
+    };
+
+    flexTemplates = {
+      overdueNotice: jest.fn().mockReturnValue({ type: 'overdue' }),
+      paymentReminder: jest.fn().mockReturnValue({ type: 'reminder' }),
+    };
+
+    lineFinance = {
+      pushMessage: jest.fn().mockResolvedValue(undefined),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [LineOaPaymentController],
+      providers: [
+        // Real services exercised through the controller — keeps every
+        // observable-behavior assertion running through the moved code.
+        PaymentEvidenceService,
+        PaymentLinkService,
+        { provide: LineOaService, useValue: lineOa },
+        { provide: PrismaService, useValue: prisma },
+        { provide: PromptPayQrService, useValue: promptPay },
+        { provide: StorageService, useValue: storage },
+        { provide: FlexTemplatesService, useValue: flexTemplates },
+        { provide: LineFinanceClientService, useValue: lineFinance },
+        {
+          provide: ConfigService,
+          useValue: { get: jest.fn().mockReturnValue('http://localhost:5173') },
+        },
+      ],
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useValue({ canActivate: () => true })
+      .overrideGuard(RolesGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+
+    controller = module.get<LineOaPaymentController>(LineOaPaymentController);
+
+    // PaymentLinkService.getPaymentLink / .createPaymentLink are still the
+    // unit-under-test's collaborators (used by resolvePaymentLink,
+    // sendPaymentFlex, and PaymentEvidenceService.uploadSlipFromLiff) —
+    // spy on the real instance so the existing stubs apply.
+    const realPaymentLink = module.get<PaymentLinkService>(PaymentLinkService);
+    paymentLink = {
+      getPaymentLink: jest.spyOn(realPaymentLink, 'getPaymentLink'),
+      createPaymentLink: jest.spyOn(realPaymentLink, 'createPaymentLink'),
+    };
+  });
+
+  // ─── getEvidenceStats ────────────────────────────────
+  describe('getEvidenceStats', () => {
+    it('returns the 4 counts + approvedAmountToday from _sum.amount', async () => {
+      prisma.paymentEvidence.count
+        .mockResolvedValueOnce(5) // pending
+        .mockResolvedValueOnce(3) // approvedToday
+        .mockResolvedValueOnce(1); // rejectedToday
+      prisma.paymentEvidence.aggregate.mockResolvedValue({ _sum: { amount: dec(1500) } });
+
+      const result = await controller.getEvidenceStats();
+
+      expect(result).toEqual({
+        pendingCount: 5,
+        approvedToday: 3,
+        rejectedToday: 1,
+        approvedAmountToday: dec(1500),
+      });
+      expect(prisma.paymentEvidence.count).toHaveBeenCalledTimes(3);
+      expect(prisma.paymentEvidence.aggregate).toHaveBeenCalledTimes(1);
+    });
+
+    it('falls back approvedAmountToday to 0 when _sum.amount is null', async () => {
+      prisma.paymentEvidence.count.mockResolvedValue(0);
+      prisma.paymentEvidence.aggregate.mockResolvedValue({ _sum: { amount: null } });
+
+      const result = await controller.getEvidenceStats();
+      expect(result.approvedAmountToday).toBe(0);
+    });
+  });
+
+  // ─── getEvidenceList ─────────────────────────────────
+  describe('getEvidenceList', () => {
+    it('builds default where (empty) + take 50, returns rows verbatim when storage not configured', async () => {
+      const rows = [{ id: 'e1', imageUrl: 'slips/key.jpg' }];
+      prisma.paymentEvidence.findMany.mockResolvedValue(rows);
+
+      const result = await controller.getEvidenceList();
+
+      expect(result).toBe(rows);
+      const arg = prisma.paymentEvidence.findMany.mock.calls[0][0];
+      expect(arg.where).toEqual({});
+      expect(arg.take).toBe(50);
+      expect(arg.orderBy).toEqual({ createdAt: 'desc' });
+      // storage not configured → imageUrl untouched
+      expect(rows[0].imageUrl).toBe('slips/key.jpg');
+    });
+
+    it('builds dynamic where for status/search/date/amount + caps take at 10000', async () => {
+      prisma.paymentEvidence.findMany.mockResolvedValue([]);
+
+      await controller.getEvidenceList(
+        'PENDING_REVIEW',
+        'สมชาย',
+        '2026-01-01',
+        '2026-01-31',
+        '100',
+        '5000',
+        '99999',
+      );
+
+      const arg = prisma.paymentEvidence.findMany.mock.calls[0][0];
+      expect(arg.where.status).toBe('PENDING_REVIEW');
+      expect(arg.where.contract).toEqual({
+        OR: [
+          { contractNumber: { contains: 'สมชาย', mode: 'insensitive' } },
+          { customer: { name: { contains: 'สมชาย', mode: 'insensitive' } } },
+        ],
+      });
+      expect(arg.where.createdAt.gte).toEqual(new Date('2026-01-01'));
+      const expectedEnd = new Date('2026-01-31');
+      expectedEnd.setHours(23, 59, 59, 999);
+      expect(arg.where.createdAt.lte).toEqual(expectedEnd);
+      expect(arg.where.amount).toEqual({ gte: 100, lte: 5000 });
+      expect(arg.take).toBe(10000); // min(99999, 10000)
+    });
+
+    it('signs S3 keys via getSignedDownloadUrl, mutates imageUrl, leaves http/absolute keys alone', async () => {
+      storage.configured = true;
+      storage.getSignedDownloadUrl.mockResolvedValue('https://signed/url');
+      const rows = [
+        { id: 'a', imageUrl: 'slips/key.jpg' },
+        { id: 'b', imageUrl: 'https://already.http/x.jpg' },
+        { id: 'c', imageUrl: '/local/path.jpg' },
+        { id: 'd', imageUrl: null },
+      ];
+      prisma.paymentEvidence.findMany.mockResolvedValue(rows);
+
+      const result = await controller.getEvidenceList();
+
+      expect(storage.getSignedDownloadUrl).toHaveBeenCalledTimes(1);
+      expect(storage.getSignedDownloadUrl).toHaveBeenCalledWith('slips/key.jpg', 3600);
+      expect((result[0] as { imageUrl: string }).imageUrl).toBe('https://signed/url');
+      expect((result[1] as { imageUrl: string }).imageUrl).toBe('https://already.http/x.jpg');
+      expect((result[2] as { imageUrl: string }).imageUrl).toBe('/local/path.jpg');
+    });
+
+    it('keeps original key if signing throws', async () => {
+      storage.configured = true;
+      storage.getSignedDownloadUrl.mockRejectedValue(new Error('boom'));
+      const rows = [{ id: 'a', imageUrl: 'slips/key.jpg' }];
+      prisma.paymentEvidence.findMany.mockResolvedValue(rows);
+
+      const result = await controller.getEvidenceList();
+      expect((result[0] as { imageUrl: string }).imageUrl).toBe('slips/key.jpg');
+    });
+  });
+
+  // ─── batchApproveEvidence ────────────────────────────
+  describe('batchApproveEvidence', () => {
+    it('skips not-found / already-reviewed and reports them in errors', async () => {
+      prisma.paymentEvidence.findUnique
+        .mockResolvedValueOnce(null) // id1 not found
+        .mockResolvedValueOnce({ id: 'id2', status: 'APPROVED' }); // already reviewed
+
+      const result = await controller.batchApproveEvidence(
+        { ids: ['id1', 'id2'], paymentMethod: 'CASH' },
+        mockReq('u1'),
+      );
+
+      expect(result).toEqual({
+        success: true,
+        count: 0,
+        errors: [
+          'id1: ข้ามรายการ (ไม่พบหรือตรวจสอบแล้ว)',
+          'id2: ข้ามรายการ (ไม่พบหรือตรวจสอบแล้ว)',
+        ],
+      });
+      expect(prisma.paymentEvidence.update).not.toHaveBeenCalled();
+    });
+
+    it('approves + sends flex with installmentNo from linked payment', async () => {
+      prisma.paymentEvidence.findUnique.mockResolvedValueOnce({
+        id: 'id1',
+        status: 'PENDING_REVIEW',
+        amount: dec(1515.83),
+        lineUserId: 'U_line',
+        payment: { installmentNo: 5 },
+        contract: {
+          contractNumber: 'C-001',
+          customer: { name: 'สมชาย' },
+          payments: [
+            { status: 'PAID', installmentNo: 1 },
+            { status: 'PENDING', installmentNo: 2 },
+          ],
+        },
+      });
+
+      const result = await controller.batchApproveEvidence(
+        { ids: ['id1'], paymentMethod: 'CASH' },
+        mockReq('u1'),
+      );
+
+      expect(result).toEqual({ success: true, count: 1, errors: [] });
+      expect(prisma.paymentEvidence.update).toHaveBeenCalledWith({
+        where: { id: 'id1' },
+        data: {
+          status: 'APPROVED',
+          amount: dec(1515.83),
+          reviewedById: 'u1',
+          reviewedAt: expect.any(Date),
+        },
+      });
+      const flexArg = lineOa.buildPaymentSuccess.mock.calls[0][0];
+      expect(flexArg.installmentNo).toBe(5); // from linked payment
+      expect(flexArg.totalInstallments).toBe(2);
+      expect(flexArg.remainingInstallments).toBe(0); // total(2) - paid(1) - 1
+      expect(flexArg.amountPaid).toBe(1515.83);
+      expect(lineOa.sendFlexMessage).toHaveBeenCalledWith('U_line', { type: 'flex' }, 'line-finance');
+    });
+
+    it('derives installmentNo from next-unpaid when no linked payment', async () => {
+      prisma.paymentEvidence.findUnique.mockResolvedValueOnce({
+        id: 'id1',
+        status: 'PENDING_REVIEW',
+        amount: null,
+        lineUserId: 'U_line',
+        payment: null,
+        contract: {
+          contractNumber: 'C-001',
+          customer: { name: 'สมชาย' },
+          payments: [
+            { status: 'PAID', installmentNo: 1 },
+            { status: 'PAID', installmentNo: 2 },
+            { status: 'PENDING', installmentNo: 3 },
+          ],
+        },
+      });
+
+      await controller.batchApproveEvidence(
+        { ids: ['id1'], paymentMethod: 'CASH' },
+        mockReq('u1'),
+      );
+
+      const flexArg = lineOa.buildPaymentSuccess.mock.calls[0][0];
+      expect(flexArg.installmentNo).toBe(3); // next unpaid
+      expect(flexArg.amountPaid).toBe(0); // amount null → 0
+    });
+
+    it('falls back installmentNo to min(paidCount+1,total) when no linked + no unpaid', async () => {
+      prisma.paymentEvidence.findUnique.mockResolvedValueOnce({
+        id: 'id1',
+        status: 'PENDING_REVIEW',
+        amount: null,
+        lineUserId: 'U_line',
+        payment: null,
+        contract: {
+          contractNumber: 'C-001',
+          customer: { name: 'สมชาย' },
+          payments: [
+            { status: 'PAID', installmentNo: 1 },
+            { status: 'PAID', installmentNo: 2 },
+          ],
+        },
+      });
+
+      await controller.batchApproveEvidence(
+        { ids: ['id1'], paymentMethod: 'CASH' },
+        mockReq('u1'),
+      );
+
+      const flexArg = lineOa.buildPaymentSuccess.mock.calls[0][0];
+      expect(flexArg.installmentNo).toBe(2); // min(2+1, 2)
+    });
+
+    it('still counts the approval when flex send throws (caught + logged)', async () => {
+      prisma.paymentEvidence.findUnique.mockResolvedValueOnce({
+        id: 'id1',
+        status: 'PENDING_REVIEW',
+        amount: dec(100),
+        lineUserId: 'U_line',
+        payment: { installmentNo: 1 },
+        contract: { contractNumber: 'C-001', customer: { name: 'สมชาย' }, payments: [] },
+      });
+      lineOa.sendFlexMessage.mockRejectedValueOnce(new Error('line down'));
+
+      const result = await controller.batchApproveEvidence(
+        { ids: ['id1'], paymentMethod: 'CASH' },
+        mockReq('u1'),
+      );
+      expect(result.count).toBe(1);
+      expect(result.errors).toEqual([]);
+    });
+
+    it('does not send flex when evidence has no lineUserId', async () => {
+      prisma.paymentEvidence.findUnique.mockResolvedValueOnce({
+        id: 'id1',
+        status: 'PENDING_REVIEW',
+        amount: dec(100),
+        lineUserId: null,
+        payment: { installmentNo: 1 },
+        contract: { contractNumber: 'C-001', customer: { name: 'สมชาย' }, payments: [] },
+      });
+
+      const result = await controller.batchApproveEvidence(
+        { ids: ['id1'], paymentMethod: 'CASH' },
+        mockReq('u1'),
+      );
+      expect(result.count).toBe(1);
+      expect(lineOa.sendFlexMessage).not.toHaveBeenCalled();
+    });
+
+    it('captures thrown errors per-id into errors[]', async () => {
+      prisma.paymentEvidence.findUnique.mockRejectedValueOnce(new Error('db fail'));
+
+      const result = await controller.batchApproveEvidence(
+        { ids: ['id1'], paymentMethod: 'CASH' },
+        mockReq('u1'),
+      );
+      expect(result.count).toBe(0);
+      expect(result.errors[0]).toContain('id1:');
+      expect(result.errors[0]).toContain('db fail');
+    });
+  });
+
+  // ─── batchRejectEvidence ─────────────────────────────
+  describe('batchRejectEvidence', () => {
+    it('skips not-found / already-reviewed', async () => {
+      prisma.paymentEvidence.findUnique
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce({ id: 'id2', status: 'REJECTED' });
+
+      const result = await controller.batchRejectEvidence(
+        { ids: ['id1', 'id2'], reviewNote: 'ไม่ชัด' },
+        mockReq('u1'),
+      );
+
+      expect(result).toEqual({
+        success: true,
+        count: 0,
+        errors: [
+          'id1: ข้ามรายการ (ไม่พบหรือตรวจสอบแล้ว)',
+          'id2: ข้ามรายการ (ไม่พบหรือตรวจสอบแล้ว)',
+        ],
+      });
+    });
+
+    it('rejects + pushes LINE text with reason', async () => {
+      prisma.paymentEvidence.findUnique.mockResolvedValueOnce({
+        id: 'id1',
+        status: 'PENDING_REVIEW',
+        lineUserId: 'U_line',
+        contract: { customer: { name: 'สมชาย' } },
+      });
+
+      const result = await controller.batchRejectEvidence(
+        { ids: ['id1'], reviewNote: 'สลิปไม่ชัด' },
+        mockReq('u1'),
+      );
+
+      expect(result).toEqual({ success: true, count: 1, errors: [] });
+      expect(prisma.paymentEvidence.update).toHaveBeenCalledWith({
+        where: { id: 'id1' },
+        data: {
+          status: 'REJECTED',
+          reviewedById: 'u1',
+          reviewedAt: expect.any(Date),
+          reviewNote: 'สลิปไม่ชัด',
+        },
+      });
+      const pushArgs = lineOa.pushMessage.mock.calls[0];
+      expect(pushArgs[0]).toBe('U_line');
+      expect(pushArgs[1][0].text).toContain('เหตุผล: สลิปไม่ชัด');
+      expect(pushArgs[2]).toBe('line-finance');
+    });
+
+    it('omits reason line when reviewNote absent', async () => {
+      prisma.paymentEvidence.findUnique.mockResolvedValueOnce({
+        id: 'id1',
+        status: 'PENDING_REVIEW',
+        lineUserId: 'U_line',
+        contract: { customer: { name: 'สมชาย' } },
+      });
+
+      await controller.batchRejectEvidence({ ids: ['id1'] }, mockReq('u1'));
+      const text = lineOa.pushMessage.mock.calls[0][1][0].text;
+      expect(text).not.toContain('เหตุผล:');
+    });
+  });
+
+  // ─── approveEvidence ─────────────────────────────────
+  describe('approveEvidence', () => {
+    function evidence(overrides: Record<string, unknown> = {}) {
+      return {
+        id: 'e1',
+        status: 'PENDING_REVIEW',
+        lineUserId: 'U_line',
+        contract: {
+          contractNumber: 'C-001',
+          customer: { name: 'สมชาย' },
+          payments: [
+            {
+              installmentNo: 1,
+              amountDue: dec(1500),
+              lateFee: dec(0),
+              amountPaid: dec(0),
+              status: 'PENDING',
+            },
+          ],
+        },
+        ...overrides,
+      };
+    }
+
+    it('returns non-throwing { error } when not found', async () => {
+      prisma.paymentEvidence.findUnique.mockResolvedValue(null);
+
+      const result = await controller.approveEvidence(
+        'e1',
+        { installmentNo: 1, amount: 1500, paymentMethod: 'CASH' },
+        mockReq('u1'),
+      );
+      expect(result).toEqual({ error: 'ไม่พบหลักฐาน' });
+      expect(prisma.paymentEvidence.update).not.toHaveBeenCalled();
+    });
+
+    it('returns non-throwing { error } when already reviewed', async () => {
+      prisma.paymentEvidence.findUnique.mockResolvedValue(evidence({ status: 'APPROVED' }));
+
+      const result = await controller.approveEvidence(
+        'e1',
+        { installmentNo: 1, amount: 1500, paymentMethod: 'CASH' },
+        mockReq('u1'),
+      );
+      expect(result).toEqual({ error: 'หลักฐานนี้ได้รับการตรวจสอบแล้ว' });
+    });
+
+    it('throws BadRequestException when amount mismatch > 100 and no acceptMismatch', async () => {
+      prisma.paymentEvidence.findUnique.mockResolvedValue(evidence());
+
+      await expect(
+        controller.approveEvidence(
+          'e1',
+          { installmentNo: 1, amount: 1700, paymentMethod: 'CASH' }, // diff 200 > 100
+          mockReq('u1'),
+        ),
+      ).rejects.toThrow(BadRequestException);
+      expect(prisma.paymentEvidence.update).not.toHaveBeenCalled();
+    });
+
+    it('approves when mismatch > 100 but acceptMismatch=true (override)', async () => {
+      prisma.paymentEvidence.findUnique.mockResolvedValue(evidence());
+
+      const result = await controller.approveEvidence(
+        'e1',
+        { installmentNo: 1, amount: 1700, paymentMethod: 'CASH', acceptMismatch: true },
+        mockReq('u1'),
+      );
+      expect(result).toEqual({ success: true, message: 'อนุมัติสลิปเรียบร้อย' });
+      expect(prisma.paymentEvidence.update).toHaveBeenCalled();
+    });
+
+    it('approves when within ±100 tolerance (no override needed)', async () => {
+      prisma.paymentEvidence.findUnique.mockResolvedValue(evidence());
+
+      const result = await controller.approveEvidence(
+        'e1',
+        { installmentNo: 1, amount: 1550, paymentMethod: 'CASH' }, // diff 50 <= 100
+        mockReq('u1'),
+      );
+      expect(result).toEqual({ success: true, message: 'อนุมัติสลิปเรียบร้อย' });
+      expect(prisma.paymentEvidence.update).toHaveBeenCalledWith({
+        where: { id: 'e1' },
+        data: {
+          status: 'APPROVED',
+          amount: 1550,
+          reviewedById: 'u1',
+          reviewedAt: expect.any(Date),
+          reviewNote: undefined,
+        },
+      });
+      expect(lineOa.sendFlexMessage).toHaveBeenCalledWith('U_line', { type: 'flex' }, 'line-finance');
+    });
+
+    it('skips tolerance check when no matching installment payment', async () => {
+      prisma.paymentEvidence.findUnique.mockResolvedValue(
+        evidence({
+          contract: {
+            contractNumber: 'C-001',
+            customer: { name: 'สมชาย' },
+            payments: [], // no installment 1
+          },
+        }),
+      );
+
+      const result = await controller.approveEvidence(
+        'e1',
+        { installmentNo: 1, amount: 99999, paymentMethod: 'CASH' },
+        mockReq('u1'),
+      );
+      expect(result).toEqual({ success: true, message: 'อนุมัติสลิปเรียบร้อย' });
+    });
+
+    it('does not notify when no lineUserId', async () => {
+      prisma.paymentEvidence.findUnique.mockResolvedValue(evidence({ lineUserId: null }));
+
+      await controller.approveEvidence(
+        'e1',
+        { installmentNo: 1, amount: 1500, paymentMethod: 'CASH' },
+        mockReq('u1'),
+      );
+      expect(lineOa.sendFlexMessage).not.toHaveBeenCalled();
+    });
+  });
+
+  // ─── rejectEvidence ──────────────────────────────────
+  describe('rejectEvidence', () => {
+    it('returns non-throwing { error } when not found', async () => {
+      prisma.paymentEvidence.findUnique.mockResolvedValue(null);
+      const result = await controller.rejectEvidence('e1', {}, mockReq('u1'));
+      expect(result).toEqual({ error: 'ไม่พบหลักฐาน' });
+      expect(prisma.paymentEvidence.update).not.toHaveBeenCalled();
+    });
+
+    it('rejects + pushes LINE text + returns success', async () => {
+      prisma.paymentEvidence.findUnique.mockResolvedValue({
+        id: 'e1',
+        lineUserId: 'U_line',
+        contract: { customer: { name: 'สมชาย' } },
+      });
+
+      const result = await controller.rejectEvidence('e1', { reviewNote: 'เบลอ' }, mockReq('u1'));
+
+      expect(result).toEqual({ success: true, message: 'ปฏิเสธสลิปเรียบร้อย' });
+      expect(prisma.paymentEvidence.update).toHaveBeenCalledWith({
+        where: { id: 'e1' },
+        data: {
+          status: 'REJECTED',
+          reviewedById: 'u1',
+          reviewedAt: expect.any(Date),
+          reviewNote: 'เบลอ',
+        },
+      });
+      expect(lineOa.pushMessage.mock.calls[0][1][0].text).toContain('เหตุผล: เบลอ');
+    });
+  });
+
+  // ─── getSuggestedMatches ─────────────────────────────
+  describe('getSuggestedMatches', () => {
+    it('throws NotFoundException when evidence missing', async () => {
+      prisma.paymentEvidence.findUnique.mockResolvedValue(null);
+      await expect(controller.getSuggestedMatches('e1')).rejects.toThrow(NotFoundException);
+    });
+
+    it('scores by amount-diff buckets, boosts overdue, sorts desc, returns top-5', async () => {
+      const today = new Date();
+      const mkPayment = (
+        id: string,
+        installmentNo: number,
+        amountDue: number,
+        daysFromToday: number,
+      ) => ({
+        id,
+        installmentNo,
+        amountDue: dec(amountDue),
+        lateFee: dec(0),
+        amountPaid: dec(0),
+        status: 'PENDING',
+        dueDate: new Date(today.getTime() - daysFromToday * 86400000),
+      });
+
+      prisma.paymentEvidence.findUnique.mockResolvedValue({
+        amount: dec(1000),
+        contract: {
+          payments: [
+            mkPayment('p1', 1, 1000, 5), // exact match (diff 0 → 1.0) overdue 5d → +0.1 capped 1.0
+            mkPayment('p2', 2, 1050, -10), // diff 50 → 0.85, future (not overdue)
+            mkPayment('p3', 3, 1200, 0), // diff 200 → 0.65
+            mkPayment('p4', 4, 1500, 0), // diff 500 → 0.4
+            mkPayment('p5', 5, 3000, 0), // diff 2000 → 0.1
+            mkPayment('p6', 6, 1001, 0), // diff 1 → 1.0 (extra, should be dropped by top-5)
+          ],
+        },
+      });
+
+      const result = await controller.getSuggestedMatches('e1');
+
+      expect(result.evidenceId).toBe('e1');
+      expect(result.slipAmount).toBe(1000);
+      expect(result.suggestions).toHaveLength(5); // top-5
+      // highest scores first
+      expect(result.suggestions[0].score).toBe(1.0);
+      // p1 exact + overdue boost capped at 1.0, p6 diff1 = 1.0 too — both 1.0, sorted by installmentNo asc
+      expect(result.suggestions[0].installmentNo).toBe(1);
+      const scores = result.suggestions.map((s) => s.score);
+      // sorted descending
+      for (let i = 1; i < scores.length; i++) {
+        expect(scores[i]).toBeLessThanOrEqual(scores[i - 1]);
+      }
+      // p1 overdue flags
+      const p1 = result.suggestions.find((s) => s.paymentId === 'p1');
+      expect(p1?.isOverdue).toBe(true);
+      expect(p1?.daysOverdue).toBe(5);
+      // p2 future → not overdue
+      const p2 = result.suggestions.find((s) => s.paymentId === 'p2');
+      expect(p2?.isOverdue).toBe(false);
+      expect(p2?.daysOverdue).toBe(0);
+    });
+
+    it('uses 0.3 base score when slip amount is null', async () => {
+      const today = new Date();
+      prisma.paymentEvidence.findUnique.mockResolvedValue({
+        amount: null,
+        contract: {
+          payments: [
+            {
+              id: 'p1',
+              installmentNo: 1,
+              amountDue: dec(1000),
+              lateFee: dec(0),
+              amountPaid: dec(0),
+              status: 'PENDING',
+              dueDate: new Date(today.getTime() + 86400000), // future, no boost
+            },
+          ],
+        },
+      });
+
+      const result = await controller.getSuggestedMatches('e1');
+      expect(result.slipAmount).toBeNull();
+      expect(result.suggestions[0].score).toBe(0.3);
+    });
+  });
+
+  // ─── generateQrCode ──────────────────────────────────
+  describe('generateQrCode', () => {
+    function mockRes(): Response {
+      return {
+        set: jest.fn(),
+        send: jest.fn(),
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn(),
+      } as unknown as Response;
+    }
+
+    it('streams PNG buffer with correct headers', async () => {
+      const buf = Buffer.from('png');
+      promptPay.generateQrBuffer.mockResolvedValue(buf);
+      const res = mockRes();
+
+      await controller.generateQrCode('pay1', '1500', res);
+
+      expect(promptPay.generateQrBuffer).toHaveBeenCalledWith(1500);
+      expect(res.set).toHaveBeenCalledWith({
+        'Content-Type': 'image/png',
+        'Content-Disposition': 'inline; filename="promptpay-qr-pay1.png"',
+        'Cache-Control': 'no-cache',
+      });
+      expect(res.send).toHaveBeenCalledWith(buf);
+    });
+
+    it('passes undefined amount when amountStr empty', async () => {
+      promptPay.generateQrBuffer.mockResolvedValue(Buffer.from('x'));
+      const res = mockRes();
+      await controller.generateQrCode('pay1', '', res);
+      expect(promptPay.generateQrBuffer).toHaveBeenCalledWith(undefined);
+    });
+
+    it('returns 500 json error on generation failure', async () => {
+      promptPay.generateQrBuffer.mockRejectedValue(new Error('qr fail'));
+      const res = mockRes();
+      await controller.generateQrCode('pay1', '1500', res);
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.json).toHaveBeenCalledWith({ error: 'ไม่สามารถสร้าง QR Code ได้' });
+    });
+  });
+
+  // ─── resolvePaymentLink ──────────────────────────────
+  describe('resolvePaymentLink', () => {
+    it('returns { valid:false } when link not found', async () => {
+      paymentLink.getPaymentLink.mockResolvedValue(null);
+      const result = await controller.resolvePaymentLink('tok');
+      expect(result).toEqual({ error: 'ลิงก์ชำระเงินไม่ถูกต้อง', valid: false });
+    });
+
+    it('returns { valid:false, status } when not ACTIVE', async () => {
+      paymentLink.getPaymentLink.mockResolvedValue({ status: 'USED' });
+      const result = await controller.resolvePaymentLink('tok');
+      expect(result).toEqual({
+        error: 'ลิงก์ชำระเงินหมดอายุหรือถูกใช้แล้ว',
+        valid: false,
+        status: 'USED',
+      });
+    });
+
+    it('returns { valid:false } when no contract (online-order link)', async () => {
+      paymentLink.getPaymentLink.mockResolvedValue({ status: 'ACTIVE', contract: null });
+      const result = await controller.resolvePaymentLink('tok');
+      expect(result).toEqual({ error: 'ลิงก์ชำระเงินไม่ถูกต้อง', valid: false });
+    });
+
+    it('returns full masked response for a valid contract link', async () => {
+      promptPay.generateQrDataUrl.mockResolvedValue('data:image/png;base64,xx');
+      const expiresAt = new Date('2026-02-01');
+      const dueDate = new Date('2026-01-15');
+      paymentLink.getPaymentLink.mockResolvedValue({
+        status: 'ACTIVE',
+        amount: dec(1500),
+        expiresAt,
+        contract: {
+          id: 'ct1',
+          contractNumber: 'C-001',
+          customer: { name: 'สมชาย ใจดี' },
+        },
+        payment: {
+          installmentNo: 3,
+          amountDue: dec(1400),
+          lateFee: dec(100),
+          dueDate,
+        },
+      });
+
+      const result = await controller.resolvePaymentLink('tok');
+
+      expect(result).toEqual({
+        valid: true,
+        token: 'tok',
+        amount: 1500,
+        status: 'ACTIVE',
+        expiresAt,
+        contract: {
+          id: 'ct1',
+          contractNumber: 'C-001',
+          customer: { name: expect.any(String) }, // masked
+        },
+        payment: {
+          installmentNo: 3,
+          amountDue: 1400,
+          lateFee: 100,
+          dueDate,
+        },
+        promptPay: {
+          qrDataUrl: 'data:image/png;base64,xx',
+          accountName: 'สมชาย',
+          maskedId: 'xxx-xxx-1234',
+        },
+      });
+      // name was masked (not the raw name)
+      expect((result as { contract: { customer: { name: string } } }).contract.customer.name).not.toBe(
+        'สมชาย ใจดี',
+      );
+    });
+
+    it('returns qrDataUrl null when QR generation fails', async () => {
+      promptPay.generateQrDataUrl.mockRejectedValue(new Error('boom'));
+      paymentLink.getPaymentLink.mockResolvedValue({
+        status: 'ACTIVE',
+        amount: dec(1500),
+        expiresAt: new Date(),
+        contract: { id: 'ct1', contractNumber: 'C-001', customer: { name: 'สมชาย' } },
+        payment: { installmentNo: 1, amountDue: dec(1500), lateFee: dec(0), dueDate: new Date() },
+      });
+
+      const result = await controller.resolvePaymentLink('tok');
+      expect(
+        (result as { promptPay: { qrDataUrl: string | null } }).promptPay.qrDataUrl,
+      ).toBeNull();
+    });
+  });
+
+  // ─── uploadSlipFromLiff ──────────────────────────────
+  describe('uploadSlipFromLiff', () => {
+    const file = {
+      mimetype: 'image/jpeg',
+      buffer: Buffer.from('img'),
+    } as Express.Multer.File;
+
+    function activeLink(overrides: Record<string, unknown> = {}) {
+      return {
+        id: 'link1',
+        status: 'ACTIVE',
+        amount: dec(1500),
+        payment: { id: 'pay1', installmentNo: 2 },
+        contract: {
+          id: 'ct1',
+          contractNumber: 'C-001',
+          totalMonths: 12,
+          customer: { name: 'สมชาย', lineIdFinance: 'U_line' },
+        },
+        ...overrides,
+      };
+    }
+
+    it('throws BadRequest when link missing/expired', async () => {
+      paymentLink.getPaymentLink.mockResolvedValue(null);
+      await expect(
+        controller.uploadSlipFromLiff(file, { token: 'tok' }),
+      ).rejects.toThrow(BadRequestException);
+      expect(storage.upload).not.toHaveBeenCalled();
+    });
+
+    it('throws BadRequest when link has no contract', async () => {
+      paymentLink.getPaymentLink.mockResolvedValue({ id: 'l', status: 'ACTIVE', contract: null });
+      await expect(
+        controller.uploadSlipFromLiff(file, { token: 'tok' }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('uploads to storage BEFORE tx, runs $transaction (TOCTOU recheck + create + notify + mark-used), confirms via LINE after', async () => {
+      paymentLink.getPaymentLink.mockResolvedValue(activeLink());
+      prisma.payment.count.mockResolvedValue(1);
+
+      // Capture the tx callback to introspect its operations
+      const tx = {
+        paymentLink: { findUnique: jest.fn().mockResolvedValue({ status: 'ACTIVE' }), update: jest.fn() },
+        paymentEvidence: { create: jest.fn().mockResolvedValue({ id: 'ev1' }) },
+        notificationLog: { create: jest.fn() },
+      };
+      prisma.$transaction.mockImplementation(async (cb: (t: typeof tx) => unknown) => cb(tx));
+
+      const result = await controller.uploadSlipFromLiff(file, { token: 'tok', amount: '1500' });
+
+      // storage upload before tx
+      expect(storage.upload).toHaveBeenCalledTimes(1);
+      const uploadKey = storage.upload.mock.calls[0][0] as string;
+      expect(uploadKey).toMatch(/^slips\/slip-liff-\d+-[a-z0-9]+\.jpg$/);
+      expect(storage.upload).toHaveBeenCalledWith(uploadKey, file.buffer, 'image/jpeg');
+
+      // tx ran
+      expect(prisma.$transaction).toHaveBeenCalledTimes(1);
+      // TOCTOU recheck
+      expect(tx.paymentLink.findUnique).toHaveBeenCalledWith({
+        where: { id: 'link1' },
+        select: { status: true },
+      });
+      // evidence create
+      expect(tx.paymentEvidence.create).toHaveBeenCalledWith({
+        data: {
+          contractId: 'ct1',
+          paymentId: 'pay1',
+          lineUserId: 'U_line',
+          imageUrl: uploadKey,
+          amount: dec(1500),
+          status: 'PENDING_REVIEW',
+        },
+      });
+      // notification
+      expect(tx.notificationLog.create).toHaveBeenCalledTimes(1);
+      expect(tx.notificationLog.create.mock.calls[0][0].data.relatedId).toBe('ev1');
+      // mark link used
+      expect(tx.paymentLink.update).toHaveBeenCalledWith({
+        where: { id: 'link1' },
+        data: { status: 'USED', usedAt: expect.any(Date) },
+      });
+      // LINE confirm after tx
+      expect(lineOa.sendFlexMessage).toHaveBeenCalledWith('U_line', { type: 'flex' }, 'line-finance');
+      const flexArg = lineOa.buildPaymentSuccess.mock.calls[0][0];
+      expect(flexArg.installmentNo).toBe(2);
+      expect(flexArg.totalInstallments).toBe(12);
+      expect(flexArg.amountPaid).toBe(1500);
+      expect(flexArg.remainingInstallments).toBe(11); // total(12) - paidCount(1)
+
+      expect(result).toEqual({ success: true, message: 'อัพโหลดสลิปเรียบร้อย กำลังตรวจสอบ' });
+    });
+
+    it('throws BadRequest inside tx when TOCTOU recheck fails (link used concurrently)', async () => {
+      paymentLink.getPaymentLink.mockResolvedValue(activeLink());
+      const tx = {
+        paymentLink: { findUnique: jest.fn().mockResolvedValue({ status: 'USED' }), update: jest.fn() },
+        paymentEvidence: { create: jest.fn() },
+        notificationLog: { create: jest.fn() },
+      };
+      prisma.$transaction.mockImplementation(async (cb: (t: typeof tx) => unknown) => cb(tx));
+
+      await expect(
+        controller.uploadSlipFromLiff(file, { token: 'tok' }),
+      ).rejects.toThrow(BadRequestException);
+      expect(tx.paymentEvidence.create).not.toHaveBeenCalled();
+    });
+
+    it('amount null when body.amount absent; lineUserId null when customer has none', async () => {
+      paymentLink.getPaymentLink.mockResolvedValue(
+        activeLink({
+          contract: {
+            id: 'ct1',
+            contractNumber: 'C-001',
+            totalMonths: 12,
+            customer: { name: 'สมชาย', lineIdFinance: null },
+          },
+        }),
+      );
+      const tx = {
+        paymentLink: { findUnique: jest.fn().mockResolvedValue({ status: 'ACTIVE' }), update: jest.fn() },
+        paymentEvidence: { create: jest.fn().mockResolvedValue({ id: 'ev1' }) },
+        notificationLog: { create: jest.fn() },
+      };
+      prisma.$transaction.mockImplementation(async (cb: (t: typeof tx) => unknown) => cb(tx));
+
+      await controller.uploadSlipFromLiff(file, { token: 'tok' });
+
+      const createArg = tx.paymentEvidence.create.mock.calls[0][0];
+      expect(createArg.data.amount).toBeNull();
+      expect(createArg.data.lineUserId).toBeNull();
+      // no LINE confirm without customer line id
+      expect(lineOa.sendFlexMessage).not.toHaveBeenCalled();
+    });
+
+    it('uses .png ext for image/png', async () => {
+      paymentLink.getPaymentLink.mockResolvedValue(activeLink());
+      const tx = {
+        paymentLink: { findUnique: jest.fn().mockResolvedValue({ status: 'ACTIVE' }), update: jest.fn() },
+        paymentEvidence: { create: jest.fn().mockResolvedValue({ id: 'ev1' }) },
+        notificationLog: { create: jest.fn() },
+      };
+      prisma.$transaction.mockImplementation(async (cb: (t: typeof tx) => unknown) => cb(tx));
+      prisma.payment.count.mockResolvedValue(0);
+
+      await controller.uploadSlipFromLiff(
+        { mimetype: 'image/png', buffer: Buffer.from('x') } as Express.Multer.File,
+        { token: 'tok' },
+      );
+      const uploadKey = storage.upload.mock.calls[0][0] as string;
+      expect(uploadKey).toMatch(/\.png$/);
+    });
+  });
+
+  // ─── createPaymentLink ───────────────────────────────
+  describe('createPaymentLink', () => {
+    it('delegates to service and spreads result with success:true', async () => {
+      paymentLink.createPaymentLink.mockResolvedValue({
+        token: 't',
+        url: 'http://x/pay/t',
+        expiresAt: new Date('2026-02-01'),
+        amount: 1500,
+      });
+
+      const result = await controller.createPaymentLink({ contractId: 'ct1', installmentNo: 3 });
+
+      expect(paymentLink.createPaymentLink).toHaveBeenCalledWith('ct1', 3);
+      expect(result).toEqual({
+        success: true,
+        token: 't',
+        url: 'http://x/pay/t',
+        expiresAt: new Date('2026-02-01'),
+        amount: 1500,
+      });
+    });
+  });
+
+  // ─── sendPaymentFlex ─────────────────────────────────
+  describe('sendPaymentFlex', () => {
+    const reqUser = { user: { id: 'staff1' } };
+
+    it('throws BadRequest when contractId missing', async () => {
+      await expect(controller.sendPaymentFlex({ contractId: '' }, reqUser)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('throws NotFound when contract not found', async () => {
+      prisma.contract.findFirst.mockResolvedValue(null);
+      await expect(controller.sendPaymentFlex({ contractId: 'ct1' }, reqUser)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('throws BadRequest when customer has no finance LINE link', async () => {
+      prisma.contract.findFirst.mockResolvedValue({
+        contractNumber: 'C-001',
+        customer: { id: 'cu1', name: 'สมชาย', lineLinks: [] },
+        payments: [{ installmentNo: 1, dueDate: new Date(), lateFee: dec(0) }],
+      });
+      await expect(controller.sendPaymentFlex({ contractId: 'ct1' }, reqUser)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('throws BadRequest when no unpaid installments', async () => {
+      prisma.contract.findFirst.mockResolvedValue({
+        contractNumber: 'C-001',
+        customer: { id: 'cu1', name: 'สมชาย', lineLinks: [{ lineUserId: 'U_line' }] },
+        payments: [],
+      });
+      await expect(controller.sendPaymentFlex({ contractId: 'ct1' }, reqUser)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('sends reminder flex + writes chatMessage with payment-reminder metaText when not overdue', async () => {
+      const future = new Date(Date.now() + 10 * 86400000);
+      prisma.contract.findFirst.mockResolvedValue({
+        id: 'ct1',
+        contractNumber: 'C-001',
+        customer: { id: 'cu1', name: 'สมชาย', lineLinks: [{ lineUserId: 'U_line' }] },
+        payments: [{ installmentNo: 4, dueDate: future, lateFee: dec(0) }],
+      });
+      paymentLink.createPaymentLink.mockResolvedValue({
+        token: 't',
+        url: 'http://x/pay/t',
+        expiresAt: new Date(),
+        amount: 1500,
+      });
+      prisma.payment.count.mockResolvedValue(12); // totalInstallments
+      prisma.chatRoom.findFirst.mockResolvedValue({ id: 'room1' });
+
+      const result = await controller.sendPaymentFlex({ contractId: 'ct1' }, reqUser);
+
+      expect(flexTemplates.paymentReminder).toHaveBeenCalled();
+      expect(flexTemplates.overdueNotice).not.toHaveBeenCalled();
+      expect(lineFinance.pushMessage).toHaveBeenCalledWith('U_line', [{ type: 'reminder' }]);
+      const msgText = prisma.chatMessage.create.mock.calls[0][0].data.text as string;
+      expect(msgText).toContain('[flex:payment-reminder|C-001|4/12|1500|');
+      expect(msgText).toContain('http://x/pay/t');
+      expect(prisma.chatRoom.update).toHaveBeenCalledWith({
+        where: { id: 'room1' },
+        data: { lastMessageAt: expect.any(Date), totalMessages: { increment: 1 } },
+      });
+      expect(result).toEqual({ success: true, type: 'reminder', url: 'http://x/pay/t' });
+    });
+
+    it('sends overdue flex + writes overdue-notice metaText when overdue', async () => {
+      const past = new Date(Date.now() - 10 * 86400000);
+      prisma.contract.findFirst.mockResolvedValue({
+        id: 'ct1',
+        contractNumber: 'C-001',
+        customer: { id: 'cu1', name: 'สมชาย', lineLinks: [{ lineUserId: 'U_line' }] },
+        payments: [{ installmentNo: 2, dueDate: past, lateFee: dec(50) }],
+      });
+      paymentLink.createPaymentLink.mockResolvedValue({
+        token: 't',
+        url: 'http://x/pay/t',
+        expiresAt: new Date(),
+        amount: 2000,
+      });
+      prisma.payment.count.mockResolvedValue(12);
+      prisma.chatRoom.findFirst.mockResolvedValue({ id: 'room1' });
+
+      const result = await controller.sendPaymentFlex({ contractId: 'ct1' }, reqUser);
+
+      expect(flexTemplates.overdueNotice).toHaveBeenCalled();
+      expect(lineFinance.pushMessage).toHaveBeenCalledWith('U_line', [{ type: 'overdue' }]);
+      const msgText = prisma.chatMessage.create.mock.calls[0][0].data.text as string;
+      expect(msgText).toContain('[flex:overdue-notice|C-001|1|2000|50|');
+      expect(result).toEqual({ success: true, type: 'overdue', url: 'http://x/pay/t' });
+    });
+
+    it('throws BadRequest when LINE push fails', async () => {
+      const future = new Date(Date.now() + 10 * 86400000);
+      prisma.contract.findFirst.mockResolvedValue({
+        id: 'ct1',
+        contractNumber: 'C-001',
+        customer: { id: 'cu1', name: 'สมชาย', lineLinks: [{ lineUserId: 'U_line' }] },
+        payments: [{ installmentNo: 1, dueDate: future, lateFee: dec(0) }],
+      });
+      paymentLink.createPaymentLink.mockResolvedValue({
+        token: 't',
+        url: 'http://x/pay/t',
+        expiresAt: new Date(),
+        amount: 1500,
+      });
+      prisma.payment.count.mockResolvedValue(12);
+      lineFinance.pushMessage.mockRejectedValue(new Error('push fail'));
+
+      await expect(controller.sendPaymentFlex({ contractId: 'ct1' }, reqUser)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('skips chatMessage when no chat room exists', async () => {
+      const future = new Date(Date.now() + 10 * 86400000);
+      prisma.contract.findFirst.mockResolvedValue({
+        id: 'ct1',
+        contractNumber: 'C-001',
+        customer: { id: 'cu1', name: 'สมชาย', lineLinks: [{ lineUserId: 'U_line' }] },
+        payments: [{ installmentNo: 1, dueDate: future, lateFee: dec(0) }],
+      });
+      paymentLink.createPaymentLink.mockResolvedValue({
+        token: 't',
+        url: 'http://x/pay/t',
+        expiresAt: new Date(),
+        amount: 1500,
+      });
+      prisma.payment.count.mockResolvedValue(12);
+      prisma.chatRoom.findFirst.mockResolvedValue(null);
+
+      const result = await controller.sendPaymentFlex({ contractId: 'ct1' }, reqUser);
+      expect(prisma.chatMessage.create).not.toHaveBeenCalled();
+      expect(result.success).toBe(true);
+    });
+  });
+});

--- a/apps/api/src/modules/line-oa/line-oa-payment.controller.ts
+++ b/apps/api/src/modules/line-oa/line-oa-payment.controller.ts
@@ -1,7 +1,4 @@
 import {
-  formatDateShort,
-} from '../../utils/thai-date.util';
-import {
   Controller,
   Post,
   Get,
@@ -14,28 +11,19 @@ import {
   Logger,
   UseInterceptors,
   UploadedFile,
-  BadRequestException,
-  NotFoundException,
 } from '@nestjs/common';
 import { ApiTags, ApiBearerAuth } from '@nestjs/swagger';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { ParseFilePipe, MaxFileSizeValidator, FileTypeValidator } from '@nestjs/common';
 import { Throttle } from '@nestjs/throttler';
 import { Request, Response } from 'express';
-import { LineOaService } from './line-oa.service';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { RolesGuard } from '../auth/guards/roles.guard';
 import { Roles } from '../auth/decorators/roles.decorator';
-import { Prisma, MessageRole, MessageType, ChatChannel, LineChannelType } from '@prisma/client';
-import { PrismaService } from '../../prisma/prisma.service';
-import { toNum as d, calcOutstanding as sumOutstanding } from '../../utils/decimal.util';
-import { maskThaiName } from '../../utils/mask-name.util';
 import { PromptPayQrService } from './promptpay/promptpay-qr.service';
 import { PaymentLinkService } from './payment-links/payment-link.service';
+import { PaymentEvidenceService } from './services/payment-evidence.service';
 import { SkipCsrf } from '../../guards/skip-csrf.decorator';
-import { StorageService } from '../storage/storage.service';
-import { FlexTemplatesService } from './flex-templates.service';
-import { LineFinanceClientService } from '../chatbot-finance/services/line-finance-client.service';
 import {
   SlipUploadBodyDto,
   ApproveEvidenceDto,
@@ -46,23 +34,13 @@ import {
 @ApiTags('LINE OA - Payments')
 @ApiBearerAuth('JWT')
 @Controller('line-oa')
-// TODO(refactor): this controller calls PrismaService directly in 7 evidence
-// endpoints — violates backend.md "controller → service → PrismaService"
-// rule. Extract to PaymentEvidenceService in a follow-up PR; deferred from
-// the post-ultrareview cleanup branch because the change would touch ~250
-// lines, has no spec coverage, and the slip-upload transaction needs to
-// remain controller-orchestrated (storage + DB + notifications).
 export class LineOaPaymentController {
   private readonly logger = new Logger(LineOaPaymentController.name);
 
   constructor(
-    private lineOaService: LineOaService,
-    private prisma: PrismaService,
     private promptPayQrService: PromptPayQrService,
     private paymentLinkService: PaymentLinkService,
-    private storageService: StorageService,
-    private flexTemplates: FlexTemplatesService,
-    private lineFinanceClient: LineFinanceClientService,
+    private paymentEvidenceService: PaymentEvidenceService,
   ) {}
 
   // ─── Slip Review API (Staff) ──────────────────────────
@@ -71,22 +49,7 @@ export class LineOaPaymentController {
   @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles('OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'ACCOUNTANT')
   async getEvidenceStats() {
-    const todayStart = new Date();
-    todayStart.setHours(0, 0, 0, 0);
-
-    const [pendingCount, approvedToday, rejectedToday, approvedAmountToday] = await Promise.all([
-      this.prisma.paymentEvidence.count({ where: { status: 'PENDING_REVIEW' } }),
-      this.prisma.paymentEvidence.count({ where: { status: 'APPROVED', reviewedAt: { gte: todayStart } } }),
-      this.prisma.paymentEvidence.count({ where: { status: 'REJECTED', reviewedAt: { gte: todayStart } } }),
-      this.prisma.paymentEvidence.aggregate({ where: { status: 'APPROVED', reviewedAt: { gte: todayStart } }, _sum: { amount: true } }),
-    ]);
-
-    return {
-      pendingCount,
-      approvedToday,
-      rejectedToday,
-      approvedAmountToday: approvedAmountToday._sum.amount || 0,
-    };
+    return this.paymentEvidenceService.getEvidenceStats();
   }
 
   @Get('evidence')
@@ -101,68 +64,15 @@ export class LineOaPaymentController {
     @Query('amountMax') amountMax?: string,
     @Query('limit') limit?: string,
   ) {
-    const where: Record<string, unknown> = {};
-    if (status) where.status = status;
-
-    if (search) {
-      where.contract = {
-        OR: [
-          { contractNumber: { contains: search, mode: 'insensitive' } },
-          { customer: { name: { contains: search, mode: 'insensitive' } } },
-        ],
-      };
-    }
-
-    if (dateFrom || dateTo) {
-      const dateFilter: Record<string, Date> = {};
-      if (dateFrom) dateFilter.gte = new Date(dateFrom);
-      if (dateTo) {
-        const end = new Date(dateTo);
-        end.setHours(23, 59, 59, 999);
-        dateFilter.lte = end;
-      }
-      where.createdAt = dateFilter;
-    }
-
-    if (amountMin || amountMax) {
-      const amountFilter: Record<string, number> = {};
-      if (amountMin) amountFilter.gte = Number(amountMin);
-      if (amountMax) amountFilter.lte = Number(amountMax);
-      where.amount = amountFilter;
-    }
-
-    const take = limit ? Math.min(Number(limit), 10000) : 50;
-
-    const evidences = await this.prisma.paymentEvidence.findMany({
-      where,
-      orderBy: { createdAt: 'desc' },
-      take,
-      include: {
-        contract: {
-          select: {
-            contractNumber: true,
-            customer: { select: { name: true, phone: true } },
-          },
-        },
-        reviewedBy: { select: { name: true } },
-      },
-    });
-
-    // Resolve S3 keys to signed download URLs for slip images
-    if (this.storageService.configured) {
-      await Promise.all(
-        evidences.map(async (ev) => {
-          if (ev.imageUrl && !ev.imageUrl.startsWith('http') && !ev.imageUrl.startsWith('/')) {
-            try {
-              (ev as { imageUrl: string }).imageUrl =
-                await this.storageService.getSignedDownloadUrl(ev.imageUrl, 3600);
-            } catch { /* keep original key if signing fails */ }
-          }
-        }),
-      );
-    }
-
-    return evidences;
+    return this.paymentEvidenceService.getEvidenceList(
+      status,
+      search,
+      dateFrom,
+      dateTo,
+      amountMin,
+      amountMax,
+      limit,
+    );
   }
 
   @Post('evidence/batch-approve')
@@ -173,77 +83,7 @@ export class LineOaPaymentController {
     @Req() req: Request,
   ) {
     const userId = (req as Request & { user?: { id: string } }).user?.id;
-    const errors: string[] = [];
-    let count = 0;
-
-    for (const id of body.ids) {
-      try {
-        const evidence = await this.prisma.paymentEvidence.findUnique({
-          where: { id },
-          include: {
-            payment: { select: { installmentNo: true } },
-            contract: {
-              include: {
-                customer: true,
-                payments: { where: { deletedAt: null }, orderBy: { installmentNo: 'asc' } },
-              },
-            },
-          },
-        });
-
-        if (!evidence || evidence.status !== 'PENDING_REVIEW') {
-          errors.push(`${id}: ข้ามรายการ (ไม่พบหรือตรวจสอบแล้ว)`);
-          continue;
-        }
-
-        await this.prisma.paymentEvidence.update({
-          where: { id },
-          data: {
-            status: 'APPROVED',
-            amount: evidence.amount,
-            reviewedById: userId,
-            reviewedAt: new Date(),
-          },
-        });
-        count++;
-
-        // Send LINE notification
-        if (evidence.lineUserId) {
-          const customer = evidence.contract.customer;
-          const contract = evidence.contract;
-          const totalInstallments = contract.payments.length;
-          const paidCount = contract.payments.filter((p) => p.status === 'PAID').length;
-          // Derive the installment this evidence pays — the linked Payment if
-          // present, else the next unpaid installment. (Was hardcoded to 1, so a
-          // customer paying installment 5/12 was told "1/12" over LINE.)
-          const nextUnpaid = contract.payments.find((p) => p.status !== 'PAID');
-          const installmentNo =
-            evidence.payment?.installmentNo ??
-            nextUnpaid?.installmentNo ??
-            Math.min(paidCount + 1, totalInstallments);
-
-          try {
-            const flex = this.lineOaService.buildPaymentSuccess({
-              customerName: customer.name,
-              contractNumber: contract.contractNumber,
-              installmentNo,
-              totalInstallments,
-              amountPaid: evidence.amount ? d(evidence.amount) : 0,
-              paymentMethod: body.paymentMethod,
-              paidDate: formatDateShort(new Date()),
-              remainingInstallments: totalInstallments - paidCount - 1,
-            });
-            await this.lineOaService.sendFlexMessage(evidence.lineUserId, flex, 'line-finance');
-          } catch (err) {
-            this.logger.error(`Failed to send batch approval notification for ${id}: ${err}`);
-          }
-        }
-      } catch (err) {
-        errors.push(`${id}: ${err}`);
-      }
-    }
-
-    return { success: true, count, errors };
+    return this.paymentEvidenceService.batchApproveEvidence(body, userId);
   }
 
   @Post('evidence/batch-reject')
@@ -254,55 +94,7 @@ export class LineOaPaymentController {
     @Req() req: Request,
   ) {
     const userId = (req as Request & { user?: { id: string } }).user?.id;
-    const errors: string[] = [];
-    let count = 0;
-
-    for (const id of body.ids) {
-      try {
-        const evidence = await this.prisma.paymentEvidence.findUnique({
-          where: { id },
-          include: { contract: { include: { customer: true } } },
-        });
-
-        if (!evidence || evidence.status !== 'PENDING_REVIEW') {
-          errors.push(`${id}: ข้ามรายการ (ไม่พบหรือตรวจสอบแล้ว)`);
-          continue;
-        }
-
-        await this.prisma.paymentEvidence.update({
-          where: { id },
-          data: {
-            status: 'REJECTED',
-            reviewedById: userId,
-            reviewedAt: new Date(),
-            reviewNote: body.reviewNote,
-          },
-        });
-        count++;
-
-        // Send LINE notification
-        if (evidence.lineUserId) {
-          try {
-            await this.lineOaService.pushMessage(
-              evidence.lineUserId,
-              [
-                {
-                  type: 'text',
-                  text: `ขออภัยค่ะ สลิปที่ส่งมาไม่ผ่านการตรวจสอบ${body.reviewNote ? `\nเหตุผล: ${body.reviewNote}` : ''}\n\nกรุณาส่งสลิปใหม่ หรือติดต่อสาขาค่ะ`,
-                },
-              ],
-              'line-finance',
-            );
-          } catch (err) {
-            this.logger.error(`Failed to send batch rejection notification for ${id}: ${err}`);
-          }
-        }
-      } catch (err) {
-        errors.push(`${id}: ${err}`);
-      }
-    }
-
-    return { success: true, count, errors };
+    return this.paymentEvidenceService.batchRejectEvidence(body, userId);
   }
 
   @Post('evidence/:id/approve')
@@ -314,89 +106,7 @@ export class LineOaPaymentController {
     @Req() req: Request,
   ) {
     const userId = (req as Request & { user?: { id: string } }).user?.id;
-    const evidence = await this.prisma.paymentEvidence.findUnique({
-      where: { id },
-      include: {
-        contract: {
-          include: {
-            customer: true,
-            payments: { where: { deletedAt: null }, orderBy: { installmentNo: 'asc' } },
-          },
-        },
-      },
-    });
-
-    if (!evidence) {
-      return { error: 'ไม่พบหลักฐาน' };
-    }
-    if (evidence.status !== 'PENDING_REVIEW') {
-      return { error: 'หลักฐานนี้ได้รับการตรวจสอบแล้ว' };
-    }
-
-    // Validate amount against actual payment due (±100 baht tolerance for rounding).
-    // (Audit finding) Previously logged a warning and approved anyway —
-    // a fraud vector. Reject unless the reviewer sets `acceptMismatch=true`
-    // in the body, which forces the override to be a deliberate, audited
-    // decision.
-    const targetPayment = evidence.contract.payments.find(
-      (p) => p.installmentNo === body.installmentNo,
-    );
-    if (targetPayment) {
-      const expectedAmount = sumOutstanding(targetPayment);
-      const diff = Math.abs(body.amount - expectedAmount);
-      if (diff > 100 && !body.acceptMismatch) {
-        this.logger.warn(
-          `[SlipReview] Amount mismatch rejected: approved=${body.amount}, expected=${expectedAmount} for evidence ${id} (diff ${diff.toFixed(2)} > 100)`,
-        );
-        throw new BadRequestException(
-          `จำนวนเงินสลิป (${body.amount.toLocaleString()}) ต่างจากยอดที่ต้องชำระ (${expectedAmount.toLocaleString()}) เกิน 100 บาท — กรุณาตรวจสอบหรือเลือก "ยืนยันแม้ยอดไม่ตรง"`,
-        );
-      }
-      if (diff > 100 && body.acceptMismatch) {
-        this.logger.warn(
-          `[SlipReview] Amount mismatch APPROVED via override: approved=${body.amount}, expected=${expectedAmount}, evidence=${id}, reviewer=${userId}`,
-        );
-      }
-    }
-
-    // Update evidence status
-    await this.prisma.paymentEvidence.update({
-      where: { id },
-      data: {
-        status: 'APPROVED',
-        amount: body.amount,
-        reviewedById: userId,
-        reviewedAt: new Date(),
-        reviewNote: body.reviewNote,
-      },
-    });
-
-    // Send success notification to customer via LINE
-    if (evidence.lineUserId) {
-      const customer = evidence.contract.customer;
-      const contract = evidence.contract;
-      const totalInstallments = contract.payments.length;
-      const paidCount = contract.payments.filter((p) => p.status === 'PAID').length;
-
-      const flex = this.lineOaService.buildPaymentSuccess({
-        customerName: customer.name,
-        contractNumber: contract.contractNumber,
-        installmentNo: body.installmentNo,
-        totalInstallments,
-        amountPaid: body.amount,
-        paymentMethod: body.paymentMethod,
-        paidDate: formatDateShort(new Date()),
-        remainingInstallments: totalInstallments - paidCount - 1,
-      });
-
-      try {
-        await this.lineOaService.sendFlexMessage(evidence.lineUserId, flex, 'line-finance');
-      } catch (err) {
-        this.logger.error(`Failed to send payment success notification: ${err}`);
-      }
-    }
-
-    return { success: true, message: 'อนุมัติสลิปเรียบร้อย' };
+    return this.paymentEvidenceService.approveEvidence(id, body, userId);
   }
 
   @Post('evidence/:id/reject')
@@ -408,111 +118,14 @@ export class LineOaPaymentController {
     @Req() req: Request,
   ) {
     const userId = (req as Request & { user?: { id: string } }).user?.id;
-    const evidence = await this.prisma.paymentEvidence.findUnique({
-      where: { id },
-      include: { contract: { include: { customer: true } } },
-    });
-
-    if (!evidence) {
-      return { error: 'ไม่พบหลักฐาน' };
-    }
-
-    await this.prisma.paymentEvidence.update({
-      where: { id },
-      data: {
-        status: 'REJECTED',
-        reviewedById: userId,
-        reviewedAt: new Date(),
-        reviewNote: body.reviewNote,
-      },
-    });
-
-    // Notify customer via LINE
-    if (evidence.lineUserId) {
-      try {
-        await this.lineOaService.pushMessage(
-          evidence.lineUserId,
-          [
-            {
-              type: 'text',
-              text: `ขออภัยค่ะ สลิปที่ส่งมาไม่ผ่านการตรวจสอบ${body.reviewNote ? `\nเหตุผล: ${body.reviewNote}` : ''}\n\nกรุณาส่งสลิปใหม่ หรือติดต่อสาขาค่ะ`,
-            },
-          ],
-          'line-finance',
-        );
-      } catch (err) {
-        this.logger.error(`Failed to send rejection notification: ${err}`);
-      }
-    }
-
-    return { success: true, message: 'ปฏิเสธสลิปเรียบร้อย' };
+    return this.paymentEvidenceService.rejectEvidence(id, body, userId);
   }
 
   @Get('evidence/:id/suggested-matches')
   @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles('OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'ACCOUNTANT')
   async getSuggestedMatches(@Param('id') id: string) {
-    const evidence = await this.prisma.paymentEvidence.findUnique({
-      where: { id },
-      include: {
-        contract: {
-          include: {
-            payments: {
-              where: { status: { not: 'PAID' } },
-              orderBy: { installmentNo: 'asc' },
-            },
-          },
-        },
-      },
-    });
-
-    if (!evidence) {
-      throw new NotFoundException('ไม่พบหลักฐานการชำระ');
-    }
-
-    const slipAmount = evidence.amount ? d(evidence.amount) : null;
-    const today = new Date();
-
-    const suggestions = evidence.contract.payments.map((payment) => {
-      const amountDue = sumOutstanding(payment);
-      let score = 0;
-
-      if (slipAmount !== null) {
-        const diff = Math.abs(slipAmount - amountDue);
-        if (diff <= 1) score = 1.0;
-        else if (diff <= 100) score = 0.85;
-        else if (diff <= 300) score = 0.65;
-        else if (diff <= 1000) score = 0.4;
-        else score = 0.1;
-      } else {
-        // No amount from OCR — rank by due date proximity
-        score = 0.3;
-      }
-
-      // Boost for overdue payments (most likely to need payment)
-      const daysOverdue = Math.floor((today.getTime() - payment.dueDate.getTime()) / (1000 * 60 * 60 * 24));
-      if (daysOverdue > 0 && daysOverdue <= 30) score = Math.min(score + 0.1, 1.0);
-
-      return {
-        paymentId: payment.id,
-        installmentNo: payment.installmentNo,
-        dueDate: payment.dueDate,
-        amountDue: amountDue,
-        status: payment.status,
-        score: Math.round(score * 100) / 100,
-        isOverdue: daysOverdue > 0,
-        daysOverdue: Math.max(0, daysOverdue),
-      };
-    });
-
-    // Sort by score desc, then by installmentNo asc
-    suggestions.sort((a, b) => b.score - a.score || a.installmentNo - b.installmentNo);
-
-    return {
-      evidenceId: id,
-      slipAmount,
-      suggestions: suggestions.slice(0, 5),
-    };
+    return this.paymentEvidenceService.getSuggestedMatches(id);
   }
 
   // ─── PromptPay QR Code ──────────────────────────────
@@ -545,61 +158,7 @@ export class LineOaPaymentController {
 
   @Get('pay/:token')
   async resolvePaymentLink(@Param('token') token: string) {
-    const link = await this.paymentLinkService.getPaymentLink(token);
-
-    if (!link) {
-      return { error: 'ลิงก์ชำระเงินไม่ถูกต้อง', valid: false };
-    }
-
-    if (link.status !== 'ACTIVE') {
-      return { error: 'ลิงก์ชำระเงินหมดอายุหรือถูกใช้แล้ว', valid: false, status: link.status };
-    }
-
-    // This LIFF endpoint only handles contract-based payment links.
-    // Online-order PaymentLinks (contract === null) are paid via PaySolutions hosted page.
-    if (!link.contract) {
-      return { error: 'ลิงก์ชำระเงินไม่ถูกต้อง', valid: false };
-    }
-
-    const payment = link.payment!;
-    const contract = link.contract;
-    // Use link.amount (authoritative) — createPaymentLink honors the
-    // overrideAmount for early-payoff links. Recomputing from the linked
-    // installment would return the single-installment total, not the full
-    // payoff amount.
-    const amount = d(link.amount);
-
-    // Generate PromptPay QR as data URL for the LIFF page
-    let qrDataUrl: string | null = null;
-    try {
-      qrDataUrl = await this.promptPayQrService.generateQrDataUrl(amount);
-    } catch (err) {
-      this.logger.warn(`QR generation failed for payment link: ${err}`);
-    }
-
-    return {
-      valid: true,
-      token,
-      amount,
-      status: link.status,
-      expiresAt: link.expiresAt,
-      contract: {
-        id: contract.id,
-        contractNumber: contract.contractNumber,
-        customer: { name: maskThaiName(contract.customer.name) },
-      },
-      payment: {
-        installmentNo: payment.installmentNo,
-        amountDue: d(payment.amountDue),
-        lateFee: d(payment.lateFee),
-        dueDate: payment.dueDate,
-      },
-      promptPay: {
-        qrDataUrl,
-        accountName: this.promptPayQrService.getAccountName(),
-        maskedId: this.promptPayQrService.getMaskedPromptPayId(),
-      },
-    };
+    return this.paymentLinkService.resolvePaymentLink(token);
   }
 
   // ─── LIFF Slip Upload ───────────────────────────────
@@ -631,109 +190,7 @@ export class LineOaPaymentController {
     file: Express.Multer.File,
     @Body() body: SlipUploadBodyDto,
   ) {
-
-    // Use transaction to prevent race condition (double slip upload)
-    const link = await this.paymentLinkService.getPaymentLink(body.token);
-    if (!link || link.status !== 'ACTIVE') {
-      throw new BadRequestException('ลิงก์ชำระเงินไม่ถูกต้องหรือหมดอายุ');
-    }
-    // Slip upload is only supported for contract-based payment links.
-    if (!link.contract) {
-      throw new BadRequestException('ลิงก์ชำระเงินไม่ถูกต้อง');
-    }
-    const linkContract = link.contract;
-
-    // Determine safe file extension from MIME type
-    const extMap: Record<string, string> = {
-      'image/jpeg': '.jpg', 'image/png': '.png',
-      'image/webp': '.webp', 'image/heic': '.heic', 'image/heif': '.heif',
-    };
-    const ext = extMap[file.mimetype] || '.jpg';
-
-    // Upload to S3/GCS storage (ephemeral filesystem on Cloud Run)
-    const filename = `slips/slip-liff-${Date.now()}-${Math.random().toString(36).substring(2, 8)}${ext}`;
-    await this.storageService.upload(filename, file.buffer, file.mimetype);
-    const imageUrl = filename;
-
-    // Atomic: create evidence + notification + mark link used in single transaction
-    await this.prisma.$transaction(async (tx) => {
-      // Re-check link status inside transaction to prevent TOCTOU race
-      const freshLink = await tx.paymentLink.findUnique({
-        where: { id: link.id },
-        select: { status: true },
-      });
-      if (!freshLink || freshLink.status !== 'ACTIVE') {
-        throw new BadRequestException('ลิงก์ชำระเงินถูกใช้แล้ว');
-      }
-
-      // Create PaymentEvidence
-      const ev = await tx.paymentEvidence.create({
-        data: {
-          contractId: linkContract.id,
-          paymentId: link.payment!.id,
-          lineUserId: linkContract.customer.lineIdFinance || null,
-          imageUrl,
-          amount: body.amount ? new Prisma.Decimal(body.amount) : null,
-          status: 'PENDING_REVIEW',
-        },
-      });
-
-      // Notify staff
-      await tx.notificationLog.create({
-        data: {
-          channel: 'IN_APP',
-          recipient: 'STAFF',
-          subject: `สลิปใหม่จาก ${linkContract.customer.name} (LIFF)`,
-          message: `ลูกค้า ${linkContract.customer.name} ส่งสลิปผ่านลิงก์ชำระเงิน สัญญา ${linkContract.contractNumber}`,
-          status: 'SENT',
-          relatedId: ev.id,
-          sentAt: new Date(),
-        },
-      });
-
-      // Mark payment link as used atomically
-      await tx.paymentLink.update({
-        where: { id: link.id },
-        data: { status: 'USED', usedAt: new Date() },
-      });
-
-      return ev;
-    });
-
-    // Send LINE confirmation message to customer
-    const customerLineId = linkContract.customer.lineIdFinance;
-    if (customerLineId) {
-      try {
-        const payment = link.payment!;
-        const paidCount = await this.prisma.payment.count({
-          where: { contractId: linkContract.id, status: 'PAID' },
-        });
-        const totalInstallments = linkContract.totalMonths;
-        // Prefer body.amount from the LIFF form → fall back to link.amount
-        // (authoritative; honors early-payoff override). Avoid sumOutstanding
-        // on the linked installment because that returns the per-installment
-        // total for early-payoff links.
-        const amount = body.amount ? d(body.amount) : d(link.amount);
-
-        const flex = this.lineOaService.buildPaymentSuccess({
-          customerName: linkContract.customer.name,
-          contractNumber: linkContract.contractNumber,
-          installmentNo: payment.installmentNo,
-          totalInstallments,
-          amountPaid: amount,
-          paymentMethod: 'BANK_TRANSFER',
-          paidDate: formatDateShort(new Date()),
-          remainingInstallments: totalInstallments - paidCount,
-        });
-        await this.lineOaService.sendFlexMessage(customerLineId, flex, 'line-finance');
-      } catch (err) {
-        this.logger.warn(`Failed to send slip confirmation: ${err}`);
-      }
-    }
-
-    this.logger.log(`[LIFF] Slip uploaded for contract ${linkContract.contractNumber}`);
-
-    return { success: true, message: 'อัพโหลดสลิปเรียบร้อย กำลังตรวจสอบ' };
+    return this.paymentEvidenceService.uploadSlipFromLiff(file, body);
   }
 
   // ─── Create Payment Link (Staff) ────────────────────
@@ -767,134 +224,7 @@ export class LineOaPaymentController {
     @Body() body: { contractId: string },
     @Req() req: { user: { id: string } },
   ) {
-    if (!body?.contractId) {
-      throw new BadRequestException('กรุณาระบุสัญญา');
-    }
-
-    const contract = await this.prisma.contract.findFirst({
-      where: { id: body.contractId, deletedAt: null },
-      include: {
-        customer: {
-          select: {
-            id: true,
-            name: true,
-            lineLinks: {
-              where: { channel: LineChannelType.FINANCE, unlinkedAt: null, deletedAt: null },
-              select: { lineUserId: true },
-              take: 1,
-            },
-          },
-        },
-        payments: {
-          where: { status: { not: 'PAID' }, deletedAt: null },
-          orderBy: { installmentNo: 'asc' },
-        },
-      },
-    });
-
-    if (!contract) {
-      throw new NotFoundException('ไม่พบสัญญา');
-    }
-
-    const financeLineId = contract.customer.lineLinks[0]?.lineUserId;
-    if (!financeLineId) {
-      throw new BadRequestException('ลูกค้ายังไม่ผูก LINE การเงิน — ไม่สามารถส่ง Flex ได้');
-    }
-
-    if (contract.payments.length === 0) {
-      throw new BadRequestException('สัญญานี้ชำระครบแล้ว');
-    }
-
-    // Determine overdue
-    const now = new Date();
-    const overduePayments = contract.payments.filter(
-      (p) => p.dueDate && new Date(p.dueDate) < now,
-    );
-    const isOverdue = overduePayments.length > 0;
-
-    // Create payment link
-    const linkResult = await this.paymentLinkService.createPaymentLink(body.contractId);
-
-    // Build flex + capture meta for inbox preview
-    const totalInstallments = await this.prisma.payment.count({
-      where: { contractId: contract.id, deletedAt: null },
-    });
-    const lateFeeTotal = overduePayments.reduce((sum, p) => sum + d(p.lateFee), 0);
-    const firstPayment = contract.payments[0];
-
-    const flex = isOverdue
-      ? this.flexTemplates.overdueNotice({
-          contractNumber: contract.contractNumber,
-          overdueInstallments: overduePayments.length,
-          totalAmount: linkResult.amount,
-          lateFee: lateFeeTotal,
-          paymentUrl: linkResult.url,
-        })
-      : this.flexTemplates.paymentReminder({
-          contractNumber: contract.contractNumber,
-          installmentNo: firstPayment.installmentNo,
-          amount: linkResult.amount,
-          dueDate: formatDateShort(firstPayment.dueDate),
-          paymentUrl: linkResult.url,
-        });
-
-    // Push via LINE Finance
-    try {
-      await this.lineFinanceClient.pushMessage(financeLineId, [flex as never]);
-    } catch (err) {
-      this.logger.error(`[payment-flex] push failed: ${err}`);
-      throw new BadRequestException('ส่ง Flex ไม่สำเร็จ — กรุณาลองใหม่');
-    }
-
-    // Save record in chat room so staff sees it in history
-    const room = await this.prisma.chatRoom.findFirst({
-      where: {
-        customerId: contract.customer.id,
-        channel: ChatChannel.LINE_FINANCE,
-        deletedAt: null,
-      },
-      orderBy: { lastMessageAt: 'desc' },
-      select: { id: true },
-    });
-
-    if (room) {
-      // Pipe-encoded meta so inbox can render a preview card matching the LINE Flex
-      // Format (reminder): [flex:payment-reminder|<contractNo>|<installmentNo>/<total>|<amount>|<dueDate>|<daysUntilDue>] <url>
-      // Format (overdue):  [flex:overdue-notice|<contractNo>|<overdueCount>|<amount>|<lateFee>|<oldestDueDate>] <url>
-      const metaText = isOverdue
-        ? (() => {
-            const oldest = overduePayments[0];
-            const oldestDue = oldest?.dueDate ? formatDateShort(oldest.dueDate) : '';
-            return `[flex:overdue-notice|${contract.contractNumber}|${overduePayments.length}|${linkResult.amount}|${lateFeeTotal}|${oldestDue}] ${linkResult.url}`;
-          })()
-        : (() => {
-            const dueDateStr = formatDateShort(firstPayment.dueDate);
-            const daysUntilDue = firstPayment.dueDate
-              ? Math.ceil((new Date(firstPayment.dueDate).getTime() - now.getTime()) / 86400000)
-              : 0;
-            return `[flex:payment-reminder|${contract.contractNumber}|${firstPayment.installmentNo}/${totalInstallments}|${linkResult.amount}|${dueDateStr}|${daysUntilDue}] ${linkResult.url}`;
-          })();
-
-      await this.prisma.chatMessage.create({
-        data: {
-          roomId: room.id,
-          role: MessageRole.STAFF,
-          type: MessageType.TEXT,
-          text: metaText,
-          staffId: req.user.id,
-        },
-      });
-      await this.prisma.chatRoom.update({
-        where: { id: room.id },
-        data: { lastMessageAt: new Date(), totalMessages: { increment: 1 } },
-      });
-    }
-
-    return {
-      success: true,
-      type: isOverdue ? 'overdue' : 'reminder',
-      url: linkResult.url,
-    };
+    return this.paymentLinkService.sendPaymentFlex(body, req);
   }
 
 }

--- a/apps/api/src/modules/line-oa/line-oa.module.ts
+++ b/apps/api/src/modules/line-oa/line-oa.module.ts
@@ -12,6 +12,7 @@ import { LineWebhookGuard } from './line-webhook.guard';
 import { LiffTokenGuard } from './guards/liff-token.guard';
 import { PromptPayQrService } from './promptpay/promptpay-qr.service';
 import { PaymentLinkService } from './payment-links/payment-link.service';
+import { PaymentEvidenceService } from './services/payment-evidence.service';
 import { RichMenuService } from './rich-menu/rich-menu.service';
 import { RichMenuRendererService } from './rich-menu/rich-menu-renderer.service';
 import { ChatbotService } from './chatbot.service';
@@ -48,6 +49,7 @@ import { StaffChatModule } from '../staff-chat/staff-chat.module';
     LiffTokenGuard,
     PromptPayQrService,
     PaymentLinkService,
+    PaymentEvidenceService,
     RichMenuService,
     RichMenuRendererService,
     ChatbotService,

--- a/apps/api/src/modules/line-oa/payment-links/payment-link.service.ts
+++ b/apps/api/src/modules/line-oa/payment-links/payment-link.service.ts
@@ -1,7 +1,13 @@
-import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { Injectable, Logger, NotFoundException, BadRequestException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import { MessageRole, MessageType, ChatChannel, LineChannelType } from '@prisma/client';
 import { PrismaService } from '../../../prisma/prisma.service';
-import { calcOutstanding } from '../../../utils/decimal.util';
+import { calcOutstanding, toNum as d } from '../../../utils/decimal.util';
+import { maskThaiName } from '../../../utils/mask-name.util';
+import { formatDateShort } from '../../../utils/thai-date.util';
+import { PromptPayQrService } from '../promptpay/promptpay-qr.service';
+import { FlexTemplatesService } from '../flex-templates.service';
+import { LineFinanceClientService } from '../../chatbot-finance/services/line-finance-client.service';
 import { randomBytes } from 'crypto';
 
 @Injectable()
@@ -13,6 +19,9 @@ export class PaymentLinkService {
   constructor(
     private configService: ConfigService,
     private prisma: PrismaService,
+    private promptPayQrService: PromptPayQrService,
+    private flexTemplates: FlexTemplatesService,
+    private lineFinanceClient: LineFinanceClientService,
   ) {
     // Fall back to FRONTEND_URL (always set in prod) before the placeholder —
     // missing PAYMENT_LINK_BASE_URL previously produced bestchoice.example.com
@@ -148,5 +157,205 @@ export class PaymentLinkService {
     }
 
     return result.count;
+  }
+
+  /**
+   * Resolve a payment-link token into the masked LIFF response payload
+   * (contract + payment + PromptPay QR). Returns the non-throwing
+   * `{ valid: false, ... }` variants for invalid / expired / non-contract links.
+   */
+  async resolvePaymentLink(token: string) {
+    const link = await this.getPaymentLink(token);
+
+    if (!link) {
+      return { error: 'ลิงก์ชำระเงินไม่ถูกต้อง', valid: false };
+    }
+
+    if (link.status !== 'ACTIVE') {
+      return { error: 'ลิงก์ชำระเงินหมดอายุหรือถูกใช้แล้ว', valid: false, status: link.status };
+    }
+
+    // This LIFF endpoint only handles contract-based payment links.
+    // Online-order PaymentLinks (contract === null) are paid via PaySolutions hosted page.
+    if (!link.contract) {
+      return { error: 'ลิงก์ชำระเงินไม่ถูกต้อง', valid: false };
+    }
+
+    const payment = link.payment!;
+    const contract = link.contract;
+    // Use link.amount (authoritative) — createPaymentLink honors the
+    // overrideAmount for early-payoff links. Recomputing from the linked
+    // installment would return the single-installment total, not the full
+    // payoff amount.
+    const amount = d(link.amount);
+
+    // Generate PromptPay QR as data URL for the LIFF page
+    let qrDataUrl: string | null = null;
+    try {
+      qrDataUrl = await this.promptPayQrService.generateQrDataUrl(amount);
+    } catch (err) {
+      this.logger.warn(`QR generation failed for payment link: ${err}`);
+    }
+
+    return {
+      valid: true,
+      token,
+      amount,
+      status: link.status,
+      expiresAt: link.expiresAt,
+      contract: {
+        id: contract.id,
+        contractNumber: contract.contractNumber,
+        customer: { name: maskThaiName(contract.customer.name) },
+      },
+      payment: {
+        installmentNo: payment.installmentNo,
+        amountDue: d(payment.amountDue),
+        lateFee: d(payment.lateFee),
+        dueDate: payment.dueDate,
+      },
+      promptPay: {
+        qrDataUrl,
+        accountName: this.promptPayQrService.getAccountName(),
+        maskedId: this.promptPayQrService.getMaskedPromptPayId(),
+      },
+    };
+  }
+
+  /**
+   * Send payment link as Flex Card via LINE Finance — picks
+   * `paymentReminder` (orange) or `overdueNotice` (red) based on whether
+   * the contract has past-due unpaid installments. Persists a pipe-encoded
+   * meta message in the staff chat room for inbox preview.
+   */
+  async sendPaymentFlex(body: { contractId: string }, req: { user: { id: string } }) {
+    if (!body?.contractId) {
+      throw new BadRequestException('กรุณาระบุสัญญา');
+    }
+
+    const contract = await this.prisma.contract.findFirst({
+      where: { id: body.contractId, deletedAt: null },
+      include: {
+        customer: {
+          select: {
+            id: true,
+            name: true,
+            lineLinks: {
+              where: { channel: LineChannelType.FINANCE, unlinkedAt: null, deletedAt: null },
+              select: { lineUserId: true },
+              take: 1,
+            },
+          },
+        },
+        payments: {
+          where: { status: { not: 'PAID' }, deletedAt: null },
+          orderBy: { installmentNo: 'asc' },
+        },
+      },
+    });
+
+    if (!contract) {
+      throw new NotFoundException('ไม่พบสัญญา');
+    }
+
+    const financeLineId = contract.customer.lineLinks[0]?.lineUserId;
+    if (!financeLineId) {
+      throw new BadRequestException('ลูกค้ายังไม่ผูก LINE การเงิน — ไม่สามารถส่ง Flex ได้');
+    }
+
+    if (contract.payments.length === 0) {
+      throw new BadRequestException('สัญญานี้ชำระครบแล้ว');
+    }
+
+    // Determine overdue
+    const now = new Date();
+    const overduePayments = contract.payments.filter(
+      (p) => p.dueDate && new Date(p.dueDate) < now,
+    );
+    const isOverdue = overduePayments.length > 0;
+
+    // Create payment link
+    const linkResult = await this.createPaymentLink(body.contractId);
+
+    // Build flex + capture meta for inbox preview
+    const totalInstallments = await this.prisma.payment.count({
+      where: { contractId: contract.id, deletedAt: null },
+    });
+    const lateFeeTotal = overduePayments.reduce((sum, p) => sum + d(p.lateFee), 0);
+    const firstPayment = contract.payments[0];
+
+    const flex = isOverdue
+      ? this.flexTemplates.overdueNotice({
+          contractNumber: contract.contractNumber,
+          overdueInstallments: overduePayments.length,
+          totalAmount: linkResult.amount,
+          lateFee: lateFeeTotal,
+          paymentUrl: linkResult.url,
+        })
+      : this.flexTemplates.paymentReminder({
+          contractNumber: contract.contractNumber,
+          installmentNo: firstPayment.installmentNo,
+          amount: linkResult.amount,
+          dueDate: formatDateShort(firstPayment.dueDate),
+          paymentUrl: linkResult.url,
+        });
+
+    // Push via LINE Finance
+    try {
+      await this.lineFinanceClient.pushMessage(financeLineId, [flex as never]);
+    } catch (err) {
+      this.logger.error(`[payment-flex] push failed: ${err}`);
+      throw new BadRequestException('ส่ง Flex ไม่สำเร็จ — กรุณาลองใหม่');
+    }
+
+    // Save record in chat room so staff sees it in history
+    const room = await this.prisma.chatRoom.findFirst({
+      where: {
+        customerId: contract.customer.id,
+        channel: ChatChannel.LINE_FINANCE,
+        deletedAt: null,
+      },
+      orderBy: { lastMessageAt: 'desc' },
+      select: { id: true },
+    });
+
+    if (room) {
+      // Pipe-encoded meta so inbox can render a preview card matching the LINE Flex
+      // Format (reminder): [flex:payment-reminder|<contractNo>|<installmentNo>/<total>|<amount>|<dueDate>|<daysUntilDue>] <url>
+      // Format (overdue):  [flex:overdue-notice|<contractNo>|<overdueCount>|<amount>|<lateFee>|<oldestDueDate>] <url>
+      const metaText = isOverdue
+        ? (() => {
+            const oldest = overduePayments[0];
+            const oldestDue = oldest?.dueDate ? formatDateShort(oldest.dueDate) : '';
+            return `[flex:overdue-notice|${contract.contractNumber}|${overduePayments.length}|${linkResult.amount}|${lateFeeTotal}|${oldestDue}] ${linkResult.url}`;
+          })()
+        : (() => {
+            const dueDateStr = formatDateShort(firstPayment.dueDate);
+            const daysUntilDue = firstPayment.dueDate
+              ? Math.ceil((new Date(firstPayment.dueDate).getTime() - now.getTime()) / 86400000)
+              : 0;
+            return `[flex:payment-reminder|${contract.contractNumber}|${firstPayment.installmentNo}/${totalInstallments}|${linkResult.amount}|${dueDateStr}|${daysUntilDue}] ${linkResult.url}`;
+          })();
+
+      await this.prisma.chatMessage.create({
+        data: {
+          roomId: room.id,
+          role: MessageRole.STAFF,
+          type: MessageType.TEXT,
+          text: metaText,
+          staffId: req.user.id,
+        },
+      });
+      await this.prisma.chatRoom.update({
+        where: { id: room.id },
+        data: { lastMessageAt: new Date(), totalMessages: { increment: 1 } },
+      });
+    }
+
+    return {
+      success: true,
+      type: isOverdue ? 'overdue' : 'reminder',
+      url: linkResult.url,
+    };
   }
 }

--- a/apps/api/src/modules/line-oa/services/payment-evidence.service.ts
+++ b/apps/api/src/modules/line-oa/services/payment-evidence.service.ts
@@ -1,0 +1,541 @@
+import { Injectable, Logger, BadRequestException, NotFoundException } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import { PrismaService } from '../../../prisma/prisma.service';
+import { toNum as d, calcOutstanding as sumOutstanding } from '../../../utils/decimal.util';
+import { formatDateShort } from '../../../utils/thai-date.util';
+import { LineOaService } from '../line-oa.service';
+import { StorageService } from '../../storage/storage.service';
+import { PaymentLinkService } from '../payment-links/payment-link.service';
+import {
+  SlipUploadBodyDto,
+  ApproveEvidenceDto,
+  BatchApproveEvidenceDto,
+  BatchRejectEvidenceDto,
+} from '../dto/evidence.dto';
+
+@Injectable()
+export class PaymentEvidenceService {
+  private readonly logger = new Logger(PaymentEvidenceService.name);
+
+  constructor(
+    private prisma: PrismaService,
+    private lineOaService: LineOaService,
+    private storageService: StorageService,
+    private paymentLinkService: PaymentLinkService,
+  ) {}
+
+  async getEvidenceStats() {
+    const todayStart = new Date();
+    todayStart.setHours(0, 0, 0, 0);
+
+    const [pendingCount, approvedToday, rejectedToday, approvedAmountToday] = await Promise.all([
+      this.prisma.paymentEvidence.count({ where: { status: 'PENDING_REVIEW' } }),
+      this.prisma.paymentEvidence.count({ where: { status: 'APPROVED', reviewedAt: { gte: todayStart } } }),
+      this.prisma.paymentEvidence.count({ where: { status: 'REJECTED', reviewedAt: { gte: todayStart } } }),
+      this.prisma.paymentEvidence.aggregate({ where: { status: 'APPROVED', reviewedAt: { gte: todayStart } }, _sum: { amount: true } }),
+    ]);
+
+    return {
+      pendingCount,
+      approvedToday,
+      rejectedToday,
+      approvedAmountToday: approvedAmountToday._sum.amount || 0,
+    };
+  }
+
+  async getEvidenceList(
+    status?: string,
+    search?: string,
+    dateFrom?: string,
+    dateTo?: string,
+    amountMin?: string,
+    amountMax?: string,
+    limit?: string,
+  ) {
+    const where: Record<string, unknown> = {};
+    if (status) where.status = status;
+
+    if (search) {
+      where.contract = {
+        OR: [
+          { contractNumber: { contains: search, mode: 'insensitive' } },
+          { customer: { name: { contains: search, mode: 'insensitive' } } },
+        ],
+      };
+    }
+
+    if (dateFrom || dateTo) {
+      const dateFilter: Record<string, Date> = {};
+      if (dateFrom) dateFilter.gte = new Date(dateFrom);
+      if (dateTo) {
+        const end = new Date(dateTo);
+        end.setHours(23, 59, 59, 999);
+        dateFilter.lte = end;
+      }
+      where.createdAt = dateFilter;
+    }
+
+    if (amountMin || amountMax) {
+      const amountFilter: Record<string, number> = {};
+      if (amountMin) amountFilter.gte = Number(amountMin);
+      if (amountMax) amountFilter.lte = Number(amountMax);
+      where.amount = amountFilter;
+    }
+
+    const take = limit ? Math.min(Number(limit), 10000) : 50;
+
+    const evidences = await this.prisma.paymentEvidence.findMany({
+      where,
+      orderBy: { createdAt: 'desc' },
+      take,
+      include: {
+        contract: {
+          select: {
+            contractNumber: true,
+            customer: { select: { name: true, phone: true } },
+          },
+        },
+        reviewedBy: { select: { name: true } },
+      },
+    });
+
+    // Resolve S3 keys to signed download URLs for slip images
+    if (this.storageService.configured) {
+      await Promise.all(
+        evidences.map(async (ev) => {
+          if (ev.imageUrl && !ev.imageUrl.startsWith('http') && !ev.imageUrl.startsWith('/')) {
+            try {
+              (ev as { imageUrl: string }).imageUrl =
+                await this.storageService.getSignedDownloadUrl(ev.imageUrl, 3600);
+            } catch { /* keep original key if signing fails */ }
+          }
+        }),
+      );
+    }
+
+    return evidences;
+  }
+
+  async batchApproveEvidence(body: BatchApproveEvidenceDto, userId?: string) {
+    const errors: string[] = [];
+    let count = 0;
+
+    for (const id of body.ids) {
+      try {
+        const evidence = await this.prisma.paymentEvidence.findUnique({
+          where: { id },
+          include: {
+            payment: { select: { installmentNo: true } },
+            contract: {
+              include: {
+                customer: true,
+                payments: { where: { deletedAt: null }, orderBy: { installmentNo: 'asc' } },
+              },
+            },
+          },
+        });
+
+        if (!evidence || evidence.status !== 'PENDING_REVIEW') {
+          errors.push(`${id}: ข้ามรายการ (ไม่พบหรือตรวจสอบแล้ว)`);
+          continue;
+        }
+
+        await this.prisma.paymentEvidence.update({
+          where: { id },
+          data: {
+            status: 'APPROVED',
+            amount: evidence.amount,
+            reviewedById: userId,
+            reviewedAt: new Date(),
+          },
+        });
+        count++;
+
+        // Send LINE notification
+        if (evidence.lineUserId) {
+          const customer = evidence.contract.customer;
+          const contract = evidence.contract;
+          const totalInstallments = contract.payments.length;
+          const paidCount = contract.payments.filter((p) => p.status === 'PAID').length;
+          // Derive the installment this evidence pays — the linked Payment if
+          // present, else the next unpaid installment. (Was hardcoded to 1, so a
+          // customer paying installment 5/12 was told "1/12" over LINE.)
+          const nextUnpaid = contract.payments.find((p) => p.status !== 'PAID');
+          const installmentNo =
+            evidence.payment?.installmentNo ??
+            nextUnpaid?.installmentNo ??
+            Math.min(paidCount + 1, totalInstallments);
+
+          try {
+            const flex = this.lineOaService.buildPaymentSuccess({
+              customerName: customer.name,
+              contractNumber: contract.contractNumber,
+              installmentNo,
+              totalInstallments,
+              amountPaid: evidence.amount ? d(evidence.amount) : 0,
+              paymentMethod: body.paymentMethod,
+              paidDate: formatDateShort(new Date()),
+              remainingInstallments: totalInstallments - paidCount - 1,
+            });
+            await this.lineOaService.sendFlexMessage(evidence.lineUserId, flex, 'line-finance');
+          } catch (err) {
+            this.logger.error(`Failed to send batch approval notification for ${id}: ${err}`);
+          }
+        }
+      } catch (err) {
+        errors.push(`${id}: ${err}`);
+      }
+    }
+
+    return { success: true, count, errors };
+  }
+
+  async batchRejectEvidence(body: BatchRejectEvidenceDto, userId?: string) {
+    const errors: string[] = [];
+    let count = 0;
+
+    for (const id of body.ids) {
+      try {
+        const evidence = await this.prisma.paymentEvidence.findUnique({
+          where: { id },
+          include: { contract: { include: { customer: true } } },
+        });
+
+        if (!evidence || evidence.status !== 'PENDING_REVIEW') {
+          errors.push(`${id}: ข้ามรายการ (ไม่พบหรือตรวจสอบแล้ว)`);
+          continue;
+        }
+
+        await this.prisma.paymentEvidence.update({
+          where: { id },
+          data: {
+            status: 'REJECTED',
+            reviewedById: userId,
+            reviewedAt: new Date(),
+            reviewNote: body.reviewNote,
+          },
+        });
+        count++;
+
+        // Send LINE notification
+        if (evidence.lineUserId) {
+          try {
+            await this.lineOaService.pushMessage(
+              evidence.lineUserId,
+              [
+                {
+                  type: 'text',
+                  text: `ขออภัยค่ะ สลิปที่ส่งมาไม่ผ่านการตรวจสอบ${body.reviewNote ? `\nเหตุผล: ${body.reviewNote}` : ''}\n\nกรุณาส่งสลิปใหม่ หรือติดต่อสาขาค่ะ`,
+                },
+              ],
+              'line-finance',
+            );
+          } catch (err) {
+            this.logger.error(`Failed to send batch rejection notification for ${id}: ${err}`);
+          }
+        }
+      } catch (err) {
+        errors.push(`${id}: ${err}`);
+      }
+    }
+
+    return { success: true, count, errors };
+  }
+
+  async approveEvidence(id: string, body: ApproveEvidenceDto, userId?: string) {
+    const evidence = await this.prisma.paymentEvidence.findUnique({
+      where: { id },
+      include: {
+        contract: {
+          include: {
+            customer: true,
+            payments: { where: { deletedAt: null }, orderBy: { installmentNo: 'asc' } },
+          },
+        },
+      },
+    });
+
+    if (!evidence) {
+      return { error: 'ไม่พบหลักฐาน' };
+    }
+    if (evidence.status !== 'PENDING_REVIEW') {
+      return { error: 'หลักฐานนี้ได้รับการตรวจสอบแล้ว' };
+    }
+
+    // Validate amount against actual payment due (±100 baht tolerance for rounding).
+    // (Audit finding) Previously logged a warning and approved anyway —
+    // a fraud vector. Reject unless the reviewer sets `acceptMismatch=true`
+    // in the body, which forces the override to be a deliberate, audited
+    // decision.
+    const targetPayment = evidence.contract.payments.find(
+      (p) => p.installmentNo === body.installmentNo,
+    );
+    if (targetPayment) {
+      const expectedAmount = sumOutstanding(targetPayment);
+      const diff = Math.abs(body.amount - expectedAmount);
+      if (diff > 100 && !body.acceptMismatch) {
+        this.logger.warn(
+          `[SlipReview] Amount mismatch rejected: approved=${body.amount}, expected=${expectedAmount} for evidence ${id} (diff ${diff.toFixed(2)} > 100)`,
+        );
+        throw new BadRequestException(
+          `จำนวนเงินสลิป (${body.amount.toLocaleString()}) ต่างจากยอดที่ต้องชำระ (${expectedAmount.toLocaleString()}) เกิน 100 บาท — กรุณาตรวจสอบหรือเลือก "ยืนยันแม้ยอดไม่ตรง"`,
+        );
+      }
+      if (diff > 100 && body.acceptMismatch) {
+        this.logger.warn(
+          `[SlipReview] Amount mismatch APPROVED via override: approved=${body.amount}, expected=${expectedAmount}, evidence=${id}, reviewer=${userId}`,
+        );
+      }
+    }
+
+    // Update evidence status
+    await this.prisma.paymentEvidence.update({
+      where: { id },
+      data: {
+        status: 'APPROVED',
+        amount: body.amount,
+        reviewedById: userId,
+        reviewedAt: new Date(),
+        reviewNote: body.reviewNote,
+      },
+    });
+
+    // Send success notification to customer via LINE
+    if (evidence.lineUserId) {
+      const customer = evidence.contract.customer;
+      const contract = evidence.contract;
+      const totalInstallments = contract.payments.length;
+      const paidCount = contract.payments.filter((p) => p.status === 'PAID').length;
+
+      const flex = this.lineOaService.buildPaymentSuccess({
+        customerName: customer.name,
+        contractNumber: contract.contractNumber,
+        installmentNo: body.installmentNo,
+        totalInstallments,
+        amountPaid: body.amount,
+        paymentMethod: body.paymentMethod,
+        paidDate: formatDateShort(new Date()),
+        remainingInstallments: totalInstallments - paidCount - 1,
+      });
+
+      try {
+        await this.lineOaService.sendFlexMessage(evidence.lineUserId, flex, 'line-finance');
+      } catch (err) {
+        this.logger.error(`Failed to send payment success notification: ${err}`);
+      }
+    }
+
+    return { success: true, message: 'อนุมัติสลิปเรียบร้อย' };
+  }
+
+  async rejectEvidence(id: string, body: { reviewNote?: string }, userId?: string) {
+    const evidence = await this.prisma.paymentEvidence.findUnique({
+      where: { id },
+      include: { contract: { include: { customer: true } } },
+    });
+
+    if (!evidence) {
+      return { error: 'ไม่พบหลักฐาน' };
+    }
+
+    await this.prisma.paymentEvidence.update({
+      where: { id },
+      data: {
+        status: 'REJECTED',
+        reviewedById: userId,
+        reviewedAt: new Date(),
+        reviewNote: body.reviewNote,
+      },
+    });
+
+    // Notify customer via LINE
+    if (evidence.lineUserId) {
+      try {
+        await this.lineOaService.pushMessage(
+          evidence.lineUserId,
+          [
+            {
+              type: 'text',
+              text: `ขออภัยค่ะ สลิปที่ส่งมาไม่ผ่านการตรวจสอบ${body.reviewNote ? `\nเหตุผล: ${body.reviewNote}` : ''}\n\nกรุณาส่งสลิปใหม่ หรือติดต่อสาขาค่ะ`,
+            },
+          ],
+          'line-finance',
+        );
+      } catch (err) {
+        this.logger.error(`Failed to send rejection notification: ${err}`);
+      }
+    }
+
+    return { success: true, message: 'ปฏิเสธสลิปเรียบร้อย' };
+  }
+
+  async getSuggestedMatches(id: string) {
+    const evidence = await this.prisma.paymentEvidence.findUnique({
+      where: { id },
+      include: {
+        contract: {
+          include: {
+            payments: {
+              where: { status: { not: 'PAID' } },
+              orderBy: { installmentNo: 'asc' },
+            },
+          },
+        },
+      },
+    });
+
+    if (!evidence) {
+      throw new NotFoundException('ไม่พบหลักฐานการชำระ');
+    }
+
+    const slipAmount = evidence.amount ? d(evidence.amount) : null;
+    const today = new Date();
+
+    const suggestions = evidence.contract.payments.map((payment) => {
+      const amountDue = sumOutstanding(payment);
+      let score = 0;
+
+      if (slipAmount !== null) {
+        const diff = Math.abs(slipAmount - amountDue);
+        if (diff <= 1) score = 1.0;
+        else if (diff <= 100) score = 0.85;
+        else if (diff <= 300) score = 0.65;
+        else if (diff <= 1000) score = 0.4;
+        else score = 0.1;
+      } else {
+        // No amount from OCR — rank by due date proximity
+        score = 0.3;
+      }
+
+      // Boost for overdue payments (most likely to need payment)
+      const daysOverdue = Math.floor((today.getTime() - payment.dueDate.getTime()) / (1000 * 60 * 60 * 24));
+      if (daysOverdue > 0 && daysOverdue <= 30) score = Math.min(score + 0.1, 1.0);
+
+      return {
+        paymentId: payment.id,
+        installmentNo: payment.installmentNo,
+        dueDate: payment.dueDate,
+        amountDue: amountDue,
+        status: payment.status,
+        score: Math.round(score * 100) / 100,
+        isOverdue: daysOverdue > 0,
+        daysOverdue: Math.max(0, daysOverdue),
+      };
+    });
+
+    // Sort by score desc, then by installmentNo asc
+    suggestions.sort((a, b) => b.score - a.score || a.installmentNo - b.installmentNo);
+
+    return {
+      evidenceId: id,
+      slipAmount,
+      suggestions: suggestions.slice(0, 5),
+    };
+  }
+
+  async uploadSlipFromLiff(file: Express.Multer.File, body: SlipUploadBodyDto) {
+
+    // Use transaction to prevent race condition (double slip upload)
+    const link = await this.paymentLinkService.getPaymentLink(body.token);
+    if (!link || link.status !== 'ACTIVE') {
+      throw new BadRequestException('ลิงก์ชำระเงินไม่ถูกต้องหรือหมดอายุ');
+    }
+    // Slip upload is only supported for contract-based payment links.
+    if (!link.contract) {
+      throw new BadRequestException('ลิงก์ชำระเงินไม่ถูกต้อง');
+    }
+    const linkContract = link.contract;
+
+    // Determine safe file extension from MIME type
+    const extMap: Record<string, string> = {
+      'image/jpeg': '.jpg', 'image/png': '.png',
+      'image/webp': '.webp', 'image/heic': '.heic', 'image/heif': '.heif',
+    };
+    const ext = extMap[file.mimetype] || '.jpg';
+
+    // Upload to S3/GCS storage (ephemeral filesystem on Cloud Run)
+    const filename = `slips/slip-liff-${Date.now()}-${Math.random().toString(36).substring(2, 8)}${ext}`;
+    await this.storageService.upload(filename, file.buffer, file.mimetype);
+    const imageUrl = filename;
+
+    // Atomic: create evidence + notification + mark link used in single transaction
+    await this.prisma.$transaction(async (tx) => {
+      // Re-check link status inside transaction to prevent TOCTOU race
+      const freshLink = await tx.paymentLink.findUnique({
+        where: { id: link.id },
+        select: { status: true },
+      });
+      if (!freshLink || freshLink.status !== 'ACTIVE') {
+        throw new BadRequestException('ลิงก์ชำระเงินถูกใช้แล้ว');
+      }
+
+      // Create PaymentEvidence
+      const ev = await tx.paymentEvidence.create({
+        data: {
+          contractId: linkContract.id,
+          paymentId: link.payment!.id,
+          lineUserId: linkContract.customer.lineIdFinance || null,
+          imageUrl,
+          amount: body.amount ? new Prisma.Decimal(body.amount) : null,
+          status: 'PENDING_REVIEW',
+        },
+      });
+
+      // Notify staff
+      await tx.notificationLog.create({
+        data: {
+          channel: 'IN_APP',
+          recipient: 'STAFF',
+          subject: `สลิปใหม่จาก ${linkContract.customer.name} (LIFF)`,
+          message: `ลูกค้า ${linkContract.customer.name} ส่งสลิปผ่านลิงก์ชำระเงิน สัญญา ${linkContract.contractNumber}`,
+          status: 'SENT',
+          relatedId: ev.id,
+          sentAt: new Date(),
+        },
+      });
+
+      // Mark payment link as used atomically
+      await tx.paymentLink.update({
+        where: { id: link.id },
+        data: { status: 'USED', usedAt: new Date() },
+      });
+
+      return ev;
+    });
+
+    // Send LINE confirmation message to customer
+    const customerLineId = linkContract.customer.lineIdFinance;
+    if (customerLineId) {
+      try {
+        const payment = link.payment!;
+        const paidCount = await this.prisma.payment.count({
+          where: { contractId: linkContract.id, status: 'PAID' },
+        });
+        const totalInstallments = linkContract.totalMonths;
+        // Prefer body.amount from the LIFF form → fall back to link.amount
+        // (authoritative; honors early-payoff override). Avoid sumOutstanding
+        // on the linked installment because that returns the per-installment
+        // total for early-payoff links.
+        const amount = body.amount ? d(body.amount) : d(link.amount);
+
+        const flex = this.lineOaService.buildPaymentSuccess({
+          customerName: linkContract.customer.name,
+          contractNumber: linkContract.contractNumber,
+          installmentNo: payment.installmentNo,
+          totalInstallments,
+          amountPaid: amount,
+          paymentMethod: 'BANK_TRANSFER',
+          paidDate: formatDateShort(new Date()),
+          remainingInstallments: totalInstallments - paidCount,
+        });
+        await this.lineOaService.sendFlexMessage(customerLineId, flex, 'line-finance');
+      } catch (err) {
+        this.logger.warn(`Failed to send slip confirmation: ${err}`);
+      }
+    }
+
+    this.logger.log(`[LIFF] Slip uploaded for contract ${linkContract.contractNumber}`);
+
+    return { success: true, message: 'อัพโหลดสลิปเรียบร้อย กำลังตรวจสอบ' };
+  }
+}


### PR DESCRIPTION
behavior-preserving (1 $tx, 0 JE). Adds a characterization controller spec FIRST (was untested — 51 tests, green before AND after extraction), then moves 21 in-handler prisma calls + evidence stats/list/approve/reject/batch/suggested-matches scoring + slip-upload $transaction (WHOLE) into new PaymentEvidenceService, and resolvePaymentLink/sendPaymentFlex into PaymentLinkService. Handlers now thin (validate->service->return); all 12 routes + 10 @Roles + guards/throttle/file-validators + response shapes (incl non-throwing {error} + {success,count,errors}) byte-identical; ±100 money tolerance + pipe-encoded metaText preserved. tsc 0 · 51 new tests + 164 sibling green · lint 0. **Adversarial review: SPEC ✅** (all 10 moved bodies byte-identical, spec genuine not tautological, $tx whole). 🤖 Generated with Claude Code