### PR TITLE
refactor(staff-chat): thin StaffChatController — move 7 fat handlers into RoomManagerService (808->663 LOC)

### DIFF
--- a/apps/api/src/modules/chat-engine/services/room-manager.service.spec.ts
+++ b/apps/api/src/modules/chat-engine/services/room-manager.service.spec.ts
@@ -3,6 +3,7 @@ import { RoomManagerService } from './room-manager.service';
 import { PrismaService } from '../../../prisma/prisma.service';
 import { ChatChannel, ChatRoomStatus, ChatPriority, MessageRole } from '@prisma/client';
 import { ChatAiDraftService } from '../../chat-ai-draft/chat-ai-draft.service';
+import { StorageService } from '../../storage/storage.service';
 
 describe('RoomManagerService', () => {
   let service: RoomManagerService;
@@ -35,6 +36,14 @@ describe('RoomManagerService', () => {
         RoomManagerService,
         { provide: PrismaService, useValue: prisma },
         { provide: ChatAiDraftService, useValue: chatAiDraftService },
+        {
+          provide: StorageService,
+          useValue: {
+            configured: true,
+            upload: jest.fn(),
+            getSignedDownloadUrl: jest.fn(),
+          },
+        },
       ],
     }).compile();
 

--- a/apps/api/src/modules/chat-engine/services/room-manager.service.ts
+++ b/apps/api/src/modules/chat-engine/services/room-manager.service.ts
@@ -11,7 +11,9 @@ import {
   Prisma,
 } from '@prisma/client';
 import { AssignmentService } from './assignment.service';
+import { MessageRouterService } from './message-router.service';
 import { ChatAiDraftService } from '../../chat-ai-draft/chat-ai-draft.service';
+import { StorageService } from '../../storage/storage.service';
 
 /**
  * RoomManagerService — generalized from SessionManagerService.
@@ -27,8 +29,11 @@ export class RoomManagerService {
 
   constructor(
     private prisma: PrismaService,
+    private storageService: StorageService,
     @Optional() @Inject(forwardRef(() => AssignmentService))
     private assignmentService?: AssignmentService,
+    @Optional() @Inject(forwardRef(() => MessageRouterService))
+    private messageRouter?: MessageRouterService,
     @Optional() @Inject(forwardRef(() => ChatAiDraftService))
     private chatAiDraftService?: ChatAiDraftService,
   ) {}
@@ -481,5 +486,218 @@ export class RoomManagerService {
       data: { readAt },
     });
     return { count: result.count };
+  }
+
+  /** Pin a room (records who pinned it and when) */
+  async pinRoom(roomId: string, userId: string): Promise<void> {
+    await this.prisma.chatRoom.update({
+      where: { id: roomId },
+      data: { pinnedAt: new Date(), pinnedById: userId },
+    });
+  }
+
+  /** Unpin a room */
+  async unpinRoom(roomId: string): Promise<void> {
+    await this.prisma.chatRoom.update({
+      where: { id: roomId },
+      data: { pinnedAt: null, pinnedById: null },
+    });
+  }
+
+  /**
+   * Mark all unread customer messages in a room as read, recompute the
+   * remaining unread count, and persist it on the room — all in one
+   * transaction so the room's unreadCount can never drift from the
+   * messages' readAt state.
+   */
+  async markAsRead(roomId: string): Promise<{ markedCount: number }> {
+    const now = new Date();
+    return this.prisma.$transaction(async (tx) => {
+      const updated = await tx.chatMessage.updateMany({
+        where: { roomId: roomId, role: 'CUSTOMER', readAt: null },
+        data: { readAt: now },
+      });
+      const remaining = await tx.chatMessage.count({
+        where: { roomId: roomId, role: 'CUSTOMER', readAt: null },
+      });
+      await tx.chatRoom.update({
+        where: { id: roomId },
+        data: { unreadCount: remaining },
+      });
+      return { markedCount: updated.count };
+    });
+  }
+
+  /**
+   * Store an uploaded file and save it as a chat message with media.
+   * Returns the persisted key + a (signed) download URL for the caller.
+   */
+  async uploadFile(
+    roomId: string,
+    file: Express.Multer.File,
+    userId: string | undefined,
+  ): Promise<{ success: boolean; url: string; key: string; filename: string }> {
+    const extMap: Record<string, string> = {
+      'image/jpeg': '.jpg', 'image/png': '.png', 'image/webp': '.webp',
+      'application/pdf': '.pdf',
+      'application/msword': '.doc',
+      'application/vnd.openxmlformats-officedocument.wordprocessingml.document': '.docx',
+    };
+    const ext = extMap[file.mimetype] || '';
+    const key = `staff-chat/${roomId}/${Date.now()}${ext}`;
+
+    await this.storageService.upload(key, file.buffer, file.mimetype);
+    const downloadUrl = this.storageService.configured
+      ? await this.storageService.getSignedDownloadUrl(key, 3600)
+      : key;
+
+    // Save as a message with media
+    await this.saveMessage({
+      roomId,
+      role: MessageRole.BOT,
+      type: file.mimetype.startsWith('image/') ? MessageType.IMAGE : MessageType.FILE,
+      text: file.originalname,
+      mediaUrl: key,
+      mediaType: file.mimetype,
+      staffId: userId,
+    });
+
+    return { success: true, url: downloadUrl, key, filename: file.originalname };
+  }
+
+  /**
+   * Last N messages across the customer's LINE rooms (LINE_FINANCE preferred).
+   * Used by the Customer 360 LineChatPanel — collectors don't need to leave
+   * the collections workspace to see what was said in chat.
+   *
+   * Returns messages in reverse-chronological order (newest first) so
+   * `before=<oldest.id>` paging walks backward through history. The frontend
+   * reverses for display.
+   */
+  async getCustomerMessages(customerId: string, take: number, before?: string) {
+    // Find the customer's LINE Finance room (preferred) or fall back to any
+    // LINE room. Collections is a finance-only workflow — no point pulling
+    // shop-side LINE chat here.
+    const room = await this.prisma.chatRoom.findFirst({
+      where: {
+        customerId,
+        deletedAt: null,
+        channel: { in: [ChatChannel.LINE_FINANCE, ChatChannel.LINE_SHOP] },
+      },
+      orderBy: [
+        // Prefer LINE_FINANCE if both exist (alphabetical "LINE_FINANCE" <
+        // "LINE_SHOP" so an explicit ordering by lastMessageAt is the
+        // tiebreaker that matters).
+        { lastMessageAt: 'desc' },
+      ],
+      select: {
+        id: true,
+        channel: true,
+        lineUserId: true,
+        lastMessageAt: true,
+        unreadCount: true,
+      },
+    });
+
+    if (!room) {
+      return { roomId: null, channel: null, messages: [], hasMore: false };
+    }
+
+    let cursorWhere: { createdAt?: { lt: Date } } = {};
+    if (before) {
+      const cursor = await this.prisma.chatMessage.findUnique({
+        where: { id: before },
+        select: { createdAt: true },
+      });
+      if (cursor) cursorWhere = { createdAt: { lt: cursor.createdAt } };
+    }
+
+    const messages = await this.prisma.chatMessage.findMany({
+      where: { roomId: room.id, deletedAt: null, ...cursorWhere },
+      orderBy: { createdAt: 'desc' },
+      take: take + 1, // overfetch by 1 to detect hasMore
+      select: {
+        id: true,
+        role: true,
+        type: true,
+        text: true,
+        mediaUrl: true,
+        mediaType: true,
+        createdAt: true,
+        readAt: true,
+        deliveredAt: true,
+        staff: { select: { id: true, name: true } },
+      },
+    });
+
+    const hasMore = messages.length > take;
+    const sliced = hasMore ? messages.slice(0, take) : messages;
+
+    return {
+      roomId: room.id,
+      channel: room.channel,
+      messages: sliced,
+      hasMore,
+    };
+  }
+
+  /**
+   * Resolve the customer's LINE room (Finance preferred) and forward the
+   * staff message through MessageRouterService. Returns `{ room: null }`
+   * when the customer has no LINE room so the caller can surface a
+   * non-throwing error; otherwise returns the resolved room + send result.
+   */
+  async sendCustomerMessage(
+    customerId: string,
+    staffId: string,
+    text: string,
+  ): Promise<
+    | { room: null }
+    | { room: { id: string }; result: { success: boolean; error?: string } }
+  > {
+    const room = await this.prisma.chatRoom.findFirst({
+      where: {
+        customerId,
+        deletedAt: null,
+        channel: { in: [ChatChannel.LINE_FINANCE, ChatChannel.LINE_SHOP] },
+      },
+      orderBy: { lastMessageAt: 'desc' },
+      select: { id: true },
+    });
+
+    if (!room) {
+      return { room: null };
+    }
+
+    const result = await this.messageRouter!.sendStaffMessage({
+      roomId: room.id,
+      staffId,
+      text,
+    });
+
+    return { room, result };
+  }
+
+  /** All of a room's customer's rooms across channels, with the latest message each */
+  async getCrossChannelRooms(roomId: string) {
+    const room = await this.prisma.chatRoom.findUnique({
+      where: { id: roomId },
+      select: { customerId: true },
+    });
+    if (!room?.customerId) return [];
+    return this.prisma.chatRoom.findMany({
+      where: { customerId: room.customerId, deletedAt: null },
+      select: {
+        id: true,
+        channel: true,
+        lastMessageAt: true,
+        messages: {
+          orderBy: { createdAt: 'desc' },
+          take: 1,
+          select: { text: true, createdAt: true },
+        },
+      },
+      orderBy: { lastMessageAt: 'desc' },
+    });
   }
 }

--- a/apps/api/src/modules/staff-chat/staff-chat.controller.spec.ts
+++ b/apps/api/src/modules/staff-chat/staff-chat.controller.spec.ts
@@ -34,13 +34,26 @@ describe('StaffChatController', () => {
   let cannedResponseBubble: CannedResponseBubbleService;
   let cannedResponseQuickReply: CannedResponseQuickReplyService;
   let cannedResponseSender: CannedResponseSenderService;
+  let roomManager: RoomManagerService;
+  let gateway: StaffChatGateway;
 
   beforeEach(async () => {
     const module = await Test.createTestingModule({
       controllers: [StaffChatController],
       providers: [
         { provide: PrismaService, useValue: {} },
-        { provide: RoomManagerService, useValue: {} },
+        {
+          provide: RoomManagerService,
+          useValue: {
+            pinRoom: jest.fn(),
+            unpinRoom: jest.fn(),
+            markAsRead: jest.fn(),
+            uploadFile: jest.fn(),
+            getCustomerMessages: jest.fn(),
+            sendCustomerMessage: jest.fn(),
+            getCrossChannelRooms: jest.fn(),
+          },
+        },
         { provide: AssignmentService, useValue: {} },
         { provide: ConversationTagService, useValue: {} },
         { provide: HandoffManagerService, useValue: {} },
@@ -65,7 +78,7 @@ describe('StaffChatController', () => {
         { provide: AiMetricsService, useValue: {} },
         { provide: ConfigService, useValue: { get: jest.fn() } },
         { provide: TrainingExtractCron, useValue: {} },
-        { provide: StaffChatGateway, useValue: {} },
+        { provide: StaffChatGateway, useValue: { emitNewMessage: jest.fn() } },
         {
           provide: CannedResponseBubbleService,
           useValue: {
@@ -105,6 +118,8 @@ describe('StaffChatController', () => {
     cannedResponseBubble = module.get(CannedResponseBubbleService);
     cannedResponseQuickReply = module.get(CannedResponseQuickReplyService);
     cannedResponseSender = module.get(CannedResponseSenderService);
+    roomManager = module.get(RoomManagerService);
+    gateway = module.get(StaffChatGateway);
   });
 
   describe('GET /staff-chat/rooms/:roomId/canned-responses/:id/preview', () => {
@@ -255,6 +270,126 @@ describe('StaffChatController', () => {
         ),
       ).rejects.toThrow('templateId');
       expect(cannedResponseSender.send).not.toHaveBeenCalled();
+    });
+  });
+
+  // ─── Moved handlers (delegate to RoomManagerService) ──────────────
+
+  describe('POST /staff-chat/rooms/:id/pin', () => {
+    it('delegates to roomManager.pinRoom with room + user id and returns success', async () => {
+      jest.spyOn(roomManager, 'pinRoom').mockResolvedValue(undefined);
+      const result = await controller.pinRoom('room-1', { user: { id: 'user-1' } } as any);
+      expect(roomManager.pinRoom).toHaveBeenCalledWith('room-1', 'user-1');
+      expect(result).toEqual({ success: true });
+    });
+  });
+
+  describe('DELETE /staff-chat/rooms/:id/pin', () => {
+    it('delegates to roomManager.unpinRoom and returns success', async () => {
+      jest.spyOn(roomManager, 'unpinRoom').mockResolvedValue(undefined);
+      const result = await controller.unpinRoom('room-1');
+      expect(roomManager.unpinRoom).toHaveBeenCalledWith('room-1');
+      expect(result).toEqual({ success: true });
+    });
+  });
+
+  describe('POST /staff-chat/rooms/:id/read', () => {
+    it('delegates to roomManager.markAsRead and returns markedCount', async () => {
+      jest.spyOn(roomManager, 'markAsRead').mockResolvedValue({ markedCount: 3 });
+      const result = await controller.markAsRead('room-1');
+      expect(roomManager.markAsRead).toHaveBeenCalledWith('room-1');
+      expect(result).toEqual({ markedCount: 3 });
+    });
+  });
+
+  describe('POST /staff-chat/rooms/:id/upload', () => {
+    it('delegates to roomManager.uploadFile with room, file, user id', async () => {
+      const file = { originalname: 'x.png', mimetype: 'image/png', buffer: Buffer.from('') } as any;
+      const uploadResult = { success: true, url: 'signed-url', key: 'k', filename: 'x.png' };
+      jest.spyOn(roomManager, 'uploadFile').mockResolvedValue(uploadResult);
+
+      const result = await controller.uploadFile('room-1', file, { user: { id: 'user-1' } } as any);
+
+      expect(roomManager.uploadFile).toHaveBeenCalledWith('room-1', file, 'user-1');
+      expect(result).toEqual(uploadResult);
+    });
+  });
+
+  describe('GET /staff-chat/customer/:customerId/messages', () => {
+    it('clamps limit and delegates to roomManager.getCustomerMessages', async () => {
+      const payload = { roomId: 'r-1', channel: 'LINE_FINANCE', messages: [], hasMore: false };
+      jest.spyOn(roomManager, 'getCustomerMessages').mockResolvedValue(payload as any);
+
+      const result = await controller.getCustomerMessages('cust-1', '30', undefined);
+
+      expect(roomManager.getCustomerMessages).toHaveBeenCalledWith('cust-1', 30, undefined);
+      expect(result).toEqual(payload);
+    });
+
+    it('clamps limit above 100 down to 100', async () => {
+      jest.spyOn(roomManager, 'getCustomerMessages').mockResolvedValue({} as any);
+      await controller.getCustomerMessages('cust-1', '999', 'msg-9');
+      expect(roomManager.getCustomerMessages).toHaveBeenCalledWith('cust-1', 100, 'msg-9');
+    });
+  });
+
+  describe('POST /staff-chat/customer/:customerId/messages', () => {
+    it('returns non-throwing {success:false} for empty text without resolving a room', async () => {
+      const result = await controller.sendCustomerMessage(
+        'cust-1',
+        { text: '   ' },
+        { user: { id: 'user-1' } } as any,
+      );
+      expect(result).toEqual({ success: false, error: 'กรุณาพิมพ์ข้อความก่อนส่ง' });
+      expect(roomManager.sendCustomerMessage).not.toHaveBeenCalled();
+    });
+
+    it('returns non-throwing {success:false} when customer has no LINE room', async () => {
+      jest.spyOn(roomManager, 'sendCustomerMessage').mockResolvedValue({ room: null });
+      const result = await controller.sendCustomerMessage(
+        'cust-1',
+        { text: 'hello' },
+        { user: { id: 'user-1' } } as any,
+      );
+      expect(roomManager.sendCustomerMessage).toHaveBeenCalledWith('cust-1', 'user-1', 'hello');
+      expect(result).toEqual({
+        success: false,
+        error: 'ลูกค้ายังไม่เคยทักเข้ามาในแชท LINE — รอลูกค้าทักก่อน',
+      });
+      expect(gateway.emitNewMessage).not.toHaveBeenCalled();
+    });
+
+    it('emits the broadcast with the exact STAFF payload and returns the send result', async () => {
+      jest
+        .spyOn(roomManager, 'sendCustomerMessage')
+        .mockResolvedValue({ room: { id: 'room-9' }, result: { success: true } });
+
+      const result = await controller.sendCustomerMessage(
+        'cust-1',
+        { text: 'hi there' },
+        { user: { id: 'user-1' } } as any,
+      );
+
+      expect(gateway.emitNewMessage).toHaveBeenCalledWith('room-9', {
+        roomId: 'room-9',
+        role: 'STAFF',
+        staffId: 'user-1',
+        text: 'hi there',
+        createdAt: expect.any(String),
+      });
+      expect(result).toEqual({ success: true });
+    });
+  });
+
+  describe('GET /staff-chat/rooms/:id/cross-channel', () => {
+    it('delegates to roomManager.getCrossChannelRooms', async () => {
+      const rooms = [{ id: 'r-1', channel: 'LINE_FINANCE', lastMessageAt: null, messages: [] }];
+      jest.spyOn(roomManager, 'getCrossChannelRooms').mockResolvedValue(rooms as any);
+
+      const result = await controller.getCrossChannelRooms('room-1');
+
+      expect(roomManager.getCrossChannelRooms).toHaveBeenCalledWith('room-1');
+      expect(result).toEqual(rooms);
     });
   });
 });

--- a/apps/api/src/modules/staff-chat/staff-chat.controller.ts
+++ b/apps/api/src/modules/staff-chat/staff-chat.controller.ts
@@ -21,7 +21,6 @@ import { ConfigService } from '@nestjs/config';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { RolesGuard } from '../auth/guards/roles.guard';
 import { Roles } from '../auth/decorators/roles.decorator';
-import { PrismaService } from '../../prisma/prisma.service';
 import { RoomManagerService } from '../chat-engine/services/room-manager.service';
 import { AssignmentService } from '../chat-engine/services/assignment.service';
 import { ConversationTagService } from '../chat-engine/services/conversation-tag.service';
@@ -50,8 +49,7 @@ import { CreateQuickReplyDto } from './dto/create-quick-reply.dto';
 import { UpdateQuickReplyDto } from './dto/update-quick-reply.dto';
 import { UpdateCannedResponseDto } from './dto/update-canned-response.dto';
 import { SessionQueryDto } from '../chat-engine/dto/session-query.dto';
-import { ChatRoomStatus, ChatChannel, ChatPriority, MessageRole, MessageType } from '@prisma/client';
-import { StorageService } from '../storage/storage.service';
+import { ChatRoomStatus, ChatChannel, ChatPriority } from '@prisma/client';
 import { MessageRouterService } from '../chat-engine/services/message-router.service';
 import { StaffChatGateway } from './staff-chat.gateway';
 import { CHAT_EVENTS, CHAT_ROOMS } from '../chat-engine/constants/chat-events';
@@ -60,7 +58,6 @@ import { CHAT_EVENTS, CHAT_ROOMS } from '../chat-engine/constants/chat-events';
 @UseGuards(JwtAuthGuard, RolesGuard)
 export class StaffChatController {
   constructor(
-    private prisma: PrismaService,
     private roomManager: RoomManagerService,
     private assignment: AssignmentService,
     private tags: ConversationTagService,
@@ -69,7 +66,6 @@ export class StaffChatController {
     private aiAssistant: AiAssistantService,
     private mediaContent: MediaContentService,
     private chatToContract: ChatToContractService,
-    private storageService: StorageService,
     private messageRouter: MessageRouterService,
     private aiSuggest: AiSuggestService,
     private leadScoring: LeadScoringService,
@@ -497,32 +493,7 @@ export class StaffChatController {
     @Req() req: Request,
   ) {
     const userId = (req as Request & { user?: { id: string } }).user?.id;
-    const extMap: Record<string, string> = {
-      'image/jpeg': '.jpg', 'image/png': '.png', 'image/webp': '.webp',
-      'application/pdf': '.pdf',
-      'application/msword': '.doc',
-      'application/vnd.openxmlformats-officedocument.wordprocessingml.document': '.docx',
-    };
-    const ext = extMap[file.mimetype] || '';
-    const key = `staff-chat/${roomId}/${Date.now()}${ext}`;
-
-    await this.storageService.upload(key, file.buffer, file.mimetype);
-    const downloadUrl = this.storageService.configured
-      ? await this.storageService.getSignedDownloadUrl(key, 3600)
-      : key;
-
-    // Save as a message with media
-    await this.roomManager.saveMessage({
-      roomId,
-      role: MessageRole.BOT,
-      type: file.mimetype.startsWith('image/') ? MessageType.IMAGE : MessageType.FILE,
-      text: file.originalname,
-      mediaUrl: key,
-      mediaType: file.mimetype,
-      staffId: userId,
-    });
-
-    return { success: true, url: downloadUrl, key, filename: file.originalname };
+    return this.roomManager.uploadFile(roomId, file, userId);
   }
 
   // ─── Contract Prefill ─────────────────────────────────
@@ -539,20 +510,14 @@ export class StaffChatController {
   @Roles('OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'SALES')
   async pinRoom(@Param('id') id: string, @Req() req: any) {
     const userId = req.user.id;
-    await this.prisma.chatRoom.update({
-      where: { id },
-      data: { pinnedAt: new Date(), pinnedById: userId },
-    });
+    await this.roomManager.pinRoom(id, userId);
     return { success: true };
   }
 
   @Delete('rooms/:id/pin')
   @Roles('OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'SALES')
   async unpinRoom(@Param('id') id: string) {
-    await this.prisma.chatRoom.update({
-      where: { id },
-      data: { pinnedAt: null, pinnedById: null },
-    });
+    await this.roomManager.unpinRoom(id);
     return { success: true };
   }
 
@@ -561,21 +526,7 @@ export class StaffChatController {
   @Post('rooms/:id/read')
   @Roles('OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'SALES')
   async markAsRead(@Param('id') id: string) {
-    const now = new Date();
-    return this.prisma.$transaction(async (tx) => {
-      const updated = await tx.chatMessage.updateMany({
-        where: { roomId: id, role: 'CUSTOMER', readAt: null },
-        data: { readAt: now },
-      });
-      const remaining = await tx.chatMessage.count({
-        where: { roomId: id, role: 'CUSTOMER', readAt: null },
-      });
-      await tx.chatRoom.update({
-        where: { id },
-        data: { unreadCount: remaining },
-      });
-      return { markedCount: updated.count };
-    });
+    return this.roomManager.markAsRead(id);
   }
 
   // ─── Customer-scoped messages (LineChatPanel — Customer 360) ──
@@ -597,71 +548,7 @@ export class StaffChatController {
     @Query('before') before?: string,
   ) {
     const take = Math.min(Math.max(parseInt(limit ?? '30', 10) || 30, 1), 100);
-
-    // Find the customer's LINE Finance room (preferred) or fall back to any
-    // LINE room. Collections is a finance-only workflow — no point pulling
-    // shop-side LINE chat here.
-    const room = await this.prisma.chatRoom.findFirst({
-      where: {
-        customerId,
-        deletedAt: null,
-        channel: { in: [ChatChannel.LINE_FINANCE, ChatChannel.LINE_SHOP] },
-      },
-      orderBy: [
-        // Prefer LINE_FINANCE if both exist (alphabetical "LINE_FINANCE" <
-        // "LINE_SHOP" so an explicit ordering by lastMessageAt is the
-        // tiebreaker that matters).
-        { lastMessageAt: 'desc' },
-      ],
-      select: {
-        id: true,
-        channel: true,
-        lineUserId: true,
-        lastMessageAt: true,
-        unreadCount: true,
-      },
-    });
-
-    if (!room) {
-      return { roomId: null, channel: null, messages: [], hasMore: false };
-    }
-
-    let cursorWhere: { createdAt?: { lt: Date } } = {};
-    if (before) {
-      const cursor = await this.prisma.chatMessage.findUnique({
-        where: { id: before },
-        select: { createdAt: true },
-      });
-      if (cursor) cursorWhere = { createdAt: { lt: cursor.createdAt } };
-    }
-
-    const messages = await this.prisma.chatMessage.findMany({
-      where: { roomId: room.id, deletedAt: null, ...cursorWhere },
-      orderBy: { createdAt: 'desc' },
-      take: take + 1, // overfetch by 1 to detect hasMore
-      select: {
-        id: true,
-        role: true,
-        type: true,
-        text: true,
-        mediaUrl: true,
-        mediaType: true,
-        createdAt: true,
-        readAt: true,
-        deliveredAt: true,
-        staff: { select: { id: true, name: true } },
-      },
-    });
-
-    const hasMore = messages.length > take;
-    const sliced = hasMore ? messages.slice(0, take) : messages;
-
-    return {
-      roomId: room.id,
-      channel: room.channel,
-      messages: sliced,
-      hasMore,
-    };
+    return this.roomManager.getCustomerMessages(customerId, take, before);
   }
 
   /**
@@ -686,39 +573,25 @@ export class StaffChatController {
       return { success: false, error: 'กรุณาพิมพ์ข้อความก่อนส่ง' };
     }
 
-    const room = await this.prisma.chatRoom.findFirst({
-      where: {
-        customerId,
-        deletedAt: null,
-        channel: { in: [ChatChannel.LINE_FINANCE, ChatChannel.LINE_SHOP] },
-      },
-      orderBy: { lastMessageAt: 'desc' },
-      select: { id: true },
-    });
+    const sent = await this.roomManager.sendCustomerMessage(customerId, req.user.id, text);
 
-    if (!room) {
+    if (!sent.room) {
       return {
         success: false,
         error: 'ลูกค้ายังไม่เคยทักเข้ามาในแชท LINE — รอลูกค้าทักก่อน',
       };
     }
 
-    const result = await this.messageRouter.sendStaffMessage({
-      roomId: room.id,
-      staffId: req.user.id,
-      text,
-    });
-
     // Broadcast to staff viewing this room so the message appears in real-time
-    this.staffChatGateway.emitNewMessage(room.id, {
-      roomId: room.id,
+    this.staffChatGateway.emitNewMessage(sent.room.id, {
+      roomId: sent.room.id,
       role: 'STAFF',
       staffId: req.user.id,
       text,
       createdAt: new Date().toISOString(),
     });
 
-    return result;
+    return sent.result;
   }
 
   // ─── Cross-Channel Rooms ──────────────────────────────
@@ -726,25 +599,7 @@ export class StaffChatController {
   @Get('rooms/:id/cross-channel')
   @Roles('OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'SALES')
   async getCrossChannelRooms(@Param('id') id: string) {
-    const room = await this.prisma.chatRoom.findUnique({
-      where: { id },
-      select: { customerId: true },
-    });
-    if (!room?.customerId) return [];
-    return this.prisma.chatRoom.findMany({
-      where: { customerId: room.customerId, deletedAt: null },
-      select: {
-        id: true,
-        channel: true,
-        lastMessageAt: true,
-        messages: {
-          orderBy: { createdAt: 'desc' },
-          take: 1,
-          select: { text: true, createdAt: true },
-        },
-      },
-      orderBy: { lastMessageAt: 'desc' },
-    });
+    return this.roomManager.getCrossChannelRooms(id);
   }
 
   // ─── AI Training & Settings ───────────────────────────


### PR DESCRIPTION
behavior-preserving (1 $tx, 0 JE). Moves 9 in-handler prisma calls + storage orchestration from markAsRead/uploadFile/getCustomerMessages/sendCustomerMessage/getCrossChannelRooms/pin/unpin into RoomManagerService (markAsRead $transaction moved WHOLE); the other ~49 thin handlers untouched. All 56 routes/56 @Roles/guards/file-validators + response shapes (incl non-throwing {success:false,error}) + emitNewMessage payload byte-identical. New forwardRef(MessageRouterService) edge breaks the RoomManager<->MessageRouter cycle (proven runtime-sound via full AppModule boot). +10 characterization tests. tsc 0 · 219 tests green · lint 0. **Adversarial review: SPEC ✅** (7 bodies byte-identical, DI edge boots, spec genuine). 🤖 Generated with Claude Code