### PR TITLE
test(expense): pin T2-C12 amount-lock — edit frozen once doc leaves DRAFT

### DIFF
--- a/apps/api/src/modules/expense-documents/__tests__/expense-document-create.service.spec.ts
+++ b/apps/api/src/modules/expense-documents/__tests__/expense-document-create.service.spec.ts
@@ -1,5 +1,7 @@
+import { BadRequestException } from '@nestjs/common';
 import { Prisma } from '@prisma/client';
 import { ExpenseDocumentsService } from '../expense-documents.service';
+import { StatusTransitionService } from '../services/status-transition.service';
 import { makeExpenseDocumentsService } from './support/make-expense-documents-service';
 
 /**
@@ -157,6 +159,50 @@ describe('ExpenseDocumentCreateService (via facade) — characterization', () =>
       expect(updArg.data.vatAmount.toFixed(2)).toBe('70.00');
       expect(updArg.data.totalAmount.toFixed(2)).toBe('1070.00');
     });
+  });
+
+  // ─── 2b. T2-C12 — update() amount-lock once a doc leaves DRAFT ──────────
+  // Regression guard for the fraud vector: requester submits a doc for approval,
+  // then quietly lowers the amount before the approver looks. `update()` is the
+  // ONLY path that mutates amount/vat/wht, and it must abort BEFORE any write for
+  // every post-DRAFT status. Uses the REAL StatusTransitionService (not the mock)
+  // so this proves update() actually wires the guard — a regression that either
+  // relaxes assertCanEdit OR drops the call from update() will fail here.
+  describe('T2-C12 — update() rejects edit + writes nothing once doc leaves DRAFT', () => {
+    it.each(['PENDING_APPROVAL', 'APPROVED', 'ACCRUAL', 'POSTED'])(
+      'status=%s → BadRequestException, no line/total mutation reaches the DB',
+      async (status) => {
+        const made = makeExpenseDocumentsService({
+          prisma,
+          transition: new StatusTransitionService(),
+        });
+        prisma.expenseDocument.findUniqueOrThrow.mockResolvedValue({
+          id: 'doc-1',
+          status,
+          deletedAt: null,
+          depositAccountCode: '11-1103',
+          expenseDetail: { priceType: 'EXCLUSIVE', lines: [] },
+        });
+
+        await expect(
+          made.service.update(
+            'doc-1',
+            {
+              // fraudster tries to slash the amount after submission
+              lines: [
+                { category: '53-1101', quantity: 1, unitPrice: 5, vatPercent: 7, whtPercent: 0 },
+              ],
+            } as never,
+            'fraudster-1',
+          ),
+        ).rejects.toBeInstanceOf(BadRequestException);
+
+        // Guard fired before any mutation — amount/line writes never happened
+        expect(prisma.expenseLine.deleteMany).not.toHaveBeenCalled();
+        expect(prisma.expenseDetail.update).not.toHaveBeenCalled();
+        expect(prisma.expenseDocument.update).not.toHaveBeenCalled();
+      },
+    );
   });
 
   // ─── 3. createDraftForRepair — uses passed-in tx, opens NO new $transaction ─

--- a/apps/api/src/modules/expense-documents/__tests__/status-transition.service.spec.ts
+++ b/apps/api/src/modules/expense-documents/__tests__/status-transition.service.spec.ts
@@ -80,5 +80,16 @@ describe('StatusTransitionService', () => {
     it('reject edit ACCRUAL', () => {
       expect(() => service.assertCanEdit({ from: 'ACCRUAL' })).toThrow(BadRequestException);
     });
+    // T2-C12 — amount-lock fraud guard. Once a doc leaves DRAFT (the requester
+    // submits it for approval), amount/vat/wht must be frozen so the requester
+    // cannot quietly lower the amount the approver already saw. Edit is the ONLY
+    // path that mutates totals, so locking it from PENDING_APPROVAL onward closes
+    // the vector. Pin these states so a future relax can't silently reopen it.
+    it('reject edit PENDING_APPROVAL (T2-C12 — amount-lock fraud guard)', () => {
+      expect(() => service.assertCanEdit({ from: 'PENDING_APPROVAL' })).toThrow(BadRequestException);
+    });
+    it('reject edit APPROVED (T2-C12)', () => {
+      expect(() => service.assertCanEdit({ from: 'APPROVED' })).toThrow(BadRequestException);
+    });
   });
 });


### PR DESCRIPTION
## What & why

**T2-C12** (Tier-8 fraud heatmap, Medium) worried that an expense requester could submit a doc for approval, then quietly lower `amount`/`vatAmount`/`withholdingTax` before the approver looks — approver signs off on a number the requester silently changed.

**Verification this session found the vector is already closed** by current code:
- `update()` is the *only* path that mutates expense totals/lines ([expense-document-create.service.ts:968](apps/api/src/modules/expense-documents/services/expense-document-create.service.ts#L968))
- it runs `StatusTransitionService.assertCanEdit` which throws for any non-`DRAFT` status ([status-transition.service.ts:64-68](apps/api/src/modules/expense-documents/services/status-transition.service.ts#L64-L68))
- `approve()` accepts no amount fields
- the legacy `accounting.service.updateExpense()` the stale tracker referenced no longer exists

But the approval-workflow states (`PENDING_APPROVAL`, `APPROVED`) were **unpinned** — a future relax of `assertCanEdit` could silently reopen the fraud vector. This PR pins the behaviour. **No production-code change.**

## Tests added (test-only)

- **unit** ([status-transition.service.spec.ts](apps/api/src/modules/expense-documents/__tests__/status-transition.service.spec.ts)): `assertCanEdit` rejects `PENDING_APPROVAL` + `APPROVED`
- **integration** ([expense-document-create.service.spec.ts](apps/api/src/modules/expense-documents/__tests__/expense-document-create.service.spec.ts)): `update()` wired with the **real** `StatusTransitionService` throws `BadRequestException` and **writes nothing** (no `expenseLine.deleteMany` / `expenseDetail.update` / `expenseDocument.update`) for every post-DRAFT status — proving `update()` actually invokes the guard

## Verification

- Mutation test: relaxing `assertCanEdit` to allow `PENDING_APPROVAL`/`APPROVED` turns **4 tests red** → the guard bites on both layers
- `npm run test -- status-transition.service expense-document-create.service` → **28/28 green**
- `./tools/check-types.sh api` → **OK**

🤖 Generated with [Claude Code](https://claude.com/claude-code)