### PR TITLE
docs(tier-8): re-verify fraud heatmap against code — 44 DONE, 7 PARTIAL, 0 OPEN

### DIFF
--- a/docs/ceo-review/tier-8-fraud-heatmap-master.md
+++ b/docs/ceo-review/tier-8-fraud-heatmap-master.md
@@ -1,7 +1,7 @@
 # Tier-8 Fraud Heatmap — Master Doc
 
 > **Created:** 2026-04-19 (regenerated from git log + fresh codebase audit)
-> **Status:** ACTIVE — source of truth for remaining fraud/governance work
+> **Status:** ACTIVE — re-verified against code 2026-06-11 (see §3.5): **44 DONE · 7 PARTIAL · 0 OPEN**
 > **Predecessor:** original doc ลบไปก่อนหน้านี้; เอกสารนี้สร้างใหม่จาก git log + parallel Explore audit ของ 4 พื้นที่ (T1+T2, T3+T4, T5, T6+T7)
 
 ---
@@ -134,321 +134,130 @@ Severity scale: **Critical** (active $ loss), **High** (enables fraud), **Medium
 
 ---
 
-## 4. Remaining Items (from 2026-04-19 audit)
+## 3.5 Re-verification 2026-06-11 (code-grounded)
 
-> **Note:** Numbering continues from completed set; gaps in sequences มีเพราะไม่มี item ที่ audit รอบใหม่นี้หา
+> A 7-agent parallel audit re-checked **all 51** "Remaining" items below against the **current** `apps/api` code on `main` (HEAD `b7677e89`). Result: **44 DONE · 7 PARTIAL · 0 OPEN** — most of the 2026-04-19 backlog shipped during the hardening + decompose campaigns. Every verdict is backed by a concrete `file:line`. Only the **7 PARTIAL** items (section 4) carry real residual work, and each needs an owner / ops / design decision rather than a quick code patch.
+>
+> **Correction vs. earlier handoff notes:** `T5-C13` was assumed DONE (its `$transaction` atomicity is in fact correct) but is **PARTIAL** — `adjustShopWarranty()` has no controller/cron/service caller, so the audited path is unreachable dead code. `T2-C12` (expense amount-lock) and `T6-C4` (PEAK HMAC) are confirmed DONE.
 
-### T1 — Money Flow Integrity (4 items)
+### Verified DONE (44) — evidence (paths relative to `apps/api/src/modules/` unless marked (prisma))
 
-#### **T1-C6 [High]** — Commission clawback cron ยังไม่ถูกเรียก
-- **Gap:** `commission.service.applyClawbackForContract()` มีอยู่ (T2-C6) แต่ถูกเรียกแค่ใน test เท่านั้น — ไม่มี controller endpoint หรือ cron ที่ทริกเกอร์เมื่อ contract default
-- **Attack:** Salesperson เก็บ commission เต็มแม้ contract default ภายใน FPD
-- **Fix:** สร้าง `commission-clawback.cron.ts` daily — scan contracts ที่ status=DEFAULT + `clawbackAppliedAt IS NULL` → call service + Sentry capture
-- **Effort:** S (1–2 hr)
-
-#### **T1-C7 [High]** — BadDebtWriteOff ไม่มี immutable audit table
-- **Gap:** Global AuditInterceptor logs request แต่ถ้า AuditLog ถูกลบ (แม้ trigger block DELETE ที่ DB) ยังไม่มี dedicated write-off log
-- **Fix:** เพิ่ม `BadDebtWriteOffAuditLog` table (immutable — createdAt only, no updatedAt/deletedAt) — `writtenOffBy`, `approverId`, `contractId`, `amount`, `reason`, `createdAt`
-- **File:** `apps/api/prisma/schema.prisma` + `apps/api/src/modules/bad-debt/`
-- **Effort:** M (3–4 hr)
-
-#### **T1-C8 [Medium]** — Refund bank reversal timestamp แก้ได้หลังล็อก
-- **Gap:** `refunds.controller.mark-reversed` + `mark-failed` ไม่มี immutability check บน `bankReversalRef` / `bankReversalAt` — FM เขียนทับเวลาที่ bank กลับเงินจริงได้
-- **Fix:** เพิ่ม `bankReversalLockedAt` flag (set เมื่อ `bankReversalRef` ถูกเขียนครั้งแรก) — reject update ถ้า locked
-- **Effort:** S
-
-#### **T1-C9 [Medium]** — Large late-fee waiver ไม่มี Sentry alert
-- **Gap:** `payments.service.waiveLateFee()` guard ด้วย role เท่านั้น — FM waive 100K/วันได้โดยไม่ alert ops
-- **Fix:** ถ้า `waivedAmount > 5000` call `Sentry.captureMessage(level:'warning')` with waivedBy, contract, amount
-- **Effort:** S (<1 hr)
-
-### T2 — Governance / Audit / Immutability (8 items)
-
-#### **T2-C9 [High]** — Journal void ไม่สร้าง reversal entry
-- **Gap:** `journal.service.void()` set status=VOIDED แต่ไม่ auto-create reversal journal (debit/credit flipped) — user void expense journal ได้โดยไม่ทิ้งร่องรอย
-- **Fix:** On void, auto-create reversal entry (`referenceType=REVERSAL`, `referenceId=original-entry-id`) posted immediately
-- **Effort:** M
-
-#### **T2-C10 [High]** — Closed AccountingPeriod reopen โดยไม่มี board guard
-- **Gap:** `POST /accounting/periods/reopen` OWNER-only แต่ไม่มี time-lock — CLOSED period > 90d ยัง reopen ได้ → ลบหลักฐาน audit
-- **Fix:** ใน `monthly-close.service.reopenPeriod()` — ถ้า `status=CLOSED && closedAt < now-90d` → `ForbiddenException('Period is locked; requires Board approval')` + OWNER override via explicit `boardResolutionId` field
-- **Effort:** S–M
-
-#### **T2-C11 [High]** — Stock adjustment role escalation gap
-- **Gap:** Schema บังคับ `approvedBy ≠ adjustedBy` (T5-C3) แต่ controller อนุญาต BM ทั้ง create + approve — BM approve adjustment ของ BM คนอื่นได้
-- **Fix:** ถ้า adjustment amount > 500K ต้อง approvedById = OWNER เท่านั้น (ไม่ใช่ BM)
-- **Effort:** S
-
-#### **T2-C12 [Medium]** — Expense amount แก้ได้ระหว่าง PENDING_APPROVAL
-- **Gap:** `accounting.service.updateExpense()` block edit เมื่อ APPROVED/PAID แต่ PENDING_APPROVAL ยัง patchable — requester submit → ลดยอด → approver approve ยอดใหม่โดยไม่รู้
-- **Fix:** Lock `amount`, `vatAmount`, `withholdingTax` เมื่อ `status >= PENDING_APPROVAL` — ให้ edit ได้แค่ description/notes/reference
-- **Effort:** S
-
-#### **T2-C13 [Medium]** — Main AuditLog retention cron ยังไม่มี
-- **Gap:** LoginAuditLog มี 90d cron (T2-C8) แต่ main AuditLog ไม่มี retention cron — PDPA data minimization risk
-- **Fix:** `audit/audit-retention.cron.ts` — archive AuditLog > configurable TTL (default 180d) ไปที่ cold storage หรือ soft-archive, log purge counts ไป Sentry
-- **Note:** ต้องประสานงานกับ Merkle chain (T2-C4 ext) — archive แต่ keep hash for verification
-- **Effort:** M
-
-#### **T2-C14 [Medium]** — Journal post audit ไม่แยกจาก global interceptor
-- **Gap:** `journal.service.post()` มี `postedById/postedAt` + interceptor log แต่ถ้า interceptor log ถูกลบ ไม่มี forensic หลักฐานว่าใคร approve
-- **Fix:** สร้าง `JournalPostAuditLog` immutable (`journalEntryId`, `postedById`, `postedAt`, `ipAddress`, `userAgent`) — เขียน synchronously ใน same tx
-- **Effort:** M
-
-#### **T2-C15 [Low]** — SystemConfig sensitive field redaction ไม่ครอบคลุม
-- **Gap:** #537 เพิ่ม audit trail แต่ต้องตรวจว่า `SENSITIVE_FIELDS` ครอบคลุม `bankApiKey`, `paymentGateway*`, `peakSecretKey`, `mdmApiKey` หรือไม่ — ถ้าไม่ครบ AuditLog.newValue จะมี plaintext secrets
-- **Fix:** Extend `audit.interceptor.ts` sanitizeBody() sensitive keys list + regex match + unit test
-- **Effort:** S
-
-#### **T2-C16 [Low]** — CommissionRule retroactive recompute
-- **Gap:** T5-C9 log rule update แต่ไม่ block การ recompute commission ที่ค้าง pending ใน period เดียวกันด้วย rate ใหม่
-- **Fix:** ใน `commission.service.updateRule()` — block ถ้ามี unpaid commission ใน period เดียวกัน เว้นแต่มี `retroactiveApproval` header + signer = OWNER
-- **Effort:** S
-
-### T3 — Customer & Payment Hygiene (7 items)
-
-#### **T3-C2 [High]** — Slip cross-contract reuse (same image across contracts)
-- **Gap:** Customer upload slip เดียวกันสำหรับ contract A งวด 1 แล้ว reuse สำหรับ contract B งวด 1 — imageUrl ไม่ถูก hash/fingerprint
-- **Fix:** สร้าง `SlipFingerprint` table (md5 hash จาก OCR ref+amount+bank) — reject ถ้า hash ตรงกับ slip ใน 30 วันล่าสุด across contracts
-- **File:** `apps/api/src/modules/slip-processing/`
-- **Effort:** M
-
-#### **T3-C3 [High]** — Loyalty redemption ไม่มี per-transaction cap
-- **Gap:** `loyalty.service.redeemPoints()` ให้ SALES redeem จนหมด balance ได้ — ไม่มี daily cap, ไม่ link กับ POS receipt จริง
-- **Fix:** Daily cap 5,000 pts/customer/day + require `posTransactionId` + OWNER approval gate ถ้า amount > 10K
-- **Effort:** M
-
-#### **T3-C4 [High]** — Late-fee waiver approver signature หาย
-- **Gap:** `waiveLateFee` มี SoD (T1-C2) แต่ approver's approval ไม่ถูก log แยกเป็น event — ถ้า manager approve ทางวาจา ไม่มีหลักฐาน
-- **Fix:** สร้าง `FeeWaiverApproval` table + require FM กด "confirm waiver" หลัง review; log timestamp แยก + ip/userAgent
-- **Effort:** M
-
-#### **T3-C5 [High]** — Payment amount mutability ยังไม่ถูกบล็อกระดับ code
-- **Gap:** Schema อนุญาต arbitrary update — ถ้าอนาคตมี PATCH/PUT endpoint (ยังไม่มี) จะเกิดปัญหา
-- **Fix:** Immutability rule: payment.amountPaid update = reject; reverse+new entry with `REVERSAL` audit action only via OWNER
-- **Effort:** S (preventive)
-
-#### **T3-C7 [Medium]** — Slip OCR duplicate detection
-- **Gap:** `slip-processing.service.createEvidence()` ไม่ hash ก่อน create — customer upload slip เดิมหลายรอบเพื่อ contracts คนละอัน
-- **Fix:** OCR hash (MD5/SHA256 ของ ref+amount+bank+date) — reject ถ้า exists ใน 7 วันล่าสุด
-- **Note:** overlap กับ T3-C2 แต่ fingerprint ต่าง scope: T3-C2 = image URL, T3-C7 = OCR content
-- **Effort:** M
-
-#### **T3-C9 [Medium]** — Phone/email dedup ยังไม่มี
-- **Gap:** Dedup check มีแค่ nationalId (T3-C8 done) — phone/email ซ้ำได้ (หลากหลาย format: "081-234-5678" vs "0812345678")
-- **Fix:** Normalize phone (strip dashes/spaces) + add `@unique` on phone; application-level check email
-- **Effort:** S
-
-#### **T3-C11 [Medium]** — Auto-escalation OVERDUE→DEFAULT ไม่มี manual hold
-- **Gap:** `overdue.service.updateContractStatuses()` cron hourly escalate อัตโนมัติ — ไม่เคารพ "promise-to-pay" flag ที่พนักงานใส่
-- **Fix:** `Contract.blockAutoEscalation` flag (24–48hr window) + respect recent `CallLog.result='PROMISED'` ภายใน 24 ชม.
-- **Effort:** M
-
-### T4 — Staff Operations & Approval Gates (6 items)
-
-#### **T4-C1 [High]** — Salesperson reassign หลัง signature
-- **Gap:** `contracts.service.create()` capture `salespersonId` แต่ไม่มี code block การเปลี่ยน salesperson หลังเซ็น — ถ้าเพิ่ม endpoint ต่อมา จะเกิด claim hijack
-- **Fix:** Workflow gate — ถ้า `workflowStatus=APPROVED` หรือมี signature แล้ว → block change ยกเว้น OWNER + audit log + commission recalc
-- **Effort:** S (preventive)
-
-#### **T4-C4 [High]** — Credit check override evidence gate
-- **Gap:** `credit-check.service.overrideById()` enforce role แต่ `overrideReason` เป็น free-text ไม่มี validation — manager เขียน "ok" ได้
-- **Fix:** `@IsNotEmpty() @MinLength(20)` + `attachmentIds[]` (proof documents) — audit log ต้องเก็บทั้ง reason + documents
-- **Effort:** S
-
-#### **T4-C6 [Medium]** — Broadcast large-audience second approval
-- **Gap:** OWNER-only guard (Sprint 4b) แต่ OWNER กด broadcast ไปทุก customer ได้ — ไม่มี log content, ไม่มี trigger-word detection
-- **Fix:** Log broadcast intent (targets, message, sender) **ก่อน**ส่ง + require second OWNER approval ถ้า audience > 1,000 หรือ message มี trigger words (repossess/legal/debt)
-- **Effort:** M
-
-#### **T4-C9 [Medium]** — LIFF per-session rate limit
-- **Gap:** `liffRegisterLookup()` throttle 5/min per IP — attacker ใช้ LINE accounts หลายตัว (5×100=500/min) enumerate phone numbers
-- **Fix:** Per-`lineUserId` counter ใน Redis (3 fail = 30min lockout) + email OTP confirmation + log failures
-- **Effort:** M
-
-#### **T4-C10 [Medium]** — Commission snapshot link to contract salesperson
-- **Gap:** `SalesCommission.salespersonId` เก็บใน DB แต่ไม่ snapshot จาก contract ณ วันขาย — ถ้า contract reassigned salesperson หลัง approve commission ไม่เปลี่ยน (same person claim คนใหม่)
-- **Fix:** Snapshot contract's salesperson ณ sale time; ถ้า contract.salesperson เปลี่ยนหลัง commission approved — commission ยังยึด original earner
-- **Overlap:** T4-C1 fix นี้เพิ่มเติม — เน้นที่ audit evidence
-- **Effort:** S
-
-#### **T4-C11 [Medium]** — Staff chat handoff commission hijack
-- **Gap:** Staff chat handoff logic ถ้ามี — agent ใหม่ take over session อาจเคลม commission ของ sale เก่า
-- **Fix:** Immutable assignment เมื่อ customer signed + log session transfers + commission ยึด signer ณ เซ็น
-- **Effort:** S–M (verify existing behavior first)
-
-### T5 — Contracts / Inventory / CRM (12 items)
-
-#### **T5-C2 [High]** — Contract void after activation
-- **Gap:** `contracts.service.softDelete()` ตรวจแค่ `status === 'DRAFT'` แต่ถ้า status drift จาก ACTIVE → user void ได้; terminal status ไม่ immutable ที่ DB
-- **Fix:** Guard `status !== 'DRAFT'` + block update/delete บน ACTIVE/OVERDUE/DEFAULT contracts; mark terminal enum ที่ schema
-- **File:** `apps/api/src/modules/contracts/contracts.service.ts` L611-638
-- **Effort:** S
-
-#### **T5-C4 [High]** — Installment amounts แก้ได้เมื่อมี PENDING payments
-- **Gap:** `contracts.service.update()` ให้แก้ sellingPrice/downPayment/totalMonths ได้ถ้า `paidOrPartialCount === 0` แม้มี PENDING payments
-- **Fix:** Block ANY financial field edit ถ้า `payment.count > 0` (รวม PENDING)
-- **File:** `contracts.service.ts` L545-604
-- **Effort:** S
-
-#### **T5-C12 [High]** — IMEI serial reuse across soft-deleted products
-- **Gap:** `trade-in.service.accept()` ตรวจ `existing.deletedAt` แต่ไม่ prevent duplicate IMEIs เมื่อ product ถูก soft-delete
-- **Fix:** Partial unique index: `CREATE UNIQUE INDEX imei_unique_active ON products (imei_serial) WHERE deleted_at IS NULL`
-- **Effort:** S
-
-#### **T5-C13 [High]** — Warranty atomic audit gap
-- **Gap:** `warranty.service.adjustShopWarranty()` enforce OWNER สำหรับ BACKWARD adjustment แต่ audit log เขียนหลัง update — race condition
-- **Fix:** Update + audit write ต้องอยู่ใน `prisma.$transaction()`; require 2-factor approval ถ้า backward > 7 days
-- **Effort:** M
-
-#### **T5-C14 [High]** — Stock adjustment DAMAGED photo gate
-- **Gap:** Photo required เฉพาะ DEFECT exchange (T5-C10) — DAMAGED stock adjustment ไม่ต้องใส่รูป → mass-damage writeoff ทำได้
-- **Fix:** Require `photos.length > 0` เมื่อ `reason=DAMAGED` + photos immutable หลัง post
-- **Effort:** S
-
-#### **T5-C15 [Medium]** — CRM stage change audit
-- **Gap:** T5-C7 log assignment แต่ไม่ log stage transition — manager mark WON retroactively (เปลี่ยน wonAt + stage) เก็บ commission เดือนเก่า
-- **Fix:** `CrmLeadStageHistory` table (`stagedBy`, `stagedAt`, `oldStage`, `newStage`) + enforce `wonAt >= createdAt`
-- **Effort:** M
-
-#### **T5-C16 [Medium]** — PO receive qty race condition
-- **Gap:** `purchase-orders.service.receive*()` ใช้ in-memory `poItem.receivedQty` — 2 concurrent GR → receivedQty > ordered
-- **Fix:** `SELECT FOR UPDATE` lock PO rows; ใช้ `SUM(receivedQty)` แทน loop accumulation
-- **File:** `purchase-orders.service.ts` L486-491, L543
-- **Effort:** M
-
-#### **T5-C17 [Medium]** — Trade-in appraisal price drift
-- **Gap:** `trade-in.service.appraise()` allow multiple calls — staff เสนอ 20K (blocked), เรียก appraise ใหม่ 18K (passed) — override หลักฐานหาย
-- **Fix:** Snapshot offeredPrice immutably ที่ first APPRAISED; require 2FA override ถ้านอก ±15% ceiling
-- **Effort:** M
-
-#### **T5-C18 [Medium]** — Supplier bank account swap mid-PO
-- **Gap:** `suppliers.service.update()` soft-delete old paymentMethods + create new — PO อ้างอิง supplierId (FK) ไม่ snapshot bank account
-- **Fix:** Snapshot `supplier.bankAccountNumber` + `bankName` ที่ PO.create(); block supplier update บน bank fields ถ้ามี non-CANCELLED PO
-- **Effort:** M
-
-#### **T5-C19 [Medium]** — Commission rate snapshot validation
-- **Gap:** T2-C5 block rule change while PENDING แต่ `SalesCommission.commissionRate` snapshot ที่ creation ไม่ถูก validate กับ rule ตอน approve
-- **Fix:** ที่ approve — validate `SalesCommission.commissionRate === rule.rate`; log rule version ID ที่ `commission.create()`
-- **Overlap:** T2-C16 — เน้นคนละ layer (T2 = rule lock, T5 = commission validation)
-- **Effort:** S
-
-#### **T5-C20 [Low]** — Contract hash integrity fields limited
-- **Gap:** `contract-workflow.service.submitForReview()` hash แค่ 6 core fields — notes, signatures, documents, customer snapshot ไม่รวม
-- **Fix:** ขยาย hash input; store on contract table; validate ทุก state transition
-- **Effort:** S
-
-#### **T5-C21 [Low]** — Inter-company SHOP↔FINANCE no FK lock
-- **Gap:** `inter-company.service.ts` resolve companyId at tx create (not FK) — ถ้า FINANCE company ถูกลบ future tx จะมี NULL fromCompanyId
-- **Fix:** NOT NULL constraint บน fromCompanyId/toCompanyId + pre-create stub companies
-- **Effort:** S
-
-### T6 — External Integrations & AI (10 items)
-
-#### **T6-C4 [Critical]** — PEAK HMAC key mix-up (connectId แทน secretKey)
-- **Gap:** `peak.service.ts` / MDM HMAC implementation: `createHmac('sha1', config.connectId).update(timeStamp)` — ควรใช้ `secretKey` ไม่ใช่ `connectId` (public identifier)
-- **Impact:** Attacker ที่มี connectId (public value) forge journal entries บน PEAK ได้
-- **Fix:** Use `secretKey` as HMAC key per PEAK spec + integration test
-- **Priority:** **ทำก่อน** (security bug active ใน prod)
-- **Effort:** S (<1 hr + migration test)
-
-#### **T6-C5 [Critical]** — PEAK partial sync rollback หาย
-- **Gap:** `peak.service.ts` L70-120 export entries sequentially — ถ้า sync ล้มกลาง batch, entries ที่เหลือ NOT synced แต่ marked as synced (race ระหว่าง Prisma update กับ HTTP timeout)
-- **Fix:** Wrap export in `prisma.$transaction()` with idempotency markers; retry on HTTP failure; Sentry alert on partial state
-- **Effort:** M–L
-
-#### **T6-C9 [Critical]** — PEAK credentials ไม่มี rotation/access audit
-- **Gap:** `PEAK_USER_TOKEN`, `PEAK_CONNECT_ID`, `PEAK_SECRET_KEY` อยู่ใน env — ไม่มี rotation cron, ไม่ log access
-- **Fix:** Credential rotation runbook (quarterly) + integration-config access logging + Vault-style storage
-- **Effort:** L (ต้องวาง design ก่อน)
-
-#### **T6-C10 [High]** — SMS webhook ไม่มี signature verification
-- **Gap:** `sms-webhook.controller.ts` accept GET+POST ไม่มี signature — throttle 60/min per-IP เท่านั้น
-- **Fix:** Contact ThaiBulkSMS สำหรับ HMAC signing spec; ระหว่างรอ — strict IP whitelist ใน CloudArmor
-- **Effort:** M (รอ provider)
-
-#### **T6-C12 [High]** — PaySolutions webhook verify merchantId เท่านั้น (ไม่มี HMAC)
-- **Gap:** `POST /api/paysolutions/webhook` accept request ใดๆที่ merchantId ถูก — spoof payment success ได้
-- **Fix:** ประสานงาน PaySolutions สำหรับ HMAC signing; ระหว่างรอ — rate-limit per merchantId (ไม่ใช่ global) + IP whitelist
-- **Effort:** M
-
-#### **T6-C13 [High]** — MDM API key ไม่มี versioning/rotation
-- **Gap:** MDM PJ-Soft API key เป็น plain string ใน `integrationConfig` — ถ้า leak attacker unlock ทุกเครื่อง + enable Lost Mode
-- **Fix:** Key versioning + annual rotation cron + deprecation grace period
-- **Effort:** M
-
-#### **T6-C14 [High]** — Facebook webhook rawBody capture fragility
-- **Gap:** `verifySignature()` ใช้ raw request body — ถ้า middleware ordering ผิด rawBody undefined → all FB events rejected (safe) แต่ไม่มี logging/alert → FB messaging เงียบหาย
-- **Fix:** SLO alarm + log metric ต่อครั้งที่ rawBody capture failed; fallback emit Sentry warning
-- **Effort:** S
-
-#### **T6-C15 [Medium]** — LIFF cross-company boundary check
-- **Gap:** `chatbot-finance-liff.controller.ts:64` — verify JWT แต่ไม่ check `lineUserId` เป็นของ requesting user's company (SHOP vs FINANCE)
-- **Fix:** Add branchId/companyId check ใน `LiffTokenGuard`
-- **Effort:** S
-
-#### **T6-C16 [Medium]** — AI Claude tool input validation
-- **Gap:** `finance-ai.service.ts:157-160` execute arbitrary tool input จาก Claude — prompt injection ดึง customer data ได้; audit log อาจมี PII leak
-- **Fix:** Validate tool.input ต่อ schema ก่อน execute; strip PII keys ใน audit log
-- **Effort:** M
-
-#### **T6-C17 [Medium]** — Webhook anomaly log abuse rate-limit
-- **Gap:** `WebhookAnomaly` table ไม่จำกัด insert rate — attacker trigger 100x invalid signatures ท่วม table
-- **Fix:** Aggregate rate-limit per provider (e.g., max 100/hr/provider) + auto-alert เมื่อ 5+ anomalies/5min spike
-- **Effort:** S
-
-### T7 — Ops / Security / Resilience (4 items)
-
-#### **T7-C2 [High]** — Password reset rate limit ยังไม่มี
-- **Gap:** `/auth/forgot-password` token validity 15min แต่ไม่มี rate limit per email → attacker spam 1000 emails → enumeration via bounce
-- **Fix:** Rate limit 3/hr per email
-- **Effort:** S
-
-#### **T7-C3 [High]** — /health/detailed leak env var names
-- **Gap:** Return 503 พร้อม `"missing env vars: S3_ACCESS_KEY, S3_SECRET_KEY"` — attacker map integrations
-- **Fix:** Return generic `"Storage misconfigured"` ไม่ระบุ var names
-- **Effort:** XS
-
-#### **T7-C5 [Medium]** — Refresh token body accept เพิ่มจาก cookie
-- **Gap:** `/auth/refresh` accept body `refreshToken` (line 110) เพิ่มจาก HttpOnly cookie — CSRF exfil path ถ้า SameSite drop
-- **Fix:** Only accept cookie; reject body refreshToken field
-- **Effort:** S
-
-#### **T7-C9 [Medium]** — Metrics token plaintext rotation
-- **Gap:** `X-Metrics-Token` header เป็น plaintext ใน env — ถ้า Prometheus scraper URL leak (logs/dashboards) scrape metrics ได้
-- **Fix:** mTLS หรือ OAuth token + auto-rotation cron
-- **Effort:** L (ต้องวาง scraper config)
+| ID | Sev | Evidence (file:line) |
+|----|-----|----------------------|
+| T1-C6 | High | commission/commission-clawback.cron.ts:33 |
+| T1-C7 | High | (prisma) schema.prisma:5821 BadDebtWriteOffAuditLog + bad-debt.service.ts:496 |
+| T1-C8 | Med | refunds/refunds.service.ts:210 (bankReversalLockedAt) |
+| T1-C9 | Med | payments/services/late-fee-waiver.service.ts:141 (Sentry >5k) |
+| T2-C9 | High | journal/journal.service.ts:283 (void → reversal entry) |
+| T2-C10 | High | accounting/monthly-close.service.ts:368 (90d board guard) |
+| T2-C11 | High | inventory/stock-adjustments.service.ts:103 (>500k OWNER) |
+| T2-C12 | Med | expense-documents/services/status-transition.service.ts:64 (DRAFT-only edit) + regression spec PR #1251 |
+| T2-C13 | Med | audit/audit-retention.cron.ts:97 |
+| T2-C14 | Med | journal/journal.service.ts:248 (JournalPostAuditLog in-tx) |
+| T2-C15 | Low | audit/audit.interceptor.ts:27 (SENSITIVE_FIELDS) |
+| T2-C16 | Low | commission/commission.service.ts:419 (retro rate guard) |
+| T3-C2 | High | chatbot-finance/services/slip-processing.service.ts:116 (SlipFingerprint) |
+| T3-C3 | High | loyalty/loyalty.service.ts:189 (cap + posTxn + OWNER) |
+| T3-C4 | High | payments/services/late-fee-waiver.service.ts:109 (FeeWaiverApproval) |
+| T3-C7 | Med | chatbot-finance/services/slip-processing.service.ts:342 (OCR hash) |
+| T3-C9 | Med | customers/services/customer-write.service.ts:157 (phone dedup) |
+| T3-C11 | Med | overdue/services/overdue-lifecycle-cron.service.ts:104 |
+| T4-C1 | High | contracts/services/contract-lifecycle.service.ts:609-645 |
+| T4-C4 | High | credit-check/dto/credit-check.dto.ts:54-64 |
+| T4-C6 | Med | broadcast/broadcast.service.ts:159-191 |
+| T4-C10 | Med | sales/services/sale-writer.service.ts:354 |
+| T4-C11 | Med | chat-engine/services/assignment.service.ts:84-128 |
+| T5-C2 | High | contracts/services/contract-lifecycle.service.ts:467 |
+| T5-C4 | High | contracts/services/contract-lifecycle.service.ts:388 |
+| T5-C12 | High | (prisma) migrations/20260525200000_product_imei_partial_unique/migration.sql:24 |
+| T5-C14 | High | inventory/stock-adjustments.service.ts:47 |
+| T5-C15 | Med | crm/services/crm-pipeline.service.ts:144 |
+| T5-C16 | Med | purchase-orders/services/po-receiving.service.ts:119 |
+| T5-C17 | Med | trade-in/services/trade-in-lifecycle.service.ts:229 |
+| T5-C18 | Med | suppliers/suppliers.service.ts:124 |
+| T5-C19 | Med | commission/commission.service.ts:223 |
+| T5-C20 | Low | contracts/contract-workflow.service.ts:106 |
+| T5-C21 | Low | (prisma) migrations/20260528300000_inter_company_not_null/migration.sql:1 |
+| T6-C4 | Crit | peak/peak.service.ts:175 (HMAC uses secretKey) |
+| T6-C10 | High | notifications/sms-webhook.controller.ts:59 |
+| T6-C12 | High | paysolutions/paysolutions.controller.ts:115 |
+| T6-C14 | High | chat-adapters/facebook-webhook.controller.ts:115 |
+| T6-C15 | Med | line-oa/guards/liff-token.guard.ts:117 |
+| T6-C16 | Med | chatbot-finance/tools/tool-executor.ts:47 |
+| T6-C17 | Med | webhook-security/webhook-anomaly.service.ts:93 |
+| T7-C2 | High | auth/auth.service.ts:370 |
+| T7-C3 | High | health/health.controller.ts:185 |
+| T7-C5 | Med | auth/auth.controller.ts:87 |
 
 ---
 
-## 5. Priority Matrix (สำหรับ pick งานถัดไป)
+## 4. Remaining Items — 7 PARTIAL (re-verified 2026-06-11)
 
-### 🔴 ต้องทำก่อน (Critical — active risk in prod)
-1. **T6-C4** — PEAK HMAC key bug (connectId vs secretKey) — **security bug ใน prod**
-2. **T6-C5** — PEAK partial sync rollback — data integrity
-3. **T6-C9** — PEAK credential rotation (runbook + impl)
+> The 44 items previously listed here are DONE (see §3.5). Only these 7 carry residual work — each is "core control present but a specified piece missing", and **none is a quick code patch** (all need an owner / ops / design decision). The original 2026-04-19 Gap/Fix prose for every item lives in this file's git history.
 
-### 🟠 High — ปิดก่อนสิ้นไตรมาส
-- T1-C6, T1-C7 (clawback cron + bad-debt audit)
-- T2-C9, T2-C10, T2-C11 (journal void reversal, period lock, stock adj OWNER gate)
-- T3-C2, T3-C3, T3-C4, T3-C5 (slip reuse, loyalty cap, waiver signature, payment immutability)
-- T4-C1, T4-C4 (salesperson reassign, credit override evidence)
-- T5-C2, T5-C4, T5-C12, T5-C13, T5-C14 (contract void, installment lock, IMEI unique, warranty atomic, damage photo)
-- T6-C10, T6-C12, T6-C13, T6-C14 (SMS/PaySolutions/MDM webhook + FB alert)
-- T7-C2, T7-C3 (password reset rate limit, health env leak)
+### T3 — Customer & Payment Hygiene (1 PARTIAL)
 
-### 🟡 Medium — ปิดได้ตามจังหวะ
-- T1-C8, T1-C9 (refund lock, waiver Sentry)
-- T2-C12 → T2-C14 (expense lock, retention cron, journal post audit)
-- T3-C7, T3-C9, T3-C11 (OCR hash, phone dedup, escalation hold)
-- T4-C6, T4-C9, T4-C10, T4-C11 (broadcast approval, LIFF rate limit, commission snapshot, handoff)
-- T5-C15 → T5-C19 (CRM stage audit, PO race, trade-in drift, supplier swap, commission rate validate)
-- T6-C15, T6-C16, T6-C17 (LIFF company check, AI tool validation, anomaly rate limit)
-- T7-C5, T7-C9 (refresh token, metrics token)
+#### **T3-C5 [High] — PARTIAL** — Payment reversal path missing
+- **Done:** Preventive immutability is in place — `payments.service.updatePayment()` throws `ForbiddenException` on any `amountPaid`/`amountDue`/`status` patch (FORBIDDEN_FIELDS, `payments.service.ts` L327-349); no prod caller mutates a posted payment.
+- **Still missing:** the corrective half — an OWNER-only "reverse + new entry with `REVERSAL` audit action". `reversePayment()` appears only in error strings; no method/endpoint exists.
+- **Gate:** feature/design — confirm a dedicated reversal flow is wanted (journal void→reversal T2-C9 may already cover the use case).
 
-### 🟢 Low — hardening / compliance
-- T2-C15, T2-C16 (config redaction, rule retroactive)
-- T5-C20, T5-C21 (contract hash, FK lock)
+### T4 — Staff Operations & Approval Gates (1 PARTIAL)
+
+#### **T4-C9 [Medium] — PARTIAL** — LIFF rate limit not multi-node-correct
+- **Done:** Per-`lineUserId` 3-fail / 30-min lockout is implemented + wired into `requestOtp()` (`chatbot-finance/services/verification.service.ts` L45-97).
+- **Still missing:** the counter is an in-memory `Map` (code comment admits "TODO Redis"); prod Cloud Run runs `--max-instances=10`, so failures spread across instances bypass the lockout. The doc also asked for email-OTP confirmation (failures are only `logger.warn`'d).
+- **Gate:** infra — needs a Redis-backed (shared) counter before it holds under horizontal scale.
+
+### T5 — Contracts / Inventory / CRM (1 PARTIAL)
+
+#### **T5-C13 [High] — PARTIAL** — Warranty adjust path is dead code
+- **Done:** `warranty.service.adjustShopWarranty()` correctly wraps the contract update + `warrantyAuditLog` write in ONE `$transaction` (atomic), OWNER-only backward, 2nd-approver gate for backward >7d (`warranty/warranty.service.ts` L210-244) + 12 passing specs.
+- **Still missing:** the method has **no caller** — no controller endpoint, no cron, no other service (grep across `apps/api/src` + `apps/web/src` finds only the method + its own spec); `WarrantyModule` declares no controller. So the audited path is unreachable, while `repair-warranty.service.ts:209` can null `shopWarrantyEndDate` outside it.
+- **Gate:** owner/feature — decide if/where warranty end-date adjustment is exposed (endpoint + roles + UI), then route it through `adjustShopWarranty` and close any bypass.
+
+### T6 — External Integrations & AI (3 PARTIAL)
+
+#### **T6-C5 [Critical] — PARTIAL** — PEAK partial-sync not transactional
+- **Done:** Idempotent per-entry mark (`updateMany WHERE peakSyncedAt=null`) + Sentry on duplicate/exception (`peak/peak.service.ts:107`) — an already-synced entry won't double-count.
+- **Still missing:** each POST-then-mark is independent; no `$transaction` wrap and no retry on transient HTTP failure → a mid-batch timeout still leaves partial state.
+- **Gate:** money-path — touches PEAK export integrity; needs accountant/owner sign-off (same gated zone as the `PAYSOLUTIONS_I2_FIX_DESIGN.md` JE work).
+
+#### **T6-C9 [Critical] — PARTIAL** — PEAK credential access not audited
+- **Done:** Quarterly/weekly stale-credential cron (Mon 06:00 BKK, 90d threshold, Sentry warn) + `docs/guides/PEAK-CREDENTIALS-RUNBOOK.md` + encrypted-at-rest storage (`integration-config.service.ts` encryptPII) — `integrations/credential-rotation.cron.ts:36`.
+- **Still missing:** credential **reads** (`getValue`/`getConfig`) are not logged; no `IntegrationAccessLog` table; no actual rotation (monitor-only).
+- **Gate:** ops/design — rotation cadence + Vault-style storage + access-log schema are an ops decision.
+
+#### **T6-C13 [High] — PARTIAL** — MDM key versioning not wired
+- **Done:** `apiKeyPrevious` grace-period field declared in `integrations/integration-registry.ts:327`; the generic weekly rotation cron covers MDM's sensitive fields.
+- **Still missing:** `mdm.service.ts:120` reads only `getValue('mdm','apiKey')` — `apiKeyPrevious`/`MDM_API_KEY_PREVIOUS` is referenced nowhere in service code; no real key-versioning / deprecation-window behaviour; no dedicated MDM rotation cron.
+- **Gate:** ops/design — same credential-rotation decision as T6-C9.
+
+### T7 — Ops / Security / Resilience (1 PARTIAL)
+
+#### **T7-C9 [Medium] — PARTIAL** — Metrics token still a shared secret
+- **Done:** `METRICS_SCRAPE_TOKEN` gated by `timingSafeEqual` + manual zero-downtime dual-token rotation (`METRICS_SCRAPE_TOKEN_PREVIOUS`) — `metrics/metrics.controller.ts:40`.
+- **Still missing:** the specified fix (mTLS or OAuth + auto-rotation cron) is not implemented; rotation is a manual env-var swap.
+- **Gate:** ops/design — needs scraper-side config (mTLS/OAuth) decision.
+
+---
+
+## 5. Priority Matrix — 7 PARTIAL only (2026-06-11)
+
+> 0 fully-open items. All 7 residuals need an owner / ops / design decision, not a quick code patch.
+
+### 🔴 Critical — PEAK integrity (gated on accountant/ops)
+- **T6-C5** — PEAK partial-sync `$transaction` + retry (money-path; needs accountant sign-off)
+- **T6-C9** — PEAK credential rotation + access-audit log (ops/design)
+
+### 🟠 High
+- **T5-C13** — wire `adjustShopWarranty` to an endpoint + close the bypass (owner/feature)
+- **T3-C5** — OWNER-only payment reversal path (feature/design; may be covered by journal reversal T2-C9)
+- **T6-C13** — MDM key versioning/rotation wiring (ops/design — pairs with T6-C9)
+
+### 🟡 Medium
+- **T4-C9** — Redis-backed LIFF lockout (infra — current in-memory Map bypassed across instances)
+- **T7-C9** — metrics mTLS/OAuth + auto-rotation (ops/design)
 
 ---
 
@@ -482,7 +291,7 @@ Severity scale: **Critical** (active $ loss), **High** (enables fraud), **Medium
 
 ---
 
-**Last audit date:** 2026-04-19
-**Total completed:** ~45 T-C items
-**Total remaining:** ~51 T-C items
+**Last audit date:** 2026-06-11 (code-grounded re-verification — see §3.5)
+**Total DONE:** 89 of 96 T-C items (45 pre-2026-04 completed + 44 of the 51 "remaining" verified shipped)
+**Total PARTIAL:** 7 · **Total OPEN:** 0
 **Est. effort to close all remaining:** 12–16 developer-weeks


### PR DESCRIPTION
## What

A **7-agent parallel audit** re-checked all **51** "remaining" items in the Tier-8 fraud heatmap against the **current** `apps/api` code on `main` (HEAD `b7677e89`), each verdict backed by a concrete `file:line`.

**Result: 44 DONE · 7 PARTIAL · 0 OPEN.** Most of the 2026-04-19 backlog shipped during the hardening + decompose campaigns; the doc was ~2 months stale.

## Doc changes (`docs/ceo-review/tier-8-fraud-heatmap-master.md`, 488→297 lines)

- **new §3.5** — code-grounded re-verification summary + a 44-row DONE evidence table (id · sev · file:line)
- **§4 trimmed** from 51 verbose Gap/Fix entries → the **7 PARTIAL** residuals, each reframed as **Done / Still-missing / Gate**. None is a quick code patch — all need an owner / ops / design decision.
- **§5 priority matrix** + footer counts updated; status header notes the re-verify

## Correction surfaced by the audit

**T5-C13** was assumed DONE in the handoff but is **PARTIAL** — `adjustShopWarranty()` is atomic + spec'd (the `$transaction` is correct) but has **no caller** (no controller endpoint, cron, or service). Independently confirmed: the only reference outside the method + its spec is in `dist/` (a build artifact). So the audited path is unreachable dead code. `T2-C12` (expense amount-lock, regression-pinned in #1251) and `T6-C4` (PEAK HMAC) are confirmed DONE.

## The 7 PARTIAL (residual work, all gated)

| ID | Sev | Gate | Gap |
|----|-----|------|-----|
| T6-C5 | Crit | money-path (accountant) | PEAK partial-sync `$transaction` + retry |
| T6-C9 | Crit | ops/design | PEAK credential access-audit log |
| T5-C13 | High | owner/feature | wire `adjustShopWarranty` to an endpoint |
| T3-C5 | High | feature/design | OWNER-only payment reversal path |
| T6-C13 | High | ops/design | MDM key versioning wiring |
| T4-C9 | Med | infra | Redis-backed LIFF lockout |
| T7-C9 | Med | ops/design | metrics mTLS/OAuth + auto-rotation |

Docs-only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)