### PR TITLE
docs(money-path): record accountant sign-off + mark I2 epic/specs IMPLEMENTED

### DIFF
--- a/PAYSOLUTIONS_I2_FIX_DESIGN.md
+++ b/PAYSOLUTIONS_I2_FIX_DESIGN.md
@@ -1,8 +1,15 @@
 # PaySolutions 2B JE fix (PR-843 / I2) — implementation design
 
-Status: **DESIGNED, NOT IMPLEMENTED.** Current buggy behaviour is locked by
-`paysolutions.callback-money.spec.ts` characterization tests + the in-source
-`TODO(PR-843/I2)`. This doc is the blueprint for a correct, reviewed implementation.
+Status: **✅ IMPLEMENTED + DEPLOYED (verified 2026-06-11).** All four defects below
+are fixed: QR webhook posts a per-receipt **delta** JE via `PaymentReceiptTemplate`
+(no cumulative double-count), partials are ledgered, late fee → Cr 42-1103, and
+over-collection parks as advance (Cr 21-1103). The `TODO(PR-843/I2)` lock is gone and
+`paysolutions.callback-money.spec.ts` now asserts the CORRECT behaviour
+("defect-1 FIXED prior-partial: delta='600' NOT cumulative 1000"). Landed across
+PR-843/I2 Phase 3/5: `d72b8b16` (wire QR onto primitive), `762e274c` (over-collection
+→21-1103), `a7f47eb5` (auto-approve ≤1฿). Accountant confirmed #3/#6 on 2026-06-11
+(`PR843_I2_ACCOUNTANT_SIGNOFF.md`). The original "two attempts FAILED" + "epic not a
+patch" notes below are kept as historical design rationale — the epic ultimately landed.
 
 ## The bug surface (in `paysolutions.service.ts` `handlePaymentCallback`)
 

--- a/PR843_I2_ACCOUNTANT_SIGNOFF.md
+++ b/PR843_I2_ACCOUNTANT_SIGNOFF.md
@@ -54,4 +54,6 @@
 ---
 **ผู้ขออนุมัติ:** _____________ วันที่ ______
 **เจ้าของยืนยัน treatment (waive CPA):** ☑ akenarin (OWNER) — 2026-06-09
-**ฝ่ายบัญชี/CPA รับรอง (ภายหลัง, แนะนำ #3/#6):** _____________ วันที่ ______
+**ฝ่ายบัญชี/CPA รับรอง (ภายหลัง, แนะนำ #3/#6):** ☑ ฝ่ายบัญชี (ร่วมกับเจ้าของ) — **2026-06-11 ยืนยันถูกต้องทั้ง #3 (เงินรับเกิน QR → 21-1103 เงินรับล่วงหน้า) และ #6 (ปัดเศษระบบ ≤1฿ งวดสุดท้าย → 52-1104 auto-approve; การจ่ายขาดจริงของลูกค้ายังต้องผู้อนุมัติ)**
+
+> **สถานะ implementation (2026-06-11):** treatment ทั้งหมดนี้ **implement + deploy ไปแล้ว** ผ่าน PR-843/I2 epic (Phase 3 3b `d72b8b16` wire QR onto PaymentReceiptTemplate · #3 over-collection→21-1103 `762e274c` · #6 auto-approve ≤1฿ `a7f47eb5`) — ไม่ใช่งานค้าง. การเซ็นนี้คือการรับรองย้อนหลังของ treatment ที่ deploy แล้ว (เดิม deploy บน owner waiver). spec `PAYSOLUTIONS_I2_FIX_DESIGN.md` stale (เขียน "NOT IMPLEMENTED") — ความจริงคือ defect 1-4 แก้ครบ, `TODO(PR-843/I2)` lock หายแล้ว, callback-money.spec assert พฤติกรรมถูก (delta ไม่ใช่ cumulative · partial ledgered · late fee→42-1103). gate เขียว: refunds 47 + paysolutions callback-money + accounting.pl-expense 7.

--- a/docs/superpowers/specs/2026-06-07-refund-reversal-je-design.md
+++ b/docs/superpowers/specs/2026-06-07-refund-reversal-je-design.md
@@ -1,7 +1,7 @@
 # Refund reversal JE — `markReversed` posts the ledger reversal (design)
 
 **Date:** 2026-06-07
-**Status:** approved (brainstorm + /scrutinize) → ready for implementation plan
+**Status:** ✅ IMPLEMENTED + DEPLOYED (verified 2026-06-11) — `markReversed` posts the reversing JE (`flow:'refund-reversal'`) + reverts the payment to unpaid, inside one `$transaction`, with period guard + CAS. Landed beyond this spec: it reverses **ALL** receipt JEs of the payment (`#1164` + PR 3.1 `5f2e2d88` + BLOCKER-2 `d77fa85c`) with a tag filter excluding overpayment-credit JEs. Covered by `refunds.service.spec.ts`. Accountant confirmed the treatment (revert JE + restore installment to unpaid) on 2026-06-11.
 **Scope:** `apps/api` `RefundsService.markReversed` + `RefundsModule` wiring + a small backward-compatible param on `ReceiptVoidReversalTemplate`. Backend only — no frontend changes.
 
 ## Problem

--- a/docs/superpowers/specs/2026-06-07-reports-pl-expense-migration-design.md
+++ b/docs/superpowers/specs/2026-06-07-reports-pl-expense-migration-design.md
@@ -1,7 +1,7 @@
 # /reports P&L — expense migration (journal-sourced, FINANCE company-wide)
 
 **Date:** 2026-06-07
-**Status:** approved (brainstorm + /scrutinize rework) → ready for implementation plan
+**Status:** ✅ IMPLEMENTED + DEPLOYED (verified 2026-06-11) — `EXPENSE_ACCOUNT_CATEGORY` map lives in `accounting/accounting-section-map.util.ts`; the company-wide `/reports` P&L + `getMonthlyPLSummary` now subtract FINANCE expenses pulled from the journal (`transactional-report.service.ts`, `expenseBasis: 'accrual-journal'`), per-branch deferred (expenses zero). Covered by `accounting.pl-expense.spec.ts` (7) + `accounting-section-map.util.spec.ts` (7). Accountant confirmed the rollup map + the company-wide profit correction (was overstated) on 2026-06-11.
 **Scope:** `apps/api` `AccountingService.getProfitLossReport` + `getMonthlyPLSummary`. Backend only — **no frontend changes**.
 
 ## Problem


### PR DESCRIPTION
## What

Verification this session (with the accountant present) found the **money-path JE work the handoff listed as "0 impl, awaiting accountant sign-off" is already implemented + deployed on main.** This PR records the accountant's sign-off and corrects the stale design docs.

## Reality (git-verified on main)

| Item | State | Evidence |
|---|---|---|
| refund-reversal-je | ✅ done | `markReversed` posts reversing JE + reverts payment to unpaid; reverses ALL receipt JEs w/ tag filter (`#1164` + `5f2e2d88` + `d77fa85c`) |
| reports-pl-expense-migration | ✅ done | `EXPENSE_ACCOUNT_CATEGORY` map + company-wide P&L/`getMonthlyPLSummary` subtract FINANCE expenses (`expenseBasis: accrual-journal`) |
| paysolutions I2 (partial double-count) | ✅ done | QR webhook on `PaymentReceiptTemplate` primitive (per-receipt **delta**); `TODO(PR-843/I2)` lock gone; `callback-money.spec` asserts "delta='600' NOT cumulative 1000" (`d72b8b16`/`762e274c`/`a7f47eb5`) |

## Accountant sign-off recorded (2026-06-11)

`PR843_I2_ACCOUNTANT_SIGNOFF.md` — accountant confirmed **#3** (over-collection → 21-1103 advance) and **#6** (auto-approve ≤1฿ system rounding; real customer underpay still needs an approver), retroactively closing the merge-gate that was deployed on owner waiver.

## Verification

Gates re-run green 2026-06-11: `refunds.service` + `paysolutions.callback-money` + `accounting.pl-expense` (7) + `accounting-section-map` (7).

Docs-only — no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)