### PR TITLE
fix(pdpa): drop { not: null } on non-nullable phone — unblocks encrypt-pii backfill + status counts

### DIFF
--- a/apps/api/src/modules/pdpa/services/pdpa-backfill.util.spec.ts
+++ b/apps/api/src/modules/pdpa/services/pdpa-backfill.util.spec.ts
@@ -1,0 +1,57 @@
+import { PII_COLUMNS, plaintextColumnAnd, plaintextWhere } from './pdpa-backfill.util';
+
+/**
+ * Regression guard for the PDPA backfill / status-count Prisma bug.
+ *
+ * `Customer.phone` is `String` (NON-nullable). The previous where-builders
+ * emitted `{ phone: { not: null } }`, which Prisma rejects at runtime with
+ * `Argument \`not\` must not be null` — breaking the encrypt-pii backfill cursor
+ * AND the /settings#pdpa status counts. The `as Prisma.CustomerWhereInput` cast
+ * hid it from the type-checker, and the service specs mock prisma.count (no
+ * where validation), so it reached production silently.
+ *
+ * Root cause confirmed against the dev DB: `{ col: { not: '' } }` generates
+ * `WHERE col <> $1`, which in PostgreSQL already excludes NULL rows
+ * (`NULL <> ''` is unknown). So `{ not: '' }` alone is correct for every column
+ * and `{ not: null }` is both redundant and invalid on non-nullable `phone`.
+ */
+
+/** Deep-scan any value for a `{ not: null }` sub-clause. */
+function hasNotNull(obj: unknown): boolean {
+  if (Array.isArray(obj)) return obj.some(hasNotNull);
+  if (obj && typeof obj === 'object') {
+    for (const [k, v] of Object.entries(obj)) {
+      if (k === 'not' && v === null) return true;
+      if (hasNotNull(v)) return true;
+    }
+  }
+  return false;
+}
+
+describe('PDPA plaintext where-builders — no { not: null } (non-nullable phone guard)', () => {
+  it('plaintextColumnAnd: phone (non-nullable String) uses { not: "" } only — no { not: null }', () => {
+    expect(plaintextColumnAnd('phone', 'phoneEncrypted')).toEqual([
+      { phone: { not: '' } },
+      { phoneEncrypted: null },
+    ]);
+  });
+
+  it('plaintextColumnAnd: every PII column yields exactly [{ plain: { not: "" } }, { enc: null }]', () => {
+    for (const [plain, enc] of PII_COLUMNS) {
+      const and = plaintextColumnAnd(plain, enc);
+      expect(and).toEqual([{ [plain]: { not: '' } }, { [enc]: null }]);
+      expect(hasNotNull(and)).toBe(false);
+    }
+  });
+
+  it('plaintextWhere() emits no { not: null } anywhere (Prisma rejects it on phone)', () => {
+    const where = plaintextWhere();
+    expect(hasNotNull(where)).toBe(false);
+  });
+
+  it('plaintextWhere() keeps the soft-delete guard + one OR branch per PII column', () => {
+    const where = plaintextWhere() as { deletedAt: null; OR: unknown[] };
+    expect(where.deletedAt).toBeNull();
+    expect(where.OR).toHaveLength(PII_COLUMNS.length);
+  });
+});

--- a/apps/api/src/modules/pdpa/services/pdpa-backfill.util.ts
+++ b/apps/api/src/modules/pdpa/services/pdpa-backfill.util.ts
@@ -41,20 +41,38 @@ export const PII_COLUMNS: ReadonlyArray<[plain: string, enc: string]> = [
 export const ERROR_TRUNC_CHARS = 1000;
 
 /**
+ * AND clause matching one PII column that still has plaintext to encrypt:
+ * the plaintext column is a non-empty string AND its encrypted column is NULL.
+ *
+ * Uses ONLY `{ not: '' }` — NOT `{ not: null }`. Two reasons:
+ *   1. In PostgreSQL `col <> ''` already excludes NULL rows (`NULL <> ''` is
+ *      unknown → filtered out), so an extra `{ not: null }` is redundant —
+ *      `{ not: '' }` alone yields exactly the non-empty, non-null set.
+ *   2. `{ not: null }` is INVALID on a non-nullable column. `Customer.phone`
+ *      is `String` (required), and Prisma rejects `{ phone: { not: null } }`
+ *      at runtime with `Argument \`not\` must not be null` — which broke the
+ *      backfill cursor + the /settings#pdpa status counts (the `as
+ *      Prisma.CustomerWhereInput` cast hid it from the type-checker). Verified
+ *      via the generated SQL: `{ not: '' }` → `WHERE col <> $1`.
+ *
+ * Single source of truth — shared by plaintextWhere() (backfill + aggregate
+ * count) and PdpaStatusService.getPlaintextCountsByColumn (per-column count).
+ */
+export function plaintextColumnAnd(plain: string, enc: string): Prisma.CustomerWhereInput[] {
+  return [
+    { [plain]: { not: '' } } as Prisma.CustomerWhereInput,
+    { [enc]: null } as Prisma.CustomerWhereInput,
+  ];
+}
+
+/**
  * Where-clause for any-column-plaintext-and-encrypted-null rows.
  * Shared by status counts + backfill cursor.
  */
 export function plaintextWhere(): Prisma.CustomerWhereInput {
-  const orConditions: Prisma.CustomerWhereInput[] = PII_COLUMNS.map(([plain, enc]) => ({
-    AND: [
-      { [plain]: { not: '' } } as Prisma.CustomerWhereInput,
-      { [plain]: { not: null } } as Prisma.CustomerWhereInput,
-      { [enc]: null } as Prisma.CustomerWhereInput,
-    ],
-  }));
   return {
     deletedAt: null,
-    OR: orConditions,
+    OR: PII_COLUMNS.map(([plain, enc]) => ({ AND: plaintextColumnAnd(plain, enc) })),
   };
 }
 

--- a/apps/api/src/modules/pdpa/services/pdpa-status.service.ts
+++ b/apps/api/src/modules/pdpa/services/pdpa-status.service.ts
@@ -1,8 +1,7 @@
 import { BadRequestException, Injectable } from '@nestjs/common';
-import { Prisma } from '@prisma/client';
 import { PrismaService } from '../../../prisma/prisma.service';
 import { CustomerPiiService } from '../../customers/customer-pii.service';
-import { PII_COLUMNS } from './pdpa-backfill.util';
+import { PII_COLUMNS, plaintextColumnAnd, plaintextWhere } from './pdpa-backfill.util';
 
 export interface PiiColumnPlaintextCount {
   column: string;
@@ -58,11 +57,7 @@ export class PdpaStatusService {
       const count = await this.prisma.customer.count({
         where: {
           deletedAt: null,
-          AND: [
-            { [plain]: { not: '' } } as Prisma.CustomerWhereInput,
-            { [plain]: { not: null } } as Prisma.CustomerWhereInput,
-            { [enc]: null } as Prisma.CustomerWhereInput,
-          ],
+          AND: plaintextColumnAnd(plain, enc),
         },
       });
       out.push({ column: plain, plaintextCount: count });
@@ -79,19 +74,9 @@ export class PdpaStatusService {
    * double-count a row that has multiple unencrypted columns.
    */
   async getAnyPlaintextCount(): Promise<number> {
-    const orConditions: Prisma.CustomerWhereInput[] = PII_COLUMNS.map(([plain, enc]) => ({
-      AND: [
-        { [plain]: { not: '' } } as Prisma.CustomerWhereInput,
-        { [plain]: { not: null } } as Prisma.CustomerWhereInput,
-        { [enc]: null } as Prisma.CustomerWhereInput,
-      ],
-    }));
-    return this.prisma.customer.count({
-      where: {
-        deletedAt: null,
-        OR: orConditions,
-      },
-    });
+    // plaintextWhere() = { deletedAt: null, OR: per-column plaintextColumnAnd(...) }
+    // — the exact aggregate this method needs (single source of truth).
+    return this.prisma.customer.count({ where: plaintextWhere() });
   }
 
   /**


### PR DESCRIPTION
## Root cause (confirmed against the dev DB)

The PDPA plaintext-detection where-clause emitted `{ [plain]: { not: null } }` for **every** PII column. But `Customer.phone` is `String` (**non-nullable**), and Prisma rejects `{ phone: { not: null } }` at runtime:

```
PrismaClientValidationError: Argument `not` must not be null.
```

This broke two real paths:
- the **encrypt-pii backfill** cursor (`plaintextWhere`)
- the **/settings#pdpa status counts** (`getAnyPlaintextCount` + `getPlaintextCountsByColumn`)

It slipped through because the `as Prisma.CustomerWhereInput` cast hid it from `tsc`, and the service specs mock `prisma.count` (no where-clause validation).

## Why `{ not: '' }` alone is correct

Captured the generated SQL: `{ col: { not: '' } }` → `WHERE col <> $1`. In PostgreSQL `NULL <> ''` is *unknown* → NULL rows are already excluded. So `{ not: '' }` yields exactly the non-empty, non-null set; `{ not: null }` was **redundant** (and invalid on `phone`). Dropping it is **semantics-preserving for every column** — this resolves the prior "removing it might change null-semantics" concern with evidence, not assumption.

Consolidated the per-column clause into one `plaintextColumnAnd(plain, enc)` helper used by all 3 call sites so it can't drift again.

## Verification

- **Regression spec** (`pdpa-backfill.util.spec.ts`): pins "no `{ not: null }` anywhere". Mutation-tested — re-adding `{ not: null }` turns 3 tests red.
- **End-to-end vs dev DB**: the real `plaintextWhere()` + every per-column count (incl. `phone`, which previously threw) now return cleanly (`count=1` for phone, was `THROW`).
- `./tools/check-types.sh api` OK · lint clean · `pdpa` suite **53/53** green.

Found via `superpowers:systematic-debugging` — full root-cause trace (schema nullability → reproduced the throw → captured the SQL proving null-handling → minimal fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)