### PR TITLE
Refactor supplier label & integrate CreateContactModal into ContactsPage

### DIFF
--- a/apps/web/src/components/contacts/ContactCombobox.tsx
+++ b/apps/web/src/components/contacts/ContactCombobox.tsx
@@ -28,7 +28,7 @@ import CreateContactModal from './CreateContactModal';
 
 const ROLE_LABELS: Record<ContactRole, string> = {
   CUSTOMER: 'ลูกค้า',
-  SUPPLIER: 'ผู้ขาย',
+  SUPPLIER: 'ผู้จัดจำหน่าย',
   TRADE_IN_SELLER: 'คนขายมือสอง',
   FINANCE_COMPANY: 'ไฟแนนซ์',
 };

--- a/apps/web/src/components/contacts/CreateContactModal.tsx
+++ b/apps/web/src/components/contacts/CreateContactModal.tsx
@@ -122,9 +122,11 @@ export default function CreateContactModal({
       }
 
       queryClient.invalidateQueries({ queryKey: contactKeys.all });
+      // Close before onCreated: parents may navigate on create (e.g. ContactsPage),
+      // which unmounts this modal — closing first keeps the open-state ordering sane.
+      onOpenChange(false);
       onCreated({ contactId: data.contactId, childId, name: returnedName, taxId });
       toast.success('สร้างผู้ติดต่อสำเร็จ');
-      onOpenChange(false);
     },
     onError: (err: unknown) => {
       const msg =

--- a/apps/web/src/config/menu.ts
+++ b/apps/web/src/config/menu.ts
@@ -238,7 +238,7 @@ const BRANCH_MANAGER_CONFIG: RoleMenuConfig = {
         { label: 'รายการสินค้า', path: '/stock/products', icon: ClipboardList },
         { label: 'พิมพ์สติกเกอร์', path: '/stickers', icon: Tag },
         { label: 'สั่งซื้อ (PO)', path: '/purchase-orders', icon: ClipboardList },
-        { label: 'ผู้ขาย', path: '/suppliers', icon: Building2 },
+        { label: 'ผู้จัดจำหน่าย', path: '/suppliers', icon: Building2 },
       ],
     },
     {
@@ -518,7 +518,7 @@ const OWNER_CONFIG: RoleMenuConfig = {
       icon: Warehouse,
       zone: 'shop',
       items: [
-        { label: 'ผู้ขาย', path: '/suppliers', icon: Building2 },
+        { label: 'ผู้จัดจำหน่าย', path: '/suppliers', icon: Building2 },
         { label: 'สั่งซื้อ (PO)', path: '/purchase-orders', icon: ClipboardList },
         { label: 'รับซื้อมือสอง', path: '/trade-in', icon: Smartphone },
         { label: 'ภาพรวมคลัง', path: '/stock', icon: Warehouse },

--- a/apps/web/src/pages/ContactDetailPage.tsx
+++ b/apps/web/src/pages/ContactDetailPage.tsx
@@ -36,7 +36,7 @@ import { customersApi, customerKeys, type CustomerSummary } from '@/lib/api/cust
 
 const ROLE_LABELS: Record<ContactRole, string> = {
   CUSTOMER: 'ลูกค้า',
-  SUPPLIER: 'ผู้ขาย',
+  SUPPLIER: 'ผู้จัดจำหน่าย',
   TRADE_IN_SELLER: 'คนขายมือสอง',
   FINANCE_COMPANY: 'ไฟแนนซ์',
 };
@@ -229,7 +229,7 @@ function SupplierTile({ supplier }: { supplier: ContactSupplierLink }) {
   return (
     <Card>
       <CardHeader className="flex-row items-center justify-between gap-2 space-y-0">
-        <CardTitle className="leading-snug">ผู้ขาย</CardTitle>
+        <CardTitle className="leading-snug">ผู้จัดจำหน่าย</CardTitle>
         <Badge variant="info" appearance="light" size="sm">
           {supplier.hasVat ? 'จด VAT' : 'ไม่จด VAT'}
         </Badge>
@@ -247,7 +247,7 @@ function SupplierTile({ supplier }: { supplier: ContactSupplierLink }) {
           />
           <Field label="ที่อยู่" value={displayAddress(supplier.address) || supplier.address} />
         </div>
-        <CardLink to={`/suppliers/${supplier.id}`} label="เปิดข้อมูลผู้ขาย / แก้ไข" />
+        <CardLink to={`/suppliers/${supplier.id}`} label="เปิดข้อมูลผู้จัดจำหน่าย / แก้ไข" />
       </CardContent>
     </Card>
   );
@@ -504,7 +504,7 @@ export default function ContactDetailPage() {
               <Card>
                 <CardContent className="pt-6">
                   <p className="text-sm text-muted-foreground leading-snug">
-                    ยังไม่ผูกกับลูกค้า/ผู้ขาย — เพิ่ม role ได้ที่หน้าลูกค้าหรือผู้ขาย
+                    ยังไม่ผูกกับลูกค้า/ผู้จัดจำหน่าย — เพิ่ม role ได้ที่หน้าลูกค้าหรือผู้จัดจำหน่าย
                   </p>
                 </CardContent>
               </Card>

--- a/apps/web/src/pages/ContactsPage.tsx
+++ b/apps/web/src/pages/ContactsPage.tsx
@@ -15,10 +15,11 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { contactKeys, contactsApi, type Contact, type ContactRole } from '@/lib/api/contacts';
+import CreateContactModal from '@/components/contacts/CreateContactModal';
 
 const ROLE_LABELS: Record<ContactRole, string> = {
   CUSTOMER: 'ลูกค้า',
-  SUPPLIER: 'ผู้ขาย',
+  SUPPLIER: 'ผู้จัดจำหน่าย',
   TRADE_IN_SELLER: 'คนขายมือสอง',
   FINANCE_COMPANY: 'ไฟแนนซ์',
 };
@@ -35,7 +36,7 @@ type GroupFilter = 'ALL' | ContactRole;
 const GROUP_FILTERS: { value: GroupFilter; label: string }[] = [
   { value: 'ALL', label: 'ทั้งหมด' },
   { value: 'CUSTOMER', label: 'ลูกค้า' },
-  { value: 'SUPPLIER', label: 'ผู้ขาย' },
+  { value: 'SUPPLIER', label: 'ผู้จัดจำหน่าย' },
   { value: 'TRADE_IN_SELLER', label: 'คนขายมือสอง' },
   { value: 'FINANCE_COMPANY', label: 'ไฟแนนซ์' },
 ];
@@ -47,6 +48,9 @@ export default function ContactsPage() {
   const [search, setSearch] = useState('');
   const [role, setRole] = useState<GroupFilter>('ALL');
   const [page, setPage] = useState(1);
+  // null = closed; CUSTOMER/SUPPLIER picks the CreateContactModal mode.
+  // Conditional render below guarantees fresh form state on every open.
+  const [createRole, setCreateRole] = useState<'CUSTOMER' | 'SUPPLIER' | null>(null);
   const debouncedSearch = useDebounce(search);
 
   useEffect(() => {
@@ -117,11 +121,11 @@ export default function ContactsPage() {
               </button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end" className="w-48">
-              <DropdownMenuItem onClick={() => navigate('/customers')}>
+              <DropdownMenuItem onClick={() => setCreateRole('CUSTOMER')}>
                 เพิ่มลูกค้า
               </DropdownMenuItem>
-              <DropdownMenuItem onClick={() => navigate('/suppliers')}>
-                เพิ่มผู้ขาย
+              <DropdownMenuItem onClick={() => setCreateRole('SUPPLIER')}>
+                เพิ่มผู้จัดจำหน่าย
               </DropdownMenuItem>
               <DropdownMenuItem onClick={() => navigate('/trade-in')}>
                 รับซื้อมือสอง
@@ -187,6 +191,17 @@ export default function ContactsPage() {
           }
         />
       </QueryBoundary>
+
+      {createRole && (
+        <CreateContactModal
+          open
+          onOpenChange={(open) => {
+            if (!open) setCreateRole(null);
+          }}
+          role={createRole}
+          onCreated={(r) => navigate(`/contacts/${r.contactId}`)}
+        />
+      )}
     </div>
   );
 }

--- a/apps/web/src/pages/__tests__/ContactDetailPage.test.tsx
+++ b/apps/web/src/pages/__tests__/ContactDetailPage.test.tsx
@@ -85,8 +85,8 @@ describe('ContactDetailPage', () => {
     await waitFor(() => expect(screen.getAllByText('บ.แอปเปิล').length).toBeGreaterThan(0));
     // taxId ปรากฏครั้งเดียว (ใน hero) — ไม่ซ้ำในการ์ด role
     expect(screen.getAllByText('0105500000010')).toHaveLength(1);
-    // การ์ดผู้ขายยังลิงก์ไป workspace
-    const link = screen.getByRole('link', { name: /แก้ไข|เปิดข้อมูล|ผู้ขาย/ });
+    // การ์ดผู้จัดจำหน่ายยังลิงก์ไป /suppliers
+    const link = screen.getByRole('link', { name: /เปิดข้อมูลผู้จัดจำหน่าย/ });
     expect(link).toHaveAttribute('href', '/suppliers/s1');
     // ฟิลด์เฉพาะ role ยังอยู่ในการ์ด
     expect(screen.getByText('คุณเอ (02)')).toBeInTheDocument();

--- a/apps/web/src/pages/__tests__/ContactDetailPage.test.tsx
+++ b/apps/web/src/pages/__tests__/ContactDetailPage.test.tsx
@@ -176,7 +176,7 @@ describe('ContactDetailPage', () => {
     });
     wrap('c1');
     await waitFor(() => expect(screen.getByText('คนเดียวดาย')).toBeInTheDocument());
-    expect(screen.getByText(/ยังไม่ผูกกับลูกค้า\/ผู้ขาย/)).toBeInTheDocument();
+    expect(screen.getByText(/ยังไม่ผูกกับลูกค้า\/ผู้จัดจำหน่าย/)).toBeInTheDocument();
     // เบอร์โผล่เป็น text ครั้งเดียว (Field ใน hero grid) — empty-state ไม่โชว์เบอร์ซ้ำอีกชุด
     expect(screen.getAllByText('0800000000')).toHaveLength(1);
   });

--- a/apps/web/src/pages/__tests__/ContactsPage.test.tsx
+++ b/apps/web/src/pages/__tests__/ContactsPage.test.tsx
@@ -1,7 +1,8 @@
 import { render, screen, waitFor } from '@testing-library/react';
-import { describe, it, expect, vi } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { MemoryRouter } from 'react-router';
+import { MemoryRouter, Route, Routes } from 'react-router';
 import type { ReactNode } from 'react';
 import ContactsPage from '../ContactsPage';
 import { contactsApi } from '@/lib/api/contacts';
@@ -11,38 +12,97 @@ vi.mock('@/lib/api/contacts', async (orig) => {
   return { ...actual, contactsApi: { ...actual.contactsApi, list: vi.fn() } };
 });
 
+// Mock CreateContactModal: renders a marker with the requested role and a
+// submit button that fires onCreated (simulates form fill + submit).
+vi.mock('@/components/contacts/CreateContactModal', () => ({
+  default: ({
+    open,
+    role,
+    onCreated,
+  }: {
+    open: boolean;
+    onOpenChange: (v: boolean) => void;
+    role: string;
+    onCreated: (r: { contactId: string; childId: string; name: string; taxId: string }) => void;
+  }) => {
+    if (!open) return null;
+    return (
+      <div data-testid="mock-create-modal" data-role={role}>
+        <button
+          data-testid="mock-create-modal-submit"
+          onClick={() => onCreated({ contactId: 'ct1', childId: 'cust1', name: 'X', taxId: '' })}
+        >
+          mock-submit
+        </button>
+      </div>
+    );
+  },
+}));
+
 function wrap(ui: ReactNode) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return render(
     <QueryClientProvider client={qc}>
-      <MemoryRouter>{ui}</MemoryRouter>
+      <MemoryRouter initialEntries={['/contacts']}>
+        <Routes>
+          <Route path="/contacts" element={ui} />
+          <Route path="/contacts/:id" element={<div data-testid="detail-probe" />} />
+        </Routes>
+      </MemoryRouter>
     </QueryClientProvider>,
   );
 }
 
+beforeEach(() => {
+  (contactsApi.list as ReturnType<typeof vi.fn>).mockResolvedValue({
+    data: [
+      {
+        id: 'c1',
+        contactCode: 'P-00001',
+        name: 'นราธิป',
+        roles: ['CUSTOMER'],
+        isActive: true,
+        taxId: null,
+        phone: null,
+        email: null,
+        peakContactCode: null,
+      },
+    ],
+    total: 1,
+    page: 1,
+    limit: 50,
+  });
+});
+
 describe('ContactsPage', () => {
   it('renders contacts returned by the api', async () => {
-    (contactsApi.list as ReturnType<typeof vi.fn>).mockResolvedValue({
-      data: [
-        {
-          id: 'c1',
-          contactCode: 'P-00001',
-          name: 'นราธิป',
-          roles: ['CUSTOMER'],
-          isActive: true,
-          taxId: null,
-          phone: null,
-          email: null,
-          peakContactCode: null,
-        },
-      ],
-      total: 1,
-      page: 1,
-      limit: 50,
-    });
-
     wrap(<ContactsPage />);
     await waitFor(() => expect(screen.getByText('นราธิป')).toBeInTheDocument());
     expect(screen.getByText('P-00001')).toBeInTheDocument();
+  });
+
+  it('เพิ่มลูกค้า opens CreateContactModal in CUSTOMER mode and navigates to the new contact on create', async () => {
+    wrap(<ContactsPage />);
+    await waitFor(() => expect(screen.getByText('นราธิป')).toBeInTheDocument());
+
+    await userEvent.click(screen.getByRole('button', { name: /เพิ่มผู้ติดต่อ/ }));
+    await userEvent.click(await screen.findByText('เพิ่มลูกค้า'));
+
+    const modal = await screen.findByTestId('mock-create-modal');
+    expect(modal.getAttribute('data-role')).toBe('CUSTOMER');
+
+    await userEvent.click(screen.getByTestId('mock-create-modal-submit'));
+    await waitFor(() => expect(screen.getByTestId('detail-probe')).toBeInTheDocument());
+  });
+
+  it('เพิ่มผู้จัดจำหน่าย opens CreateContactModal in SUPPLIER mode', async () => {
+    wrap(<ContactsPage />);
+    await waitFor(() => expect(screen.getByText('นราธิป')).toBeInTheDocument());
+
+    await userEvent.click(screen.getByRole('button', { name: /เพิ่มผู้ติดต่อ/ }));
+    await userEvent.click(await screen.findByText('เพิ่มผู้จัดจำหน่าย'));
+
+    const modal = await screen.findByTestId('mock-create-modal');
+    expect(modal.getAttribute('data-role')).toBe('SUPPLIER');
   });
 });

--- a/apps/web/src/pages/__tests__/ContactsPage.test.tsx
+++ b/apps/web/src/pages/__tests__/ContactsPage.test.tsx
@@ -12,11 +12,13 @@ vi.mock('@/lib/api/contacts', async (orig) => {
   return { ...actual, contactsApi: { ...actual.contactsApi, list: vi.fn() } };
 });
 
-// Mock CreateContactModal: renders a marker with the requested role and a
-// submit button that fires onCreated (simulates form fill + submit).
+// Mock CreateContactModal: renders a marker with the requested role, a submit
+// button that fires onCreated (simulates form fill + submit), and a close
+// button that fires onOpenChange(false) (simulates กดยกเลิก/ESC).
 vi.mock('@/components/contacts/CreateContactModal', () => ({
   default: ({
     open,
+    onOpenChange,
     role,
     onCreated,
   }: {
@@ -33,6 +35,9 @@ vi.mock('@/components/contacts/CreateContactModal', () => ({
           onClick={() => onCreated({ contactId: 'ct1', childId: 'cust1', name: 'X', taxId: '' })}
         >
           mock-submit
+        </button>
+        <button data-testid="mock-create-modal-close" onClick={() => onOpenChange(false)}>
+          mock-close
         </button>
       </div>
     );
@@ -104,5 +109,23 @@ describe('ContactsPage', () => {
 
     const modal = await screen.findByTestId('mock-create-modal');
     expect(modal.getAttribute('data-role')).toBe('SUPPLIER');
+  });
+
+  it('dismissing the modal removes it without navigating', async () => {
+    wrap(<ContactsPage />);
+    await waitFor(() => expect(screen.getByText('นราธิป')).toBeInTheDocument());
+
+    await userEvent.click(screen.getByRole('button', { name: /เพิ่มผู้ติดต่อ/ }));
+    await userEvent.click(await screen.findByText('เพิ่มลูกค้า'));
+    await screen.findByTestId('mock-create-modal');
+
+    await userEvent.click(screen.getByTestId('mock-create-modal-close'));
+
+    await waitFor(() =>
+      expect(screen.queryByTestId('mock-create-modal')).not.toBeInTheDocument(),
+    );
+    // ยังอยู่หน้า list เดิม — ไม่ navigate ไป detail
+    expect(screen.queryByTestId('detail-probe')).not.toBeInTheDocument();
+    expect(screen.getByText('นราธิป')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
Updates Thai terminology for supplier-related labels across the application and integrates the `CreateContactModal` component directly into `ContactsPage` to enable inline contact creation with role selection (CUSTOMER/SUPPLIER) and automatic navigation to the newly created contact.

## Key Changes

### Terminology Updates
- Changed "ผู้ขาย" (seller) → "ผู้จัดจำหน่าย" (distributor/supplier) throughout the codebase for consistency with business terminology
  - Updated in `ContactsPage`, `ContactDetailPage`, menu config, and `ContactCombobox`
  - Updated test assertions to match new labels

### ContactsPage Integration
- Added `createRole` state to manage `CreateContactModal` visibility and mode (CUSTOMER/SUPPLIER)
- Replaced navigation-based dropdown items with state setters:
  - "เพิ่มลูกค้า" now opens modal in CUSTOMER mode
  - "เพิ่มผู้จัดจำหน่าย" now opens modal in SUPPLIER mode
- Modal conditionally renders when `createRole` is not null
- On successful creation, navigates to `/contacts/{contactId}`
- On modal dismiss, closes without navigation

### CreateContactModal Behavior Fix
- Reordered `onOpenChange(false)` to fire **before** `onCreated()` callback
- Prevents state ordering issues when parent navigates on create (unmounting the modal)

### Test Coverage
- Added `beforeEach` hook to mock `contactsApi.list` response
- Added comprehensive test cases:
  - "เพิ่มลูกค้า" opens modal in CUSTOMER mode and navigates on create
  - "เพิ่มผู้จัดจำหน่าย" opens modal in SUPPLIER mode
  - Dismissing modal removes it without navigation
- Updated test selectors and assertions for new modal behavior

### Test Infrastructure
- Enhanced test wrapper with `Routes` and detail probe route for navigation verification
- Added `userEvent` import for realistic user interaction testing
- Mocked `CreateContactModal` with submit/close button simulation

https://claude.ai/code/session_01BMoXtgkuRbR7vzdbgxvwKv