### PR TITLE
เพิ่มคำนำหน้าสำหรับบุคคล + จด VAT เฉพาะนิติบุคคล (CreateContactModal)

### DIFF
--- a/apps/web/src/components/contacts/CreateContactModal.test.tsx
+++ b/apps/web/src/components/contacts/CreateContactModal.test.tsx
@@ -227,6 +227,60 @@ describe('CreateContactModal', () => {
     await waitFor(() => expect(apiPostMock).toHaveBeenCalledOnce());
   });
 
+  // ── คำนำหน้า + จด VAT visibility ──────────────────────────────────────────
+
+  it('SUPPLIER: hides จด VAT checkbox when switching to บุคคลธรรมดา', async () => {
+    const user = userEvent.setup();
+    renderModal({ role: 'SUPPLIER' });
+
+    // default JURISTIC — VAT checkbox visible
+    expect(screen.getByLabelText(/จด VAT/)).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'บุคคลธรรมดา' }));
+    expect(screen.queryByLabelText(/จด VAT/)).toBeNull();
+  });
+
+  it('SUPPLIER: hides คำนำหน้า for JURISTIC, sends titleName for INDIVIDUAL', async () => {
+    const user = userEvent.setup();
+    apiPostMock.mockResolvedValueOnce({
+      data: { id: 'sup5', contactId: 'ct5', name: 'สมชาย ใจดี', taxId: null },
+    });
+
+    renderModal({ role: 'SUPPLIER' });
+
+    // JURISTIC default — no prefix select
+    expect(screen.queryByLabelText('คำนำหน้า')).toBeNull();
+
+    await user.click(screen.getByRole('button', { name: 'บุคคลธรรมดา' }));
+    await user.selectOptions(screen.getByLabelText('คำนำหน้า'), 'นาย');
+    await user.type(screen.getByLabelText(/ชื่อ/), 'สมชาย ใจดี');
+    await user.type(screen.getByLabelText(/เบอร์โทร/), '0812345678');
+    await user.click(screen.getByRole('button', { name: 'สร้าง' }));
+
+    await waitFor(() => expect(apiPostMock).toHaveBeenCalledOnce());
+    const [, payload] = apiPostMock.mock.calls[0];
+    expect(payload).toMatchObject({ type: 'INDIVIDUAL', titleName: 'นาย' });
+    expect(payload.hasVat).toBe(false);
+  });
+
+  it('CUSTOMER: sends prefix when คำนำหน้า selected', async () => {
+    const user = userEvent.setup();
+    apiPostMock.mockResolvedValueOnce({
+      data: { id: 'cust6', contactId: 'ct6', name: 'สมหญิง รักดี', nationalId: null },
+    });
+
+    renderModal({ role: 'CUSTOMER' });
+
+    await user.selectOptions(screen.getByLabelText('คำนำหน้า'), 'นางสาว');
+    await user.type(screen.getByLabelText(/ชื่อ/), 'สมหญิง รักดี');
+    await user.type(screen.getByLabelText(/เบอร์โทร/), '0812345678');
+    await user.click(screen.getByRole('button', { name: 'สร้าง' }));
+
+    await waitFor(() => expect(apiPostMock).toHaveBeenCalledOnce());
+    const [, payload] = apiPostMock.mock.calls[0];
+    expect(payload.prefix).toBe('นางสาว');
+  });
+
   // ── Default type per role ─────────────────────────────────────────────────
 
   it('SUPPLIER: defaults to นิติบุคคล (เลขผู้เสียภาษี label shown)', () => {

--- a/apps/web/src/components/contacts/CreateContactModal.tsx
+++ b/apps/web/src/components/contacts/CreateContactModal.tsx
@@ -19,6 +19,7 @@ import AddressForm, {
   emptyAddress,
   serializeAddress,
 } from '@/components/ui/AddressForm';
+import { THAI_NAME_PREFIXES } from '@/lib/constants';
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
@@ -44,6 +45,9 @@ interface Props {
 const defaultTypeFor = (role: 'SUPPLIER' | 'CUSTOMER'): ContactType =>
   role === 'SUPPLIER' ? 'JURISTIC' : 'INDIVIDUAL';
 
+// Supplier.titleName accepts คุณ as well (mirrors SupplierForm TITLE_OPTIONS)
+const SUPPLIER_TITLE_OPTIONS = [...THAI_NAME_PREFIXES, 'คุณ'];
+
 // ── Component ──────────────────────────────────────────────────────────────
 
 export default function CreateContactModal({
@@ -54,6 +58,7 @@ export default function CreateContactModal({
   onCreated,
 }: Props) {
   const [contactType, setContactType] = useState<ContactType>(defaultTypeFor(role));
+  const [prefix, setPrefix] = useState(''); // คำนำหน้า — persons only
   const [name, setName] = useState(initialName);
   const [idNumber, setIdNumber] = useState(''); // taxId (JURISTIC) or nationalId (INDIVIDUAL)
   const [phone, setPhone] = useState('');
@@ -65,6 +70,7 @@ export default function CreateContactModal({
   useEffect(() => {
     if (!open) return;
     setContactType(defaultTypeFor(role));
+    setPrefix('');
     setName(initialName);
     setIdNumber('');
     setPhone('');
@@ -82,6 +88,7 @@ export default function CreateContactModal({
       name: name.trim(),
       phone: phone.trim(),
     };
+    if (contactType === 'INDIVIDUAL' && prefix) payload.titleName = prefix;
     const serialized = serializeAddress(address);
     if (serialized) payload.address = serialized;
     if (idNumber.trim()) {
@@ -96,6 +103,7 @@ export default function CreateContactModal({
       name: name.trim(),
       phone: phone.trim(),
     };
+    if (prefix) payload.prefix = prefix;
     if (idNumber.trim()) {
       payload.nationalId = idNumber.trim();
     }
@@ -200,6 +208,7 @@ export default function CreateContactModal({
                     onClick={() => {
                       setContactType(t);
                       setIdNumber('');
+                      setPrefix('');
                       if (t === 'INDIVIDUAL') setHasVat(false);
                     }}
                     className={[
@@ -216,23 +225,41 @@ export default function CreateContactModal({
             </div>
           )}
 
-          {/* ── ชื่อ (required) ── */}
+          {/* ── คำนำหน้า + ชื่อ (required) — คำนำหน้าเฉพาะบุคคลธรรมดา ── */}
           <div className="space-y-1.5">
             <Label htmlFor="ccm-name" className="leading-snug">
               ชื่อ <span className="text-destructive">*</span>
             </Label>
-            <Input
-              id="ccm-name"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              placeholder={
-                role === 'SUPPLIER' && contactType === 'JURISTIC'
-                  ? 'ชื่อบริษัท'
-                  : 'ชื่อ-นามสกุล'
-              }
-              autoComplete="off"
-              autoFocus
-            />
+            <div className="flex gap-2">
+              {contactType === 'INDIVIDUAL' && (
+                <select
+                  aria-label="คำนำหน้า"
+                  value={prefix}
+                  onChange={(e) => setPrefix(e.target.value)}
+                  className="h-9 w-28 shrink-0 rounded-md border border-input bg-background px-2 text-sm outline-hidden focus:ring-2 focus:ring-ring/30"
+                >
+                  <option value="">คำนำหน้า</option>
+                  {(role === 'SUPPLIER' ? SUPPLIER_TITLE_OPTIONS : THAI_NAME_PREFIXES).map((p) => (
+                    <option key={p} value={p}>
+                      {p}
+                    </option>
+                  ))}
+                </select>
+              )}
+              <Input
+                id="ccm-name"
+                className="flex-1"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder={
+                  role === 'SUPPLIER' && contactType === 'JURISTIC'
+                    ? 'ชื่อบริษัท'
+                    : 'ชื่อ-นามสกุล'
+                }
+                autoComplete="off"
+                autoFocus
+              />
+            </div>
           </div>
 
           {/* ── เลขประจำตัว (optional) ── */}
@@ -282,8 +309,8 @@ export default function CreateContactModal({
           {/* ── ที่อยู่ (optional) — โครงสร้างเดียวกับหน้าลูกค้า/ผู้จัดจำหน่าย ── */}
           <AddressForm value={address} onChange={setAddress} label="ที่อยู่ (ไม่บังคับ)" />
 
-          {/* ── จด VAT — SUPPLIER only ── */}
-          {role === 'SUPPLIER' && (
+          {/* ── จด VAT — เฉพาะนิติบุคคล (mirror SupplierForm: บุคคลธรรมดาไม่มีจด VAT) ── */}
+          {role === 'SUPPLIER' && contactType === 'JURISTIC' && (
             <div className="flex items-center gap-2">
               <Checkbox
                 id="ccm-hasvat"


### PR DESCRIPTION
## Summary

ต่อจาก PR #1259 (merge ไปแล้ว) — commit `0716bae` ที่ push หลัง merge: แก้ CreateContactModal ตาม feedback จาก production

### เพิ่มคำนำหน้าสำหรับบุคคล
- Select คำนำหน้า หน้าช่องชื่อ แสดงเมื่อเป็นบุคคลธรรมดา
- โหมดลูกค้า: นาย/นาง/นางสาว (`THAI_NAME_PREFIXES` ตัวเดียวกับหน้าลูกค้า) → `Customer.prefix`
- โหมดผู้จัดจำหน่ายแบบบุคคล: นาย/นาง/นางสาว/คุณ (ตาม `TITLE_OPTIONS` ของ SupplierForm) → `Supplier.titleName`
- นิติบุคคลไม่แสดงช่องนี้ + reset ค่าเมื่อสลับประเภทหรือเปิด modal ใหม่

### จด VAT เฉพาะนิติบุคคล
- จด VAT checkbox แสดงเฉพาะ SUPPLIER + นิติบุคคล — mirror พฤติกรรม `SupplierForm` ตัวเต็มที่ซ่อน `hasVat` เมื่อเป็นบุคคลธรรมดา
- เลือกบุคคลธรรมดา → checkbox หาย + `hasVat` reset เป็น false เสมอ

## Testing

- เพิ่ม 3 unit tests: VAT ซ่อนเมื่อสลับเป็นบุคคล, `titleName` ใน supplier payload, `prefix` ใน customer payload
- Contacts tests 25/25 ผ่าน, TypeScript 0 errors

https://claude.ai/code/session_01BMoXtgkuRbR7vzdbgxvwKv

---
_Generated by [Claude Code](https://claude.ai/code/session_01BMoXtgkuRbR7vzdbgxvwKv)_