### PR TITLE
feat(contacts): ใส่ขีดคั่นอัตโนมัติ เลขบัตร/เลขผู้เสียภาษี + เบอร์โทร ใน popup ผู้ติดต่อ

### DIFF
--- a/apps/web/src/components/contacts/CreateContactModal.tsx
+++ b/apps/web/src/components/contacts/CreateContactModal.tsx
@@ -21,6 +21,7 @@ import AddressForm, {
   serializeAddress,
 } from '@/components/ui/AddressForm';
 import { THAI_NAME_PREFIXES } from '@/lib/constants';
+import { formatIdNumberInput, formatPhoneInput } from '@/utils/mask.util';
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
@@ -287,9 +288,9 @@ export default function CreateContactModal({
                 </Label>
                 <Input
                   id="ccm-idnumber"
-                  value={idNumber}
+                  value={formatIdNumberInput(idNumber)}
                   onChange={(e) => setIdNumber(e.target.value.replace(/\D/g, '').slice(0, 13))}
-                  placeholder="ตัวเลข 13 หลัก"
+                  placeholder="1-2345-67890-12-3"
                   inputMode="numeric"
                   autoComplete="off"
                   data-1p-ignore
@@ -308,9 +309,9 @@ export default function CreateContactModal({
                 </Label>
                 <Input
                   id="ccm-phone"
-                  value={phone}
-                  onChange={(e) => setPhone(e.target.value)}
-                  placeholder="0812345678"
+                  value={formatPhoneInput(phone)}
+                  onChange={(e) => setPhone(e.target.value.replace(/\D/g, '').slice(0, 10))}
+                  placeholder="081-234-5678"
                   inputMode="tel"
                   autoComplete="off"
                   data-1p-ignore

--- a/apps/web/src/pages/CustomerIntakePage/components/QuickIntakeStep.tsx
+++ b/apps/web/src/pages/CustomerIntakePage/components/QuickIntakeStep.tsx
@@ -5,23 +5,11 @@ import { CreditCard, Loader2, ArrowRight } from 'lucide-react';
 import { checkCardReaderStatus, readSmartCard } from '@/lib/cardReader';
 import { toast } from 'sonner';
 import { THAI_NAME_PREFIXES } from '@/lib/constants';
+import {
+  formatIdNumberInput as formatNationalId,
+  formatPhoneInput as formatPhone,
+} from '@/utils/mask.util';
 import type { QuickIntakeForm } from '../types';
-
-function formatNationalId(value: string): string {
-  const d = value.replace(/\D/g, '').slice(0, 13);
-  if (d.length <= 1) return d;
-  if (d.length <= 5) return `${d.slice(0, 1)}-${d.slice(1)}`;
-  if (d.length <= 10) return `${d.slice(0, 1)}-${d.slice(1, 5)}-${d.slice(5)}`;
-  if (d.length <= 12) return `${d.slice(0, 1)}-${d.slice(1, 5)}-${d.slice(5, 10)}-${d.slice(10)}`;
-  return `${d.slice(0, 1)}-${d.slice(1, 5)}-${d.slice(5, 10)}-${d.slice(10, 12)}-${d.slice(12)}`;
-}
-
-function formatPhone(value: string): string {
-  const d = value.replace(/\D/g, '').slice(0, 10);
-  if (d.length <= 3) return d;
-  if (d.length <= 6) return `${d.slice(0, 3)}-${d.slice(3)}`;
-  return `${d.slice(0, 3)}-${d.slice(3, 6)}-${d.slice(6)}`;
-}
 
 interface Props {
   form: QuickIntakeForm;

--- a/apps/web/src/pages/SuppliersPage/components/SupplierForm.tsx
+++ b/apps/web/src/pages/SuppliersPage/components/SupplierForm.tsx
@@ -1,6 +1,7 @@
 import { Building2, User2 } from 'lucide-react';
 import AddressForm, { AddressData } from '@/components/ui/AddressForm';
 import { cn } from '@/lib/utils';
+import { formatIdNumberInput, formatPhoneInput } from '@/utils/mask.util';
 import type { PaymentMethod } from './SupplierTable';
 
 export type SupplierType = 'INDIVIDUAL' | 'JURISTIC';
@@ -35,23 +36,12 @@ export const emptyPaymentMethod: PaymentMethod = {
 
 const TITLE_OPTIONS = ['นาย', 'นาง', 'นางสาว', 'คุณ'];
 
-export function formatPhone(value: string): string {
-  const digits = value.replace(/\D/g, '').slice(0, 10);
-  if (digits.length <= 3) return digits;
-  if (digits.length <= 6) return `${digits.slice(0, 3)}-${digits.slice(3)}`;
-  return `${digits.slice(0, 3)}-${digits.slice(3, 6)}-${digits.slice(6)}`;
-}
-
-export function formatTaxId(value: string): string {
-  const digits = value.replace(/\D/g, '').slice(0, 13);
-  if (digits.length <= 1) return digits;
-  if (digits.length <= 5) return `${digits.slice(0, 1)}-${digits.slice(1)}`;
-  if (digits.length <= 10)
-    return `${digits.slice(0, 1)}-${digits.slice(1, 5)}-${digits.slice(5)}`;
-  if (digits.length <= 12)
-    return `${digits.slice(0, 1)}-${digits.slice(1, 5)}-${digits.slice(5, 10)}-${digits.slice(10)}`;
-  return `${digits.slice(0, 1)}-${digits.slice(1, 5)}-${digits.slice(5, 10)}-${digits.slice(10, 12)}-${digits.slice(12)}`;
-}
+// Shared progressive masks live in utils/mask.util.ts — aliased to keep the
+// existing call sites readable. Note: this form stores the FORMATTED value in
+// state and submits it as-is (dashes included), unlike CreateContactModal
+// which keeps raw digits.
+const formatPhone = formatPhoneInput;
+const formatTaxId = formatIdNumberInput;
 
 export function formatBranchCode(value: string): string {
   return value.replace(/\D/g, '').slice(0, 5);

--- a/apps/web/src/utils/mask.util.test.ts
+++ b/apps/web/src/utils/mask.util.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { maskNationalId, formatNationalId, maskPhone, maskAccountNumber } from './mask.util';
+import {
+  maskNationalId,
+  formatNationalId,
+  formatIdNumberInput,
+  formatPhoneInput,
+  maskPhone,
+  maskAccountNumber,
+} from './mask.util';
 
 describe('mask.util — PDPA masking', () => {
   describe('maskNationalId', () => {
@@ -35,6 +42,53 @@ describe('mask.util — PDPA masking', () => {
 
     it('returns "-" for empty input', () => {
       expect(formatNationalId('')).toBe('-');
+    });
+  });
+
+  describe('formatIdNumberInput', () => {
+    it('formats a complete 13-digit ID as 1-4-5-2-1', () => {
+      expect(formatIdNumberInput('1234567890123')).toBe('1-2345-67890-12-3');
+    });
+
+    it('formats progressively while typing', () => {
+      expect(formatIdNumberInput('1')).toBe('1');
+      expect(formatIdNumberInput('12')).toBe('1-2');
+      expect(formatIdNumberInput('12345')).toBe('1-2345');
+      expect(formatIdNumberInput('123456')).toBe('1-2345-6');
+      expect(formatIdNumberInput('1234567890')).toBe('1-2345-67890');
+      expect(formatIdNumberInput('12345678901')).toBe('1-2345-67890-1');
+      expect(formatIdNumberInput('123456789012')).toBe('1-2345-67890-12');
+    });
+
+    it('strips existing separators and caps at 13 digits', () => {
+      expect(formatIdNumberInput('1-2345-67890-12-3')).toBe('1-2345-67890-12-3');
+      expect(formatIdNumberInput('12345678901234567')).toBe('1-2345-67890-12-3');
+    });
+
+    it('returns empty string for empty input', () => {
+      expect(formatIdNumberInput('')).toBe('');
+    });
+  });
+
+  describe('formatPhoneInput', () => {
+    it('formats a complete mobile number as 3-3-4', () => {
+      expect(formatPhoneInput('0812345678')).toBe('081-234-5678');
+    });
+
+    it('formats progressively while typing', () => {
+      expect(formatPhoneInput('081')).toBe('081');
+      expect(formatPhoneInput('0812')).toBe('081-2');
+      expect(formatPhoneInput('081234')).toBe('081-234');
+      expect(formatPhoneInput('0812345')).toBe('081-234-5');
+    });
+
+    it('strips existing separators and caps at 10 digits', () => {
+      expect(formatPhoneInput('081-234-5678')).toBe('081-234-5678');
+      expect(formatPhoneInput('081234567890')).toBe('081-234-5678');
+    });
+
+    it('returns empty string for empty input', () => {
+      expect(formatPhoneInput('')).toBe('');
     });
   });
 

--- a/apps/web/src/utils/mask.util.ts
+++ b/apps/web/src/utils/mask.util.ts
@@ -23,6 +23,31 @@ export function formatNationalId(nationalId: string): string {
 }
 
 /**
+ * Progressive input mask for 13-digit Thai IDs — เลขบัตรประชาชน / เลขผู้เสียภาษี /
+ * เลขทะเบียนนิติบุคคล share the same 1-4-5-2-1 grouping (1-2345-67890-12-3).
+ * For controlled inputs: keep state as raw digits, render with this.
+ */
+export function formatIdNumberInput(value: string): string {
+  const d = value.replace(/\D/g, '').slice(0, 13);
+  if (d.length <= 1) return d;
+  if (d.length <= 5) return `${d.slice(0, 1)}-${d.slice(1)}`;
+  if (d.length <= 10) return `${d.slice(0, 1)}-${d.slice(1, 5)}-${d.slice(5)}`;
+  if (d.length <= 12) return `${d.slice(0, 1)}-${d.slice(1, 5)}-${d.slice(5, 10)}-${d.slice(10)}`;
+  return `${d.slice(0, 1)}-${d.slice(1, 5)}-${d.slice(5, 10)}-${d.slice(10, 12)}-${d.slice(12)}`;
+}
+
+/**
+ * Progressive input mask for Thai mobile numbers: 081-234-5678 (3-3-4).
+ * For controlled inputs: keep state as raw digits, render with this.
+ */
+export function formatPhoneInput(value: string): string {
+  const d = value.replace(/\D/g, '').slice(0, 10);
+  if (d.length <= 3) return d;
+  if (d.length <= 6) return `${d.slice(0, 3)}-${d.slice(3)}`;
+  return `${d.slice(0, 3)}-${d.slice(3, 6)}-${d.slice(6)}`;
+}
+
+/**
  * Mask phone number: show last 4 digits only
  * e.g. 08x-xxx-1234
  */


### PR DESCRIPTION
## สรุป
- เลขบัตรประชาชน / เลขผู้เสียภาษี แสดงเป็น `1-2345-67890-12-3` และเบอร์โทรเป็น `081-234-5678` อัตโนมัติขณะพิมพ์ใน popup เพิ่มลูกค้า/ผู้จัดจำหน่าย (ค่าที่ส่งเข้า API ยังเป็นตัวเลขล้วน)
- เพิ่ม `formatIdNumberInput` + `formatPhoneInput` เป็น mask กลางใน `utils/mask.util.ts` + tests 8 ตัว
- รวมโค้ดซ้ำ: QuickIntakeStep + SupplierForm import จาก mask กลาง (เดิมก๊อปไว้ 3 ที่) — พฤติกรรมเดิม

## การทดสอบ
- TypeScript ผ่าน, vitest 46 ตัวผ่าน (mask.util 21 + CreateContactModal/ContactsPage 23 + อื่นๆ)
- Playwright พิมพ์จริงทั้งโหมดลูกค้า/ผู้จัดจำหน่าย — ขีดคั่นถูกต้องทั้งสองช่อง

## หมายเหตุ (follow-up แยกต่างหาก)
SuppliersPage ส่ง taxId/phone แบบมีขีดเข้า API ขณะที่ ContactResolver เทียบ natural key แบบ exact string → เสี่ยง contact ซ้ำ ควร normalize ฝั่ง API เป็นงานถัดไป

🤖 Generated with [Claude Code](https://claude.com/claude-code)