### PR TITLE
feat(contacts): show trade-in seller name + phone in the trade-in tile

### DIFF
--- a/apps/web/src/pages/ContactDetailPage.tsx
+++ b/apps/web/src/pages/ContactDetailPage.tsx
@@ -298,6 +298,14 @@ function TradeInTile({ tradeIn }: { tradeIn: ContactTradeInLink }) {
       </CardHeader>
       <CardContent className="flex flex-col gap-3">
         <Field
+          label="ชื่อผู้ขาย"
+          value={
+            tradeIn.sellerName
+              ? `${tradeIn.sellerName}${tradeIn.sellerPhone ? ` (${tradeIn.sellerPhone})` : ''}`
+              : tradeIn.sellerPhone
+          }
+        />
+        <Field
           label="วันที่รับซื้อ"
           value={new Date(tradeIn.createdAt).toLocaleDateString('th-TH', { timeZone: 'Asia/Bangkok' })}
         />

--- a/apps/web/src/pages/__tests__/ContactDetailPage.test.tsx
+++ b/apps/web/src/pages/__tests__/ContactDetailPage.test.tsx
@@ -237,4 +237,22 @@ describe('ContactDetailPage', () => {
     expect(screen.getByText('สถานะภาษี')).toBeInTheDocument();
     expect(screen.getAllByText('จด VAT').length).toBeGreaterThan(0);
   });
+
+  it('shows the seller name + phone in the trade-in tile (not just the date)', async () => {
+    (contactsApi.detail as any).mockResolvedValue({
+      id: 'c1', contactCode: 'P-7', name: 'สมชาย', roles: ['TRADE_IN_SELLER'], isActive: true,
+      taxId: null, phone: null, email: null, address: null, lineId: null, peakContactCode: null,
+      customers: [], suppliers: [],
+      tradeInsAsSeller: [
+        { id: 't1', sellerName: 'สมชาย', sellerPhone: '0899998888', createdAt: '2026-05-01T03:00:00.000Z' },
+      ],
+      externalFinanceCompany: [],
+    });
+    wrap('c1');
+    // "ชื่อผู้ขาย" label exists only inside the trade-in tile ("คนขายมือสอง" also
+    // appears as a role badge in the hero, so don't key off the title).
+    await waitFor(() => expect(screen.getByText('ชื่อผู้ขาย')).toBeInTheDocument());
+    // parenthesised name+phone string is unique to the tile (not the hero h1)
+    expect(screen.getByText('สมชาย (0899998888)')).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary
The contact-detail `TradeInTile` showed only the purchase date. This surfaces the **seller name (+ phone)** that the contacts API already returns — `ContactTradeInLink.sellerName`/`sellerPhone` are already selected in `contacts.service.ts` and present on the type, so this is a frontend-display-only change (no backend/type change).

Re-applies the intent of stale PR #1150 (240 commits behind, edits pre-refactor inline tile code) cleanly on top of the current `TradeInTile` component. **Supersedes #1150.**

## Test plan
- `apps/web` vitest `ContactDetailPage`: 8/8 pass (new: "shows the seller name + phone in the trade-in tile")
- `apps/web` `tsc --noEmit`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)