### PR TITLE
docs: go-live ops checklist + owner-decision brief (2026-06-22 survey)

### DIFF
--- a/docs/ceo-review/owner-decisions-pending-2026-06-22.md
+++ b/docs/ceo-review/owner-decisions-pending-2026-06-22.md
@@ -1,0 +1,69 @@
+# Owner Decisions Pending (2026-06-22)
+
+> These items are **decision-gated, not engineering-gated** — code work cannot proceed correctly
+> until the owner/ops makes a call. Verified against current code (re: the 2026-06-22 repo survey +
+> `docs/ceo-review/deep-audit-2026-06-11-findings.md` + `tier-8-fraud-heatmap-master.md`). Each entry
+> states the decision needed, the options, a recommendation, and what it unblocks. **Do not start the
+> code work until the decision is recorded here.**
+
+---
+
+## D1 — SHOP-side accounting JE wiring (deep-audit F3) — most material accounting gap
+
+**State:** 7 of 8 `shop-*` JE templates have **zero production callers** (only `ShopExchangeReturnTemplate`
+is wired, at `contract-exchange.service.ts:396`). So `/shop/accounting` Trial Balance + P&L are
+near-empty even though SHOP is actively selling (real numbers live in the `Sale` table / Dashboard). A
+disclaimer banner is already on `ShopAccountingPage.tsx`, so there is no misleading-report harm today.
+
+**Decision needed:** At contract activation (and cash sale / trade-in accept), should the system post the
+SHOP-side JEs, and should activation post **SHOP + FINANCE atomically** (Phase A.5 brief §4)?
+
+- **Option A (recommended):** Approve atomic SHOP+FINANCE posting at activation; wire all 7 templates to
+  their intended triggers (cash sale → `ShopCashSaleTemplate`; down payment → `ShopDownPaymentTemplate`;
+  activation → `ShopInventoryTransfer` + `ShopFinanceReceipt`; trade-in accept → `ShopTradeInTemplate`;
+  shop expenses → `ShopExpenseTemplate`). Reuse the existing idempotent `metadata.flow` + `CompanyResolverService`
+  and the existing golden `.spec.ts` files as acceptance tests.
+- **Option B:** Keep SHOP accounting non-authoritative (disclaimer stays); revisit at multi-entity split (D3).
+
+**Unblocks:** real SHOP Trial Balance / P&L. **Effort:** LARGE. Also do deep-audit **X5** first (add
+`companyCode:FINANCE` filter to PEAK sync) so SHOP JEs don't leak into the PEAK export.
+
+---
+
+## D2 — Tier-8 controls: 7 PARTIAL items (all owner/ops/design-gated)
+
+Tracker (`tier-8-fraud-heatmap-master.md`): 44 DONE / 7 PARTIAL / 0 OPEN. None is a quick code patch.
+The one item that can proceed **without** an owner sign-off is flagged ⚡.
+
+| ID | Control | Decision needed | Rec. |
+|----|---------|-----------------|------|
+| ⚡ **T6-C5** | PEAK partial-sync has no retry/backoff | None for retry itself — add bounded retry/backoff on transient PEAK HTTP errors (does NOT touch JE numbers, no accountant sign-off). Confirm PEAK dedupes `/DailyJournals` on `code`/`reference` to close the POST-then-mark-fails double-post window. | Do when PEAK is enabled. **Downgrade from CRITICAL** — sync is self-healing via `peakSyncedAt=null` re-attempt; PEAK is unset in current env. |
+| T3-C5 | OWNER-only payment reversal path missing | Feature/design: do you want a dedicated reverse-posted-payment flow, or does journal void→reversal (T2-C9) suffice? | Likely suffices → close, else build `reversePayment()`. |
+| T4-C9 | LIFF OTP/lockout uses in-memory Map (not multi-node correct) | Infra: provision/standardize Redis, then move the per-`lineUserId` fail counter there. | Gate on Redis decision. |
+| T5-C13 | `adjustShopWarranty` is unreachable (no endpoint) | Feature: expose warranty-end-date adjustment via endpoint+roles+UI through the gated `adjustShopWarranty`? | Owner call. **Note:** the tracker's "bypass writer at repair-warranty.service.ts:209" claim is **false** (that file is read-only) — fix the tracker; this is not a security gap, just a missing feature. |
+| T6-C9 | PEAK credential reads not audited; rotation is monitor-only | Ops/design: rotation cadence + storage + add an `IntegrationAccessLog` (or reuse `AuditLog` READ action) on `getValue/getConfig`. | Pair with T6-C13. Cheapest v1 = log reads to existing `AuditLog`. |
+| T6-C13 | MDM `apiKeyPrevious` declared but not used in service | Ops/design (pairs with T6-C9): make `mdm.service` read `apiKeyPrevious` during a grace window + retry on 401/403. | Decide rotation policy first. |
+| T7-C9 | `/metrics` scrape token is a shared secret (manual dual-token rotation) | Ops/design: mTLS or OAuth + auto-rotation cron; needs scraper-side config decision. | Low priority. |
+
+---
+
+## D3 — Multi-entity legal split (roadmap Phase 6.1 / P3-SP7) — the one un-started big rock
+
+**State:** system is **1 legal entity, 1 Postgres DB** partitioned by `companyCode` ('SHOP'/'FINANCE')
+with an `S`-prefix CoA convention. No second Prisma client / separate SHOP DB exists.
+
+**Decision needed:** Register the 2nd นิติบุคคล and commit to splitting? (Business + legal decision —
+the real entity `บริษัท เบสท์ช้อยส์โฟน จำกัด` exists; see memory `company_legal_entity`.)
+
+- If **yes**: stand up a 2nd legal company + 2nd DB/Prisma client; convert inter-company JEs'
+  `from_company_id`/`to_company_id` into cross-company FKs; route SHOP JEs through `PairedJournalService`.
+  Depends on D1 being wired first. **Effort:** LARGE.
+- If **not yet**: stay single-DB partitioned (current). No code action.
+
+---
+
+## Low-value engineering debt (not owner-gated — listed for completeness)
+
+- Split `expense-document-create.service.ts` (1061 LOC, 7 create-* methods) — behavior-preserving. LOW/MEDIUM.
+- Chatbot Phase 7.2: route simple/no-tool queries to Haiku (`finance-ai.service.ts:99` hardcodes Sonnet) — cost saving, SMALL.
+- Branch hygiene: ~23 fully-merged local branches safe to delete; ~33 stale rebase artifacts.

--- a/docs/runbooks/go-live-checklist.md
+++ b/docs/runbooks/go-live-checklist.md
@@ -1,0 +1,79 @@
+# Go-Live Checklist (real นิติบุคคล cutover)
+
+> Generated 2026-06-22. Context: current prod is **throwaway test data, wiped before real go-live**
+> (see memory `prod-is-testing-phase-data-wiped`). This checklist is the set of **manual ops steps**
+> that are NOT wired into the deploy pipeline (`deploy-gcp.yml` only runs `prisma migrate deploy`).
+> Code/engineering go-live blockers are tracked as PRs, not here.
+
+## 0. Pre-cutover code gates (must be merged to `main` first)
+
+- [ ] **PR #1265** — `chat_snoozes` / `chat_side_messages` migration. **CRITICAL**: a freshly-migrated
+      go-live DB is missing both tables → snooze cron `P2021` every minute + staff-chat snooze/side
+      endpoints 500. Must land before the real DB is built.
+- [ ] **PR #1264** — users/employees merge (no schema/data impact; ship when green).
+- [ ] Confirm `main` Deploy-to-GCP is green after merges.
+
+## 1. Build the go-live database
+
+`deploy-gcp.yml` Job `migrate-db` runs `prisma migrate deploy` against prod Cloud SQL. After it succeeds:
+
+- [ ] Seed the FINANCE + SHOP chart of accounts (non-destructive upsert):
+  ```bash
+  EXPECTED_DB_NAME=<prod-db> npm --prefix apps/api run seed:coa
+  ```
+- [ ] Verify CoA counts (per `.claude/rules/accounting.md`):
+  - `SELECT COUNT(*) FROM chart_of_accounts WHERE code NOT LIKE 'S%';` → **99** (FINANCE)
+  - `SELECT COUNT(*) FROM chart_of_accounts WHERE code LIKE 'S%';` → **~56** (SHOP)
+- [ ] Confirm `chat_snoozes` + `chat_side_messages` exist (`\d chat_snoozes`) — i.e. PR #1265 applied.
+
+## 2. Run the run-once backfill CLIs (in order)
+
+> All are **dry-run by default**; pass `APPLY=true` (or `--apply`) to write, plus
+> `ALLOW_PROD_BACKFILL=YES_I_AM_SURE` on prod. Idempotent. On a freshly-seeded DB with few/no legacy
+> rows these are near no-ops, **but still run them** so FKs are populated for any pre-existing rows.
+> Run order matters where noted. Prefer Cloud Run Jobs for prod.
+
+- [ ] **A — Party-master contacts** (creates `Contact` rows from Customer/Supplier/TradeIn/ExtFinance + sets `contact_id` FKs):
+  ```bash
+  CONFIRM_BACKFILL=YES_I_AM_SURE EXPECTED_DB_NAME=<prod-db> ALLOW_PROD_BACKFILL=YES_I_AM_SURE \
+    npm --prefix apps/api run backfill:contacts
+  ```
+- [ ] **B — Employee profiles** (provision `EmployeeProfile` per active non-system User) — **run before C**:
+  ```bash
+  EXPECTED_DB_NAME=<prod-db> APPLY=true ALLOW_PROD_BACKFILL=YES_I_AM_SURE \
+    npm --prefix apps/api run backfill:employee-profiles
+  ```
+- [ ] **C — Payroll → user FK** (link `payroll_lines.user_id`) — **after B**. Tier-1 by default; tier-2 does name-matching + audit:
+  ```bash
+  EXPECTED_DB_NAME=<prod-db> APPLY=true ALLOW_PROD_BACKFILL=YES_I_AM_SURE \
+    npm --prefix apps/api run backfill:payroll-user-fk
+  # optional tier-2: add --tier=2 BACKFILL_ACTOR_USER_ID=<owner-uuid>
+  ```
+- [ ] **(only if PII encryption is enabled for go-live)** `backfill:encrypt-pii` — needs `PII_ENCRYPTION_KEY` (64 hex) + `PII_HASH_SALT` (≥32 chars). See `backfill:encrypt-pii:help`.
+- [ ] Record the date/operator of each run (no run-record is auto-kept).
+
+## 3. Runtime smoke (post-deploy, ~5 min)
+
+- [ ] **Staff login is single-step** (2FA removed in #1169) — log in as `admin@bestchoice.com`, confirm no OTP step. (Customer LIFF/KYC OTP is a separate system, expected to remain.)
+- [ ] **Staff-chat snooze/side** — open a chat room, create a snooze + a side message → no 500; confirm Sentry has no `P2021` `chat_snoozes` spam after a few minutes.
+- [ ] One contract end-to-end via UI; run Trial Balance `scope=FINANCE` and confirm it balances.
+- [ ] `/users` — create a user with an HR block, edit across the 3 tabs (single save), remove-from-payroll (validates PR #1264 in prod).
+
+## 4. LINE OA configuration (ops + design — done in LINE OA Manager, not code)
+
+> The code side (`line-oa/rich-menu/rich-menu.service.ts`) exists; these are manual console steps.
+
+- [ ] Upload Rich Menu artwork + set default rich menu (per `docs/sales/line-oa-deployment-plan.md`).
+- [ ] Configure auto-reply / keyword / quick-reply.
+- [ ] Point the FINANCE + SHOP LINE OA webhooks at the prod API; verify a test message routes.
+
+## 5. Integrations (only if enabled for go-live)
+
+- [ ] **PEAK** — set `PEAK_USER_TOKEN` / `PEAK_CONNECT_ID` / `PEAK_SECRET_KEY` (currently unset → sync is a no-op). If enabling, see the owner-decision brief re: PEAK retry/backoff (T6-C5).
+- [ ] **MDM PJ-Soft** — confirm `mdm` credentials in IntegrationConfig.
+- [ ] **PaySolutions** — confirm merchant credentials + webhook URL.
+
+---
+
+**Owner-gated items that are NOT go-live blockers** (SHOP-side JE wiring, Tier-8 partials, multi-entity
+split) are tracked separately in [`docs/ceo-review/owner-decisions-pending-2026-06-22.md`](../ceo-review/owner-decisions-pending-2026-06-22.md).


### PR DESCRIPTION
Two reference docs from the 2026-06-22 repo survey:

- **`docs/runbooks/go-live-checklist.md`** — the manual ops steps that are NOT in the deploy pipeline: the chat-tables migration gate (#1265), CoA seed + counts, the three run-once backfill CLIs in order (contacts → employee-profiles → payroll-user-fk), runtime smoke (single-step login, staff-chat snooze/side, contract TB), and LINE OA Manager config.
- **`docs/ceo-review/owner-decisions-pending-2026-06-22.md`** — decision-gated work with options + recommendations: SHOP-side JE wiring (deep-audit F3), the 7 Tier-8 PARTIAL controls (incl. the ⚡ T6-C5 retry that needs no sign-off, and the false T5-C13 bypass-writer evidence to correct), and the multi-entity legal split.

Docs only — no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)