### PR TITLE
feat(chatbot-finance): Haiku→Sonnet model routing (Phase 7.2)

### DIFF
--- a/apps/api/src/modules/chatbot-finance/services/finance-ai.service.spec.ts
+++ b/apps/api/src/modules/chatbot-finance/services/finance-ai.service.spec.ts
@@ -7,6 +7,25 @@ import { IntegrationConfigService } from '../../integrations/integration-config.
 import { AiUsageService } from '../../ai-usage/ai-usage.service';
 import { PrismaService } from '../../../prisma/prisma.service';
 
+// Phase 7.2 model-routing tests drive the Anthropic tool loop, so mock the SDK to give
+// `new Anthropic()` a controllable `messages.create`. (Other tests never invoke create.)
+const mockCreate = jest.fn();
+jest.mock('@anthropic-ai/sdk', () => ({
+  __esModule: true,
+  default: jest.fn().mockImplementation(() => ({ messages: { create: mockCreate } })),
+}));
+
+const textResponse = (text: string) => ({
+  stop_reason: 'end_turn',
+  content: [{ type: 'text', text }],
+  usage: { input_tokens: 5, output_tokens: 5 },
+});
+const toolUseResponse = (name: string) => ({
+  stop_reason: 'tool_use',
+  content: [{ type: 'tool_use', id: 'tu_1', name, input: {} }],
+  usage: { input_tokens: 5, output_tokens: 5 },
+});
+
 describe('FinanceAiService', () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let toolExecutor: any;
@@ -147,9 +166,10 @@ describe('FinanceAiService', () => {
       expect(prompt).not.toContain('คุณundefined');
     });
 
-    it('uses Sonnet 4.6 for customer-facing replies', () => {
-      // Task 8: customer quality > cost — reply model must be claude-sonnet-4-6
+    it('declares the Haiku→Sonnet routing model pair (Phase 7.2)', () => {
+      // Simple replies use Haiku for cost; tool-using replies escalate to Sonnet for quality.
       expect((service as any).modelSonnet).toBe('claude-sonnet-4-6');
+      expect((service as any).modelHaiku).toBe('claude-haiku-4-5-20251001');
     });
 
     it('loadHistory fetches last 10 messages oldest-first and maps roles', async () => {
@@ -230,6 +250,54 @@ describe('FinanceAiService', () => {
       const lastMsg = result[result.length - 1];
       expect(lastMsg.role).toBe('user');
       expect(String(lastMsg.content)).toContain('new question');
+    });
+  });
+
+  describe('model routing (Phase 7.2)', () => {
+    let service: FinanceAiService;
+
+    beforeEach(async () => {
+      mockCreate.mockReset();
+      toolExecutor = { execute: jest.fn().mockResolvedValue({ ok: true, data: { ok: 1 }, triggeredHandoff: false }) };
+      prisma = { chatMessage: { findMany: jest.fn().mockResolvedValue([]) } };
+      const module: TestingModule = await Test.createTestingModule({
+        providers: [
+          FinanceAiService,
+          { provide: ConfigService, useValue: { get: jest.fn().mockReturnValue('sk-ant-test-key') } },
+          { provide: FinanceToolExecutor, useValue: toolExecutor },
+          { provide: FinanceConfigService, useValue: { bankInfoBlock: '' } },
+          {
+            provide: IntegrationConfigService,
+            useValue: { getValue: jest.fn().mockResolvedValue('test-api-key') },
+          },
+          { provide: AiUsageService, useValue: { record: jest.fn().mockResolvedValue(undefined) } },
+          { provide: PrismaService, useValue: prisma },
+        ],
+      }).compile();
+      service = module.get(FinanceAiService);
+    });
+
+    it('answers a simple no-tool query on Haiku (cost path)', async () => {
+      mockCreate.mockResolvedValueOnce(textResponse('สวัสดีค่ะ 😊'));
+      const result = await service.generateReply(defaultParams);
+      expect(result?.text).toBe('สวัสดีค่ะ 😊');
+      expect(result?.model).toBe('claude-haiku-4-5-20251001');
+      expect(mockCreate).toHaveBeenCalledTimes(1);
+      expect(mockCreate.mock.calls[0][0].model).toBe('claude-haiku-4-5-20251001');
+      expect(toolExecutor.execute).not.toHaveBeenCalled();
+    });
+
+    it('escalates to Sonnet once the model needs a tool (quality path)', async () => {
+      mockCreate
+        .mockResolvedValueOnce(toolUseResponse('get_contract_status'))
+        .mockResolvedValueOnce(textResponse('ยอดคงเหลือของคุณคือ 5,000 บาทค่ะ'));
+      const result = await service.generateReply(defaultParams);
+      // turn 0 (decides to use a tool) on Haiku; turn 1 (synthesis after tool result) on Sonnet
+      expect(mockCreate.mock.calls[0][0].model).toBe('claude-haiku-4-5-20251001');
+      expect(mockCreate.mock.calls[1][0].model).toBe('claude-sonnet-4-6');
+      expect(result?.model).toBe('claude-sonnet-4-6');
+      expect(result?.toolsUsed).toContain('get_contract_status');
+      expect(toolExecutor.execute).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/apps/api/src/modules/chatbot-finance/services/finance-ai.service.ts
+++ b/apps/api/src/modules/chatbot-finance/services/finance-ai.service.ts
@@ -36,8 +36,12 @@ export class FinanceAiService {
   private readonly logger = new Logger(FinanceAiService.name);
   private anthropic: Anthropic | null = null;
 
-  // Sonnet 4.6 for customer-facing replies — quality matters (Task 8, Week 1 Hybrid C plan)
+  // Model routing (ULTRAPLAN v5 Phase 7.2): start every reply on Haiku for cost; the moment
+  // the model decides it needs a tool (i.e. it must look up real contract/payment data) we
+  // escalate to Sonnet for the rest of the loop so the customer-facing synthesis stays at
+  // Sonnet quality. Simple no-tool replies (greetings/FAQ) stay on Haiku.
   private readonly modelSonnet = 'claude-sonnet-4-6';
+  private readonly modelHaiku = 'claude-haiku-4-5-20251001';
   private readonly maxTokens = 1024;
   private readonly historyLimit = 20;
   /** DB-backed history window (Task 8): 10 most recent messages, oldest-first */
@@ -62,7 +66,7 @@ export class FinanceAiService {
     if (!apiKey) return null;
     if (!this.anthropic) {
       this.anthropic = new Anthropic({ apiKey });
-      this.logger.log('[FinanceAI] Initialized (Sonnet 4.6 + tools)');
+      this.logger.log('[FinanceAI] Initialized (Haiku→Sonnet routing + tools)');
     }
     return this.anthropic;
   }
@@ -96,7 +100,8 @@ export class FinanceAiService {
       let totalOutput = 0;
       let handoffTriggered = false;
       const toolsUsed: string[] = [];
-      const activeModel = this.modelSonnet;
+      // Phase 7.2: begin on Haiku; escalate to Sonnet on first tool_use (see below).
+      let activeModel = this.modelHaiku;
 
       // Tool use loop
       for (let iteration = 0; iteration < MAX_TOOL_ITERATIONS; iteration++) {
@@ -158,7 +163,11 @@ export class FinanceAiService {
           };
         }
 
-        // มี tool_use → execute แล้ว append result
+        // มี tool_use → query ต้องใช้ข้อมูลจริง → escalate เป็น Sonnet สำหรับ iteration ถัดไป
+        // (รวมถึงการสังเคราะห์คำตอบสุดท้ายหลังได้ tool result) เพื่อรักษาคุณภาพคำตอบที่ลูกค้าเห็น
+        activeModel = this.modelSonnet;
+
+        // execute แล้ว append result
         const toolUseBlocks = response.content.filter(
           (b): b is ToolUseBlock => b.type === 'tool_use',
         );


### PR DESCRIPTION
## Summary
Implements ULTRAPLAN v5 **Phase 7.2** (model routing): simple queries → Haiku, tool-using queries → Sonnet.

`finance-ai.service.ts` started every reply on Sonnet. Now it begins on **Haiku** and escalates to **Sonnet** the instant the model emits a `tool_use` (i.e. it must look up real contract/payment data). The customer-facing synthesis after tool results therefore stays at Sonnet quality — only genuinely simple no-tool replies (greetings/FAQ) are answered by Haiku, for cost.

This intentionally supersedes the earlier "Task 8 / Hybrid C" comment that pinned all replies to Sonnet (that test now asserts the routing model *pair*).

> Note: this is a customer-facing quality-vs-cost change. The escalate-on-tool_use design keeps all data-driven answers on Sonnet; the only residual is that a query Haiku answers directly (no tool) is Haiku-quality. If you'd rather gate this behind a SystemConfig flag for A/B, say so and I'll add it.

## Test plan
- `apps/api` jest `finance-ai.service.spec.ts`: 14/14 pass, incl. 2 new SDK-mocked routing tests (simple→Haiku; tool→Haiku then Sonnet).
- `apps/api` `tsc --noEmit`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)