### PR TITLE
chore(vscode): add shared workspace config (extensions + settings)

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,21 @@
+{
+  // รายการ extension แนะนำสำหรับโปรเจค BESTCHOICE (monorepo: React+Vite+Tailwind / NestJS+Prisma)
+  // VSCode จะเด้งถามให้ลงชุดนี้เมื่อเปิดโปรเจค — ทำให้ทุกเครื่อง (Mac/Windows) ใน setup เดียวกัน
+  "recommendations": [
+    // --- จำเป็น (ตรงกับ tooling ของ repo) ---
+    "Prisma.prisma",                 // schema.prisma: highlight + autocomplete + format
+    "dbaeumer.vscode-eslint",        // อ่าน eslint.config.mjs (ESLint 9 flat config) ทั้ง web + api
+    "esbenp.prettier-vscode",        // format ตาม .prettierrc (singleQuote, printWidth 100)
+    "bradlc.vscode-tailwindcss",     // Tailwind v4 IntelliSense (CSS-based config auto-detect)
+
+    // --- testing (web ใช้ vitest, e2e ใช้ playwright) ---
+    "vitest.explorer",               // รัน/debug unit tests จาก test explorer
+    "ms-playwright.playwright",      // รัน/debug E2E จาก apps/web/e2e
+
+    // --- DX / คุณภาพชีวิต ---
+    "usernamehw.errorlens",          // โชว์ TS/ESLint error inline ในบรรทัด
+    "yoavbls.pretty-ts-errors",      // อ่าน type error ของ NestJS/Prisma generic ง่ายขึ้น
+    "mikestead.dotenv",              // highlight .env / .env.example
+    "ms-azuretools.vscode-docker"    // Dockerfile, docker-compose.yml
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,58 @@
+{
+  // ===== Formatting: Prettier เป็น default + format on save =====
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.formatOnSave": true,
+  "prettier.requireConfig": true,
+  "[typescript]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
+  "[typescriptreact]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
+  "[javascript]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
+  "[json]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
+  "[jsonc]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
+  "[css]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
+  "[prisma]": { "editor.defaultFormatter": "Prisma.prisma" },
+
+  // ===== ESLint: flat config (eslint.config.mjs) + auto-fix on save =====
+  "eslint.useFlatConfig": true,
+  "eslint.workingDirectories": [
+    { "directory": "apps/web", "changeProcessCWD": true },
+    { "directory": "apps/api", "changeProcessCWD": true }
+  ],
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": "explicit"
+  },
+
+  // ===== TypeScript: ใช้ version ของ workspace (ไม่ใช่ของ VSCode) =====
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "typescript.enablePromptUseWorkspaceTsdk": true,
+
+  // ===== Tailwind v4: ให้ IntelliSense ทำงานใน cn()/cva()/clsx() =====
+  "tailwindCSS.experimental.classRegex": [
+    ["cva\\(([^)]*)\\)", "[\"'`]([^\"'`]*).*?[\"'`]"],
+    ["cx\\(([^)]*)\\)", "(?:'|\"|`)([^']*)(?:'|\"|`)"],
+    ["cn\\(([^)]*)\\)", "[\"'`]([^\"'`]*).*?[\"'`]"]
+  ],
+  "editor.quickSuggestions": { "strings": "on" },
+
+  // ===== Performance: กัน VSCode ไล่ scan node_modules ทั้ง monorepo =====
+  // (เคยทำให้ search/file-watcher ช้า/timeout)
+  "files.watcherExclude": {
+    "**/node_modules/**": true,
+    "**/dist/**": true,
+    "**/.turbo/**": true,
+    "**/build/**": true,
+    "**/apps/web/dist/**": true,
+    "**/apps/api/dist/**": true
+  },
+  "search.exclude": {
+    "**/node_modules": true,
+    "**/dist": true,
+    "**/.turbo": true,
+    "**/build": true,
+    "**/*.tsbuildinfo": true,
+    "**/playwright-report": true
+  },
+
+  // ===== Misc =====
+  "files.eol": "\n",
+  "editor.bracketPairColorization.enabled": true
+}


### PR DESCRIPTION
## สรุป
เพิ่ม `.vscode/` workspace config เพื่อให้ทุกเครื่อง (Mac / Windows / ทีม) มี dev environment ชุดเดียวกัน

## ไฟล์ที่เพิ่ม
- **`.vscode/extensions.json`** — แนะนำ extension: Prisma, ESLint, Prettier, Tailwind v4, Vitest, Playwright, Error Lens, Pretty TS Errors, DotENV, Docker
- **`.vscode/settings.json`**
  - Prettier เป็น default formatter + format on save (ตาม `.prettierrc`)
  - ESLint flat config (`eslint.useFlatConfig`) + fixAll on save, workingDirectories แยก web/api
  - TypeScript ใช้ workspace tsdk
  - Tailwind v4 `classRegex` รองรับ `cn()` / `cva()` / `clsx()`
  - `files.watcherExclude` + `search.exclude` node_modules/dist/.turbo — แก้ search ช้าใน monorepo

## ผลกระทบ
- ไม่แตะ production / โค้ด runtime — เป็น editor config ล้วน
- ไม่ trigger deploy (อยู่นอก path ที่ deploy ใช้)

🤖 Generated with [Claude Code](https://claude.com/claude-code)