### PR TITLE
fix(docker): use pgvector/pgvector:pg16 for local postgres

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   postgres:
-    image: postgres:16-alpine
+    image: pgvector/pgvector:pg16
     container_name: installment-postgres
     environment:
       POSTGRES_USER: postgres
@@ -14,7 +14,7 @@ services:
       - postgres_data:/var/lib/postgresql/data
 
   postgres-finance:
-    image: postgres:16-alpine
+    image: pgvector/pgvector:pg16
     container_name: installment-postgres-finance
     environment:
       POSTGRES_USER: postgres


### PR DESCRIPTION
## ปัญหา
Local dev postgres ใน `docker-compose.yml` ใช้ image `postgres:16-alpine` ซึ่ง **ไม่มี pgvector extension** ทำให้ migration `20260801000000_add_pgvector_to_ai_training_pairs` (`CREATE EXTENSION vector` + HNSW index สำหรับ AI embedding) apply ไม่ผ่านบนเครื่อง local:

```
ERROR: extension vector is not available
DETAIL: Could not open extension control file .../vector.control: No such file or directory
```

ผลคือ `prisma migrate deploy` / `reset` พังกลางคัน → setup เครื่อง local ใหม่ไม่สำเร็จ

## การแก้
เปลี่ยน image ของทั้ง `postgres` + `postgres-finance` เป็น **`pgvector/pgvector:pg16`** ให้ตรงกับที่ **CI ใช้อยู่แล้ว**:
- `.github/workflows/e2e-tests.yml:23`
- `.github/workflows/deploy-gcp.yml:50`

Image นี้ build บน `postgres:16` มาตรฐาน + มี `pgvector` และ `pgcrypto` (contrib ที่ migration อื่นใช้) ครบในตัว — data format เข้ากันได้กับ PG16 เดิม

## ทดสอบแล้ว
- `docker compose up -d` → `pg_available_extensions` มี `vector` ✓
- `prisma migrate reset` (main) apply migration ครบ + seed ผ่าน ✓
- `prisma migrate deploy` (finance) ผ่าน ✓
- `npm run dev` → API + Web ขึ้น, login admin → 201 + JWT ✓

## หมายเหตุ
ไม่กระทบ production (Cloud SQL — ไม่ได้ใช้ compose นี้) เป็น dev tooling อย่างเดียว

🤖 Generated with [Claude Code](https://claude.com/claude-code)