### PR TITLE
feat(shop): wire SHOP-side JEs for the installment lifecycle (P0+P1)

### DIFF
--- a/apps/api/prisma/migrations/20260974000000_add_shop_cash_account_code_to_branch/migration.sql
+++ b/apps/api/prisma/migrations/20260974000000_add_shop_cash_account_code_to_branch/migration.sql
@@ -1,0 +1,3 @@
+-- Add the SHOP per-branch cash-till account code (S11-110x). Nullable: set per branch
+-- in settings before SHOP cash-route JEs (down payment / cash sale / trade-in) post.
+ALTER TABLE "branches" ADD COLUMN IF NOT EXISTS "shop_cash_account_code" TEXT;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -547,6 +547,7 @@ model Branch {
 
   isMainWarehouse Boolean   @default(false) @map("is_main_warehouse")
   deletedAt       DateTime? @map("deleted_at")
+  shopCashAccountCode String?   @map("shop_cash_account_code")
 
   company                  CompanyInfo?              @relation(fields: [companyId], references: [id])
   users                    User[]

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -126,6 +126,8 @@ import { ShopBuybackModule } from './modules/shop-buyback/shop-buyback.module';
 import { ShopInstallmentApplyModule } from './modules/shop-installment-apply/shop-installment-apply.module';
 import { ShopSavingPlanModule } from './modules/shop-saving-plan/shop-saving-plan.module';
 import { ShopPublicConfigModule } from './modules/shop-public-config/shop-public-config.module';
+// Task 8 — Finance-settlement endpoint (POST /shop/finance-settlements + GET pending)
+import { ShopFinanceSettlementModule } from './modules/shop-finance-settlement/shop-finance-settlement.module';
 import { DataAuditModule } from './modules/data-audit/data-audit.module';
 import { IntegrationsModule } from './modules/integrations/integrations.module';
 import { ReportingModule } from './modules/reporting/reporting.module';
@@ -362,6 +364,8 @@ import { AppCacheModule } from './cache/cache.module';
     ShopSavingPlanModule,
     // Online Shop — public runtime config (GA4 / FB Pixel IDs) (Phase 3 follow-up)
     ShopPublicConfigModule,
+    // Task 8 — Finance-settlement endpoint (POST /shop/finance-settlements + GET pending)
+    ShopFinanceSettlementModule,
     // MASTER: Management
     UsersModule,
     SettingsModule,

--- a/apps/api/src/modules/accounting/peak-export.service.spec.ts
+++ b/apps/api/src/modules/accounting/peak-export.service.spec.ts
@@ -1,0 +1,38 @@
+import { Test } from '@nestjs/testing';
+import { PeakExportService } from './peak-export.service';
+import { PrismaService } from '../../prisma/prisma.service';
+import { CompanyResolverService } from '../journal/company-resolver.service';
+
+describe('PeakExportService', () => {
+  let service: PeakExportService;
+  let prisma: any;
+
+  beforeEach(async () => {
+    prisma = {
+      journalLine: { findMany: jest.fn().mockResolvedValue([]) },
+      chartOfAccount: { findMany: jest.fn().mockResolvedValue([]) },
+    };
+    const mod = await Test.createTestingModule({
+      providers: [
+        PeakExportService,
+        { provide: PrismaService, useValue: prisma },
+        {
+          provide: CompanyResolverService,
+          useValue: { getFinanceCompanyId: jest.fn().mockResolvedValue('finance-co-id') },
+        },
+      ],
+    }).compile();
+    service = mod.get(PeakExportService);
+  });
+
+  it('scopes the export to FINANCE company (X5)', async () => {
+    await service.exportJournalWithPeakCodes(new Date('2026-06-01'), new Date('2026-06-30'));
+    expect(prisma.journalLine.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          journalEntry: expect.objectContaining({ companyId: 'finance-co-id' }),
+        }),
+      }),
+    );
+  });
+});

--- a/apps/api/src/modules/accounting/peak-export.service.ts
+++ b/apps/api/src/modules/accounting/peak-export.service.ts
@@ -1,6 +1,7 @@
 import { BadRequestException, Injectable } from '@nestjs/common';
 import { Prisma } from '@prisma/client';
 import { PrismaService } from '../../prisma/prisma.service';
+import { CompanyResolverService } from '../journal/company-resolver.service';
 
 // ============================================================
 // P3-SP3: PEAK CSV export (journal lines tagged with PEAK code)
@@ -8,7 +9,10 @@ import { PrismaService } from '../../prisma/prisma.service';
 
 @Injectable()
 export class PeakExportService {
-  constructor(private prisma: PrismaService) {}
+  constructor(
+    private prisma: PrismaService,
+    private companyResolver: CompanyResolverService,
+  ) {}
 
   /**
    * Build a CSV of POSTED journal lines within `[periodStart, periodEnd]`
@@ -57,6 +61,9 @@ export class PeakExportService {
 
     // 2) Fetch journal lines in range. Order by entryDate then entryNumber so
     //    the CSV is deterministic for reconciliation diffs.
+    // X5: scope to FINANCE company so SHOP (S-prefix) entries never leak into
+    //     the PEAK CSV that the CPA uploads to peakaccount.com.
+    const financeCompanyId = await this.companyResolver.getFinanceCompanyId();
     const lines = await this.prisma.journalLine.findMany({
       where: {
         deletedAt: null,
@@ -64,6 +71,7 @@ export class PeakExportService {
           status: 'POSTED',
           entryDate: { gte: periodStart, lte: periodEnd },
           deletedAt: null,
+          companyId: financeCompanyId,
         },
       },
       select: {

--- a/apps/api/src/modules/contracts/contract-hash.spec.ts
+++ b/apps/api/src/modules/contracts/contract-hash.spec.ts
@@ -7,6 +7,10 @@ import { JournalAutoService } from '../journal/journal-auto.service';
 import { ProductsService } from '../products/products.service';
 import { ContractActivation1ATemplate } from '../journal/cpa-templates/contract-activation-1a.template';
 import { ContractExchangeService } from '../contract-exchange/contract-exchange.service';
+import { ShopDownPaymentTemplate } from '../journal/cpa-templates/shop-down-payment.template';
+import { ShopInventoryTransferTemplate } from '../journal/cpa-templates/shop-inventory-transfer.template';
+import { ShopAccountResolver } from '../journal/shop-account-resolver.service';
+import { TestModeService } from '../test-mode/test-mode.service';
 
 /**
  * T5-C20 — extended contract integrity hash.
@@ -29,6 +33,10 @@ describe('ContractWorkflowService — hash integrity (T5-C20)', () => {
         { provide: ProductsService, useValue: {} },
         { provide: ContractActivation1ATemplate, useValue: { execute: jest.fn().mockResolvedValue({ entryNo: 'JE-MOCK' }) } },
         { provide: ContractExchangeService, useValue: { finalizeAfterActivation: jest.fn() } },
+        { provide: ShopDownPaymentTemplate, useValue: { execute: jest.fn().mockResolvedValue({ entryNo: 'JE-001', journalEntryId: 'je-1' }) } },
+        { provide: ShopInventoryTransferTemplate, useValue: { execute: jest.fn().mockResolvedValue({ entryNo: 'JE-002', journalEntryId: 'je-2' }) } },
+        { provide: ShopAccountResolver, useValue: { resolveBranchCashAccount: jest.fn().mockResolvedValue('S11-1102'), resolveProductAccounts: jest.fn() } },
+        { provide: TestModeService, useValue: { isEnabled: jest.fn().mockResolvedValue(false) } },
       ],
     }).compile();
     service = module.get(ContractWorkflowService);

--- a/apps/api/src/modules/contracts/contract-signing-workflow.spec.ts
+++ b/apps/api/src/modules/contracts/contract-signing-workflow.spec.ts
@@ -10,6 +10,7 @@ import { DocumentsService } from './documents.service';
 import { ContractActivation1ATemplate } from '../journal/cpa-templates/contract-activation-1a.template';
 import { ContractExchangeService } from '../contract-exchange/contract-exchange.service';
 import { ShopDownPaymentTemplate } from '../journal/cpa-templates/shop-down-payment.template';
+import { ShopDownPaymentReversalTemplate } from '../journal/cpa-templates/shop-down-payment-reversal.template';
 import { ShopInventoryTransferTemplate } from '../journal/cpa-templates/shop-inventory-transfer.template';
 import { ShopAccountResolver } from '../journal/shop-account-resolver.service';
 import { TestModeService } from '../test-mode/test-mode.service';
@@ -230,6 +231,7 @@ describe('Contract Signing & Workflow', () => {
         { provide: ContractActivation1ATemplate, useValue: { execute: jest.fn().mockResolvedValue({ entryNo: 'JE-MOCK' }) } },
         { provide: ContractExchangeService, useValue: { finalizeAfterActivation: jest.fn() } },
         { provide: ShopDownPaymentTemplate, useValue: { execute: jest.fn().mockResolvedValue({ entryNo: 'JE-001', journalEntryId: 'je-1' }) } },
+        { provide: ShopDownPaymentReversalTemplate, useValue: { execute: jest.fn().mockResolvedValue({ entryNo: 'JE-REV-001', journalEntryId: 'je-rev-1' }) } },
         { provide: ShopInventoryTransferTemplate, useValue: { execute: jest.fn().mockResolvedValue({ entryNo: 'JE-002', journalEntryId: 'je-2' }) } },
         { provide: ShopAccountResolver, useValue: { resolveBranchCashAccount: jest.fn().mockResolvedValue('S11-1102'), resolveProductAccounts: jest.fn().mockReturnValue({ inventoryAccountCode: 'S11-2001', cogsAccountCode: 'S50-1101', revenueAccountCode: 'S41-1101' }) } },
         { provide: TestModeService, useValue: { isEnabled: jest.fn().mockResolvedValue(false) } },

--- a/apps/api/src/modules/contracts/contract-signing-workflow.spec.ts
+++ b/apps/api/src/modules/contracts/contract-signing-workflow.spec.ts
@@ -9,6 +9,10 @@ import { ProductsService } from '../products/products.service';
 import { DocumentsService } from './documents.service';
 import { ContractActivation1ATemplate } from '../journal/cpa-templates/contract-activation-1a.template';
 import { ContractExchangeService } from '../contract-exchange/contract-exchange.service';
+import { ShopDownPaymentTemplate } from '../journal/cpa-templates/shop-down-payment.template';
+import { ShopInventoryTransferTemplate } from '../journal/cpa-templates/shop-inventory-transfer.template';
+import { ShopAccountResolver } from '../journal/shop-account-resolver.service';
+import { TestModeService } from '../test-mode/test-mode.service';
 
 // Mock utility modules
 jest.mock('../../utils/installment.util', () => ({
@@ -115,6 +119,7 @@ describe('Contract Signing & Workflow', () => {
       imeiSerial: '123456789012345',
       category: 'PHONE_NEW',
       status: 'RESERVED',
+      costPrice: 18000,
     },
     branch: { id: 'branch-1', name: 'สาขาทดสอบ' },
     salesperson: { id: 'user-1', name: 'Staff' },
@@ -167,6 +172,9 @@ describe('Contract Signing & Workflow', () => {
       },
       companyInfo: {
         findFirst: jest.fn().mockResolvedValue({ id: 'finance-1' }),
+      },
+      journalEntry: {
+        findFirst: jest.fn().mockResolvedValue(null),
       },
     };
 
@@ -221,6 +229,10 @@ describe('Contract Signing & Workflow', () => {
         { provide: ProductsService, useValue: { transferOwnership: jest.fn() } },
         { provide: ContractActivation1ATemplate, useValue: { execute: jest.fn().mockResolvedValue({ entryNo: 'JE-MOCK' }) } },
         { provide: ContractExchangeService, useValue: { finalizeAfterActivation: jest.fn() } },
+        { provide: ShopDownPaymentTemplate, useValue: { execute: jest.fn().mockResolvedValue({ entryNo: 'JE-001', journalEntryId: 'je-1' }) } },
+        { provide: ShopInventoryTransferTemplate, useValue: { execute: jest.fn().mockResolvedValue({ entryNo: 'JE-002', journalEntryId: 'je-2' }) } },
+        { provide: ShopAccountResolver, useValue: { resolveBranchCashAccount: jest.fn().mockResolvedValue('S11-1102'), resolveProductAccounts: jest.fn().mockReturnValue({ inventoryAccountCode: 'S11-2001', cogsAccountCode: 'S50-1101', revenueAccountCode: 'S41-1101' }) } },
+        { provide: TestModeService, useValue: { isEnabled: jest.fn().mockResolvedValue(false) } },
       ],
     }).compile();
 

--- a/apps/api/src/modules/contracts/contract-workflow.schedule.spec.ts
+++ b/apps/api/src/modules/contracts/contract-workflow.schedule.spec.ts
@@ -18,7 +18,8 @@ import { ContractWorkflowService } from './contract-workflow.service';
  */
 
 const stub = {} as never;
-const service = new ContractWorkflowService(stub, stub, stub, stub, stub, stub);
+// Task 5: constructor now has 9 params (3 SHOP deps added); pass stubs for all.
+const service = new ContractWorkflowService(stub, stub, stub, stub, stub, stub, stub, stub, stub);
 
 type Rows = Prisma.InstallmentScheduleCreateManyInput[];
 

--- a/apps/api/src/modules/contracts/contract-workflow.service.spec.ts
+++ b/apps/api/src/modules/contracts/contract-workflow.service.spec.ts
@@ -8,6 +8,9 @@ import { ProductsService } from '../products/products.service';
 import { ContractActivation1ATemplate } from '../journal/cpa-templates/contract-activation-1a.template';
 import { ContractExchangeService } from '../contract-exchange/contract-exchange.service';
 import { TestModeService } from '../test-mode/test-mode.service';
+import { ShopInventoryTransferTemplate } from '../journal/cpa-templates/shop-inventory-transfer.template';
+import { ShopDownPaymentTemplate } from '../journal/cpa-templates/shop-down-payment.template';
+import { ShopAccountResolver } from '../journal/shop-account-resolver.service';
 import { BadRequestException } from '@nestjs/common';
 
 /**
@@ -45,6 +48,10 @@ describe('ContractWorkflowService', () => {
   let notificationsMock: { send: jest.Mock };
   let exchangeServiceMock: { finalizeAfterActivation: jest.Mock };
   let testModeMock: { isEnabled: jest.Mock };
+  // Task 5: SHOP JE wiring mocks
+  let shopInventoryTransferTemplate: { execute: jest.Mock };
+  let shopDownPaymentTemplate: { execute: jest.Mock };
+  let shopAccountResolver: { resolveProductAccounts: jest.Mock; resolveBranchCashAccount: jest.Mock };
 
   const mockProduct = {
     id: 'product-1',
@@ -150,6 +157,10 @@ describe('ContractWorkflowService', () => {
       payment: {
         findFirst: jest.fn().mockResolvedValue(null),
       },
+      journalEntry: {
+        // Default: a prior down JE exists → catch-up skipped in existing tests.
+        findFirst: jest.fn().mockResolvedValue({ id: 'down-je-1' }),
+      },
       companyInfo: {
         findFirst: jest.fn().mockResolvedValue({ id: 'finance-co-1' }),
       },
@@ -173,6 +184,23 @@ describe('ContractWorkflowService', () => {
     // Default: test-mode OFF.
     testModeMock = { isEnabled: jest.fn().mockResolvedValue(false) };
 
+    // Task 5: SHOP wiring mocks
+    shopInventoryTransferTemplate = {
+      execute: jest.fn().mockResolvedValue({
+        batchId: 'b', cogsEntryNo: 'c', cogsJournalEntryId: 'cj',
+        revenueEntryNo: 'r', revenueJournalEntryId: 'rj',
+      }),
+    };
+    shopDownPaymentTemplate = { execute: jest.fn().mockResolvedValue({ entryNo: 'dp', journalEntryId: 'dpj' }) };
+    shopAccountResolver = {
+      resolveProductAccounts: jest.fn().mockReturnValue({
+        inventoryAccountCode: 'S11-2001',
+        cogsAccountCode: 'S50-1101',
+        revenueAccountCode: 'S41-1101',
+      }),
+      resolveBranchCashAccount: jest.fn().mockResolvedValue('S11-1102'),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         ContractWorkflowService,
@@ -183,6 +211,9 @@ describe('ContractWorkflowService', () => {
         { provide: ContractActivation1ATemplate, useValue: { execute: jest.fn().mockResolvedValue({ entryNo: 'JE-MOCK' }) } },
         { provide: ContractExchangeService, useValue: exchangeServiceMock },
         { provide: TestModeService, useValue: testModeMock },
+        { provide: ShopInventoryTransferTemplate, useValue: shopInventoryTransferTemplate },
+        { provide: ShopDownPaymentTemplate, useValue: shopDownPaymentTemplate },
+        { provide: ShopAccountResolver, useValue: shopAccountResolver },
       ],
     }).compile();
 
@@ -310,6 +341,125 @@ describe('ContractWorkflowService', () => {
         // standard 1A path was not used here
         expect(contractActivationTemplateMock.execute).not.toHaveBeenCalled();
       });
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // Task 5: SHOP inventory-transfer JE wiring (standard branch only)
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  describe('SHOP inventory-transfer wiring (Task 5 / D-1)', () => {
+    // Contract with the exact values from the brief:
+    // sellingPrice 20000, downPayment 2000, financedAmount 18000, storeCommission 1500
+    // product category PHONE_NEW, costPrice 15000
+    const shopProduct = {
+      id: 'product-shop',
+      name: 'Samsung A55',
+      brand: 'Samsung',
+      model: 'A55',
+      category: 'PHONE_NEW',
+      status: 'RESERVED',
+      imeiSerial: '111222333444555',
+      costPrice: new Prisma.Decimal(15000),
+      deletedAt: null,
+      prices: [],
+    };
+    const shopContract = {
+      id: 'c-1',
+      contractNumber: 'BC-2026-SHOP',
+      customerId: 'customer-1',
+      productId: 'product-shop',
+      branchId: 'branch-1',
+      salespersonId: 'user-1',
+      status: 'DRAFT',
+      workflowStatus: 'APPROVED',
+      sellingPrice: new Prisma.Decimal(20000),
+      downPayment: new Prisma.Decimal(2000),
+      totalMonths: 12,
+      interestRate: new Prisma.Decimal(0.08),
+      interestTotal: new Prisma.Decimal(1440),
+      financedAmount: new Prisma.Decimal(18000),
+      storeCommission: new Prisma.Decimal(1500),
+      vatAmount: new Prisma.Decimal(0),
+      vatPct: new Prisma.Decimal(0.07),
+      monthlyPayment: new Prisma.Decimal(1620),
+      paymentDueDay: 5,
+      notes: null,
+      deletedAt: null,
+      pdpaConsentId: 'pdpa-shop-1',
+      contractHash: null,
+      customer: mockCustomer,
+      product: { ...shopProduct, prices: [] },
+      branch: { id: 'branch-1', name: 'สาขาลาดพร้าว' },
+      salesperson: { id: 'user-1', name: 'พนักงาน 1' },
+      reviewedBy: null,
+      interestConfig: null,
+      payments: [],
+      signatures: [
+        { id: 's1', signerType: 'CUSTOMER', signedAt: new Date(), staffUserId: null, deletedAt: null },
+        { id: 's2', signerType: 'COMPANY', signedAt: new Date(), staffUserId: 'user-1', deletedAt: null },
+        { id: 's3', signerType: 'WITNESS_1', signedAt: new Date(), staffUserId: 'user-1', deletedAt: null },
+        { id: 's4', signerType: 'WITNESS_2', signedAt: new Date(), staffUserId: 'user-1', deletedAt: null },
+      ],
+      eDocuments: [],
+      contractDocuments: [],
+      creditCheck: { id: 'cc-shop', status: 'APPROVED' },
+    };
+
+    beforeEach(() => {
+      prisma.contract.findUnique.mockResolvedValue(shopContract);
+      prisma.product.findUnique.mockResolvedValue(shopProduct);
+      // Default: down JE already exists → catch-up skipped.
+      prisma.journalEntry.findFirst.mockResolvedValue({ id: 'down-je-1' });
+    });
+
+    it('posts ShopInventoryTransfer with salePrice = down + financed at activation', async () => {
+      await service.activate('c-1');
+      const input = shopInventoryTransferTemplate.execute.mock.calls[0][0];
+      // D-8: salePrice must be down + financed (2000 + 18000 = 20000), NOT raw sellingPrice
+      expect(input.salePrice.toString()).toBe('20000');
+      expect(input.downAmount.toString()).toBe('2000');
+      expect(input.financedAmount.toString()).toBe('18000');
+      expect(input.commission.toString()).toBe('1500');
+      expect(input.costPrice.toString()).toBe('15000');
+      expect(input).toMatchObject({
+        inventoryAccountCode: 'S11-2001',
+        cogsAccountCode: 'S50-1101',
+        revenueAccountCode: 'S41-1101',
+        idempotencyKey: 'shop-inventory-transfer:c-1',
+      });
+      // Called with the outer tx as second argument (atomicity guarantee)
+      expect(shopInventoryTransferTemplate.execute.mock.calls[0][1]).toBeDefined();
+    });
+
+    it('posts a catch-up ShopDownPayment for in-flight contract with down but no down JE', async () => {
+      // No prior down JE → pre-Task-6 in-flight contract → catch-up fires
+      prisma.journalEntry.findFirst.mockResolvedValue(null);
+      shopAccountResolver.resolveBranchCashAccount.mockResolvedValue('S11-1102');
+      await service.activate('c-1');
+      expect(shopDownPaymentTemplate.execute).toHaveBeenCalledTimes(1);
+      expect(shopDownPaymentTemplate.execute.mock.calls[0][0]).toMatchObject({
+        idempotencyKey: 'shop-down-payment:c-1',
+        cashAccountCode: 'S11-1102',
+      });
+    });
+
+    it('skips the catch-up when a down JE already exists (post-Task-6 contract)', async () => {
+      prisma.journalEntry.findFirst.mockResolvedValue({ id: 'down-je-1' });
+      await service.activate('c-1');
+      expect(shopDownPaymentTemplate.execute).not.toHaveBeenCalled();
+    });
+
+    it('does NOT post SHOP JEs for exchange contracts (exchange branch only)', async () => {
+      const exchangeShopContract = {
+        ...shopContract,
+        id: 'c-exch',
+        exchangedFromContractId: 'c-original',
+      };
+      prisma.contract.findUnique.mockResolvedValue(exchangeShopContract);
+      await service.activate('c-exch');
+      expect(shopInventoryTransferTemplate.execute).not.toHaveBeenCalled();
+      expect(shopDownPaymentTemplate.execute).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/api/src/modules/contracts/contract-workflow.service.ts
+++ b/apps/api/src/modules/contracts/contract-workflow.service.ts
@@ -14,9 +14,13 @@ import { generateSaleNumber } from '../../utils/sequence.util';
 import { buildInstallmentScheduleRows } from '../../utils/installment-schedule.util';
 import { JournalAutoService } from '../journal/journal-auto.service';
 import { ContractActivation1ATemplate } from '../journal/cpa-templates/contract-activation-1a.template';
+import { ShopInventoryTransferTemplate } from '../journal/cpa-templates/shop-inventory-transfer.template';
+import { ShopDownPaymentTemplate } from '../journal/cpa-templates/shop-down-payment.template';
+import { ShopAccountResolver } from '../journal/shop-account-resolver.service';
 import { ProductsService } from '../products/products.service';
 import { ContractExchangeService } from '../contract-exchange/contract-exchange.service';
 import { TestModeService } from '../test-mode/test-mode.service';
+import { Decimal } from '@prisma/client/runtime/library';
 import * as crypto from 'crypto';
 
 @Injectable()
@@ -29,6 +33,9 @@ export class ContractWorkflowService {
     private contractActivation1ATemplate: ContractActivation1ATemplate,
     private productsService: ProductsService,
     private contractExchangeService: ContractExchangeService,
+    private shopInventoryTransferTemplate: ShopInventoryTransferTemplate,
+    private shopDownPaymentTemplate: ShopDownPaymentTemplate,
+    private shopAccountResolver: ShopAccountResolver,
     @Optional() private testMode?: TestModeService,
   ) {}
 
@@ -492,6 +499,63 @@ export class ContractWorkflowService {
         // fire-and-forget pattern violated by leaving contracts ACTIVE without
         // any ledger entry when the JE failed.
         await this.contractActivation1ATemplate.execute(contract.id, tx);
+
+        // SHOP-side: post inventory transfer (COGS + revenue + receivables + down clearance),
+        // atomic with the FINANCE 1A entry. salePrice is reconstructed as down+financed (D-8)
+        // so the template's financing-identity assertion holds by construction.
+        const downAmount = new Decimal(contract.downPayment.toString());
+        const financedAmt = new Decimal(contract.financedAmount.toString());
+
+        // In-flight rollout guard (spec §12): a contract created BEFORE this feature
+        // shipped never got a ShopDownPayment JE, but ShopInventoryTransfer below will
+        // Dr S21-2001 to "clear" the down payable. If no down JE exists yet, post a
+        // catch-up ShopDownPayment first so the clearance lands against a real credit.
+        if (downAmount.gt(0)) {
+          const downJe = await tx.journalEntry.findFirst({
+            where: {
+              AND: [
+                { metadata: { path: ['flow'], equals: 'shop-down-payment' } as any },
+                { metadata: { path: ['idempotencyKey'], equals: `shop-down-payment:${contract.id}` } as any },
+              ],
+              deletedAt: null,
+            },
+            select: { id: true },
+          });
+          if (!downJe) {
+            const cashAccountCode = await this.shopAccountResolver.resolveBranchCashAccount(contract.branchId, tx);
+            await this.shopDownPaymentTemplate.execute(
+              {
+                idempotencyKey: `shop-down-payment:${contract.id}`,
+                contractId: contract.id,
+                contractNumber: contract.contractNumber,
+                cashAccountCode,
+                downAmount,
+              },
+              tx,
+            );
+          }
+        }
+
+        const acc = this.shopAccountResolver.resolveProductAccounts(contract.product.category);
+        await this.shopInventoryTransferTemplate.execute(
+          {
+            idempotencyKey: `shop-inventory-transfer:${contract.id}`,
+            contractId: contract.id,
+            contractNumber: contract.contractNumber,
+            productId: contract.productId,
+            inventoryAccountCode: acc.inventoryAccountCode,
+            cogsAccountCode: acc.cogsAccountCode,
+            revenueAccountCode: acc.revenueAccountCode,
+            costPrice: new Decimal(contract.product.costPrice.toString()),
+            salePrice: downAmount.plus(financedAmt),
+            downAmount,
+            financedAmount: financedAmt,
+            commission: contract.storeCommission
+              ? new Decimal(contract.storeCommission.toString())
+              : new Decimal(0),
+          },
+          tx,
+        );
       }
 
       // Phase A.4 — generate installment_schedules rows so accrual cron + payment

--- a/apps/api/src/modules/contracts/contracts.service.spec.ts
+++ b/apps/api/src/modules/contracts/contracts.service.spec.ts
@@ -5,6 +5,8 @@ import { ContractsService } from './contracts.service';
 import { PrismaService } from '../../prisma/prisma.service';
 import { TestModeService } from '../test-mode/test-mode.service';
 import { AuditService } from '../audit/audit.service';
+import { ShopDownPaymentTemplate } from '../journal/cpa-templates/shop-down-payment.template';
+import { ShopAccountResolver } from '../journal/shop-account-resolver.service';
 
 /**
  * ContractsService unit tests.
@@ -257,6 +259,8 @@ describe('ContractsService', () => {
         { provide: PrismaService, useValue: prisma },
         { provide: TestModeService, useValue: testModeMock },
         { provide: AuditService, useValue: auditMock },
+        { provide: ShopDownPaymentTemplate, useValue: { execute: jest.fn().mockResolvedValue({ entryNo: 'JE-001', journalEntryId: 'je-1' }) } },
+        { provide: ShopAccountResolver, useValue: { resolveBranchCashAccount: jest.fn().mockResolvedValue('S11-1102'), resolveProductAccounts: jest.fn() } },
       ],
     }).compile();
 
@@ -1333,6 +1337,8 @@ describe('ContractsService', () => {
           ContractsService,
           { provide: PrismaService, useValue: prisma },
           { provide: 'ContractCancellationTemplate', useValue: mockCancellationTemplate },
+          { provide: ShopDownPaymentTemplate, useValue: { execute: jest.fn().mockResolvedValue({ entryNo: 'JE-001', journalEntryId: 'je-1' }) } },
+          { provide: ShopAccountResolver, useValue: { resolveBranchCashAccount: jest.fn().mockResolvedValue('S11-1102'), resolveProductAccounts: jest.fn() } },
         ],
       }).compile();
       const svcWithTemplate = moduleWithTemplate.get<ContractsService>(ContractsService);

--- a/apps/api/src/modules/contracts/contracts.service.spec.ts
+++ b/apps/api/src/modules/contracts/contracts.service.spec.ts
@@ -6,6 +6,7 @@ import { PrismaService } from '../../prisma/prisma.service';
 import { TestModeService } from '../test-mode/test-mode.service';
 import { AuditService } from '../audit/audit.service';
 import { ShopDownPaymentTemplate } from '../journal/cpa-templates/shop-down-payment.template';
+import { ShopDownPaymentReversalTemplate } from '../journal/cpa-templates/shop-down-payment-reversal.template';
 import { ShopAccountResolver } from '../journal/shop-account-resolver.service';
 
 /**
@@ -246,6 +247,9 @@ describe('ContractsService', () => {
       auditLog: {
         create: jest.fn().mockResolvedValue({}),
       },
+      journalEntry: {
+        findFirst: jest.fn().mockResolvedValue(null),
+      },
       $transaction: makeTxMock(),
     };
 
@@ -260,6 +264,7 @@ describe('ContractsService', () => {
         { provide: TestModeService, useValue: testModeMock },
         { provide: AuditService, useValue: auditMock },
         { provide: ShopDownPaymentTemplate, useValue: { execute: jest.fn().mockResolvedValue({ entryNo: 'JE-001', journalEntryId: 'je-1' }) } },
+        { provide: ShopDownPaymentReversalTemplate, useValue: { execute: jest.fn().mockResolvedValue({ entryNo: 'JE-REV-001', journalEntryId: 'je-rev-1' }) } },
         { provide: ShopAccountResolver, useValue: { resolveBranchCashAccount: jest.fn().mockResolvedValue('S11-1102'), resolveProductAccounts: jest.fn() } },
       ],
     }).compile();
@@ -1338,6 +1343,7 @@ describe('ContractsService', () => {
           { provide: PrismaService, useValue: prisma },
           { provide: 'ContractCancellationTemplate', useValue: mockCancellationTemplate },
           { provide: ShopDownPaymentTemplate, useValue: { execute: jest.fn().mockResolvedValue({ entryNo: 'JE-001', journalEntryId: 'je-1' }) } },
+          { provide: ShopDownPaymentReversalTemplate, useValue: { execute: jest.fn().mockResolvedValue({ entryNo: 'JE-REV-001', journalEntryId: 'je-rev-1' }) } },
           { provide: ShopAccountResolver, useValue: { resolveBranchCashAccount: jest.fn().mockResolvedValue('S11-1102'), resolveProductAccounts: jest.fn() } },
         ],
       }).compile();

--- a/apps/api/src/modules/contracts/contracts.service.ts
+++ b/apps/api/src/modules/contracts/contracts.service.ts
@@ -9,6 +9,7 @@ import { ContractQueryService, BranchAccessUser } from './services/contract-quer
 import { ContractLifecycleService } from './services/contract-lifecycle.service';
 import { ContractCancellationService } from './services/contract-cancellation.service';
 import { ShopDownPaymentTemplate } from '../journal/cpa-templates/shop-down-payment.template';
+import { ShopDownPaymentReversalTemplate } from '../journal/cpa-templates/shop-down-payment-reversal.template';
 import { ShopAccountResolver } from '../journal/shop-account-resolver.service';
 
 export { BranchAccessUser };
@@ -40,6 +41,7 @@ export class ContractsService {
   constructor(
     private prisma: PrismaService,
     private shopDownPaymentTemplate: ShopDownPaymentTemplate,
+    private shopDownPaymentReversalTemplate: ShopDownPaymentReversalTemplate,
     private shopAccountResolver: ShopAccountResolver,
     @Optional() private warrantyService?: WarrantyService,
     @Optional() private cancellationTemplate?: ContractCancellationTemplate,
@@ -47,7 +49,7 @@ export class ContractsService {
     @Optional() private audit?: AuditService,
   ) {
     this.query = new ContractQueryService(prisma, testMode);
-    this.lifecycle = new ContractLifecycleService(prisma, this.query, shopDownPaymentTemplate, shopAccountResolver, warrantyService, audit);
+    this.lifecycle = new ContractLifecycleService(prisma, this.query, shopDownPaymentTemplate, shopDownPaymentReversalTemplate, shopAccountResolver, warrantyService, audit);
     // Late-bind the cancellation template via accessor so a post-construction
     // mutation of `this.cancellationTemplate` (the unit-test hack) is honored.
     this.cancellation = new ContractCancellationService(prisma, () => this.cancellationTemplate);

--- a/apps/api/src/modules/contracts/contracts.service.ts
+++ b/apps/api/src/modules/contracts/contracts.service.ts
@@ -8,6 +8,8 @@ import { AuditService } from '../audit/audit.service';
 import { ContractQueryService, BranchAccessUser } from './services/contract-query.service';
 import { ContractLifecycleService } from './services/contract-lifecycle.service';
 import { ContractCancellationService } from './services/contract-cancellation.service';
+import { ShopDownPaymentTemplate } from '../journal/cpa-templates/shop-down-payment.template';
+import { ShopAccountResolver } from '../journal/shop-account-resolver.service';
 
 export { BranchAccessUser };
 
@@ -41,9 +43,11 @@ export class ContractsService {
     @Optional() private cancellationTemplate?: ContractCancellationTemplate,
     @Optional() private testMode?: TestModeService,
     @Optional() private audit?: AuditService,
+    @Optional() private shopDownPaymentTemplate?: ShopDownPaymentTemplate,
+    @Optional() private shopAccountResolver?: ShopAccountResolver,
   ) {
     this.query = new ContractQueryService(prisma, testMode);
-    this.lifecycle = new ContractLifecycleService(prisma, this.query, warrantyService, audit);
+    this.lifecycle = new ContractLifecycleService(prisma, this.query, warrantyService, audit, shopDownPaymentTemplate, shopAccountResolver);
     // Late-bind the cancellation template via accessor so a post-construction
     // mutation of `this.cancellationTemplate` (the unit-test hack) is honored.
     this.cancellation = new ContractCancellationService(prisma, () => this.cancellationTemplate);

--- a/apps/api/src/modules/contracts/contracts.service.ts
+++ b/apps/api/src/modules/contracts/contracts.service.ts
@@ -39,15 +39,15 @@ export class ContractsService {
 
   constructor(
     private prisma: PrismaService,
+    private shopDownPaymentTemplate: ShopDownPaymentTemplate,
+    private shopAccountResolver: ShopAccountResolver,
     @Optional() private warrantyService?: WarrantyService,
     @Optional() private cancellationTemplate?: ContractCancellationTemplate,
     @Optional() private testMode?: TestModeService,
     @Optional() private audit?: AuditService,
-    @Optional() private shopDownPaymentTemplate?: ShopDownPaymentTemplate,
-    @Optional() private shopAccountResolver?: ShopAccountResolver,
   ) {
     this.query = new ContractQueryService(prisma, testMode);
-    this.lifecycle = new ContractLifecycleService(prisma, this.query, warrantyService, audit, shopDownPaymentTemplate, shopAccountResolver);
+    this.lifecycle = new ContractLifecycleService(prisma, this.query, shopDownPaymentTemplate, shopAccountResolver, warrantyService, audit);
     // Late-bind the cancellation template via accessor so a post-construction
     // mutation of `this.cancellationTemplate` (the unit-test hack) is honored.
     this.cancellation = new ContractCancellationService(prisma, () => this.cancellationTemplate);

--- a/apps/api/src/modules/contracts/services/contract-lifecycle.service.spec.ts
+++ b/apps/api/src/modules/contracts/services/contract-lifecycle.service.spec.ts
@@ -1,8 +1,11 @@
 /**
- * ContractLifecycleService — ShopDownPayment wiring tests (Task 6).
+ * ContractLifecycleService — ShopDownPayment wiring tests (Task 6 + Task 7).
  *
- * Verifies that `create()` posts `ShopDownPaymentTemplate` exactly when
+ * Task 6: `create()` posts `ShopDownPaymentTemplate` exactly when
  * `downPayment > 0`, and skips it when `downPayment = 0`.
+ *
+ * Task 7: `softDelete()` posts `ShopDownPaymentReversalTemplate` when
+ * `downPayment > 0` AND a down JE exists, and skips it when no down JE exists.
  *
  * The service is instantiated directly (not via NestJS DI) to match the
  * way `ContractsService` constructs it with `new ContractLifecycleService(...)`.
@@ -11,6 +14,7 @@
 import { Decimal } from '@prisma/client/runtime/library';
 import { ContractLifecycleService } from './contract-lifecycle.service';
 import { ShopDownPaymentTemplate } from '../../journal/cpa-templates/shop-down-payment.template';
+import { ShopDownPaymentReversalTemplate } from '../../journal/cpa-templates/shop-down-payment-reversal.template';
 import { ShopAccountResolver } from '../../journal/shop-account-resolver.service';
 
 // ─── module-level mocks (must be hoisted before imports are used) ─────────────
@@ -124,6 +128,7 @@ describe('ContractLifecycleService — ShopDownPayment wiring', () => {
   let prisma: any;
   let tx: any;
   let shopDownPaymentTemplate: jest.Mocked<Pick<ShopDownPaymentTemplate, 'execute'>>;
+  let shopDownPaymentReversalTemplate: jest.Mocked<Pick<ShopDownPaymentReversalTemplate, 'execute'>>;
   let shopAccountResolver: jest.Mocked<Pick<ShopAccountResolver, 'resolveBranchCashAccount'>>;
   let queryMock: any;
 
@@ -133,16 +138,19 @@ describe('ContractLifecycleService — ShopDownPayment wiring', () => {
       creditCheck: {
         findFirst: jest.fn().mockResolvedValue({ id: 'cc-1', status: 'APPROVED', contractId: null }),
         update: jest.fn().mockResolvedValue({}),
+        updateMany: jest.fn().mockResolvedValue({ count: 0 }),
       },
       product: {
         findUnique: jest.fn().mockResolvedValue(mockProduct),
         update: jest.fn().mockResolvedValue({ ...mockProduct, status: 'RESERVED' }),
+        updateMany: jest.fn().mockResolvedValue({ count: 1 }),
       },
       customer: {
         findUnique: jest.fn().mockResolvedValue(mockCustomer),
       },
       contract: {
         create: jest.fn().mockResolvedValue(mockCreatedContract),
+        update: jest.fn().mockResolvedValue(mockCreatedContract),
       },
       payment: {
         createMany: jest.fn().mockResolvedValue({ count: 12 }),
@@ -152,6 +160,15 @@ describe('ContractLifecycleService — ShopDownPayment wiring', () => {
       },
       branch: {
         findUnique: jest.fn().mockResolvedValue({ shopCashAccountCode: 'S11-1102' }),
+      },
+      signature: {
+        updateMany: jest.fn().mockResolvedValue({ count: 0 }),
+      },
+      kycVerification: {
+        updateMany: jest.fn().mockResolvedValue({ count: 0 }),
+      },
+      auditLog: {
+        create: jest.fn().mockResolvedValue({}),
       },
     };
 
@@ -182,6 +199,10 @@ describe('ContractLifecycleService — ShopDownPayment wiring', () => {
       execute: jest.fn().mockResolvedValue({ entryNo: 'JE-001', journalEntryId: 'je-1' }),
     };
 
+    shopDownPaymentReversalTemplate = {
+      execute: jest.fn().mockResolvedValue({ entryNo: 'JE-REV-001', journalEntryId: 'je-rev-1' }),
+    };
+
     shopAccountResolver = {
       resolveBranchCashAccount: jest.fn().mockResolvedValue('S11-1102'),
     };
@@ -190,6 +211,7 @@ describe('ContractLifecycleService — ShopDownPayment wiring', () => {
       prisma as any,
       queryMock as any,
       shopDownPaymentTemplate as any,
+      shopDownPaymentReversalTemplate as any,
       shopAccountResolver as any,
       undefined, // warrantyService — optional
       undefined, // audit — optional
@@ -237,5 +259,49 @@ describe('ContractLifecycleService — ShopDownPayment wiring', () => {
     await service.create({ ...baseDto, downPayment: 0 } as any, 'sp-1');
 
     expect(shopDownPaymentTemplate.execute).not.toHaveBeenCalled();
+  });
+
+  // ─── Task-7 reversal assertions ──────────────────────────────────────────────
+
+  it('reverses the SHOP down payment when voiding a DRAFT contract that had a down JE', async () => {
+    // query.findOne returns DRAFT/CREATING contract with downPayment 2000, branchId 'br-1'
+    queryMock.findOne.mockResolvedValue({
+      ...mockCreatedContract,
+      downPayment: new Decimal(2000),
+      branchId: 'br-1',
+      signatures: [],
+      payments: [],
+    });
+    // a shop-down-payment JE exists for this contract:
+    tx.journalEntry.findFirst.mockResolvedValue({ id: 'down-je-1' });
+    shopAccountResolver.resolveBranchCashAccount.mockResolvedValue('S11-1102');
+
+    await service.softDelete('c-1', 'user-1');
+
+    const input = (shopDownPaymentReversalTemplate.execute as jest.Mock).mock.calls[0][0];
+    expect(input).toMatchObject({
+      idempotencyKey: 'shop-down-payment-reversal:c-1',
+      refundAccountCode: 'S11-1102',
+      originalJournalEntryId: 'down-je-1',
+    });
+    expect(input.downAmount.toString()).toBe('2000');
+    // Confirm template was called with tx as 2nd arg (atomic)
+    expect(shopDownPaymentReversalTemplate.execute).toHaveBeenCalledWith(input, tx);
+  });
+
+  it('does NOT reverse when no down JE was posted', async () => {
+    queryMock.findOne.mockResolvedValue({
+      ...mockCreatedContract,
+      downPayment: new Decimal(2000),
+      branchId: 'br-1',
+      signatures: [],
+      payments: [],
+    });
+    // No down JE found
+    tx.journalEntry.findFirst.mockResolvedValue(null);
+
+    await service.softDelete('c-1', 'user-1');
+
+    expect(shopDownPaymentReversalTemplate.execute).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/modules/contracts/services/contract-lifecycle.service.spec.ts
+++ b/apps/api/src/modules/contracts/services/contract-lifecycle.service.spec.ts
@@ -1,0 +1,242 @@
+/**
+ * ContractLifecycleService — ShopDownPayment wiring tests (Task 6).
+ *
+ * Verifies that `create()` posts `ShopDownPaymentTemplate` exactly when
+ * `downPayment > 0`, and skips it when `downPayment = 0`.
+ *
+ * The service is instantiated directly (not via NestJS DI) to match the
+ * way `ContractsService` constructs it with `new ContractLifecycleService(...)`.
+ */
+
+import { Prisma } from '@prisma/client';
+import { Decimal } from '@prisma/client/runtime/library';
+import { ContractLifecycleService } from './contract-lifecycle.service';
+import { ShopDownPaymentTemplate } from '../../journal/cpa-templates/shop-down-payment.template';
+import { ShopAccountResolver } from '../../journal/shop-account-resolver.service';
+
+// ─── module-level mocks (must be hoisted before imports are used) ─────────────
+
+jest.mock('../../../utils/installment.util', () => ({
+  calculateInstallmentWithInterest: jest.fn().mockReturnValue({
+    principal: 17000,
+    interestTotal: 1632,
+    storeCommission: 1700,
+    vatAmount: 213.78,
+    financedAmount: 20545.78,
+    monthlyPayment: 1712,
+  }),
+  roundBaht: jest.fn().mockImplementation((v: number) => Math.round(v * 100) / 100),
+  generatePaymentSchedule: jest.fn().mockReturnValue([
+    { contractId: 'c-1', installmentNo: 1, amountDue: 1712, dueDate: new Date(), status: 'PENDING' },
+  ]),
+}));
+
+jest.mock('../../../utils/get-rate-for-months.util', () => ({
+  getRateForMonths: jest.fn().mockResolvedValue(0.96),
+}));
+
+jest.mock('../../../utils/config.util', () => ({
+  loadInstallmentConfig: jest.fn().mockResolvedValue({}),
+  resolveInstallmentParams: jest.fn().mockReturnValue({
+    interestRate: 0.08,
+    minDownPaymentPct: 0.05,
+    minInstallmentMonths: 6,
+    maxInstallmentMonths: 24,
+    storeCommissionPct: 0.10,
+    vatPct: 0.07,
+  }),
+  resolveVatPctForBranch: jest.fn().mockResolvedValue(0.07),
+}));
+
+jest.mock('../../../utils/sequence.util', () => ({
+  generateContractNumber: jest.fn().mockResolvedValue('CN-1'),
+}));
+
+// ─── fixtures ────────────────────────────────────────────────────────────────
+
+const mockProduct = {
+  id: 'prod-1',
+  status: 'IN_STOCK',
+  category: 'PHONE_NEW',
+  imeiSerial: '123456789012345',
+  deletedAt: null,
+};
+
+const mockCustomer = {
+  id: 'cust-1',
+  name: 'ทดสอบ',
+  prefix: 'นาย',
+  nickname: null,
+  nationalId: '1234567890123',
+  phone: '0891234567',
+  phoneSecondary: null,
+  email: null,
+  lineIdFinance: null,
+  lineIdShop: null,
+  occupation: null,
+  salary: null,
+  workplace: null,
+  addressIdCard: 'กรุงเทพ',
+  addressCurrent: 'กรุงเทพ',
+  addressWork: null,
+  references: [],
+  birthDate: null,
+  facebookLink: null,
+  facebookName: null,
+  googleMapLink: null,
+  deletedAt: null,
+};
+
+const mockCreatedContract = {
+  id: 'c-1',
+  contractNumber: 'CN-1',
+  customerId: 'cust-1',
+  productId: 'prod-1',
+  branchId: 'br-1',
+  salespersonId: 'sp-1',
+  status: 'DRAFT',
+  workflowStatus: 'CREATING',
+  sellingPrice: new Decimal(20000),
+  downPayment: new Decimal(2000),
+  totalMonths: 12,
+  interestConfigId: null,
+  deletedAt: null,
+};
+
+/** Base DTO used across tests — individual tests override as needed. */
+const baseDto = {
+  customerId: 'cust-1',
+  productId: 'prod-1',
+  branchId: 'br-1',
+  sellingPrice: 20000,
+  downPayment: 2000,
+  totalMonths: 12,
+  paymentDueDay: 5,
+  planType: 'STORE_DIRECT' as const,
+  notes: null,
+  interestRate: undefined,
+  overrideActiveContractCheck: false,
+};
+
+// ─── suite ───────────────────────────────────────────────────────────────────
+
+describe('ContractLifecycleService — ShopDownPayment wiring', () => {
+  let service: ContractLifecycleService;
+  let prisma: any;
+  let tx: any;
+  let shopDownPaymentTemplate: jest.Mocked<Pick<ShopDownPaymentTemplate, 'execute'>>;
+  let shopAccountResolver: jest.Mocked<Pick<ShopAccountResolver, 'resolveBranchCashAccount'>>;
+  let queryMock: any;
+
+  beforeEach(() => {
+    // Inner tx object — the callback arg when prisma.$transaction(cb) is called
+    tx = {
+      creditCheck: {
+        findFirst: jest.fn().mockResolvedValue({ id: 'cc-1', status: 'APPROVED', contractId: null }),
+        update: jest.fn().mockResolvedValue({}),
+      },
+      product: {
+        findUnique: jest.fn().mockResolvedValue(mockProduct),
+        update: jest.fn().mockResolvedValue({ ...mockProduct, status: 'RESERVED' }),
+      },
+      customer: {
+        findUnique: jest.fn().mockResolvedValue(mockCustomer),
+      },
+      contract: {
+        create: jest.fn().mockResolvedValue(mockCreatedContract),
+      },
+      payment: {
+        createMany: jest.fn().mockResolvedValue({ count: 12 }),
+      },
+      journalEntry: {
+        findFirst: jest.fn().mockResolvedValue(null),
+      },
+      branch: {
+        findUnique: jest.fn().mockResolvedValue({ shopCashAccountCode: 'S11-1102' }),
+      },
+    };
+
+    // Outer prisma — $transaction passes the callback + tx
+    prisma = {
+      contract: {
+        findMany: jest.fn().mockResolvedValue([]), // no active contracts
+      },
+      product: {
+        findUnique: jest.fn().mockResolvedValue(mockProduct),
+      },
+      interestConfig: {
+        findFirst: jest.fn().mockResolvedValue(null),
+      },
+      systemConfig: {
+        findMany: jest.fn().mockResolvedValue([]),
+      },
+      $transaction: jest.fn().mockImplementation(async (cb: (tx: any) => Promise<any>) => cb(tx)),
+    };
+
+    // Mocked query service — only needs `isTestModeEnabled` and `findOne`
+    queryMock = {
+      isTestModeEnabled: jest.fn().mockResolvedValue(false),
+      findOne: jest.fn().mockResolvedValue({ ...mockCreatedContract, signatures: [], payments: [] }),
+    };
+
+    shopDownPaymentTemplate = {
+      execute: jest.fn().mockResolvedValue({ entryNo: 'JE-001', journalEntryId: 'je-1' }),
+    };
+
+    shopAccountResolver = {
+      resolveBranchCashAccount: jest.fn().mockResolvedValue('S11-1102'),
+    };
+
+    service = new ContractLifecycleService(
+      prisma as any,
+      queryMock as any,
+      undefined, // warrantyService — optional
+      undefined, // audit — optional
+      shopDownPaymentTemplate as any,
+      shopAccountResolver as any,
+    );
+  });
+
+  // ─── Task-6 core assertions ─────────────────────────────────────────────────
+
+  it('posts ShopDownPayment when downPayment > 0', async () => {
+    await service.create({ ...baseDto, downPayment: 2000, branchId: 'br-1' } as any, 'sp-1');
+
+    expect(shopAccountResolver.resolveBranchCashAccount).toHaveBeenCalledWith('br-1', tx);
+
+    const input = (shopDownPaymentTemplate.execute as jest.Mock).mock.calls[0][0];
+    expect(input).toMatchObject({
+      idempotencyKey: expect.stringContaining('shop-down-payment:'),
+      cashAccountCode: 'S11-1102',
+    });
+    expect(input.downAmount.toString()).toBe('2000');
+
+    // Confirm the idempotency key encodes the contract id
+    expect(input.idempotencyKey).toBe(`shop-down-payment:${mockCreatedContract.id}`);
+
+    // Confirm template was called with the tx (atomic)
+    expect(shopDownPaymentTemplate.execute).toHaveBeenCalledWith(input, tx);
+  });
+
+  it('skips ShopDownPayment when downPayment = 0', async () => {
+    // A contract with zero down-payment — update the tx.contract.create return value
+    const contractWithZeroDown = { ...mockCreatedContract, downPayment: new Decimal(0) };
+    tx.contract.create.mockResolvedValue(contractWithZeroDown);
+    queryMock.findOne.mockResolvedValue({ ...contractWithZeroDown, signatures: [], payments: [] });
+
+    // Need minDownPaymentPct=0 to allow 0 down
+    const { resolveInstallmentParams } = jest.requireMock('../../../utils/config.util');
+    resolveInstallmentParams.mockReturnValueOnce({
+      interestRate: 0.08,
+      minDownPaymentPct: 0,
+      minInstallmentMonths: 6,
+      maxInstallmentMonths: 24,
+      storeCommissionPct: 0.10,
+      vatPct: 0.07,
+    });
+
+    await service.create({ ...baseDto, downPayment: 0 } as any, 'sp-1');
+
+    expect(shopDownPaymentTemplate.execute).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/modules/contracts/services/contract-lifecycle.service.spec.ts
+++ b/apps/api/src/modules/contracts/services/contract-lifecycle.service.spec.ts
@@ -8,7 +8,6 @@
  * way `ContractsService` constructs it with `new ContractLifecycleService(...)`.
  */
 
-import { Prisma } from '@prisma/client';
 import { Decimal } from '@prisma/client/runtime/library';
 import { ContractLifecycleService } from './contract-lifecycle.service';
 import { ShopDownPaymentTemplate } from '../../journal/cpa-templates/shop-down-payment.template';
@@ -190,10 +189,10 @@ describe('ContractLifecycleService — ShopDownPayment wiring', () => {
     service = new ContractLifecycleService(
       prisma as any,
       queryMock as any,
-      undefined, // warrantyService — optional
-      undefined, // audit — optional
       shopDownPaymentTemplate as any,
       shopAccountResolver as any,
+      undefined, // warrantyService — optional
+      undefined, // audit — optional
     );
   });
 

--- a/apps/api/src/modules/contracts/services/contract-lifecycle.service.ts
+++ b/apps/api/src/modules/contracts/services/contract-lifecycle.service.ts
@@ -29,10 +29,10 @@ export class ContractLifecycleService {
   constructor(
     private prisma: PrismaService,
     private query: ContractQueryService,
+    private shopDownPaymentTemplate: ShopDownPaymentTemplate,
+    private shopAccountResolver: ShopAccountResolver,
     private warrantyService?: WarrantyService,
     private audit?: AuditService,
-    private shopDownPaymentTemplate?: ShopDownPaymentTemplate,
-    private shopAccountResolver?: ShopAccountResolver,
   ) {}
 
   async create(dto: CreateContractDto, salespersonId: string, salespersonRole?: string) {
@@ -216,21 +216,19 @@ export class ContractLifecycleService {
           await tx.payment.createMany({ data: payments });
 
           // SHOP-side: record the down payment received at contract creation.
-          if (this.shopDownPaymentTemplate && this.shopAccountResolver) {
-            const downPayment = new Decimal(dto.downPayment.toString());
-            if (downPayment.gt(0)) {
-              const cashAccountCode = await this.shopAccountResolver.resolveBranchCashAccount(dto.branchId, tx);
-              await this.shopDownPaymentTemplate.execute(
-                {
-                  idempotencyKey: `shop-down-payment:${newContract.id}`,
-                  contractId: newContract.id,
-                  contractNumber: newContract.contractNumber,
-                  cashAccountCode,
-                  downAmount: downPayment,
-                },
-                tx,
-              );
-            }
+          const downPayment = new Decimal(dto.downPayment.toString());
+          if (downPayment.gt(0)) {
+            const cashAccountCode = await this.shopAccountResolver.resolveBranchCashAccount(dto.branchId, tx);
+            await this.shopDownPaymentTemplate.execute(
+              {
+                idempotencyKey: `shop-down-payment:${newContract.id}`,
+                contractId: newContract.id,
+                contractNumber: newContract.contractNumber,
+                cashAccountCode,
+                downAmount: downPayment,
+              },
+              tx,
+            );
           }
 
           // Reserve product

--- a/apps/api/src/modules/contracts/services/contract-lifecycle.service.ts
+++ b/apps/api/src/modules/contracts/services/contract-lifecycle.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger, NotFoundException, BadRequestException, ForbiddenException, ConflictException, InternalServerErrorException } from '@nestjs/common';
 import { StructuredLoggerService } from '../../../common/logger';
 import { PlanType, Prisma } from '@prisma/client';
+import { Decimal } from '@prisma/client/runtime/library';
 import { PrismaService } from '../../../prisma/prisma.service';
 import { CreateContractDto, UpdateContractDto } from '../dto/contract.dto';
 import { calculateInstallmentWithInterest, generatePaymentSchedule, roundBaht } from '../../../utils/installment.util';
@@ -11,6 +12,8 @@ import { d } from '../../../utils/decimal.util';
 import { WarrantyService } from '../../warranty/warranty.service';
 import { AuditService } from '../../audit/audit.service';
 import { ContractQueryService } from './contract-query.service';
+import { ShopDownPaymentTemplate } from '../../journal/cpa-templates/shop-down-payment.template';
+import { ShopAccountResolver } from '../../journal/shop-account-resolver.service';
 
 /**
  * ContractLifecycleService — write-side lifecycle of a contract: create
@@ -28,6 +31,8 @@ export class ContractLifecycleService {
     private query: ContractQueryService,
     private warrantyService?: WarrantyService,
     private audit?: AuditService,
+    private shopDownPaymentTemplate?: ShopDownPaymentTemplate,
+    private shopAccountResolver?: ShopAccountResolver,
   ) {}
 
   async create(dto: CreateContractDto, salespersonId: string, salespersonRole?: string) {
@@ -209,6 +214,24 @@ export class ContractLifecycleService {
             { principal: calc.principal, interestTotal: calc.interestTotal, storeCommission: calc.storeCommission, vatAmount: calc.vatAmount },
           );
           await tx.payment.createMany({ data: payments });
+
+          // SHOP-side: record the down payment received at contract creation.
+          if (this.shopDownPaymentTemplate && this.shopAccountResolver) {
+            const downPayment = new Decimal(dto.downPayment.toString());
+            if (downPayment.gt(0)) {
+              const cashAccountCode = await this.shopAccountResolver.resolveBranchCashAccount(dto.branchId, tx);
+              await this.shopDownPaymentTemplate.execute(
+                {
+                  idempotencyKey: `shop-down-payment:${newContract.id}`,
+                  contractId: newContract.id,
+                  contractNumber: newContract.contractNumber,
+                  cashAccountCode,
+                  downAmount: downPayment,
+                },
+                tx,
+              );
+            }
+          }
 
           // Reserve product
           await tx.product.update({

--- a/apps/api/src/modules/contracts/services/contract-lifecycle.service.ts
+++ b/apps/api/src/modules/contracts/services/contract-lifecycle.service.ts
@@ -13,6 +13,7 @@ import { WarrantyService } from '../../warranty/warranty.service';
 import { AuditService } from '../../audit/audit.service';
 import { ContractQueryService } from './contract-query.service';
 import { ShopDownPaymentTemplate } from '../../journal/cpa-templates/shop-down-payment.template';
+import { ShopDownPaymentReversalTemplate } from '../../journal/cpa-templates/shop-down-payment-reversal.template';
 import { ShopAccountResolver } from '../../journal/shop-account-resolver.service';
 
 /**
@@ -30,6 +31,7 @@ export class ContractLifecycleService {
     private prisma: PrismaService,
     private query: ContractQueryService,
     private shopDownPaymentTemplate: ShopDownPaymentTemplate,
+    private shopDownPaymentReversalTemplate: ShopDownPaymentReversalTemplate,
     private shopAccountResolver: ShopAccountResolver,
     private warrantyService?: WarrantyService,
     private audit?: AuditService,
@@ -527,39 +529,66 @@ export class ContractLifecycleService {
     const now = new Date();
     const cascadedSignatures = hasSignatures ? contract.signatures.length : 0;
 
-    await this.prisma.$transaction([
-      this.prisma.contract.update({ where: { id }, data: { deletedAt: now } }),
+    await this.prisma.$transaction(async (tx) => {
+      // Reverse the SHOP down-payment JE if one was posted for this DRAFT contract.
+      const downPayment = new Decimal(contract.downPayment.toString());
+      if (downPayment.gt(0)) {
+        const downJe = await tx.journalEntry.findFirst({
+          where: {
+            AND: [
+              { metadata: { path: ['flow'], equals: 'shop-down-payment' } as any },
+              { metadata: { path: ['idempotencyKey'], equals: `shop-down-payment:${id}` } as any },
+            ],
+            deletedAt: null,
+          },
+          select: { id: true },
+        });
+        if (downJe) {
+          const refundAccountCode = await this.shopAccountResolver.resolveBranchCashAccount(contract.branchId, tx);
+          await this.shopDownPaymentReversalTemplate.execute(
+            {
+              idempotencyKey: `shop-down-payment-reversal:${id}`,
+              contractId: id,
+              contractNumber: contract.contractNumber,
+              refundAccountCode,
+              downAmount: downPayment,
+              originalJournalEntryId: downJe.id,
+            },
+            tx,
+          );
+        }
+      }
+
+      await tx.contract.update({ where: { id }, data: { deletedAt: now } });
       // Cascade soft-delete signatures only when the contract is REJECTED.
       // No-op when there are no signatures (unsigned drafts).
-      ...(cascadedSignatures > 0
-        ? [
-            this.prisma.signature.updateMany({
-              where: { contractId: id, deletedAt: null },
-              data: { deletedAt: now },
-            }),
-          ]
-        : []),
+      if (cascadedSignatures > 0) {
+        await tx.signature.updateMany({
+          where: { contractId: id, deletedAt: null },
+          data: { deletedAt: now },
+        });
+      }
       // Release the credit check back to the customer — unlinking from this
       // (now-deleted) contract lets them reuse the APPROVED decision for a
       // future contract. The gate at contracts.service.ts:332 filters on
       // `contractId: null`, so a stale link would trap the approval.
-      this.prisma.creditCheck.updateMany({
+      await tx.creditCheck.updateMany({
         where: { contractId: id },
         data: { contractId: null },
-      }),
+      });
       // KYC records captured for this contract (OTP + ID card photo) become
       // orphans otherwise. Soft-delete keeps the row for audit but marks it
       // as no-longer-tied-to-an-active-contract.
-      this.prisma.kycVerification.updateMany({
+      await tx.kycVerification.updateMany({
         where: { contractId: id, deletedAt: null },
         data: { deletedAt: now },
-      }),
+      });
       // Release reserved product back to IN_STOCK
-      this.prisma.product.updateMany({
+      await tx.product.updateMany({
         where: { id: contract.productId, status: 'RESERVED' },
         data: { status: 'IN_STOCK' },
-      }),
-      this.prisma.auditLog.create({
+      });
+      await tx.auditLog.create({
         data: {
           userId,
           action: 'CONTRACT_DELETE',
@@ -574,8 +603,8 @@ export class ContractLifecycleService {
             cascadedSignatures,
           },
         },
-      }),
-    ]);
+      });
+    });
 
     return {
       message:

--- a/apps/api/src/modules/journal/journal.module.ts
+++ b/apps/api/src/modules/journal/journal.module.ts
@@ -39,6 +39,7 @@ import { PettyCashTemplate } from './cpa-templates/petty-cash.template';
 import { YearEndClosingTemplate } from './cpa-templates/year-end-closing.template';
 // P3-SP5 — SHOP-side accounting
 import { CompanyResolverService } from './company-resolver.service';
+import { ShopAccountResolver } from './shop-account-resolver.service';
 import { PairedJournalService } from './paired-journal.service';
 import { ShopCashSaleTemplate } from './cpa-templates/shop-cash-sale.template';
 import { ShopDownPaymentTemplate } from './cpa-templates/shop-down-payment.template';
@@ -98,6 +99,7 @@ import { ReconcileController } from './reconcile.controller';
     YearEndClosingTemplate,
     // P3-SP5 — SHOP-side accounting
     CompanyResolverService,
+    ShopAccountResolver,
     PairedJournalService,
     ShopCashSaleTemplate,
     ShopDownPaymentTemplate,
@@ -150,6 +152,7 @@ import { ReconcileController } from './reconcile.controller';
     YearEndClosingTemplate,
     // P3-SP5 — SHOP-side accounting
     CompanyResolverService,
+    ShopAccountResolver,
     PairedJournalService,
     ShopCashSaleTemplate,
     ShopDownPaymentTemplate,

--- a/apps/api/src/modules/journal/shop-account-resolver.service.spec.ts
+++ b/apps/api/src/modules/journal/shop-account-resolver.service.spec.ts
@@ -1,0 +1,38 @@
+import { Test } from '@nestjs/testing';
+import { BadRequestException } from '@nestjs/common';
+import { ShopAccountResolver } from './shop-account-resolver.service';
+import { PrismaService } from '../../prisma/prisma.service';
+
+describe('ShopAccountResolver', () => {
+  let resolver: ShopAccountResolver;
+  let prisma: any;
+
+  beforeEach(async () => {
+    prisma = { branch: { findUnique: jest.fn() } };
+    const mod = await Test.createTestingModule({
+      providers: [ShopAccountResolver, { provide: PrismaService, useValue: prisma }],
+    }).compile();
+    resolver = mod.get(ShopAccountResolver);
+  });
+
+  it('maps PHONE_NEW + TABLET to the new-phone S-codes', () => {
+    const expected = { inventoryAccountCode: 'S11-2001', cogsAccountCode: 'S50-1101', revenueAccountCode: 'S41-1101' };
+    expect(resolver.resolveProductAccounts('PHONE_NEW')).toEqual(expected);
+    expect(resolver.resolveProductAccounts('TABLET')).toEqual(expected);
+  });
+
+  it('maps PHONE_USED and ACCESSORY to their S-codes', () => {
+    expect(resolver.resolveProductAccounts('PHONE_USED')).toEqual({ inventoryAccountCode: 'S11-2002', cogsAccountCode: 'S50-1102', revenueAccountCode: 'S41-1102' });
+    expect(resolver.resolveProductAccounts('ACCESSORY')).toEqual({ inventoryAccountCode: 'S11-2003', cogsAccountCode: 'S50-1103', revenueAccountCode: 'S41-1103' });
+  });
+
+  it('resolves a configured branch cash account', async () => {
+    prisma.branch.findUnique.mockResolvedValue({ shopCashAccountCode: 'S11-1102' });
+    await expect(resolver.resolveBranchCashAccount('br-1')).resolves.toBe('S11-1102');
+  });
+
+  it('fail-closed: throws when branch has no shopCashAccountCode', async () => {
+    prisma.branch.findUnique.mockResolvedValue({ shopCashAccountCode: null });
+    await expect(resolver.resolveBranchCashAccount('br-1')).rejects.toThrow(BadRequestException);
+  });
+});

--- a/apps/api/src/modules/journal/shop-account-resolver.service.ts
+++ b/apps/api/src/modules/journal/shop-account-resolver.service.ts
@@ -1,0 +1,53 @@
+import { BadRequestException, Injectable } from '@nestjs/common';
+import { Prisma, ProductCategory } from '@prisma/client';
+import { PrismaService } from '../../prisma/prisma.service';
+
+export interface ShopProductAccounts {
+  inventoryAccountCode: string;
+  cogsAccountCode: string;
+  revenueAccountCode: string;
+}
+
+/**
+ * Single source of truth for resolving SHOP-side account codes:
+ * product category → inventory/COGS/revenue S-codes, and branch → cash till.
+ */
+@Injectable()
+export class ShopAccountResolver {
+  /** SHOP bank that receives inflows (down/cash-sale transfer + FINANCE settlement). */
+  static readonly SHOP_RECEIVING_BANK = 'S11-1201';
+  /** SHOP bank that funds outflows (branch expenses, transfer trade-in payout). */
+  static readonly SHOP_PAYING_BANK = 'S11-1202';
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  /** TABLET reuses PHONE_NEW codes (D-5); dedicated tablet S-codes deferred. */
+  resolveProductAccounts(category: ProductCategory): ShopProductAccounts {
+    switch (category) {
+      case 'PHONE_USED':
+        return { inventoryAccountCode: 'S11-2002', cogsAccountCode: 'S50-1102', revenueAccountCode: 'S41-1102' };
+      case 'ACCESSORY':
+        return { inventoryAccountCode: 'S11-2003', cogsAccountCode: 'S50-1103', revenueAccountCode: 'S41-1103' };
+      case 'PHONE_NEW':
+      case 'TABLET':
+        return { inventoryAccountCode: 'S11-2001', cogsAccountCode: 'S50-1101', revenueAccountCode: 'S41-1101' };
+      default:
+        throw new BadRequestException(`ShopAccountResolver: unknown ProductCategory "${category as string}"`);
+    }
+  }
+
+  /** Fail-closed: a branch must have shopCashAccountCode set before SHOP cash JEs can post. */
+  async resolveBranchCashAccount(branchId: string, tx?: Prisma.TransactionClient): Promise<string> {
+    const client = (tx ?? this.prisma) as Prisma.TransactionClient;
+    const branch = await client.branch.findUnique({
+      where: { id: branchId },
+      select: { shopCashAccountCode: true },
+    });
+    if (!branch?.shopCashAccountCode) {
+      throw new BadRequestException(
+        `ShopAccountResolver: branch ${branchId} has no shopCashAccountCode — set it in branch settings before posting SHOP cash entries`,
+      );
+    }
+    return branch.shopCashAccountCode;
+  }
+}

--- a/apps/api/src/modules/peak/peak.service.spec.ts
+++ b/apps/api/src/modules/peak/peak.service.spec.ts
@@ -4,6 +4,7 @@ import { createHmac } from 'crypto';
 import { PeakService } from './peak.service';
 import { PrismaService } from '../../prisma/prisma.service';
 import { IntegrationConfigService } from '../integrations/integration-config.service';
+import { CompanyResolverService } from '../journal/company-resolver.service';
 
 jest.mock('@sentry/nestjs', () => ({
   captureException: jest.fn(),
@@ -47,6 +48,7 @@ describe('PeakService', () => {
         { provide: PrismaService, useValue: prisma },
         { provide: ConfigService, useValue: { get: () => '' } },
         { provide: IntegrationConfigService, useValue: integrationConfig },
+        { provide: CompanyResolverService, useValue: { getFinanceCompanyId: jest.fn().mockResolvedValue('finance-co-id') } },
       ],
     }).compile();
     service = mod.get(PeakService);
@@ -325,6 +327,17 @@ describe('PeakService', () => {
       expect(prisma.journalEntry.updateMany).not.toHaveBeenCalled();
       expect(result.exported).toBe(0);
       expect(result.errors[0]).toContain('server fail');
+    });
+
+    it('only exports FINANCE-company entries (X5 — SHOP S-prefix excluded)', async () => {
+      mockPeakHeaders();
+      prisma.journalEntry.findMany.mockResolvedValue([]);
+      await service.exportJournalEntries(new Date('2026-06-01'), new Date('2026-06-30'));
+      expect(prisma.journalEntry.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ companyId: 'finance-co-id' }),
+        }),
+      );
     });
   });
 });

--- a/apps/api/src/modules/peak/peak.service.ts
+++ b/apps/api/src/modules/peak/peak.service.ts
@@ -4,6 +4,7 @@ import * as Sentry from '@sentry/nestjs';
 import { createHmac } from 'crypto';
 import { PrismaService } from '../../prisma/prisma.service';
 import { IntegrationConfigService } from '../integrations/integration-config.service';
+import { CompanyResolverService } from '../journal/company-resolver.service';
 
 export interface PeakExportResult {
   exported: number;
@@ -43,6 +44,7 @@ export class PeakService {
     private prisma: PrismaService,
     private configService: ConfigService,
     private integrationConfig: IntegrationConfigService,
+    private companyResolver: CompanyResolverService,
   ) {}
 
   /** Check if PEAK integration is configured */
@@ -72,12 +74,14 @@ export class PeakService {
       return { exported: 0, skipped: 0, errors: ['PEAK ยังไม่ได้ตั้งค่า'] };
     }
 
+    const financeCompanyId = await this.companyResolver.getFinanceCompanyId();
     const entries = await this.prisma.journalEntry.findMany({
       where: {
         status: 'POSTED',
         entryDate: { gte: startDate, lte: endDate },
         deletedAt: null,
         peakSyncedAt: null,
+        companyId: financeCompanyId,
       },
       include: {
         lines: true,

--- a/apps/api/src/modules/shop-finance-settlement/dto/finance-settlement.dto.ts
+++ b/apps/api/src/modules/shop-finance-settlement/dto/finance-settlement.dto.ts
@@ -1,0 +1,17 @@
+import { IsArray, IsString, IsOptional, ArrayNotEmpty } from 'class-validator';
+
+export class SettleFinanceDto {
+  @IsArray()
+  @ArrayNotEmpty({ message: 'ต้องระบุสัญญาอย่างน้อย 1 รายการ' })
+  @IsString({ each: true })
+  contractIds: string[];
+
+  /** SHOP receiving bank (S11-12XX). Defaults to ShopAccountResolver.SHOP_RECEIVING_BANK. */
+  @IsOptional()
+  @IsString()
+  bankAccountCode?: string;
+
+  @IsOptional()
+  @IsString()
+  postedAt?: string;
+}

--- a/apps/api/src/modules/shop-finance-settlement/shop-finance-settlement.controller.ts
+++ b/apps/api/src/modules/shop-finance-settlement/shop-finance-settlement.controller.ts
@@ -1,0 +1,27 @@
+import { Body, Controller, Get, Post, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { ShopFinanceSettlementService } from './shop-finance-settlement.service';
+import { SettleFinanceDto } from './dto/finance-settlement.dto';
+
+@ApiTags('Shop Finance Settlement')
+@ApiBearerAuth('JWT')
+@Controller('shop/finance-settlements')
+@UseGuards(JwtAuthGuard, RolesGuard)
+export class ShopFinanceSettlementController {
+  constructor(private readonly service: ShopFinanceSettlementService) {}
+
+  @Post()
+  @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT')
+  settle(@Body() dto: SettleFinanceDto) {
+    return this.service.settle(dto);
+  }
+
+  @Get('pending')
+  @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT')
+  pending() {
+    return this.service.listPending();
+  }
+}

--- a/apps/api/src/modules/shop-finance-settlement/shop-finance-settlement.module.ts
+++ b/apps/api/src/modules/shop-finance-settlement/shop-finance-settlement.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { PrismaModule } from '../../prisma/prisma.module';
+import { JournalModule } from '../journal/journal.module';
+import { ShopFinanceSettlementService } from './shop-finance-settlement.service';
+import { ShopFinanceSettlementController } from './shop-finance-settlement.controller';
+
+@Module({
+  imports: [PrismaModule, JournalModule], // JournalModule exports ShopFinanceReceiptTemplate
+  controllers: [ShopFinanceSettlementController],
+  providers: [ShopFinanceSettlementService],
+})
+export class ShopFinanceSettlementModule {}

--- a/apps/api/src/modules/shop-finance-settlement/shop-finance-settlement.service.spec.ts
+++ b/apps/api/src/modules/shop-finance-settlement/shop-finance-settlement.service.spec.ts
@@ -1,0 +1,46 @@
+import { Test } from '@nestjs/testing';
+import { Decimal } from '@prisma/client/runtime/library';
+import { ShopFinanceSettlementService } from './shop-finance-settlement.service';
+import { PrismaService } from '../../prisma/prisma.service';
+import { ShopFinanceReceiptTemplate } from '../journal/cpa-templates/shop-finance-receipt.template';
+
+describe('ShopFinanceSettlementService', () => {
+  let service: ShopFinanceSettlementService;
+  let prisma: any;
+  let template: any;
+
+  beforeEach(async () => {
+    prisma = {
+      contract: { findMany: jest.fn() },
+      journalEntry: { findMany: jest.fn().mockResolvedValue([]) },
+      $transaction: jest.fn(async (cb) => cb(prisma)),
+    };
+    template = { execute: jest.fn().mockResolvedValue({ entryNo: 'JE-1', journalEntryId: 'je-1' }) };
+    const mod = await Test.createTestingModule({
+      providers: [
+        ShopFinanceSettlementService,
+        { provide: PrismaService, useValue: prisma },
+        { provide: ShopFinanceReceiptTemplate, useValue: template },
+      ],
+    }).compile();
+    service = mod.get(ShopFinanceSettlementService);
+  });
+
+  it('posts a ShopFinanceReceipt per contract with financed+commission from the contract', async () => {
+    prisma.contract.findMany.mockResolvedValue([
+      { id: 'c-1', contractNumber: 'CN-1', financedAmount: new Decimal('18000'), storeCommission: new Decimal('1500'), status: 'ACTIVE', deletedAt: null },
+    ]);
+    await service.settle({ contractIds: ['c-1'] });
+    const input = template.execute.mock.calls[0][0];
+    expect(input).toMatchObject({ idempotencyKey: 'finance-receipt-c-1', contractId: 'c-1', bankAccountCode: 'S11-1201' });
+    expect(input.financedAmount.toString()).toBe('18000');
+    expect(input.commission.toString()).toBe('1500');
+  });
+
+  it('listPending returns ACTIVE contracts without a shop-finance-receipt JE', async () => {
+    prisma.contract.findMany.mockResolvedValue([{ id: 'c-1' }, { id: 'c-2' }]);
+    prisma.journalEntry.findMany.mockResolvedValue([{ metadata: { contractId: 'c-1' } }]);
+    const pending = await service.listPending();
+    expect(pending.map((c: any) => c.id)).toEqual(['c-2']);
+  });
+});

--- a/apps/api/src/modules/shop-finance-settlement/shop-finance-settlement.service.spec.ts
+++ b/apps/api/src/modules/shop-finance-settlement/shop-finance-settlement.service.spec.ts
@@ -37,6 +37,20 @@ describe('ShopFinanceSettlementService', () => {
     expect(input.commission.toString()).toBe('1500');
   });
 
+  it('does not post a receipt for DRAFT contracts (settle status guard)', async () => {
+    // findMany returns [] because the DRAFT contract is filtered out by the status filter
+    prisma.contract.findMany.mockResolvedValue([]);
+    await service.settle({ contractIds: ['draft-contract-1'] });
+    expect(prisma.contract.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          status: expect.objectContaining({ in: expect.arrayContaining(['ACTIVE']) }),
+        }),
+      }),
+    );
+    expect(template.execute).not.toHaveBeenCalled();
+  });
+
   it('listPending returns ACTIVE contracts without a shop-finance-receipt JE', async () => {
     prisma.contract.findMany.mockResolvedValue([{ id: 'c-1' }, { id: 'c-2' }]);
     prisma.journalEntry.findMany.mockResolvedValue([{ metadata: { contractId: 'c-1' } }]);

--- a/apps/api/src/modules/shop-finance-settlement/shop-finance-settlement.service.spec.ts
+++ b/apps/api/src/modules/shop-finance-settlement/shop-finance-settlement.service.spec.ts
@@ -57,4 +57,23 @@ describe('ShopFinanceSettlementService', () => {
     const pending = await service.listPending();
     expect(pending.map((c: any) => c.id)).toEqual(['c-2']);
   });
+
+  it('settles + surfaces activated terminal states — TERMINATED/EXCHANGED/DEFECT_EXCHANGED/CLOSED_BAD_DEBT (owner decision 2026-06-23)', async () => {
+    // A contract that reached a terminal state still owes the FINANCE→SHOP receivable
+    // (S11-3001/3002) booked at activation, so it stays settleable + visible in pending.
+    prisma.contract.findMany.mockResolvedValue([
+      { id: 't-1', contractNumber: 'CN-T', financedAmount: new Decimal('5000'), storeCommission: null, status: 'TERMINATED', deletedAt: null },
+    ]);
+    await service.settle({ contractIds: ['t-1'] });
+    const settleWhere = prisma.contract.findMany.mock.calls[0][0].where;
+    expect(settleWhere.status.in).toEqual(
+      expect.arrayContaining(['TERMINATED', 'EXCHANGED', 'DEFECT_EXCHANGED', 'CLOSED_BAD_DEBT']),
+    );
+    // DRAFT + CANCELED stay excluded
+    expect(settleWhere.status.in).not.toContain('DRAFT');
+    expect(settleWhere.status.in).not.toContain('CANCELED');
+    expect(template.execute).toHaveBeenCalledTimes(1);
+    expect(template.execute.mock.calls[0][0]).toMatchObject({ idempotencyKey: 'finance-receipt-t-1' });
+    expect(template.execute.mock.calls[0][0].commission.toString()).toBe('0');
+  });
 });

--- a/apps/api/src/modules/shop-finance-settlement/shop-finance-settlement.service.ts
+++ b/apps/api/src/modules/shop-finance-settlement/shop-finance-settlement.service.ts
@@ -1,0 +1,56 @@
+import { Injectable } from '@nestjs/common';
+import { Decimal } from '@prisma/client/runtime/library';
+import { PrismaService } from '../../prisma/prisma.service';
+import { ShopFinanceReceiptTemplate } from '../journal/cpa-templates/shop-finance-receipt.template';
+import { ShopAccountResolver } from '../journal/shop-account-resolver.service';
+import { SettleFinanceDto } from './dto/finance-settlement.dto';
+
+/** Contract statuses that count as "has been activated" for settlement purposes. */
+const ACTIVATED_STATUSES = ['ACTIVE', 'OVERDUE', 'DEFAULT', 'EARLY_PAYOFF', 'COMPLETED'] as const;
+
+@Injectable()
+export class ShopFinanceSettlementService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly shopFinanceReceiptTemplate: ShopFinanceReceiptTemplate,
+  ) {}
+
+  async settle(dto: SettleFinanceDto) {
+    const bankAccountCode = dto.bankAccountCode ?? ShopAccountResolver.SHOP_RECEIVING_BANK;
+    const postedAt = dto.postedAt ? new Date(dto.postedAt) : undefined;
+    const contracts = await this.prisma.contract.findMany({
+      where: { id: { in: dto.contractIds }, deletedAt: null },
+      select: { id: true, contractNumber: true, financedAmount: true, storeCommission: true },
+    });
+    const results: { contractId: string; entryNo: string }[] = [];
+    for (const c of contracts) {
+      const res = await this.shopFinanceReceiptTemplate.execute({
+        idempotencyKey: `finance-receipt-${c.id}`,
+        contractId: c.id,
+        contractNumber: c.contractNumber,
+        bankAccountCode,
+        financedAmount: new Decimal(c.financedAmount.toString()),
+        commission: c.storeCommission ? new Decimal(c.storeCommission.toString()) : new Decimal(0),
+        postedAt,
+      });
+      results.push({ contractId: c.id, entryNo: res.entryNo });
+    }
+    return { settled: results.length, results };
+  }
+
+  /** Activated contracts that do not yet have a shop-finance-receipt JE. */
+  async listPending() {
+    const contracts = await this.prisma.contract.findMany({
+      where: { status: { in: [...ACTIVATED_STATUSES] }, deletedAt: null },
+      select: { id: true, contractNumber: true, financedAmount: true, storeCommission: true, branchId: true },
+    });
+    const settledJEs = await this.prisma.journalEntry.findMany({
+      where: { metadata: { path: ['flow'], equals: 'shop-finance-receipt' } as any, deletedAt: null },
+      select: { metadata: true },
+    });
+    const settledIds = new Set(
+      settledJEs.map((j) => (j.metadata as any)?.contractId).filter(Boolean),
+    );
+    return contracts.filter((c) => !settledIds.has(c.id));
+  }
+}

--- a/apps/api/src/modules/shop-finance-settlement/shop-finance-settlement.service.ts
+++ b/apps/api/src/modules/shop-finance-settlement/shop-finance-settlement.service.ts
@@ -19,7 +19,7 @@ export class ShopFinanceSettlementService {
     const bankAccountCode = dto.bankAccountCode ?? ShopAccountResolver.SHOP_RECEIVING_BANK;
     const postedAt = dto.postedAt ? new Date(dto.postedAt) : undefined;
     const contracts = await this.prisma.contract.findMany({
-      where: { id: { in: dto.contractIds }, deletedAt: null },
+      where: { id: { in: dto.contractIds }, status: { in: [...ACTIVATED_STATUSES] }, deletedAt: null },
       select: { id: true, contractNumber: true, financedAmount: true, storeCommission: true },
     });
     const results: { contractId: string; entryNo: string }[] = [];

--- a/apps/api/src/modules/shop-finance-settlement/shop-finance-settlement.service.ts
+++ b/apps/api/src/modules/shop-finance-settlement/shop-finance-settlement.service.ts
@@ -5,8 +5,25 @@ import { ShopFinanceReceiptTemplate } from '../journal/cpa-templates/shop-financ
 import { ShopAccountResolver } from '../journal/shop-account-resolver.service';
 import { SettleFinanceDto } from './dto/finance-settlement.dto';
 
-/** Contract statuses that count as "has been activated" for settlement purposes. */
-const ACTIVATED_STATUSES = ['ACTIVE', 'OVERDUE', 'DEFAULT', 'EARLY_PAYOFF', 'COMPLETED'] as const;
+/**
+ * Contract statuses that carry a FINANCE→SHOP receivable from activation (S11-3001/3002).
+ * Anything that has been activated — including terminal states (TERMINATED / EXCHANGED /
+ * DEFECT_EXCHANGED / CLOSED_BAD_DEBT) — still owes that inter-company receivable until FINANCE
+ * settles it, so it remains settleable and appears in the pending worklist (owner decision
+ * 2026-06-23). Excludes DRAFT (never activated) and CANCELED (full reversal via
+ * ContractCancellation).
+ */
+const ACTIVATED_STATUSES = [
+  'ACTIVE',
+  'OVERDUE',
+  'DEFAULT',
+  'EARLY_PAYOFF',
+  'COMPLETED',
+  'TERMINATED',
+  'EXCHANGED',
+  'DEFECT_EXCHANGED',
+  'CLOSED_BAD_DEBT',
+] as const;
 
 @Injectable()
 export class ShopFinanceSettlementService {

--- a/docs/superpowers/plans/2026-06-23-shop-je-wiring-p0-p1.md
+++ b/docs/superpowers/plans/2026-06-23-shop-je-wiring-p0-p1.md
@@ -1,0 +1,951 @@
+# SHOP-side JE Wiring — P0 + P1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire the SHOP-side journal-entry templates for the installment lifecycle so `/shop/accounting` Trial Balance + P&L reflect real activity, gated behind PEAK isolation.
+
+**Architecture:** A new `ShopAccountResolver` maps product category → S-coded inventory/COGS/revenue accounts and branch → cash till. The 4 lifecycle templates (already built + golden-spec'd) are injected into their trigger services and called synchronously inside each trigger's existing Prisma `$transaction`, following the `contract-exchange.service.ts:396` pattern. A new finance-settlement module exposes the "FINANCE paid SHOP" action.
+
+**Tech Stack:** NestJS, Prisma (PostgreSQL), TypeScript, jest (`--runInBand`).
+
+**Spec:** `docs/superpowers/specs/2026-06-23-shop-je-wiring-design.md` (commit `bb3e50ac`). Branch: `feat/shop-je-wiring`.
+
+**Scope:** P0 (prereqs) + P1 (installment lifecycle) only. P2 ShopCashSale / P3 ShopTradeIn / P4 ShopExpense are **separate follow-on plans** (each its own working deliverable) authored after P1 ships.
+
+## Global Constraints
+
+- **X5 is a hard gate:** no SHOP JE wiring (Tasks 5-8) may merge until both PEAK export queries are FINANCE-filtered (Tasks 1-2 on `main`).
+- **Atomic (D-1):** every SHOP template is called with the trigger's outer `tx`; a SHOP-JE failure must roll back the host operation.
+- **D-8:** `ShopInventoryTransfer` is fed `salePrice = downPayment + financedAmount` (NOT raw `sellingPrice`) so its strict financing-identity assertion holds by construction and can never throw at activation.
+- **D-5:** TABLET reuses PHONE_NEW codes (S41-1101 / S50-1101 / S11-2001).
+- **Money:** always `Decimal`; construct from Prisma decimals via `new Decimal(x.toString())`; never `Number()`.
+- **Idempotency:** templates self-dedupe on `metadata.flow + metadata.idempotencyKey`; callers pass a stable key per entity.
+- **SHOP companyId:** templates resolve it internally via `CompanyResolverService.getShopCompanyId(tx)`; callers do NOT pass companyId.
+- **Account codes:** all SHOP codes are `S`-prefixed; templates throw `BadRequestException` on non-S codes.
+- **Test runner:** `npm --prefix apps/api test -- <relativeSpecPath>` (the `test` script is `jest --runInBand --forceExit`).
+- **Commit cadence:** one commit per task (after its tests pass).
+
+---
+
+## File Structure
+
+| File | Responsibility | Task |
+|---|---|---|
+| `apps/api/src/modules/peak/peak.service.ts` (modify) | add FINANCE companyId filter to `exportJournalEntries` | 1 |
+| `apps/api/src/modules/peak/peak.service.spec.ts` (modify) | regression: findMany filtered by companyId | 1 |
+| `apps/api/src/modules/accounting/peak-export.service.ts` (modify) | add FINANCE companyId filter to `exportJournalWithPeakCodes` | 2 |
+| `apps/api/src/modules/accounting/peak-export.service.spec.ts` (create) | regression for path 2 | 2 |
+| `apps/api/prisma/schema.prisma` + `migrations/20260974000000_add_shop_cash_account_code_to_branch/migration.sql` | `Branch.shopCashAccountCode` | 3 |
+| `apps/api/src/modules/journal/shop-account-resolver.service.ts` (create) | category→S-codes + branch→cash, fail-closed | 4 |
+| `apps/api/src/modules/journal/shop-account-resolver.service.spec.ts` (create) | resolver unit tests | 4 |
+| `apps/api/src/modules/journal/journal.module.ts` (modify) | register + export `ShopAccountResolver` | 4 |
+| `apps/api/src/modules/contracts/contract-workflow.service.ts` (modify) | inject + call `ShopInventoryTransferTemplate` in activate() standard branch | 5 |
+| `apps/api/src/modules/contracts/contracts.module.ts` (modify) | provide resolver+template deps | 5 |
+| `apps/api/src/modules/contracts/services/contract-lifecycle.service.ts` (modify) | call `ShopDownPaymentTemplate` in create() (guarded) + refactor softDelete() to callback `$tx` + `ShopDownPaymentReversalTemplate` | 6, 7 |
+| `apps/api/src/modules/shop-finance-settlement/*` (create) | module + service + controller + DTO for ShopFinanceReceipt | 8 |
+| `apps/api/src/app.module.ts` (modify) | register `ShopFinanceSettlementModule` | 8 |
+
+---
+
+## Task 1: X5 — FINANCE-filter `PeakService.exportJournalEntries`
+
+**Files:**
+- Modify: `apps/api/src/modules/peak/peak.service.ts:42-46` (ctor), `:70-87` (findMany)
+- Test: `apps/api/src/modules/peak/peak.service.spec.ts:20-53` (providers)
+
+**Interfaces:**
+- Consumes: `CompanyResolverService.getFinanceCompanyId(tx?): Promise<string>` (exported by `JournalModule`, which `PeakModule` already imports).
+- Produces: nothing new.
+
+- [ ] **Step 1: Add the regression test.** In `peak.service.spec.ts`, add `{ provide: CompanyResolverService, useValue: { getFinanceCompanyId: jest.fn().mockResolvedValue('finance-co-id') } }` to the `providers` array (and `import { CompanyResolverService } from '../journal/company-resolver.service';`). Add this test:
+
+```typescript
+it('only exports FINANCE-company entries (X5 — SHOP S-prefix excluded)', async () => {
+  mockPeakHeaders();
+  prisma.journalEntry.findMany.mockResolvedValue([]);
+  await service.exportJournalEntries(new Date('2026-06-01'), new Date('2026-06-30'));
+  expect(prisma.journalEntry.findMany).toHaveBeenCalledWith(
+    expect.objectContaining({
+      where: expect.objectContaining({ companyId: 'finance-co-id' }),
+    }),
+  );
+});
+```
+
+- [ ] **Step 2: Run it — expect FAIL** (`where` has no `companyId`).
+
+Run: `npm --prefix apps/api test -- src/modules/peak/peak.service.spec.ts`
+Expected: FAIL on the new test (`companyId` not in where).
+
+- [ ] **Step 3: Implement.** Inject the resolver and filter:
+
+```typescript
+// top of file, with other imports
+import { CompanyResolverService } from '../journal/company-resolver.service';
+
+// constructor (peak.service.ts:42-46) — add the param
+constructor(
+  private prisma: PrismaService,
+  private configService: ConfigService,
+  private integrationConfig: IntegrationConfigService,
+  private companyResolver: CompanyResolverService,
+) {}
+
+// inside exportJournalEntries, before the findMany (after the isConfigured guard):
+const financeCompanyId = await this.companyResolver.getFinanceCompanyId();
+const entries = await this.prisma.journalEntry.findMany({
+  where: {
+    status: 'POSTED',
+    entryDate: { gte: startDate, lte: endDate },
+    deletedAt: null,
+    peakSyncedAt: null,
+    companyId: financeCompanyId,
+  },
+  include: { lines: true, company: { select: { nameTh: true } } },
+  orderBy: { entryDate: 'asc' },
+});
+```
+
+- [ ] **Step 4: Run tests — expect PASS** (new test + existing suite).
+
+Run: `npm --prefix apps/api test -- src/modules/peak/peak.service.spec.ts`
+Expected: PASS (all).
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add apps/api/src/modules/peak/peak.service.ts apps/api/src/modules/peak/peak.service.spec.ts
+git commit -m "fix(peak): X5 — scope PEAK push export to FINANCE company (exclude SHOP S-prefix)"
+```
+
+---
+
+## Task 2: X5 — FINANCE-filter `PeakExportService.exportJournalWithPeakCodes`
+
+**Files:**
+- Modify: `apps/api/src/modules/accounting/peak-export.service.ts:9-11` (ctor), `:60-88` (findMany)
+- Test: `apps/api/src/modules/accounting/peak-export.service.spec.ts` (create)
+
+**Interfaces:**
+- Consumes: `CompanyResolverService.getFinanceCompanyId()` (exported by `JournalModule`, imported by `AccountingModule`).
+
+- [ ] **Step 1: Write the failing test** (`peak-export.service.spec.ts`):
+
+```typescript
+import { Test } from '@nestjs/testing';
+import { PeakExportService } from './peak-export.service';
+import { PrismaService } from '../../prisma/prisma.service';
+import { CompanyResolverService } from '../journal/company-resolver.service';
+
+describe('PeakExportService', () => {
+  let service: PeakExportService;
+  let prisma: any;
+
+  beforeEach(async () => {
+    prisma = { journalLine: { findMany: jest.fn().mockResolvedValue([]) }, chartOfAccount: { findMany: jest.fn().mockResolvedValue([]) } };
+    const mod = await Test.createTestingModule({
+      providers: [
+        PeakExportService,
+        { provide: PrismaService, useValue: prisma },
+        { provide: CompanyResolverService, useValue: { getFinanceCompanyId: jest.fn().mockResolvedValue('finance-co-id') } },
+      ],
+    }).compile();
+    service = mod.get(PeakExportService);
+  });
+
+  it('scopes the export to FINANCE company (X5)', async () => {
+    await service.exportJournalWithPeakCodes(new Date('2026-06-01'), new Date('2026-06-30'));
+    expect(prisma.journalLine.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          journalEntry: expect.objectContaining({ companyId: 'finance-co-id' }),
+        }),
+      }),
+    );
+  });
+});
+```
+
+> If `exportJournalWithPeakCodes` has a different arg list, read `peak-export.service.ts:27` and match it; the assertion on `journalLine.findMany` where-clause is the load-bearing part.
+
+- [ ] **Step 2: Run it — expect FAIL** (missing `companyId`; possibly also a DI error until ctor updated).
+
+Run: `npm --prefix apps/api test -- src/modules/accounting/peak-export.service.spec.ts`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement.**
+
+```typescript
+import { CompanyResolverService } from '../journal/company-resolver.service';
+
+@Injectable()
+export class PeakExportService {
+  constructor(
+    private prisma: PrismaService,
+    private companyResolver: CompanyResolverService,
+  ) {}
+  // ... inside exportJournalWithPeakCodes, before the findMany:
+  // const financeCompanyId = await this.companyResolver.getFinanceCompanyId();
+  // then add `companyId: financeCompanyId` INSIDE the nested journalEntry: { ... } where block:
+  //   journalEntry: { status: 'POSTED', entryDate: { gte: periodStart, lte: periodEnd }, deletedAt: null, companyId: financeCompanyId },
+}
+```
+
+- [ ] **Step 4: Run tests — expect PASS.**
+
+Run: `npm --prefix apps/api test -- src/modules/accounting/peak-export.service.spec.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add apps/api/src/modules/accounting/peak-export.service.ts apps/api/src/modules/accounting/peak-export.service.spec.ts
+git commit -m "fix(peak): X5 — scope CSV PEAK export to FINANCE company"
+```
+
+---
+
+## Task 3: `Branch.shopCashAccountCode` column
+
+**Files:**
+- Modify: `apps/api/prisma/schema.prisma:538-585` (Branch model)
+- Create: `apps/api/prisma/migrations/20260974000000_add_shop_cash_account_code_to_branch/migration.sql`
+
+**Interfaces:**
+- Produces: `Branch.shopCashAccountCode: string | null` (column `shop_cash_account_code`).
+
+- [ ] **Step 1: Add the field to schema.prisma.** Inside `model Branch`, right after the `deletedAt DateTime? @map("deleted_at")` line:
+
+```prisma
+  shopCashAccountCode String?   @map("shop_cash_account_code")
+```
+
+- [ ] **Step 2: Create the migration SQL** at `apps/api/prisma/migrations/20260974000000_add_shop_cash_account_code_to_branch/migration.sql`:
+
+```sql
+-- Add the SHOP per-branch cash-till account code (S11-110x). Nullable: set per branch
+-- in settings before SHOP cash-route JEs (down payment / cash sale / trade-in) post.
+ALTER TABLE "branches" ADD COLUMN IF NOT EXISTS "shop_cash_account_code" TEXT;
+```
+
+- [ ] **Step 3: Regenerate the client + validate** (no DB needed for either):
+
+Run: `cd apps/api && npx prisma generate && npx prisma validate`
+Expected: "The schema ... is valid 🚀" and client regenerated (so `branch.shopCashAccountCode` typechecks in Task 4).
+
+- [ ] **Step 4: Verify no drift for this table** (from-empty diff includes the new column):
+
+Run: `cd /Users/iamnaii/Desktop/App/BESTCHOICE && npx prisma migrate diff --from-empty --to-schema-datamodel apps/api/prisma/schema.prisma --script | grep shop_cash_account_code`
+Expected: a line containing `"shop_cash_account_code" TEXT` (confirms schema + intent match).
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add apps/api/prisma/schema.prisma apps/api/prisma/migrations/20260974000000_add_shop_cash_account_code_to_branch/
+git commit -m "feat(branch): add shopCashAccountCode (per-branch SHOP cash till) + migration"
+```
+
+---
+
+## Task 4: `ShopAccountResolver`
+
+**Files:**
+- Create: `apps/api/src/modules/journal/shop-account-resolver.service.ts`
+- Test: `apps/api/src/modules/journal/shop-account-resolver.service.spec.ts`
+- Modify: `apps/api/src/modules/journal/journal.module.ts:40-49` (import), `:99-108` (providers), `:151-160` (exports)
+
+**Interfaces:**
+- Consumes: `PrismaService`; `Branch.shopCashAccountCode` (Task 3); `ProductCategory` from `@prisma/client`.
+- Produces:
+  - `resolveProductAccounts(category: ProductCategory): { inventoryAccountCode: string; cogsAccountCode: string; revenueAccountCode: string }` (sync)
+  - `resolveBranchCashAccount(branchId: string, tx?: Prisma.TransactionClient): Promise<string>` (throws if unconfigured)
+  - `static readonly SHOP_RECEIVING_BANK = 'S11-1201'`
+
+- [ ] **Step 1: Write the failing test** (`shop-account-resolver.service.spec.ts`):
+
+```typescript
+import { Test } from '@nestjs/testing';
+import { BadRequestException } from '@nestjs/common';
+import { ShopAccountResolver } from './shop-account-resolver.service';
+import { PrismaService } from '../../prisma/prisma.service';
+
+describe('ShopAccountResolver', () => {
+  let resolver: ShopAccountResolver;
+  let prisma: any;
+
+  beforeEach(async () => {
+    prisma = { branch: { findUnique: jest.fn() } };
+    const mod = await Test.createTestingModule({
+      providers: [ShopAccountResolver, { provide: PrismaService, useValue: prisma }],
+    }).compile();
+    resolver = mod.get(ShopAccountResolver);
+  });
+
+  it('maps PHONE_NEW + TABLET to the new-phone S-codes', () => {
+    const expected = { inventoryAccountCode: 'S11-2001', cogsAccountCode: 'S50-1101', revenueAccountCode: 'S41-1101' };
+    expect(resolver.resolveProductAccounts('PHONE_NEW')).toEqual(expected);
+    expect(resolver.resolveProductAccounts('TABLET')).toEqual(expected);
+  });
+
+  it('maps PHONE_USED and ACCESSORY to their S-codes', () => {
+    expect(resolver.resolveProductAccounts('PHONE_USED')).toEqual({ inventoryAccountCode: 'S11-2002', cogsAccountCode: 'S50-1102', revenueAccountCode: 'S41-1102' });
+    expect(resolver.resolveProductAccounts('ACCESSORY')).toEqual({ inventoryAccountCode: 'S11-2003', cogsAccountCode: 'S50-1103', revenueAccountCode: 'S41-1103' });
+  });
+
+  it('resolves a configured branch cash account', async () => {
+    prisma.branch.findUnique.mockResolvedValue({ shopCashAccountCode: 'S11-1102' });
+    await expect(resolver.resolveBranchCashAccount('br-1')).resolves.toBe('S11-1102');
+  });
+
+  it('fail-closed: throws when branch has no shopCashAccountCode', async () => {
+    prisma.branch.findUnique.mockResolvedValue({ shopCashAccountCode: null });
+    await expect(resolver.resolveBranchCashAccount('br-1')).rejects.toThrow(BadRequestException);
+  });
+});
+```
+
+- [ ] **Step 2: Run it — expect FAIL** (module not found).
+
+Run: `npm --prefix apps/api test -- src/modules/journal/shop-account-resolver.service.spec.ts`
+Expected: FAIL ("Cannot find module './shop-account-resolver.service'").
+
+- [ ] **Step 3: Implement** `shop-account-resolver.service.ts`:
+
+```typescript
+import { BadRequestException, Injectable } from '@nestjs/common';
+import { Prisma, ProductCategory } from '@prisma/client';
+import { PrismaService } from '../../prisma/prisma.service';
+
+export interface ShopProductAccounts {
+  inventoryAccountCode: string;
+  cogsAccountCode: string;
+  revenueAccountCode: string;
+}
+
+/**
+ * Single source of truth for resolving SHOP-side account codes:
+ * product category → inventory/COGS/revenue S-codes, and branch → cash till.
+ */
+@Injectable()
+export class ShopAccountResolver {
+  /** SHOP bank that receives inflows (down/cash-sale transfer + FINANCE settlement). */
+  static readonly SHOP_RECEIVING_BANK = 'S11-1201';
+  /** SHOP bank that funds outflows (branch expenses, transfer trade-in payout). */
+  static readonly SHOP_PAYING_BANK = 'S11-1202';
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  /** TABLET reuses PHONE_NEW codes (D-5); dedicated tablet S-codes deferred. */
+  resolveProductAccounts(category: ProductCategory): ShopProductAccounts {
+    switch (category) {
+      case 'PHONE_USED':
+        return { inventoryAccountCode: 'S11-2002', cogsAccountCode: 'S50-1102', revenueAccountCode: 'S41-1102' };
+      case 'ACCESSORY':
+        return { inventoryAccountCode: 'S11-2003', cogsAccountCode: 'S50-1103', revenueAccountCode: 'S41-1103' };
+      case 'PHONE_NEW':
+      case 'TABLET':
+        return { inventoryAccountCode: 'S11-2001', cogsAccountCode: 'S50-1101', revenueAccountCode: 'S41-1101' };
+      default:
+        throw new BadRequestException(`ShopAccountResolver: unknown ProductCategory "${category as string}"`);
+    }
+  }
+
+  /** Fail-closed: a branch must have shopCashAccountCode set before SHOP cash JEs can post. */
+  async resolveBranchCashAccount(branchId: string, tx?: Prisma.TransactionClient): Promise<string> {
+    const client = (tx ?? this.prisma) as Prisma.TransactionClient;
+    const branch = await client.branch.findUnique({
+      where: { id: branchId },
+      select: { shopCashAccountCode: true },
+    });
+    if (!branch?.shopCashAccountCode) {
+      throw new BadRequestException(
+        `ShopAccountResolver: branch ${branchId} has no shopCashAccountCode — set it in branch settings before posting SHOP cash entries`,
+      );
+    }
+    return branch.shopCashAccountCode;
+  }
+}
+```
+
+- [ ] **Step 4: Register in `journal.module.ts`** — add `import { ShopAccountResolver } from './shop-account-resolver.service';` near line 40, and add `ShopAccountResolver,` to BOTH the providers array (near `CompanyResolverService` at :99-108) and the exports array (:151-160).
+
+- [ ] **Step 5: Run tests — expect PASS.**
+
+Run: `npm --prefix apps/api test -- src/modules/journal/shop-account-resolver.service.spec.ts`
+Expected: PASS (4 tests).
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add apps/api/src/modules/journal/shop-account-resolver.service.ts apps/api/src/modules/journal/shop-account-resolver.service.spec.ts apps/api/src/modules/journal/journal.module.ts
+git commit -m "feat(journal): add ShopAccountResolver (category->S-codes + branch->cash, fail-closed)"
+```
+
+---
+
+## Task 5: Wire `ShopInventoryTransferTemplate` into `activate()` (atomic, standard branch)
+
+**Files:**
+- Modify: `apps/api/src/modules/contracts/contract-workflow.service.ts:25-33` (ctor), `:418-506` ($tx body, after the 1A call at :494)
+- Modify: `apps/api/src/modules/contracts/contracts.module.ts` (ensure `ShopInventoryTransferTemplate` + `ShopAccountResolver` injectable — both exported by `JournalModule`, which the contracts module imports; no re-provide needed, just confirm the import)
+- Test: `apps/api/src/modules/contracts/contract-workflow.service.spec.ts` (add a wiring test; create the file if absent following the `contract-exchange.service.spec.ts:1-63` pattern)
+
+**Interfaces:**
+- Consumes: `ShopInventoryTransferTemplate.execute(input: ShopInventoryTransferInput, outerTx?): Promise<ShopInventoryTransferResult>`; `ShopAccountResolver.resolveProductAccounts(category)`; `ShopDownPaymentTemplate.execute(...)` + `ShopAccountResolver.resolveBranchCashAccount(branchId, tx)` (in-flight catch-up only).
+- Produces: posts the SHOP inventory-transfer JE pair inside the activation `$tx` (+ a catch-up down JE for pre-P1 contracts).
+
+- [ ] **Step 1: Write the failing test.** In `contract-workflow.service.spec.ts`, build a `TestingModule` providing `ContractWorkflowService` with mocked `PrismaService`, `ShopInventoryTransferTemplate` (`{ execute: jest.fn().mockResolvedValue({ batchId:'b', cogsEntryNo:'c', cogsJournalEntryId:'cj', revenueEntryNo:'r', revenueJournalEntryId:'rj' }) }`), `ContractActivation1ATemplate` (`{ execute: jest.fn() }`), `ShopAccountResolver` (`{ resolveProductAccounts: jest.fn().mockReturnValue({ inventoryAccountCode:'S11-2001', cogsAccountCode:'S50-1101', revenueAccountCode:'S41-1101' }) }`), and the other ctor deps as `{}` mocks. Make `prisma.$transaction` invoke its callback with a `tx` mock. Assert:
+
+```typescript
+it('posts ShopInventoryTransfer with salePrice = down + financed at activation', async () => {
+  // arrange: findOne returns an APPROVED/DRAFT standard contract with product
+  // sellingPrice 20000, downPayment 2000, financedAmount 18000, storeCommission 1500,
+  // product { category:'PHONE_NEW', costPrice: 15000 }, no exchangedFromContractId.
+  await service.activate('c-1');
+  const input = shopInventoryTransferTemplate.execute.mock.calls[0][0];
+  expect(input.salePrice.toString()).toBe('20000'); // down(2000)+financed(18000) — NOT raw sellingPrice
+  expect(input.downAmount.toString()).toBe('2000');
+  expect(input.financedAmount.toString()).toBe('18000');
+  expect(input.commission.toString()).toBe('1500');
+  expect(input.costPrice.toString()).toBe('15000');
+  expect(input).toMatchObject({ inventoryAccountCode: 'S11-2001', cogsAccountCode: 'S50-1101', revenueAccountCode: 'S41-1101', idempotencyKey: 'shop-inventory-transfer:c-1' });
+  // called with the same tx as ContractActivation1A (2nd arg present)
+  expect(shopInventoryTransferTemplate.execute.mock.calls[0][1]).toBeDefined();
+});
+
+it('posts a catch-up ShopDownPayment for an in-flight contract with down but no down JE', async () => {
+  // down 2000, but tx.journalEntry.findFirst returns null (no prior down JE → pre-P1 contract)
+  tx.journalEntry.findFirst.mockResolvedValue(null);
+  shopAccountResolver.resolveBranchCashAccount.mockResolvedValue('S11-1102');
+  await service.activate('c-1');
+  expect(shopDownPaymentTemplate.execute).toHaveBeenCalledTimes(1);
+  expect(shopDownPaymentTemplate.execute.mock.calls[0][0]).toMatchObject({ idempotencyKey: 'shop-down-payment:c-1', cashAccountCode: 'S11-1102' });
+});
+
+it('skips the catch-up when a down JE already exists (post-P1 contract)', async () => {
+  tx.journalEntry.findFirst.mockResolvedValue({ id: 'down-je-1' });
+  await service.activate('c-1');
+  expect(shopDownPaymentTemplate.execute).not.toHaveBeenCalled();
+});
+```
+
+> Mirror the provider/mocked-prisma setup from `contract-exchange.service.spec.ts:1-63`. Also provide `{ provide: ShopDownPaymentTemplate, useValue: { execute: jest.fn() } }`. For `$transaction`, use `prisma.$transaction = jest.fn(async (cb) => cb(tx))` where `tx` is an object of jest.fn()s (`product.findUnique` → returns RESERVED product, `contract.update`, `product.update`, `sale.create`, `journalEntry.findFirst`, etc.). Stub `productsService.transferOwnership`, `generateInstallmentSchedules` (spy), and `generateSaleNumber`. In the first test set `tx.journalEntry.findFirst.mockResolvedValue({ id: 'down-je-1' })` so the catch-up is skipped.
+
+- [ ] **Step 2: Run it — expect FAIL** (template not called / DI missing).
+
+Run: `npm --prefix apps/api test -- src/modules/contracts/contract-workflow.service.spec.ts`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement.** Add to the constructor (`:25-33`):
+
+```typescript
+import { ShopInventoryTransferTemplate } from '../journal/cpa-templates/shop-inventory-transfer.template';
+import { ShopDownPaymentTemplate } from '../journal/cpa-templates/shop-down-payment.template';
+import { ShopAccountResolver } from '../journal/shop-account-resolver.service';
+import { Decimal } from '@prisma/client/runtime/library';
+// ...
+constructor(
+  private prisma: PrismaService,
+  private notificationsService: NotificationsService,
+  private journalAutoService: JournalAutoService,
+  private contractActivation1ATemplate: ContractActivation1ATemplate,
+  private productsService: ProductsService,
+  private contractExchangeService: ContractExchangeService,
+  private shopInventoryTransferTemplate: ShopInventoryTransferTemplate,
+  private shopDownPaymentTemplate: ShopDownPaymentTemplate,
+  private shopAccountResolver: ShopAccountResolver,
+  @Optional() private testMode?: TestModeService,
+) {}
+```
+
+In the `else` (standard) branch, immediately after `await this.contractActivation1ATemplate.execute(contract.id, tx);` (`:494`):
+
+```typescript
+        // SHOP-side: post inventory transfer (COGS + revenue + receivables + down clearance),
+        // atomic with the FINANCE 1A entry. salePrice is reconstructed as down+financed (D-8)
+        // so the template's financing-identity assertion holds by construction.
+        const downAmount = new Decimal(contract.downPayment.toString());
+        const financedAmount = new Decimal(contract.financedAmount.toString());
+
+        // In-flight rollout guard (spec §12): a contract created BEFORE this feature
+        // shipped never got a ShopDownPayment JE, but ShopInventoryTransfer below will
+        // Dr S21-2001 to "clear" the down payable. If no down JE exists yet, post a
+        // catch-up ShopDownPayment first so the clearance lands against a real credit.
+        if (downAmount.gt(0)) {
+          const downJe = await tx.journalEntry.findFirst({
+            where: {
+              AND: [
+                { metadata: { path: ['flow'], equals: 'shop-down-payment' } as any },
+                { metadata: { path: ['idempotencyKey'], equals: `shop-down-payment:${contract.id}` } as any },
+              ],
+              deletedAt: null,
+            },
+            select: { id: true },
+          });
+          if (!downJe) {
+            const cashAccountCode = await this.shopAccountResolver.resolveBranchCashAccount(contract.branchId, tx);
+            await this.shopDownPaymentTemplate.execute(
+              {
+                idempotencyKey: `shop-down-payment:${contract.id}`,
+                contractId: contract.id,
+                contractNumber: contract.contractNumber,
+                cashAccountCode,
+                downAmount,
+              },
+              tx,
+            );
+          }
+        }
+
+        const acc = this.shopAccountResolver.resolveProductAccounts(contract.product.category);
+        await this.shopInventoryTransferTemplate.execute(
+          {
+            idempotencyKey: `shop-inventory-transfer:${contract.id}`,
+            contractId: contract.id,
+            contractNumber: contract.contractNumber,
+            productId: contract.productId,
+            inventoryAccountCode: acc.inventoryAccountCode,
+            cogsAccountCode: acc.cogsAccountCode,
+            revenueAccountCode: acc.revenueAccountCode,
+            costPrice: new Decimal(contract.product.costPrice.toString()),
+            salePrice: downAmount.plus(financedAmount),
+            downAmount,
+            financedAmount,
+            commission: contract.storeCommission ? new Decimal(contract.storeCommission.toString()) : new Decimal(0),
+          },
+          tx,
+        );
+```
+
+> `productName` is omitted (optional on the input); add it only if you confirm a `Product.name`/`model` field via `findOne`'s include. `contract.product.costPrice` is non-null in schema but follow the exchange precedent if a null-guard is desired. The catch-up keeps the standard (post-P1) path a no-op extra `findFirst` (the down JE already exists from Task 6) while making pre-P1 contracts self-heal.
+
+- [ ] **Step 4: Run tests — expect PASS** (new test + existing contract-workflow suite).
+
+Run: `npm --prefix apps/api test -- src/modules/contracts/contract-workflow.service.spec.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Verify DI graph compiles** (the contracts module resolves the new deps via `JournalModule` exports):
+
+Run: `npm --prefix apps/api test -- src/modules/contracts/contract-workflow.service.spec.ts` and `cd apps/api && npx tsc --noEmit -p tsconfig.json`
+Expected: tests PASS; tsc exit 0. If Nest reports "can't resolve ShopInventoryTransferTemplate/ShopAccountResolver", confirm `contracts.module.ts` `imports` includes `JournalModule` (it already imports it for `ContractActivation1ATemplate`); both new deps are exported from `JournalModule` (Task 4).
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add apps/api/src/modules/contracts/contract-workflow.service.ts apps/api/src/modules/contracts/contract-workflow.service.spec.ts
+git commit -m "feat(contracts): post ShopInventoryTransfer atomically at contract activation (D-1/D-8)"
+```
+
+---
+
+## Task 6: Wire `ShopDownPaymentTemplate` into `create()` (guarded `downPayment > 0`)
+
+**Files:**
+- Modify: `apps/api/src/modules/contracts/services/contract-lifecycle.service.ts:33` (ctor — add deps), `:131-211` (inside the create `$transaction`, after `tx.payment.createMany`)
+- Test: `apps/api/src/modules/contracts/services/contract-lifecycle.service.spec.ts` (add a wiring test)
+
+**Interfaces:**
+- Consumes: `ShopDownPaymentTemplate.execute(input: ShopDownPaymentInput, outerTx?): Promise<{entryNo,journalEntryId}>`; `ShopAccountResolver.resolveBranchCashAccount(branchId, tx)`.
+
+- [ ] **Step 1: Write the failing test.** Build a `ContractLifecycleService` `TestingModule` with mocked deps; mock `prisma.$transaction = jest.fn(async (cb) => cb(tx))` and the resolver to return `'S11-1102'`. Assert two behaviors:
+
+```typescript
+it('posts ShopDownPayment when downPayment > 0', async () => {
+  // create() called with dto.downPayment = 2000, branchId 'br-1'
+  await service.create({ ...dto, downPayment: 2000, branchId: 'br-1' } as any, 'sp-1');
+  expect(shopAccountResolver.resolveBranchCashAccount).toHaveBeenCalledWith('br-1', tx);
+  const input = shopDownPaymentTemplate.execute.mock.calls[0][0];
+  expect(input).toMatchObject({ idempotencyKey: expect.stringContaining('shop-down-payment:'), cashAccountCode: 'S11-1102' });
+  expect(input.downAmount.toString()).toBe('2000');
+});
+
+it('skips ShopDownPayment when downPayment = 0', async () => {
+  await service.create({ ...dto, downPayment: 0 } as any, 'sp-1');
+  expect(shopDownPaymentTemplate.execute).not.toHaveBeenCalled();
+});
+```
+
+> `tx` must expose `contract.create` (returns `{ id:'c-1', contractNumber:'CN-1', ... }`), `payment.createMany`, `product.update`, plus whatever the create body calls (credit-check link, customer snapshot). Mirror the existing `contract-lifecycle.service.spec.ts` setup if present; otherwise mirror `contract-exchange.service.spec.ts`.
+
+- [ ] **Step 2: Run — expect FAIL.**
+
+Run: `npm --prefix apps/api test -- src/modules/contracts/services/contract-lifecycle.service.spec.ts`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement.** Add ctor deps + import:
+
+```typescript
+import { ShopDownPaymentTemplate } from '../../journal/cpa-templates/shop-down-payment.template';
+import { ShopAccountResolver } from '../../journal/shop-account-resolver.service';
+import { Decimal } from '@prisma/client/runtime/library';
+```
+
+Inside the create `$transaction`, after `await tx.payment.createMany({ data: payments });` and before `return newContract;`:
+
+```typescript
+          // SHOP-side: record the down payment received at contract creation.
+          const downPayment = new Decimal(dto.downPayment.toString());
+          if (downPayment.gt(0)) {
+            const cashAccountCode = await this.shopAccountResolver.resolveBranchCashAccount(dto.branchId, tx);
+            await this.shopDownPaymentTemplate.execute(
+              {
+                idempotencyKey: `shop-down-payment:${newContract.id}`,
+                contractId: newContract.id,
+                contractNumber: newContract.contractNumber,
+                cashAccountCode,
+                downAmount: downPayment,
+              },
+              tx,
+            );
+          }
+```
+
+- [ ] **Step 4: Run — expect PASS.**
+
+Run: `npm --prefix apps/api test -- src/modules/contracts/services/contract-lifecycle.service.spec.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add apps/api/src/modules/contracts/services/contract-lifecycle.service.ts apps/api/src/modules/contracts/services/contract-lifecycle.service.spec.ts
+git commit -m "feat(contracts): post ShopDownPayment at contract creation when down > 0"
+```
+
+---
+
+## Task 7: Wire `ShopDownPaymentReversalTemplate` into `softDelete()` (pre-activation void)
+
+**Files:**
+- Modify: `apps/api/src/modules/contracts/services/contract-lifecycle.service.ts:460-557` (refactor array-form `$transaction` → callback form, add reversal)
+- Test: same spec as Task 6 (add reversal test)
+
+**Interfaces:**
+- Consumes: `ShopDownPaymentReversalTemplate.execute(input: ShopDownPaymentReversalInput, outerTx?)`; reuses `ShopAccountResolver.resolveBranchCashAccount`.
+
+> **Why a refactor:** `softDelete` currently uses the **array form** `this.prisma.$transaction([...])` which cannot host an `async` template call. Convert it to the **callback form** `this.prisma.$transaction(async (tx) => { ... })`, replacing each `this.prisma.X` with `tx.X`, then add the reversal. Use `ContractCancellationService.approveCancellation` (`contract-cancellation.service.ts:76-159`) as the structural reference for callback-form `$tx` + `template.execute(input, tx)` + audit.
+
+- [ ] **Step 1: Write the failing test:**
+
+```typescript
+it('reverses the SHOP down payment when voiding a DRAFT contract that had a down JE', async () => {
+  // query.findOne returns DRAFT/CREATING contract with downPayment 2000, branchId 'br-1'
+  // a shop-down-payment JE exists for this contract:
+  tx.journalEntry.findFirst.mockResolvedValue({ id: 'down-je-1' });
+  shopAccountResolver.resolveBranchCashAccount.mockResolvedValue('S11-1102');
+  await service.softDelete('c-1', 'user-1');
+  const input = shopDownPaymentReversalTemplate.execute.mock.calls[0][0];
+  expect(input).toMatchObject({ idempotencyKey: 'shop-down-payment-reversal:c-1', refundAccountCode: 'S11-1102', originalJournalEntryId: 'down-je-1' });
+  expect(input.downAmount.toString()).toBe('2000');
+});
+
+it('does NOT reverse when no down JE was posted', async () => {
+  tx.journalEntry.findFirst.mockResolvedValue(null);
+  await service.softDelete('c-1', 'user-1');
+  expect(shopDownPaymentReversalTemplate.execute).not.toHaveBeenCalled();
+});
+```
+
+- [ ] **Step 2: Run — expect FAIL.**
+
+Run: `npm --prefix apps/api test -- src/modules/contracts/services/contract-lifecycle.service.spec.ts`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement.** Refactor the `$transaction([...])` block to callback form and add the reversal before the soft-delete update:
+
+```typescript
+    await this.prisma.$transaction(async (tx) => {
+      // Reverse the SHOP down-payment JE if one was posted for this DRAFT contract.
+      const downPayment = new Decimal(contract.downPayment.toString());
+      if (downPayment.gt(0)) {
+        const downJe = await tx.journalEntry.findFirst({
+          where: {
+            AND: [
+              { metadata: { path: ['flow'], equals: 'shop-down-payment' } as any },
+              { metadata: { path: ['idempotencyKey'], equals: `shop-down-payment:${id}` } as any },
+            ],
+            deletedAt: null,
+          },
+          select: { id: true },
+        });
+        if (downJe) {
+          const refundAccountCode = await this.shopAccountResolver.resolveBranchCashAccount(contract.branchId, tx);
+          await this.shopDownPaymentReversalTemplate.execute(
+            {
+              idempotencyKey: `shop-down-payment-reversal:${id}`,
+              contractId: id,
+              contractNumber: contract.contractNumber,
+              refundAccountCode,
+              downAmount: downPayment,
+              originalJournalEntryId: downJe.id,
+            },
+            tx,
+          );
+        }
+      }
+
+      await tx.contract.update({ where: { id }, data: { deletedAt: now } });
+      if (cascadedSignatures > 0) {
+        await tx.signature.updateMany({ where: { contractId: id, deletedAt: null }, data: { deletedAt: now } });
+      }
+      await tx.creditCheck.updateMany({ where: { contractId: id }, data: { contractId: null } });
+      await tx.kycVerification.updateMany({ where: { contractId: id, deletedAt: null }, data: { deletedAt: now } });
+      await tx.product.updateMany({ where: { id: contract.productId, status: 'RESERVED' }, data: { status: 'IN_STOCK' } });
+      await tx.auditLog.create({
+        data: {
+          userId, action: 'CONTRACT_DELETE', entity: 'contract', entityId: id,
+          oldValue: { contractNumber: contract.contractNumber, status: contract.status, workflowStatus: contract.workflowStatus },
+          newValue: { cascadedSignatures },
+        },
+      });
+    });
+```
+
+Add ctor dep `private shopDownPaymentReversalTemplate: ShopDownPaymentReversalTemplate` + import from `../../journal/cpa-templates/shop-down-payment-reversal.template`.
+
+- [ ] **Step 4: Run — expect PASS** (new tests + existing softDelete tests; verify the callback refactor preserves all original updates).
+
+Run: `npm --prefix apps/api test -- src/modules/contracts/services/contract-lifecycle.service.spec.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add apps/api/src/modules/contracts/services/contract-lifecycle.service.ts apps/api/src/modules/contracts/services/contract-lifecycle.service.spec.ts
+git commit -m "feat(contracts): reverse SHOP down payment when voiding a pre-activation DRAFT (callback-form tx)"
+```
+
+---
+
+## Task 8: Finance-settlement module — `POST /shop/finance-settlements` + `GET .../pending`
+
+**Files:**
+- Create: `apps/api/src/modules/shop-finance-settlement/shop-finance-settlement.module.ts`
+- Create: `apps/api/src/modules/shop-finance-settlement/shop-finance-settlement.service.ts`
+- Create: `apps/api/src/modules/shop-finance-settlement/shop-finance-settlement.controller.ts`
+- Create: `apps/api/src/modules/shop-finance-settlement/dto/finance-settlement.dto.ts`
+- Test: `apps/api/src/modules/shop-finance-settlement/shop-finance-settlement.service.spec.ts`
+- Modify: `apps/api/src/app.module.ts` (register module)
+
+**Interfaces:**
+- Consumes: `ShopFinanceReceiptTemplate.execute(input: ShopFinanceReceiptInput, outerTx?): Promise<{entryNo,journalEntryId}>` + `Contract` rows.
+- Produces: `settle(contractIds: string[], bankAccountCode, postedAt?): Promise<...>` and `listPending(): Promise<Contract[]>`.
+
+- [ ] **Step 1: DTO.** Create `dto/finance-settlement.dto.ts`:
+
+```typescript
+import { IsArray, IsString, IsOptional, ArrayNotEmpty } from 'class-validator';
+
+export class SettleFinanceDto {
+  @IsArray()
+  @ArrayNotEmpty({ message: 'ต้องระบุสัญญาอย่างน้อย 1 รายการ' })
+  @IsString({ each: true })
+  contractIds: string[];
+
+  /** SHOP receiving bank (S11-12XX). Defaults to ShopAccountResolver.SHOP_RECEIVING_BANK. */
+  @IsOptional()
+  @IsString()
+  bankAccountCode?: string;
+
+  @IsOptional()
+  @IsString()
+  postedAt?: string;
+}
+```
+
+- [ ] **Step 2: Write the failing service test** (`shop-finance-settlement.service.spec.ts`):
+
+```typescript
+import { Test } from '@nestjs/testing';
+import { Decimal } from '@prisma/client/runtime/library';
+import { ShopFinanceSettlementService } from './shop-finance-settlement.service';
+import { PrismaService } from '../../prisma/prisma.service';
+import { ShopFinanceReceiptTemplate } from '../journal/cpa-templates/shop-finance-receipt.template';
+
+describe('ShopFinanceSettlementService', () => {
+  let service: ShopFinanceSettlementService;
+  let prisma: any;
+  let template: any;
+
+  beforeEach(async () => {
+    prisma = {
+      contract: { findMany: jest.fn() },
+      journalEntry: { findMany: jest.fn().mockResolvedValue([]) },
+      $transaction: jest.fn(async (cb) => cb(prisma)),
+    };
+    template = { execute: jest.fn().mockResolvedValue({ entryNo: 'JE-1', journalEntryId: 'je-1' }) };
+    const mod = await Test.createTestingModule({
+      providers: [
+        ShopFinanceSettlementService,
+        { provide: PrismaService, useValue: prisma },
+        { provide: ShopFinanceReceiptTemplate, useValue: template },
+      ],
+    }).compile();
+    service = mod.get(ShopFinanceSettlementService);
+  });
+
+  it('posts a ShopFinanceReceipt per contract with financed+commission from the contract', async () => {
+    prisma.contract.findMany.mockResolvedValue([
+      { id: 'c-1', contractNumber: 'CN-1', financedAmount: new Decimal('18000'), storeCommission: new Decimal('1500'), status: 'ACTIVE', deletedAt: null },
+    ]);
+    await service.settle({ contractIds: ['c-1'] });
+    const input = template.execute.mock.calls[0][0];
+    expect(input).toMatchObject({ idempotencyKey: 'finance-receipt-c-1', contractId: 'c-1', bankAccountCode: 'S11-1201' });
+    expect(input.financedAmount.toString()).toBe('18000');
+    expect(input.commission.toString()).toBe('1500');
+  });
+
+  it('listPending returns ACTIVE contracts without a shop-finance-receipt JE', async () => {
+    prisma.contract.findMany.mockResolvedValue([{ id: 'c-1' }, { id: 'c-2' }]);
+    prisma.journalEntry.findMany.mockResolvedValue([{ metadata: { contractId: 'c-1' } }]);
+    const pending = await service.listPending();
+    expect(pending.map((c: any) => c.id)).toEqual(['c-2']);
+  });
+});
+```
+
+- [ ] **Step 3: Run — expect FAIL** (module not found).
+
+Run: `npm --prefix apps/api test -- src/modules/shop-finance-settlement/shop-finance-settlement.service.spec.ts`
+Expected: FAIL.
+
+- [ ] **Step 4: Implement the service** (`shop-finance-settlement.service.ts`):
+
+```typescript
+import { Injectable } from '@nestjs/common';
+import { Decimal } from '@prisma/client/runtime/library';
+import { PrismaService } from '../../prisma/prisma.service';
+import { ShopFinanceReceiptTemplate } from '../journal/cpa-templates/shop-finance-receipt.template';
+import { ShopAccountResolver } from '../journal/shop-account-resolver.service';
+import { SettleFinanceDto } from './dto/finance-settlement.dto';
+
+/** Contract statuses that count as "has been activated" for settlement purposes. */
+const ACTIVATED_STATUSES = ['ACTIVE', 'OVERDUE', 'DEFAULT', 'EARLY_PAYOFF', 'COMPLETED'] as const;
+
+@Injectable()
+export class ShopFinanceSettlementService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly shopFinanceReceiptTemplate: ShopFinanceReceiptTemplate,
+  ) {}
+
+  async settle(dto: SettleFinanceDto) {
+    const bankAccountCode = dto.bankAccountCode ?? ShopAccountResolver.SHOP_RECEIVING_BANK;
+    const postedAt = dto.postedAt ? new Date(dto.postedAt) : undefined;
+    const contracts = await this.prisma.contract.findMany({
+      where: { id: { in: dto.contractIds }, deletedAt: null },
+      select: { id: true, contractNumber: true, financedAmount: true, storeCommission: true },
+    });
+    const results: { contractId: string; entryNo: string }[] = [];
+    for (const c of contracts) {
+      const res = await this.shopFinanceReceiptTemplate.execute({
+        idempotencyKey: `finance-receipt-${c.id}`,
+        contractId: c.id,
+        contractNumber: c.contractNumber,
+        bankAccountCode,
+        financedAmount: new Decimal(c.financedAmount.toString()),
+        commission: c.storeCommission ? new Decimal(c.storeCommission.toString()) : new Decimal(0),
+        postedAt,
+      });
+      results.push({ contractId: c.id, entryNo: res.entryNo });
+    }
+    return { settled: results.length, results };
+  }
+
+  /** Activated contracts that do not yet have a shop-finance-receipt JE. */
+  async listPending() {
+    const contracts = await this.prisma.contract.findMany({
+      where: { status: { in: [...ACTIVATED_STATUSES] }, deletedAt: null },
+      select: { id: true, contractNumber: true, financedAmount: true, storeCommission: true, branchId: true },
+    });
+    const settledJEs = await this.prisma.journalEntry.findMany({
+      where: { metadata: { path: ['flow'], equals: 'shop-finance-receipt' } as any, deletedAt: null },
+      select: { metadata: true },
+    });
+    const settledIds = new Set(
+      settledJEs.map((j) => (j.metadata as any)?.contractId).filter(Boolean),
+    );
+    return contracts.filter((c) => !settledIds.has(c.id));
+  }
+}
+```
+
+- [ ] **Step 5: Implement the controller** (`shop-finance-settlement.controller.ts`):
+
+```typescript
+import { Body, Controller, Get, Post, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { ShopFinanceSettlementService } from './shop-finance-settlement.service';
+import { SettleFinanceDto } from './dto/finance-settlement.dto';
+
+@ApiTags('Shop Finance Settlement')
+@ApiBearerAuth('JWT')
+@Controller('shop/finance-settlements')
+@UseGuards(JwtAuthGuard, RolesGuard)
+export class ShopFinanceSettlementController {
+  constructor(private readonly service: ShopFinanceSettlementService) {}
+
+  @Post()
+  @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT')
+  settle(@Body() dto: SettleFinanceDto) {
+    return this.service.settle(dto);
+  }
+
+  @Get('pending')
+  @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT')
+  pending() {
+    return this.service.listPending();
+  }
+}
+```
+
+> No `BranchGuard` — this aggregates cross-branch like the other SHOP-accounting endpoints; `BRANCH_MANAGER` intentionally excluded.
+
+- [ ] **Step 6: Implement the module** (`shop-finance-settlement.module.ts`) + register in `app.module.ts`:
+
+```typescript
+import { Module } from '@nestjs/common';
+import { PrismaModule } from '../../prisma/prisma.module';
+import { JournalModule } from '../journal/journal.module';
+import { ShopFinanceSettlementService } from './shop-finance-settlement.service';
+import { ShopFinanceSettlementController } from './shop-finance-settlement.controller';
+
+@Module({
+  imports: [PrismaModule, JournalModule], // JournalModule exports ShopFinanceReceiptTemplate
+  controllers: [ShopFinanceSettlementController],
+  providers: [ShopFinanceSettlementService],
+})
+export class ShopFinanceSettlementModule {}
+```
+
+Add `ShopFinanceSettlementModule` to the `imports` array in `apps/api/src/app.module.ts`.
+
+- [ ] **Step 7: Run — expect PASS** + typecheck.
+
+Run: `npm --prefix apps/api test -- src/modules/shop-finance-settlement/shop-finance-settlement.service.spec.ts && cd apps/api && npx tsc --noEmit -p tsconfig.json`
+Expected: tests PASS; tsc exit 0.
+
+- [ ] **Step 8: Commit.**
+
+```bash
+git add apps/api/src/modules/shop-finance-settlement/ apps/api/src/app.module.ts
+git commit -m "feat(shop): finance-settlement endpoint — POST /shop/finance-settlements + GET pending (ShopFinanceReceipt)"
+```
+
+---
+
+## Acceptance (run after Task 8)
+
+- [ ] Full API typecheck: `cd apps/api && npx tsc --noEmit -p tsconfig.json` → exit 0.
+- [ ] Touched-module tests: `npm --prefix apps/api test -- src/modules/peak src/modules/journal src/modules/contracts src/modules/shop-finance-settlement` → all green.
+- [ ] Existing SHOP template golden specs still green: `npm --prefix apps/api test -- src/modules/journal/shop-templates`.
+- [ ] Manual reasoning check: an installment contract created with down 2000 / financed 18000 / commission 1500 → after create: `S21-2001` Cr 2000; after activate: COGS + revenue 20000 + `S11-3001` 18000 + `S11-3002` 1500 + `S21-2001` Dr 2000 (cleared); after settle: `S11-1201` Dr 19500 / `S11-3001`+`S11-3002` cleared → SHOP TB for this contract nets to inventory-out + cash-in, balanced.
+- [ ] X5: no `S`-prefix JE appears in either PEAK export (Tasks 1-2 tests prove the `companyId` filter).
+
+## Out of scope (separate plans)
+- **P2** ShopCashSale (per-product, bundle-aware — see spec §6B), **P3** ShopTradeIn, **P4** ShopExpense.
+- Branch settings UI for `shopCashAccountCode` (a small frontend follow-on; the column + fail-closed guard ship here, the UI to set it is P2-adjacent — until then set it via seed/SQL for go-live).
+- Removing the `/shop/accounting` disclaimer banner (owner decision after rollout).

--- a/docs/superpowers/specs/2026-06-23-shop-je-wiring-design.md
+++ b/docs/superpowers/specs/2026-06-23-shop-je-wiring-design.md
@@ -36,6 +36,9 @@ The 7 templates: `ShopCashSale`, `ShopDownPayment`, `ShopDownPaymentReversal`, `
 | D-5 | `TABLET` category accounts | **Reuse PHONE_NEW codes** (S41-1101 / S50-1101 / S11-2001); dedicated codes deferrable |
 | D-6 | `ShopFinanceReceipt` persistence | **No new model** — the JE (queryable by `metadata.flow`) + audit log is the record |
 | D-7 | Posting style | **Synchronous, inside each trigger's `$transaction`** (not event-driven) |
+| D-8 | `salePrice` fed to `ShopInventoryTransfer` (resolves Blocker-1) | **Reconstructed = `downPayment + financedAmount`** (NOT raw `sellingPrice`) so the financing-identity assertion holds by construction and can never throw inside the activation `$tx` |
+
+> **Changelog:** D-8 + §4A + §6 bundle handling + §6A pending-settlements + §9 hard-gate added 2026-06-23 after `/scrutinize` (Blocker-1 + Majors 2/3 + Minor 4).
 
 ## 4. Architecture
 
@@ -59,6 +62,16 @@ activate() :494       ShopInventoryTransfer  JE-A Dr S50-xx / Cr S11-200x  (COGS
 FINANCE จ่าย SHOP      ShopFinanceReceipt     Dr bank (S11-1201) / Cr S11-3001 + S11-3002
   (new endpoint)
 ```
+
+### 4A. Activation atomicity safety (Blocker-1 resolution)
+
+Because D-1 makes a SHOP-JE failure roll back contract activation (a customer-facing critical op), the SHOP JE posted at activation **must not be able to throw**. Two facts make this safe:
+
+1. **Financing identity holds by construction (D-8).** `ShopInventoryTransfer` asserts `downAmount + financedAmount === salePrice` with strict `Decimal` equality (`shop-inventory-transfer.template.ts:110`). `financedAmount` is stored as `roundBaht(sellingPrice - downPayment)` (`contract-lifecycle.service.ts:107`), so passing the raw `sellingPrice` would throw whenever `sellingPrice - downPayment` is not whole-baht. We therefore pass **`salePrice := downPayment + financedAmount`** — the identity is then true by definition and the assertion can never fire inside the activation `$tx`.
+   - **Consequence:** SHOP financed-sale revenue (`Cr S41-revenue`) = `downPayment + financedAmount`. In the normal whole-baht case this equals `sellingPrice`. Any sub-baht difference from `roundBaht` (rare) is simply not booked as SHOP revenue; immaterial for a non-VAT SHOP. **Owner confirm:** acceptable (vs. adding a rounding line to book to exact `sellingPrice`).
+2. **No cash-account dependency at activation.** `ShopInventoryTransfer` posts only COGS + receivables + revenue + down-clearance — **no cash/bank line** — so the fail-closed `Branch.shopCashAccountCode` rule (§5C) does **not** apply at activation. The cash-account dependency exists only at down-payment (creation), cash-sale, and trade-in triggers — none of which are inside the activation `$tx`.
+
+Net: the only inputs to the activation SHOP JE are contract fields + product cost + resolved S-codes (category mapping, never null for a valid category). With D-8, activation cannot be blocked by SHOP-side rounding or missing cash config.
 
 ## 5. `ShopAccountResolver` spec
 
@@ -98,7 +111,7 @@ If `Branch.shopCashAccountCode` is null when a CASH route is needed, the resolve
 | ShopInventoryTransfer | `ContractWorkflowService.activate()` (`contract-workflow.service.ts:494`), in the existing activation `$tx`, immediately after `ContractActivation1ATemplate` | category→codes; cost from product; assert `down + financed === salePrice` | `shop-inventory-transfer:<contractId>` | stamp `batchRef = contractId` to pair with FINANCE |
 | ShopDownPaymentReversal | pre-activation cancel `$tx` (flow to be located) | refund account = original down cash account | `shop-down-payment-reversal:<contractId>` | only if a down JE was posted |
 | ShopFinanceReceipt | **new** `POST /shop/finance-settlements` | bank `S11-1201` | `shop-finance-receipt:<contractId>` | per-contract; batchable in one call |
-| ShopCashSale | `SaleWriterService.createCashSale()` (`sale-writer.service.ts:111`), existing `$tx` (replaces TODO at ~:147) | category→codes; cost from product; cash from (branch, method) | `shop-cash-sale:<saleId>` | — |
+| ShopCashSale | `SaleWriterService.createCashSale()` (`sale-writer.service.ts:111`), existing `$tx` (replaces TODO at ~:147) | category→codes per product; cost from each product; cash from (branch, method) | `shop-cash-sale:<saleId>:<productId>` | **one JE per product** (see §6B) |
 | ShopTradeIn | `TradeInLifecycleService.accept()` (`trade-in-lifecycle.service.ts:350`), existing `$tx` | inventory `S11-2002`; cash from (branch, method/transfer) | `shop-trade-in:<tradeInId>` | post on ACCEPTED |
 | ShopExpense | hook when an expense-document with `companyId = SHOP` is POSTED (`expense-document-lifecycle.service.ts`) | expense code from the doc; mode CASH/ACCRUAL from doc; paying bank `S11-1202` for CASH | `shop-expense:<expenseDocId>` | companyId = SHOP only |
 
@@ -109,6 +122,10 @@ If `Branch.shopCashAccountCode` is null when a CASH route is needed, the resolve
 - Roles: `OWNER`, `FINANCE_MANAGER`, `ACCOUNTANT` (same as other SHOP-accounting endpoints; BRANCH_MANAGER excluded per existing W5 policy).
 - For each contract: resolve outstanding `financedAmount + storeCommission`, post `ShopFinanceReceipt` idempotently (`shop-finance-receipt:<contractId>`), audit `SHOP_FINANCE_SETTLED`.
 - No new model (D-6); the posted JE + audit log are the record. "Which contracts are settled" is queryable via `metadata.flow = 'shop-finance-receipt'`.
+- **Pending-settlements list (Minor-4):** the operator UI needs "which activated contracts has FINANCE not yet paid SHOP." Specify a read endpoint `GET /shop/finance-settlements/pending` = contracts that are ACTIVE/activated **minus** those that already have a posted `shop-finance-receipt:<contractId>` JE (left-anti-join on `journal_entries.metadata.flow`). This keeps D-6 (no new model) while giving the UI a concrete worklist. If the anti-join proves too slow at scale, revisit a `shopFinanceSettledAt` timestamp on `Contract` (cheaper than a full model).
+
+### 6B. Cash-sale bundle handling (Major-3)
+`Sale.bundleProductIds[]` (`schema.prisma:2452`) means one cash sale can span several products across mixed categories (e.g. PHONE_NEW + ACCESSORY → S41-1101 **and** S41-1103). `ShopCashSale` takes a single revenue/COGS/inventory triple, so the wiring **iterates the sale's products and posts one `ShopCashSale` JE per product** (key `shop-cash-sale:<saleId>:<productId>`), each resolving its own category codes + cost + the shared cash account. Per-line `revenueAmount` = that product's portion of `sellingPrice` (allocation rule for bundles — equal to each product's listed/line price; define the allocation source during implementation since `Sale` stores one `sellingPrice` for the bundle). **Open:** confirm whether bundle line prices are recoverable per product, else allocate proportionally by cost (flag for implementation).
 
 ## 7. Error handling
 - Templates balance-check (Dr=Cr) **before** any DB write; on failure they throw → the host `$transaction` rolls back (atomic at every trigger, not just activation).
@@ -122,8 +139,11 @@ If `Branch.shopCashAccountCode` is null when a CASH route is needed, the resolve
 - The 7 templates' existing golden specs (`apps/api/src/modules/journal/shop-templates/*.spec.ts`) remain the JE-correctness acceptance net.
 - `finance-settlements` endpoint spec: roles, idempotency (double-call = single JE), batch.
 
-## 9. Prerequisite — X5 (PEAK isolation)
-Before wiring any SHOP JE, add a `companyCode = FINANCE` filter to the PEAK sync/export (deep-audit X5) so newly-posted SHOP (`S`-prefix) JEs do not leak into FINANCE's PEAK export. This is a small, must-land-first guard.
+## 9. Prerequisite — X5 (PEAK isolation) — HARD GATE, must merge before P1
+
+**Verified (scrutiny):** `peak.service.ts:75-88` selects journal entries with `where: { status:'POSTED', entryDate, deletedAt:null, peakSyncedAt:null }` — **no company filter at all**. The moment a SHOP (`S`-prefix) JE is POSTED it would be pulled into FINANCE's PEAK export (where `S`-codes have no PEAK mapping → silently skipped or mis-exported).
+
+Therefore X5 is a **hard gate, not a nicety**: add `company: { companyCode: 'FINANCE' }` (or `companyId = getFinanceCompanyId()`) to that `findMany` where-clause (and to the `/expenses/journal/export-peak` query, same module) **and merge it before any SHOP JE goes live**. Add a regression test asserting a posted `S`-prefix JE is excluded from the PEAK export. No SHOP JE wiring (P1+) may ship until X5 is on `main`.
 
 ## 10. Implementation phasing (writing-plans will detail)
 - **P0:** X5 PEAK filter + `ShopAccountResolver` + `Branch.shopCashAccountCode` (migration + settings UI) + go-live config guard.
@@ -140,6 +160,12 @@ Before wiring any SHOP JE, add a `companyCode = FINANCE` filter to the PEAK sync
 - `/shop/accounting` TB/P&L reflect real posted activity for the wired triggers.
 
 ## 12. Open items for spec review
+
+_Resolved by `/scrutinize` (2026-06-23): Blocker-1 (atomic × strict assertion × `roundBaht`) → D-8 + §4A; Major-2 (PEAK no-company-filter) → §9 hard gate; Major-3 (cash-sale bundles) → §6B; Minor-4 (pending-settlements) → §6A._
+
+Remaining owner/implementation confirms:
+- **Revenue = `downPayment + financedAmount` for financed sales (D-8/§4A)** — confirm the sub-baht `roundBaht` delta vs raw `sellingPrice` is acceptable to leave unbooked (vs adding a rounding line).
+- **Bundle price allocation (§6B)** — confirm per-product line prices are recoverable for a bundled `Sale`; else allocate proportionally by cost.
 - TABLET reusing PHONE_NEW codes (D-5) — confirm vs. adding dedicated tablet S-codes.
 - Fail-closed on missing `Branch.shopCashAccountCode` (§5C) — confirm acceptable that an unconfigured branch blocks cash-route posting (mitigated by go-live guard).
 - `ShopFinanceReceipt` with no tracking model (D-6) — confirm JE+audit is sufficient (no per-settlement entity).

--- a/docs/superpowers/specs/2026-06-23-shop-je-wiring-design.md
+++ b/docs/superpowers/specs/2026-06-23-shop-je-wiring-design.md
@@ -1,0 +1,146 @@
+# SHOP-side Journal-Entry Wiring — Design Spec
+
+**Date:** 2026-06-23
+**Status:** Design (approved decisions; pending spec review + implementation plan)
+**Owner-decision source:** `docs/ceo-review/owner-decisions-pending-2026-06-22.md` (D1) · deep-audit F3 (`docs/ceo-review/deep-audit-2026-06-11-findings.md`) · `.claude/rules/accounting.md` (SHOP JE templates + 3-event flow + WIRING STATUS — DEFERRED)
+
+---
+
+## 1. Problem
+
+7 of 8 SHOP-side JE templates are code-complete + golden-spec-covered but have **zero production callers** (only `ShopExchangeReturnTemplate` is wired, at `contract-exchange.service.ts:396`). Consequently `/shop/accounting` Trial Balance + P&L are near-empty even though SHOP is the actively-selling business; the page currently carries a disclaimer banner (`ShopAccountingPage.tsx`). This spec wires all 7 to their real triggers so SHOP books become real and (eventually) tax/audit-authoritative.
+
+The 7 templates: `ShopCashSale`, `ShopDownPayment`, `ShopDownPaymentReversal`, `ShopInventoryTransfer`, `ShopFinanceReceipt`, `ShopTradeIn`, `ShopExpense`.
+
+## 2. Goals / Non-goals
+
+**Goals**
+- Wire all 7 templates to real production triggers so SHOP TB/P&L reflect actual business.
+- SHOP + FINANCE stay consistent at contract activation (atomic).
+- One source of truth for SHOP account-code resolution (category → revenue/COGS/inventory; branch/method → cash/bank).
+
+**Non-goals (explicitly out of scope)**
+- Multi-entity legal split (P3-SP7 / D3) — still 1 DB partitioned by `companyCode`.
+- SHOP VAT (SHOP not VAT-registered).
+- Historical migration of past SHOP transactions — forward-only.
+- Removing the `/shop/accounting` disclaimer banner — stays until owner declares SHOP reports authoritative (post-rollout decision).
+
+## 3. Approved decisions
+
+| # | Decision | Choice |
+|---|----------|--------|
+| D-1 | Contract activation posts SHOP + FINANCE | **Atomic** — both in one `$transaction`; SHOP-JE failure rolls back activation |
+| D-2 | Scope | **All 7 templates** |
+| D-3 | `ShopFinanceReceipt` trigger | **New action/endpoint** "record FINANCE→SHOP payment" (no existing event) |
+| D-4 | Branch → cash-till mapping | **New field `Branch.shopCashAccountCode`** (+ migration, settings UI), fail-closed |
+| D-5 | `TABLET` category accounts | **Reuse PHONE_NEW codes** (S41-1101 / S50-1101 / S11-2001); dedicated codes deferrable |
+| D-6 | `ShopFinanceReceipt` persistence | **No new model** — the JE (queryable by `metadata.flow`) + audit log is the record |
+| D-7 | Posting style | **Synchronous, inside each trigger's `$transaction`** (not event-driven) |
+
+## 4. Architecture
+
+**Approach chosen:** central resolver + synchronous in-`$tx` posting helpers (vs. inline-everywhere, vs. event-driven which conflicts with D-1 atomic).
+
+**New components**
+- **`ShopAccountResolver`** (`apps/api/src/modules/journal/shop-account-resolver.service.ts`) — single source of truth for SHOP account-code resolution. Pure mapping + small DB reads (product cost, branch till). Mirrors the role of `CompanyResolverService`.
+- **`FinanceToShopSettlement`** flow — `POST /shop/finance-settlements` endpoint + service method that posts `ShopFinanceReceipt` (D-3, D-6).
+- **`Branch.shopCashAccountCode`** column (D-4) + settings UI to set it per branch.
+
+**Reuse / pattern to copy:** `contract-exchange.service.ts:396` (the one wired example): inject template → resolve inputs → `template.execute(input, tx)` inside the host `$transaction` → store back-ref JE id on the source entity → audit log. Every SHOP template is stateless; all data flows via the input DTO; idempotency via `metadata.flow + metadata.idempotencyKey` (DB partial-unique index `journal_entries_idempotency_idx`). Always resolve SHOP companyId via `CompanyResolverService.getShopCompanyId(tx)` (never cache).
+
+**Installment 3-event flow (atomic at activation):**
+```
+สร้างสัญญา (down>0)   ShopDownPayment        Dr cash / Cr S21-2001
+        │
+activate() :494       ShopInventoryTransfer  JE-A Dr S50-xx / Cr S11-200x  (COGS)
+  (one $tx, atomic)                          JE-B Dr S11-3001 + S11-3002 + S21-2001 / Cr S41-revenue + S41-1201
+        │             + ContractActivation1A (FINANCE) in the SAME $tx; shared metadata.batchRef = contractId
+        ▼
+FINANCE จ่าย SHOP      ShopFinanceReceipt     Dr bank (S11-1201) / Cr S11-3001 + S11-3002
+  (new endpoint)
+```
+
+## 5. `ShopAccountResolver` spec
+
+### 5A. Category → revenue / COGS / inventory
+
+| `ProductCategory` | revenue | COGS | inventory |
+|---|---|---|---|
+| PHONE_NEW | S41-1101 | S50-1101 | S11-2001 |
+| PHONE_USED | S41-1102 | S50-1102 | S11-2002 |
+| ACCESSORY | S41-1103 | S50-1103 | S11-2003 |
+| TABLET | S41-1101 | S50-1101 | S11-2001 (per D-5) |
+
+### 5B. Cash / bank routing
+
+CoA: per-branch cash tills `S11-1101` (กลาง) / `S11-1102` (ลาดพร้าว) / `S11-1103` (รามอินทรา); bank `S11-1201` (รับเงิน: ดาวน์/ขายสด) / `S11-1202` (จ่าย: ค่าใช้จ่ายสาขา).
+
+Sale/Contract/TradeIn carry only `branchId` + `paymentMethod` (no per-txn account field), so the resolver derives:
+
+| Money flow | Rule |
+|---|---|
+| Inflow, CASH (cash sale / down) | `Branch.shopCashAccountCode` of that branch (S11-110x) |
+| Inflow, TRANSFER / QR | `S11-1201` (receiving bank) |
+| Outflow, CASH (trade-in payout) | `Branch.shopCashAccountCode` (S11-110x) |
+| Outflow, TRANSFER (trade-in payout) | `S11-1202` (paying bank) |
+| Branch expense (ShopExpense CASH mode) | `S11-1202` (paying bank) |
+
+`S11-1201` / `S11-1202` are constants in the resolver for now (single receiving/paying bank); can be lifted to config later if SHOP adds bank accounts.
+
+### 5C. Fail-closed
+If `Branch.shopCashAccountCode` is null when a CASH route is needed, the resolver **throws** a clear error (rolls back the host `$tx`) — it never silently picks a default. Mitigation: go-live checklist gains a step "every active branch has `shopCashAccountCode` set"; a startup/CI guard can assert this.
+
+## 6. Per-trigger wiring
+
+| Template | Trigger site | Resolver inputs | Idempotency key | Condition |
+|---|---|---|---|---|
+| ShopDownPayment | contract creation `$tx` (flow to be located under `contracts/`) | cash from (branch, method) | `shop-down-payment:<contractId>` | only if `downPayment > 0` |
+| ShopInventoryTransfer | `ContractWorkflowService.activate()` (`contract-workflow.service.ts:494`), in the existing activation `$tx`, immediately after `ContractActivation1ATemplate` | category→codes; cost from product; assert `down + financed === salePrice` | `shop-inventory-transfer:<contractId>` | stamp `batchRef = contractId` to pair with FINANCE |
+| ShopDownPaymentReversal | pre-activation cancel `$tx` (flow to be located) | refund account = original down cash account | `shop-down-payment-reversal:<contractId>` | only if a down JE was posted |
+| ShopFinanceReceipt | **new** `POST /shop/finance-settlements` | bank `S11-1201` | `shop-finance-receipt:<contractId>` | per-contract; batchable in one call |
+| ShopCashSale | `SaleWriterService.createCashSale()` (`sale-writer.service.ts:111`), existing `$tx` (replaces TODO at ~:147) | category→codes; cost from product; cash from (branch, method) | `shop-cash-sale:<saleId>` | — |
+| ShopTradeIn | `TradeInLifecycleService.accept()` (`trade-in-lifecycle.service.ts:350`), existing `$tx` | inventory `S11-2002`; cash from (branch, method/transfer) | `shop-trade-in:<tradeInId>` | post on ACCEPTED |
+| ShopExpense | hook when an expense-document with `companyId = SHOP` is POSTED (`expense-document-lifecycle.service.ts`) | expense code from the doc; mode CASH/ACCRUAL from doc; paying bank `S11-1202` for CASH | `shop-expense:<expenseDocId>` | companyId = SHOP only |
+
+**To-locate during implementation** (not yet pinned in code): the contract-creation down-payment flow and the pre-activation cancel flow. Both will post inside their respective existing `$transaction`.
+
+### 6A. `ShopFinanceReceipt` endpoint
+- `POST /shop/finance-settlements` — body: `{ contractIds: string[], bankAccountCode?: string (default S11-1201), postedAt? }`.
+- Roles: `OWNER`, `FINANCE_MANAGER`, `ACCOUNTANT` (same as other SHOP-accounting endpoints; BRANCH_MANAGER excluded per existing W5 policy).
+- For each contract: resolve outstanding `financedAmount + storeCommission`, post `ShopFinanceReceipt` idempotently (`shop-finance-receipt:<contractId>`), audit `SHOP_FINANCE_SETTLED`.
+- No new model (D-6); the posted JE + audit log are the record. "Which contracts are settled" is queryable via `metadata.flow = 'shop-finance-receipt'`.
+
+## 7. Error handling
+- Templates balance-check (Dr=Cr) **before** any DB write; on failure they throw → the host `$transaction` rolls back (atomic at every trigger, not just activation).
+- **Period lock:** validate the SHOP company's accounting period is open before posting (consistent with FINANCE templates' `validatePeriodOpen`).
+- **Missing config** (`Branch.shopCashAccountCode` null on a CASH route): fail-closed (§5C).
+- **Activation risk:** since SHOP-JE failure now rolls back contract activation (D-1), the SHOP path must be robust — covered by golden specs + the go-live config guard. This is the accepted trade-off vs. SHOP/FINANCE divergence.
+
+## 8. Testing
+- `ShopAccountResolver` unit tests: category→codes (incl. TABLET), branch→till, inflow/outflow/transfer routing, fail-closed on null config.
+- Per-trigger integration specs (jest, mock `PrismaService`, `--runInBand`): assert the correct template is invoked with correctly-resolved inputs inside the trigger's `$tx`; mirror the existing chatbot/expense mock-based style.
+- The 7 templates' existing golden specs (`apps/api/src/modules/journal/shop-templates/*.spec.ts`) remain the JE-correctness acceptance net.
+- `finance-settlements` endpoint spec: roles, idempotency (double-call = single JE), batch.
+
+## 9. Prerequisite — X5 (PEAK isolation)
+Before wiring any SHOP JE, add a `companyCode = FINANCE` filter to the PEAK sync/export (deep-audit X5) so newly-posted SHOP (`S`-prefix) JEs do not leak into FINANCE's PEAK export. This is a small, must-land-first guard.
+
+## 10. Implementation phasing (writing-plans will detail)
+- **P0:** X5 PEAK filter + `ShopAccountResolver` + `Branch.shopCashAccountCode` (migration + settings UI) + go-live config guard.
+- **P1 (installment lifecycle):** ShopDownPayment + ShopInventoryTransfer (atomic at activation) + ShopDownPaymentReversal + ShopFinanceReceipt endpoint.
+- **P2:** ShopCashSale.
+- **P3:** ShopTradeIn.
+- **P4:** ShopExpense.
+
+## 11. Acceptance criteria
+- After P1, an end-to-end installment (create-with-down → activate → record finance settlement) produces a balanced SHOP TB where S11-3001/3002 net to zero once settled, and SHOP P&L shows the sale revenue + COGS.
+- `prisma migrate deploy` on a fresh DB succeeds with the new `Branch.shopCashAccountCode` column.
+- No SHOP (`S`-prefix) lines appear in the PEAK export (X5).
+- All new + existing journal/shop specs green; `tsc` 0.
+- `/shop/accounting` TB/P&L reflect real posted activity for the wired triggers.
+
+## 12. Open items for spec review
+- TABLET reusing PHONE_NEW codes (D-5) — confirm vs. adding dedicated tablet S-codes.
+- Fail-closed on missing `Branch.shopCashAccountCode` (§5C) — confirm acceptable that an unconfigured branch blocks cash-route posting (mitigated by go-live guard).
+- `ShopFinanceReceipt` with no tracking model (D-6) — confirm JE+audit is sufficient (no per-settlement entity).
+- **In-flight contracts at P1 rollout (down/transfer coupling):** a contract *created before* P1 (no `ShopDownPayment` JE) but *activated after* P1 would make `ShopInventoryTransfer` Dr S21-2001 to clear a down-payable that was never credited → negative liability. The implementation plan must pick a rollout strategy: (a) the activation wiring checks whether a `shop-down-payment:<contractId>` JE exists and, if absent for a down>0 contract, posts a catch-up down JE first (or omits the S21-2001 clearance line); or (b) a cutover date after which only post-P1 contracts get SHOP JEs. Recommend (a) so books stay complete. Same consideration for `ShopDownPaymentReversal` on pre-P1 contracts.

--- a/docs/superpowers/specs/2026-06-23-shop-je-wiring-design.md
+++ b/docs/superpowers/specs/2026-06-23-shop-je-wiring-design.md
@@ -163,10 +163,10 @@ Therefore X5 is a **hard gate, not a nicety**: add `company: { companyCode: 'FIN
 
 _Resolved by `/scrutinize` (2026-06-23): Blocker-1 (atomic × strict assertion × `roundBaht`) → D-8 + §4A; Major-2 (PEAK no-company-filter) → §9 hard gate; Major-3 (cash-sale bundles) → §6B; Minor-4 (pending-settlements) → §6A._
 
-Remaining owner/implementation confirms:
-- **Revenue = `downPayment + financedAmount` for financed sales (D-8/§4A)** — confirm the sub-baht `roundBaht` delta vs raw `sellingPrice` is acceptable to leave unbooked (vs adding a rounding line).
-- **Bundle price allocation (§6B)** — confirm per-product line prices are recoverable for a bundled `Sale`; else allocate proportionally by cost.
-- TABLET reusing PHONE_NEW codes (D-5) — confirm vs. adding dedicated tablet S-codes.
+Owner confirms — **ALL ACCEPTED at recommended defaults (2026-06-23):**
+- ✅ **Revenue = `downPayment + financedAmount` for financed sales (D-8/§4A)** — sub-baht `roundBaht` delta vs raw `sellingPrice` left unbooked (no rounding line). Immaterial; SHOP not VAT-registered.
+- ✅ **Bundle allocation (§6B)** — use per-product line price when recoverable, else allocate proportionally by cost (which-source confirmed at implementation).
+- ✅ **TABLET → PHONE_NEW codes (D-5)** — S41-1101 / S50-1101 / S11-2001; dedicated tablet S-codes deferred.
 - Fail-closed on missing `Branch.shopCashAccountCode` (§5C) — confirm acceptable that an unconfigured branch blocks cash-route posting (mitigated by go-live guard).
 - `ShopFinanceReceipt` with no tracking model (D-6) — confirm JE+audit is sufficient (no per-settlement entity).
 - **In-flight contracts at P1 rollout (down/transfer coupling):** a contract *created before* P1 (no `ShopDownPayment` JE) but *activated after* P1 would make `ShopInventoryTransfer` Dr S21-2001 to clear a down-payable that was never credited → negative liability. The implementation plan must pick a rollout strategy: (a) the activation wiring checks whether a `shop-down-payment:<contractId>` JE exists and, if absent for a down>0 contract, posts a catch-up down JE first (or omits the S21-2001 clearance line); or (b) a cutover date after which only post-P1 contracts get SHOP JEs. Recommend (a) so books stay complete. Same consideration for `ShopDownPaymentReversal` on pre-P1 contracts.


### PR DESCRIPTION
## Summary
Wires the SHOP-side accounting journal entries for the **installment lifecycle** (P0+P1 of the SHOP-JE wiring spec) so `/shop/accounting` Trial Balance + P&L reflect real activity. Built task-by-task with TDD via subagent-driven development; every per-task review + a final whole-branch opus review passed.

Spec: `docs/superpowers/specs/2026-06-23-shop-je-wiring-design.md` · Plan: `docs/superpowers/plans/2026-06-23-shop-je-wiring-p0-p1.md`

⚠️ **Merging deploys to production** (GCP + `prisma migrate deploy`, incl. the new `Branch.shopCashAccountCode` column). Prod is throwaway test data pre-go-live, but treat as a real deploy.

## What landed (8 tasks → `Closes #1270 #1271 #1272 #1273 #1274 #1275 #1276 #1277`)
- **X5 (hard gate):** both PEAK exports (`PeakService.exportJournalEntries` + `PeakExportService.exportJournalWithPeakCodes`) are now FINANCE-company-scoped, so SHOP `S`-prefix JEs never leak into FINANCE's PEAK export.
- **`Branch.shopCashAccountCode`** nullable column + migration `20260974000000_add_shop_cash_account_code_to_branch`.
- **`ShopAccountResolver`** — single source of truth: `ProductCategory → S-codes` (TABLET reuses PHONE_NEW, D-5) + `branchId → cash till` (**fail-closed**) + `SHOP_RECEIVING_BANK` constant.
- **`ShopInventoryTransfer`** posted **atomically** at contract activation (standard branch), with `salePrice = downPayment + financedAmount` (D-8) so the financing-identity assertion holds by construction; includes an in-flight catch-up for pre-feature contracts.
- **`ShopDownPayment`** at contract creation (guarded `downPayment > 0`).
- **`ShopDownPaymentReversal`** at pre-activation void (`softDelete()` refactored array→callback `$transaction`, all 6 original ops preserved).
- **finance-settlement module:** `POST /shop/finance-settlements` + `GET /shop/finance-settlements/pending` wiring `ShopFinanceReceipt`.

The down-payable (`S21-2001`) lifecycle nets to zero on both the activate and void paths; idempotency keys are consistent across the down→transfer→reversal→receipt chain; all SHOP posts use the host `tx` (atomic).

## Test plan
- `apps/api` `tsc --noEmit`: **exit 0**.
- Touched-module jest suites (`--runInBand`): **20 suites / 265 tests pass** (peak, journal/shop-account-resolver, accounting/peak-export, contracts incl. full 240, shop-finance-settlement).
- CI `Lint & Test` runs the full suite on this PR.

## Review status
- Per-task reviews: all clean (money-path tasks got opus adversarial reviews). One fail-open guard caught + fixed at T6; one DI fan-out caught + fixed; one holistic MUST-FIX caught at the final review (`settle()` lacked a contract-status guard → could clear receivables that don't exist) — **fixed** (`status: { in: ACTIVATED_STATUSES }` + test).

## Deferred follow-ups (NOT blocking; logged)
- ⚠️ **OWNER decision:** `listPending` omits `TERMINATED/EXCHANGED/DEFECT_EXCHANGED/CLOSED_BAD_DEBT` — these carry activation receivables (`S11-3001/3002`); confirm they're settled by another path or widen the set.
- Period-lock on the settlement endpoint; `costPrice = 0` go-live data check; commission-null/bank-override + peak-export guard tests; stale `softDelete` JSDoc; doc: settlement key is `finance-receipt-<id>` (align spec text).
- **Go-live:** set `Branch.shopCashAccountCode` on every active branch before SHOP cash JEs post (fail-closed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
