### PR TITLE
feat(shop): P2 — post ShopCashSale per product at cash sale (bundle-aware)

### DIFF
--- a/apps/api/src/modules/journal/shop-account-resolver.service.spec.ts
+++ b/apps/api/src/modules/journal/shop-account-resolver.service.spec.ts
@@ -46,4 +46,10 @@ describe('ShopAccountResolver', () => {
     await expect(resolver.resolveInflowCashAccount('br-1', 'QR_EWALLET')).resolves.toBe('S11-1201');
     expect(prisma.branch.findUnique).not.toHaveBeenCalled();
   });
+
+  it('resolveInflowCashAccount: non-CASH methods (CREDIT_BALANCE, ONLINE_GATEWAY) → S11-1201', async () => {
+    await expect(resolver.resolveInflowCashAccount('br-1', 'CREDIT_BALANCE')).resolves.toBe('S11-1201');
+    await expect(resolver.resolveInflowCashAccount('br-1', 'ONLINE_GATEWAY')).resolves.toBe('S11-1201');
+    expect(prisma.branch.findUnique).not.toHaveBeenCalled();
+  });
 });

--- a/apps/api/src/modules/journal/shop-account-resolver.service.spec.ts
+++ b/apps/api/src/modules/journal/shop-account-resolver.service.spec.ts
@@ -35,4 +35,15 @@ describe('ShopAccountResolver', () => {
     prisma.branch.findUnique.mockResolvedValue({ shopCashAccountCode: null });
     await expect(resolver.resolveBranchCashAccount('br-1')).rejects.toThrow(BadRequestException);
   });
+
+  it('resolveInflowCashAccount: CASH → the branch till', async () => {
+    prisma.branch.findUnique.mockResolvedValue({ shopCashAccountCode: 'S11-1102' });
+    await expect(resolver.resolveInflowCashAccount('br-1', 'CASH')).resolves.toBe('S11-1102');
+  });
+
+  it('resolveInflowCashAccount: non-CASH (transfer/QR) → the receiving bank S11-1201', async () => {
+    await expect(resolver.resolveInflowCashAccount('br-1', 'BANK_TRANSFER')).resolves.toBe('S11-1201');
+    await expect(resolver.resolveInflowCashAccount('br-1', 'QR_EWALLET')).resolves.toBe('S11-1201');
+    expect(prisma.branch.findUnique).not.toHaveBeenCalled();
+  });
 });

--- a/apps/api/src/modules/journal/shop-account-resolver.service.ts
+++ b/apps/api/src/modules/journal/shop-account-resolver.service.ts
@@ -1,5 +1,5 @@
 import { BadRequestException, Injectable } from '@nestjs/common';
-import { Prisma, ProductCategory } from '@prisma/client';
+import { Prisma, ProductCategory, PaymentMethod } from '@prisma/client';
 import { PrismaService } from '../../prisma/prisma.service';
 
 export interface ShopProductAccounts {
@@ -49,5 +49,21 @@ export class ShopAccountResolver {
       );
     }
     return branch.shopCashAccountCode;
+  }
+
+  /**
+   * Resolve the SHOP cash/bank account that RECEIVES an inflow (cash sale, down
+   * payment). CASH → the branch's physical till (fail-closed); any electronic method
+   * (transfer/QR/etc.) → the single SHOP receiving bank S11-1201 (spec §5B).
+   */
+  async resolveInflowCashAccount(
+    branchId: string,
+    paymentMethod: PaymentMethod | null | undefined,
+    tx?: Prisma.TransactionClient,
+  ): Promise<string> {
+    if (paymentMethod === 'CASH') {
+      return this.resolveBranchCashAccount(branchId, tx);
+    }
+    return ShopAccountResolver.SHOP_RECEIVING_BANK;
   }
 }

--- a/apps/api/src/modules/sales/sales.module.ts
+++ b/apps/api/src/modules/sales/sales.module.ts
@@ -2,9 +2,10 @@ import { Module } from '@nestjs/common';
 import { SalesController } from './sales.controller';
 import { SalesService } from './sales.service';
 import { InterCompanyModule } from '../inter-company/inter-company.module';
+import { JournalModule } from '../journal/journal.module';
 
 @Module({
-  imports: [InterCompanyModule],
+  imports: [InterCompanyModule, JournalModule],
   controllers: [SalesController],
   providers: [SalesService],
   exports: [SalesService],

--- a/apps/api/src/modules/sales/sales.service.spec.ts
+++ b/apps/api/src/modules/sales/sales.service.spec.ts
@@ -4,6 +4,8 @@ import { Prisma } from '@prisma/client';
 import { SalesService } from './sales.service';
 import { PrismaService } from '../../prisma/prisma.service';
 import { InterCompanyService } from '../inter-company/inter-company.service';
+import { ShopCashSaleTemplate } from '../journal/cpa-templates/shop-cash-sale.template';
+import { ShopAccountResolver } from '../journal/shop-account-resolver.service';
 
 /**
  * SalesService unit tests.
@@ -214,6 +216,14 @@ describe('SalesService', () => {
         SalesService,
         { provide: PrismaService, useValue: prisma },
         { provide: InterCompanyService, useValue: interCompanyService },
+        {
+          provide: ShopCashSaleTemplate,
+          useValue: { execute: jest.fn().mockResolvedValue({ entryNo: 'JE-1', journalEntryId: 'je-1' }) },
+        },
+        {
+          provide: ShopAccountResolver,
+          useValue: { resolveInflowCashAccount: jest.fn().mockResolvedValue('S11-1102'), resolveProductAccounts: jest.fn().mockReturnValue({ inventoryAccountCode: 'S11-2001', cogsAccountCode: 'S50-1101', revenueAccountCode: 'S41-1101' }) },
+        },
       ],
     }).compile();
 
@@ -371,6 +381,7 @@ describe('SalesService', () => {
             product: {
               ...prisma.product,
               findUnique: jest.fn().mockResolvedValue(mockProduct),
+              findMany: jest.fn().mockResolvedValue([{ id: 'product-1', category: 'PHONE_NEW', costPrice: mockProduct.costPrice }]),
               update: jest.fn().mockImplementation((args: { data: { status: string } }) => {
                 if (args.data.status === 'SOLD_CASH') updateCalled = true;
                 return Promise.resolve({ ...mockProduct, status: 'SOLD_CASH' });
@@ -396,6 +407,7 @@ describe('SalesService', () => {
             ...prisma,
             product: {
               findUnique: jest.fn().mockResolvedValue(mockProduct),
+              findMany: jest.fn().mockResolvedValue([{ id: 'product-1', category: 'PHONE_NEW', costPrice: mockProduct.costPrice }]),
               update: jest.fn().mockResolvedValue({ ...mockProduct, status: 'SOLD_CASH' }),
             },
             sale: { create: jest.fn().mockResolvedValue(mockSale) },
@@ -426,6 +438,7 @@ describe('SalesService', () => {
             ...prisma,
             product: {
               findUnique: jest.fn().mockResolvedValue(mockProduct),
+              findMany: jest.fn().mockResolvedValue([{ id: 'product-1', category: 'PHONE_NEW', costPrice: mockProduct.costPrice }]),
               update: jest.fn().mockResolvedValue({ ...mockProduct, status: 'SOLD_CASH' }),
             },
             sale: { create: jest.fn().mockResolvedValue(mockSale) },

--- a/apps/api/src/modules/sales/sales.service.ts
+++ b/apps/api/src/modules/sales/sales.service.ts
@@ -5,15 +5,16 @@ import { InterCompanyService } from '../inter-company/inter-company.service';
 import { SalesQueryService } from './services/sales-query.service';
 import { SaleWriterService } from './services/sale-writer.service';
 import { SaleCreationService } from './services/sale-creation.service';
+import { ShopCashSaleTemplate } from '../journal/cpa-templates/shop-cash-sale.template';
+import { ShopAccountResolver } from '../journal/shop-account-resolver.service';
 
 /**
  * SalesService — facade over the decomposed sales sub-services.
  *
- * The 8-method public surface + constructor `(prisma, interCompanyService)` are
- * preserved byte-identically so the forwardRef token in
- * `online-order-sale.adapter.ts`, the `sales.module.ts` provider wiring, and the
- * existing spec all stay untouched. Sub-services are plain classes constructed
- * INTERNALLY in the constructor body (no DI provider entries needed):
+ * The 8-method public surface is preserved. Sub-services are constructed
+ * INTERNALLY in the constructor body. SaleWriterService now requires
+ * ShopCashSaleTemplate + ShopAccountResolver (injected via NestJS DI from
+ * JournalModule which is imported in SalesModule).
  *
  *  - SalesQueryService   — read-side queries + role-dependent response shaping
  *  - SaleWriterService   — the 3 per-type $transaction writers (cash/external =
@@ -31,9 +32,16 @@ export class SalesService {
   constructor(
     private prisma: PrismaService,
     private interCompanyService: InterCompanyService,
+    private shopCashSaleTemplate: ShopCashSaleTemplate,
+    private shopAccountResolver: ShopAccountResolver,
   ) {
     this.query = new SalesQueryService(this.prisma);
-    this.writer = new SaleWriterService(this.prisma, this.interCompanyService);
+    this.writer = new SaleWriterService(
+      this.prisma,
+      this.interCompanyService,
+      this.shopCashSaleTemplate,
+      this.shopAccountResolver,
+    );
     this.creation = new SaleCreationService(this.prisma, this.writer, this.interCompanyService);
   }
 

--- a/apps/api/src/modules/sales/services/sale-writer.service.spec.ts
+++ b/apps/api/src/modules/sales/services/sale-writer.service.spec.ts
@@ -254,4 +254,52 @@ describe('SaleWriterService — createCashSale JE wiring', () => {
       tx,
     );
   });
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // (d) Zero-cost product in bundle → skipped by wiring (continue on !alloc.revenue.gt(0))
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  it('(d) 2-product bundle with second product costPrice=0 → skips zero-cost product, 1 JE posted', async () => {
+    // markBundleProductsSold calls findMany({where:{id:{in:['p2']},deletedAt:null},...}) — return 1 item
+    // JE allocation block calls findMany({where:{id:{in:['p1','p2']}},...}) — return both with full data
+    tx.product.findMany
+      .mockResolvedValueOnce([
+        { id: 'p2', status: 'IN_STOCK', name: 'Case' },
+      ])
+      .mockResolvedValueOnce([
+        { id: 'p1', category: 'PHONE_NEW', costPrice: new Decimal(7000), status: 'IN_STOCK', name: 'Phone' },
+        { id: 'p2', category: 'ACCESSORY', costPrice: new Decimal(0), status: 'IN_STOCK', name: 'Case' },
+      ]);
+
+    shopAccountResolver.resolveProductAccounts.mockImplementation(
+      (category: string) => {
+        if (category === 'PHONE_NEW') {
+          return { inventoryAccountCode: 'S11-2001', cogsAccountCode: 'S50-1101', revenueAccountCode: 'S41-1101' };
+        }
+        // ACCESSORY
+        return { inventoryAccountCode: 'S11-2003', cogsAccountCode: 'S50-1103', revenueAccountCode: 'S41-1103' };
+      },
+    );
+
+    await service.createCashSale(
+      {
+        productId: 'p1',
+        branchId: 'br-1',
+        customerId: 'c1',
+        sellingPrice: 10000,
+        bundleProductIds: ['p2'],
+        paymentMethod: 'CASH',
+      } as any,
+      'sp-1',
+      10000,
+      0,
+    );
+
+    // Main product only (p2 skipped because allocation.revenue = 0)
+    expect(shopCashSaleTemplate.execute).toHaveBeenCalledTimes(1);
+
+    const [input] = shopCashSaleTemplate.execute.mock.calls[0];
+    expect(input.idempotencyKey).toBe('shop-cash-sale:sale-1:p1');
+    expect(input.revenueAmount.toString()).toBe('10000');
+  });
 });

--- a/apps/api/src/modules/sales/services/sale-writer.service.spec.ts
+++ b/apps/api/src/modules/sales/services/sale-writer.service.spec.ts
@@ -1,0 +1,257 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException } from '@nestjs/common';
+import { Decimal } from '@prisma/client/runtime/library';
+import { SaleWriterService } from './sale-writer.service';
+import { PrismaService } from '../../../prisma/prisma.service';
+import { InterCompanyService } from '../../inter-company/inter-company.service';
+import { ShopCashSaleTemplate } from '../../journal/cpa-templates/shop-cash-sale.template';
+import { ShopAccountResolver } from '../../journal/shop-account-resolver.service';
+
+// ─── module-level mocks ───────────────────────────────────────────────────────
+
+jest.mock('../../../utils/sequence.util', () => ({
+  generateSaleNumber: jest.fn().mockResolvedValue('SL000001'),
+  generateContractNumber: jest.fn().mockResolvedValue('BC-2026-TEST-001'),
+}));
+
+jest.mock('../../../utils/commission.util', () => ({
+  computeCommissionAmount: jest.fn().mockReturnValue(250),
+}));
+
+// ─── test suite ──────────────────────────────────────────────────────────────
+
+describe('SaleWriterService — createCashSale JE wiring', () => {
+  let service: SaleWriterService;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let tx: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let shopCashSaleTemplate: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let shopAccountResolver: any;
+
+  const mockSale = { id: 'sale-1', saleNumber: 'SL000001' };
+
+  const mockCommissionRule = {
+    id: 'cr-1',
+    isActive: true,
+    deletedAt: null,
+    rate: new Decimal(0.025),
+    createdAt: new Date(),
+  };
+
+  beforeEach(async () => {
+    // ── per-test tx mock (mimics what $transaction exposes inside callback) ──
+    tx = {
+      sale: {
+        create: jest.fn().mockResolvedValue(mockSale),
+      },
+      product: {
+        findUnique: jest.fn().mockResolvedValue({
+          id: 'p1',
+          status: 'IN_STOCK',
+          deletedAt: null,
+          wasPreviouslyDamaged: false,
+        }),
+        findMany: jest.fn().mockResolvedValue([]),
+        update: jest.fn().mockResolvedValue({}),
+        updateMany: jest.fn().mockResolvedValue({ count: 0 }),
+      },
+      commissionRule: {
+        findFirst: jest.fn().mockResolvedValue(mockCommissionRule),
+      },
+      salesCommission: {
+        create: jest.fn().mockResolvedValue({}),
+      },
+    };
+
+    prisma = {
+      $transaction: jest.fn().mockImplementation(async (cb: (tx: unknown) => Promise<unknown>) =>
+        cb(tx),
+      ),
+    };
+
+    shopCashSaleTemplate = {
+      execute: jest.fn().mockResolvedValue({ entryNo: 'JE-1', journalEntryId: 'je-1' }),
+    };
+
+    shopAccountResolver = {
+      resolveInflowCashAccount: jest.fn().mockResolvedValue('S11-1102'),
+      resolveProductAccounts: jest.fn().mockReturnValue({
+        inventoryAccountCode: 'S11-2001',
+        cogsAccountCode: 'S50-1101',
+        revenueAccountCode: 'S41-1101',
+      }),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SaleWriterService,
+        { provide: PrismaService, useValue: prisma },
+        { provide: InterCompanyService, useValue: { createFromSaleInTx: jest.fn() } },
+        { provide: ShopCashSaleTemplate, useValue: shopCashSaleTemplate },
+        { provide: ShopAccountResolver, useValue: shopAccountResolver },
+      ],
+    }).compile();
+
+    service = module.get<SaleWriterService>(SaleWriterService);
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // (a) single CASH product → 1 JE
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  it('(a) single CASH product → posts one ShopCashSale JE with correct key, codes, revenue, cost, and tx', async () => {
+    tx.product.findMany.mockResolvedValue([
+      { id: 'p1', category: 'PHONE_NEW', costPrice: new Decimal(7000) },
+    ]);
+    shopAccountResolver.resolveInflowCashAccount.mockResolvedValue('S11-1102');
+    shopAccountResolver.resolveProductAccounts.mockReturnValue({
+      inventoryAccountCode: 'S11-2001',
+      cogsAccountCode: 'S50-1101',
+      revenueAccountCode: 'S41-1101',
+    });
+
+    await service.createCashSale(
+      {
+        productId: 'p1',
+        branchId: 'br-1',
+        customerId: 'c1',
+        sellingPrice: 10000,
+        bundleProductIds: [],
+        paymentMethod: 'CASH',
+      } as any,
+      'sp-1',
+      10000,
+      0,
+    );
+
+    expect(shopCashSaleTemplate.execute).toHaveBeenCalledTimes(1);
+
+    const [input, passedTx] = shopCashSaleTemplate.execute.mock.calls[0];
+    expect(input).toMatchObject({
+      idempotencyKey: 'shop-cash-sale:sale-1:p1',
+      saleId: 'sale-1',
+      cashAccountCode: 'S11-1102',
+      revenueAccountCode: 'S41-1101',
+      cogsAccountCode: 'S50-1101',
+      inventoryAccountCode: 'S11-2001',
+    });
+    expect(input.revenueAmount.toString()).toBe('10000');
+    expect(input.inventoryCost.toString()).toBe('7000');
+    // tx must be passed (atomicity)
+    expect(passedTx).toBeDefined();
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // (b) 2-product bundle → 2 JEs, per-product keys, revenues sum to net
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  it('(b) 2-product bundle (PHONE_NEW + ACCESSORY) → 2 JEs, per-product keys, revenues sum to net', async () => {
+    // markBundleProductsSold calls findMany({where:{id:{in:['p2']},deletedAt:null},...}) — return 1 item
+    // JE allocation block calls findMany({where:{id:{in:['p1','p2']}},...}) — return both with full data
+    tx.product.findMany
+      .mockResolvedValueOnce([
+        { id: 'p2', status: 'IN_STOCK', name: 'Case' },
+      ])
+      .mockResolvedValueOnce([
+        { id: 'p1', category: 'PHONE_NEW', costPrice: new Decimal(6000), status: 'IN_STOCK', name: 'Phone' },
+        { id: 'p2', category: 'ACCESSORY', costPrice: new Decimal(400), status: 'IN_STOCK', name: 'Case' },
+      ]);
+
+    // resolveProductAccounts returns different codes based on category
+    shopAccountResolver.resolveProductAccounts.mockImplementation(
+      (category: string) => {
+        if (category === 'PHONE_NEW') {
+          return { inventoryAccountCode: 'S11-2001', cogsAccountCode: 'S50-1101', revenueAccountCode: 'S41-1101' };
+        }
+        // ACCESSORY
+        return { inventoryAccountCode: 'S11-2003', cogsAccountCode: 'S50-1103', revenueAccountCode: 'S41-1103' };
+      },
+    );
+
+    await service.createCashSale(
+      {
+        productId: 'p1',
+        branchId: 'br-1',
+        customerId: 'c1',
+        sellingPrice: 1000,
+        bundleProductIds: ['p2'],
+        paymentMethod: 'CASH',
+      } as any,
+      'sp-1',
+      1000,
+      0,
+    );
+
+    expect(shopCashSaleTemplate.execute).toHaveBeenCalledTimes(2);
+
+    const calls = shopCashSaleTemplate.execute.mock.calls;
+
+    // First call = p1 (main product, preserving order)
+    const [input1] = calls[0];
+    expect(input1.idempotencyKey).toBe('shop-cash-sale:sale-1:p1');
+    expect(input1.revenueAccountCode).toBe('S41-1101');
+    expect(input1.cogsAccountCode).toBe('S50-1101');
+    expect(input1.inventoryAccountCode).toBe('S11-2001');
+
+    // Second call = p2 (bundle product)
+    const [input2] = calls[1];
+    expect(input2.idempotencyKey).toBe('shop-cash-sale:sale-1:p2');
+    expect(input2.revenueAccountCode).toBe('S41-1103');
+    expect(input2.cogsAccountCode).toBe('S50-1103');
+    expect(input2.inventoryAccountCode).toBe('S11-2003');
+
+    // Revenues sum to net (1000)
+    const rev1 = new Decimal(input1.revenueAmount.toString());
+    const rev2 = new Decimal(input2.revenueAmount.toString());
+    expect(rev1.plus(rev2).toNumber()).toBe(1000);
+
+    // Both allocations have > 0 revenue (totalCost = 6400, both cost > 0)
+    expect(rev1.gt(0)).toBe(true);
+    expect(rev2.gt(0)).toBe(true);
+
+    // p1 cost allocation: 6000/6400 × 1000 = 937.50
+    expect(input1.inventoryCost.toString()).toBe('6000');
+    // p2 cost allocation: 400
+    expect(input2.inventoryCost.toString()).toBe('400');
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // (c) BANK_TRANSFER → cash account = S11-1201
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  it('(c) BANK_TRANSFER payment → cashAccountCode = S11-1201', async () => {
+    tx.product.findMany.mockResolvedValue([
+      { id: 'p1', category: 'PHONE_NEW', costPrice: new Decimal(5000) },
+    ]);
+    // resolveInflowCashAccount returns SHOP_RECEIVING_BANK for non-CASH methods
+    shopAccountResolver.resolveInflowCashAccount.mockResolvedValue('S11-1201');
+
+    await service.createCashSale(
+      {
+        productId: 'p1',
+        branchId: 'br-1',
+        customerId: 'c1',
+        sellingPrice: 8000,
+        bundleProductIds: [],
+        paymentMethod: 'BANK_TRANSFER',
+      } as any,
+      'sp-1',
+      8000,
+      0,
+    );
+
+    expect(shopCashSaleTemplate.execute).toHaveBeenCalledTimes(1);
+    const [input] = shopCashSaleTemplate.execute.mock.calls[0];
+    expect(input.cashAccountCode).toBe('S11-1201');
+
+    // Confirm that resolveInflowCashAccount was called with branchId + BANK_TRANSFER
+    expect(shopAccountResolver.resolveInflowCashAccount).toHaveBeenCalledWith(
+      'br-1',
+      'BANK_TRANSFER',
+      tx,
+    );
+  });
+});

--- a/apps/api/src/modules/sales/services/sale-writer.service.ts
+++ b/apps/api/src/modules/sales/services/sale-writer.service.ts
@@ -1,5 +1,6 @@
-import { BadRequestException, ForbiddenException } from '@nestjs/common';
+import { BadRequestException, ForbiddenException, Injectable } from '@nestjs/common';
 import { PaymentMethod, PlanType, Prisma } from '@prisma/client';
+import { Decimal } from '@prisma/client/runtime/library';
 import { PrismaService } from '../../../prisma/prisma.service';
 import { CreateSaleDto } from '../dto/sale.dto';
 import {
@@ -12,6 +13,9 @@ import { getRateForMonths } from '../../../utils/get-rate-for-months.util';
 import { loadInstallmentConfig, resolveInstallmentParams, resolveVatPctForBranch } from '../../../utils/config.util';
 import { generateContractNumber, generateSaleNumber } from '../../../utils/sequence.util';
 import { InterCompanyService } from '../../inter-company/inter-company.service';
+import { ShopCashSaleTemplate } from '../../journal/cpa-templates/shop-cash-sale.template';
+import { ShopAccountResolver } from '../../journal/shop-account-resolver.service';
+import { allocateCashSaleByCost } from '../shop-cash-sale-allocation.util';
 
 /**
  * Per-sale-type transactional writers extracted from SalesService.
@@ -25,10 +29,13 @@ import { InterCompanyService } from '../../inter-company/inter-company.service';
  * Bodies are verbatim from the original SalesService — only `this.<dep>`
  * resolution and import paths changed.
  */
+@Injectable()
 export class SaleWriterService {
   constructor(
     private prisma: PrismaService,
     private interCompanyService: InterCompanyService,
+    private shopCashSaleTemplate: ShopCashSaleTemplate,
+    private shopAccountResolver: ShopAccountResolver,
   ) {}
 
   private async resolveExternalFinanceCompanyId(
@@ -141,10 +148,43 @@ export class SaleWriterService {
         data: { status: 'SOLD_CASH' },
       });
 
-      // W-007: COGS tracked via sale.product.costPrice relationship.
-      // P&L report (AccountingService.getProfitLossReport) captures product cost
-      // by joining Sale → Product.costPrice, including bundle products.
-      // TODO: Implement perpetual inventory journal for real-time COGS ledger entries.
+      // SHOP-side: post one cash-sale JE per product (bundle-aware). Sale has no
+      // per-product price, so revenue is allocated proportionally by product cost.
+      const productIds = [dto.productId, ...(dto.bundleProductIds || [])];
+      const prods = await tx.product.findMany({
+        where: { id: { in: productIds } },
+        select: { id: true, category: true, costPrice: true },
+      });
+      const ordered = productIds
+        .map((id) => prods.find((p) => p.id === id))
+        .filter((p): p is (typeof prods)[number] => !!p);
+      const cashAccountCode = await this.shopAccountResolver.resolveInflowCashAccount(
+        dto.branchId,
+        dto.paymentMethod as PaymentMethod,
+        tx,
+      );
+      const allocations = allocateCashSaleByCost(
+        new Decimal(netAmount.toString()),
+        ordered.map((p) => ({ id: p.id, costPrice: new Decimal(p.costPrice.toString()) })),
+      );
+      for (const alloc of allocations) {
+        if (!alloc.revenue.gt(0)) continue; // template requires revenueAmount > 0
+        const prod = ordered.find((p) => p.id === alloc.productId)!;
+        const acc = this.shopAccountResolver.resolveProductAccounts(prod.category);
+        await this.shopCashSaleTemplate.execute(
+          {
+            idempotencyKey: `shop-cash-sale:${sale.id}:${alloc.productId}`,
+            saleId: sale.id,
+            cashAccountCode,
+            revenueAccountCode: acc.revenueAccountCode,
+            revenueAmount: alloc.revenue,
+            cogsAccountCode: acc.cogsAccountCode,
+            inventoryAccountCode: acc.inventoryAccountCode,
+            inventoryCost: alloc.cost,
+          },
+          tx,
+        );
+      }
 
       // Auto-create sales commission (read from CommissionRule, fallback to 3%)
       const now = new Date();

--- a/apps/api/src/modules/sales/shop-cash-sale-allocation.util.spec.ts
+++ b/apps/api/src/modules/sales/shop-cash-sale-allocation.util.spec.ts
@@ -1,0 +1,50 @@
+import { Decimal } from '@prisma/client/runtime/library';
+import { allocateCashSaleByCost } from './shop-cash-sale-allocation.util';
+
+const D = (v: string | number) => new Decimal(v);
+
+describe('allocateCashSaleByCost', () => {
+  it('single product → all revenue, its own cost', () => {
+    const res = allocateCashSaleByCost(D(10000), [{ id: 'p1', costPrice: D(7000) }]);
+    expect(res).toHaveLength(1);
+    expect(res[0].productId).toBe('p1');
+    expect(res[0].revenue.toString()).toBe('10000');
+    expect(res[0].cost.toString()).toBe('7000');
+  });
+
+  it('allocates proportionally by cost; revenues sum EXACTLY to netAmount', () => {
+    const res = allocateCashSaleByCost(D(1000), [
+      { id: 'phone', costPrice: D(600) },
+      { id: 'case', costPrice: D(400) },
+    ]);
+    expect(res.map((r) => r.revenue.toString())).toEqual(['600', '400']);
+    expect(res.map((r) => r.cost.toString())).toEqual(['600', '400']);
+    const sum = res.reduce((s, r) => s.plus(r.revenue), new Decimal(0));
+    expect(sum.toString()).toBe('1000');
+  });
+
+  it('last product absorbs the rounding residual (sum stays exact)', () => {
+    const res = allocateCashSaleByCost(D(1000), [
+      { id: 'a', costPrice: D(1) },
+      { id: 'b', costPrice: D(1) },
+      { id: 'c', costPrice: D(1) },
+    ]);
+    // 1000 * 1/3 = 333.3333 → 333.33 each for a,b; c absorbs residual 333.34
+    expect(res.map((r) => r.revenue.toString())).toEqual(['333.33', '333.33', '333.34']);
+    const sum = res.reduce((s, r) => s.plus(r.revenue), new Decimal(0));
+    expect(sum.toString()).toBe('1000');
+  });
+
+  it('zero total cost (give-away bundle) → all revenue on the main (first) product', () => {
+    const res = allocateCashSaleByCost(D(500), [
+      { id: 'main', costPrice: D(0) },
+      { id: 'free', costPrice: D(0) },
+    ]);
+    expect(res.map((r) => r.revenue.toString())).toEqual(['500', '0']);
+    expect(res.map((r) => r.cost.toString())).toEqual(['0', '0']);
+  });
+
+  it('empty products → empty allocation', () => {
+    expect(allocateCashSaleByCost(D(100), [])).toEqual([]);
+  });
+});

--- a/apps/api/src/modules/sales/shop-cash-sale-allocation.util.ts
+++ b/apps/api/src/modules/sales/shop-cash-sale-allocation.util.ts
@@ -1,0 +1,55 @@
+import { Decimal } from '@prisma/client/runtime/library';
+
+export interface CashSaleProduct {
+  id: string;
+  costPrice: Decimal;
+}
+
+export interface CashSaleAllocation {
+  productId: string;
+  revenue: Decimal;
+  cost: Decimal;
+}
+
+/**
+ * Split a cash sale's net revenue across its products. `Sale` has no per-product
+ * line price, so revenue is allocated proportionally by each product's `costPrice`
+ * (confirmed default — spec §6B). The LAST product absorbs the rounding residual so
+ * the allocated revenue sums EXACTLY to `netAmount`. If total cost is 0 (all
+ * give-aways) all revenue lands on the first (main) product. Each product's `cost`
+ * is its own `costPrice`.
+ */
+export function allocateCashSaleByCost(
+  netAmount: Decimal,
+  products: CashSaleProduct[],
+): CashSaleAllocation[] {
+  if (products.length === 0) return [];
+  const net = new Decimal(netAmount.toString());
+  const totalCost = products.reduce(
+    (s, p) => s.plus(new Decimal(p.costPrice.toString())),
+    new Decimal(0),
+  );
+
+  if (!totalCost.gt(0)) {
+    return products.map((p, i) => ({
+      productId: p.id,
+      revenue: i === 0 ? net : new Decimal(0),
+      cost: new Decimal(0),
+    }));
+  }
+
+  const allocations: CashSaleAllocation[] = [];
+  let allocated = new Decimal(0);
+  products.forEach((p, i) => {
+    const cost = new Decimal(p.costPrice.toString());
+    let revenue: Decimal;
+    if (i === products.length - 1) {
+      revenue = net.sub(allocated); // last absorbs residual → exact sum
+    } else {
+      revenue = net.mul(cost).div(totalCost).toDecimalPlaces(2, Decimal.ROUND_HALF_UP);
+      allocated = allocated.plus(revenue);
+    }
+    allocations.push({ productId: p.id, revenue, cost });
+  });
+  return allocations;
+}

--- a/docs/superpowers/plans/2026-06-23-shop-je-wiring-p2-cashsale.md
+++ b/docs/superpowers/plans/2026-06-23-shop-je-wiring-p2-cashsale.md
@@ -1,0 +1,365 @@
+# SHOP-side JE Wiring — P2 (ShopCashSale) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Post SHOP cash-sale journal entries when a cash `Sale` is recorded, one JE per product (bundle-aware), so `/shop/accounting` reflects cash-sale revenue + COGS.
+
+**Architecture:** At `SaleWriterService.createCashSale()` (replacing the `W-007` TODO), load the sale's products (main + bundle), allocate the net revenue across them **proportionally by `Product.costPrice`** (the `Sale` model has no per-product line price — confirmed default, spec §6B), then post `ShopCashSaleTemplate` per product **inside the existing `$transaction`**, resolving category→S-codes + cash account via the `ShopAccountResolver` built in P1.
+
+**Tech Stack:** NestJS, Prisma (PostgreSQL), TypeScript, jest (`--runInBand`).
+
+**Spec:** `docs/superpowers/specs/2026-06-23-shop-je-wiring-design.md` (§6 ShopCashSale + §6B bundles + §5 resolver).
+
+**Depends on P0+P1** (`ShopAccountResolver`, X5 PEAK isolation) — in **PR #1280**. **Branch P2 off `feat/shop-je-wiring`** so the resolver + X5 are present; rebase onto `main` once #1280 merges. **Do not merge P2 before #1280** (X5 must be on `main` before any SHOP JE reaches prod).
+
+## Global Constraints
+
+- **Atomic:** `ShopCashSaleTemplate.execute(..., tx)` is called with the `createCashSale` `$transaction` `tx` (Serializable) so a JE failure rolls back the whole sale.
+- **One JE per product**, idempotency key `shop-cash-sale:<saleId>:<productId>` (the template self-dedupes on `metadata.flow='shop-cash-sale'` + `idempotencyKey`).
+- **Revenue base = `netAmount`** (after discount); cash + revenue both = the product's allocated share; allocated shares **sum exactly to `netAmount`** (last product absorbs the rounding residual).
+- **Allocation:** proportional by `Product.costPrice`; if total cost = 0 (all give-aways), all revenue → the main (first) product. Each product's `inventoryCost` = its own `costPrice`. Skip a product whose allocated revenue is 0 (the template requires `revenueAmount > 0`; its COGS pair is optional when cost is 0).
+- **Cash routing:** `paymentMethod === 'CASH'` → branch till (`resolveBranchCashAccount`); any other method → `S11-1201` (`SHOP_RECEIVING_BANK`).
+- **Account codes** from `ShopAccountResolver.resolveProductAccounts(product.category)` (PHONE_NEW/TABLET→…2001/1101/1101, PHONE_USED→…2002/1102/1102, ACCESSORY→…2003/1103/1103).
+- **Money:** `Decimal` only (`new Decimal(x.toString())`); never `Number()`. Rounding `toDecimalPlaces(2, Decimal.ROUND_HALF_UP)`.
+- **Test runner:** `npm --prefix apps/api test -- <spec>` (run from repo root; jest `--runInBand`). Output pristine.
+- **DI fan-out:** adding required ctor deps to `SaleWriterService` breaks every TestingModule that constructs it — update ALL and run the whole `src/modules/sales` suite (lesson from P1 Task 6/7).
+
+---
+
+## File Structure
+
+| File | Responsibility | Task |
+|---|---|---|
+| `apps/api/src/modules/sales/shop-cash-sale-allocation.util.ts` (create) | pure `allocateCashSaleByCost(netAmount, products)` → per-product `{revenue,cost}` | 1 |
+| `apps/api/src/modules/sales/shop-cash-sale-allocation.util.spec.ts` (create) | allocation golden tests | 1 |
+| `apps/api/src/modules/journal/shop-account-resolver.service.ts` (modify) | add `resolveInflowCashAccount(branchId, paymentMethod, tx?)` | 2 |
+| `apps/api/src/modules/journal/shop-account-resolver.service.spec.ts` (modify) | routing tests | 2 |
+| `apps/api/src/modules/sales/services/sale-writer.service.ts` (modify ~:111-147) | inject template+resolver; post ShopCashSale per product (replace TODO) | 3 |
+| `apps/api/src/modules/sales/services/sale-writer.service.spec.ts` (create/modify) | wiring integration tests | 3 |
+| `apps/api/src/modules/sales/sales.module.ts` (verify/modify) | ensure `JournalModule` imported (resolver+template injectable) | 3 |
+
+---
+
+## Task 1: `allocateCashSaleByCost` pure util
+
+**Files:**
+- Create: `apps/api/src/modules/sales/shop-cash-sale-allocation.util.ts`
+- Test: `apps/api/src/modules/sales/shop-cash-sale-allocation.util.spec.ts`
+
+**Interfaces:**
+- Produces: `allocateCashSaleByCost(netAmount: Decimal, products: { id: string; costPrice: Decimal }[]): { productId: string; revenue: Decimal; cost: Decimal }[]`
+
+- [ ] **Step 1: Write the failing tests** (`shop-cash-sale-allocation.util.spec.ts`):
+
+```typescript
+import { Decimal } from '@prisma/client/runtime/library';
+import { allocateCashSaleByCost } from './shop-cash-sale-allocation.util';
+
+const D = (v: string | number) => new Decimal(v);
+
+describe('allocateCashSaleByCost', () => {
+  it('single product → all revenue, its own cost', () => {
+    const res = allocateCashSaleByCost(D(10000), [{ id: 'p1', costPrice: D(7000) }]);
+    expect(res).toHaveLength(1);
+    expect(res[0].productId).toBe('p1');
+    expect(res[0].revenue.toString()).toBe('10000');
+    expect(res[0].cost.toString()).toBe('7000');
+  });
+
+  it('allocates proportionally by cost; revenues sum EXACTLY to netAmount', () => {
+    const res = allocateCashSaleByCost(D(1000), [
+      { id: 'phone', costPrice: D(600) },
+      { id: 'case', costPrice: D(400) },
+    ]);
+    expect(res.map((r) => r.revenue.toString())).toEqual(['600', '400']);
+    expect(res.map((r) => r.cost.toString())).toEqual(['600', '400']);
+    const sum = res.reduce((s, r) => s.plus(r.revenue), new Decimal(0));
+    expect(sum.toString()).toBe('1000');
+  });
+
+  it('last product absorbs the rounding residual (sum stays exact)', () => {
+    const res = allocateCashSaleByCost(D(1000), [
+      { id: 'a', costPrice: D(1) },
+      { id: 'b', costPrice: D(1) },
+      { id: 'c', costPrice: D(1) },
+    ]);
+    // 1000 * 1/3 = 333.3333 → 333.33 each for a,b; c absorbs residual 333.34
+    expect(res.map((r) => r.revenue.toString())).toEqual(['333.33', '333.33', '333.34']);
+    const sum = res.reduce((s, r) => s.plus(r.revenue), new Decimal(0));
+    expect(sum.toString()).toBe('1000');
+  });
+
+  it('zero total cost (give-away bundle) → all revenue on the main (first) product', () => {
+    const res = allocateCashSaleByCost(D(500), [
+      { id: 'main', costPrice: D(0) },
+      { id: 'free', costPrice: D(0) },
+    ]);
+    expect(res.map((r) => r.revenue.toString())).toEqual(['500', '0']);
+    expect(res.map((r) => r.cost.toString())).toEqual(['0', '0']);
+  });
+
+  it('empty products → empty allocation', () => {
+    expect(allocateCashSaleByCost(D(100), [])).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run — expect FAIL** (module not found).
+
+Run: `npm --prefix apps/api test -- src/modules/sales/shop-cash-sale-allocation.util.spec.ts`
+Expected: FAIL ("Cannot find module './shop-cash-sale-allocation.util'").
+
+- [ ] **Step 3: Implement** `shop-cash-sale-allocation.util.ts`:
+
+```typescript
+import { Decimal } from '@prisma/client/runtime/library';
+
+export interface CashSaleProduct {
+  id: string;
+  costPrice: Decimal;
+}
+
+export interface CashSaleAllocation {
+  productId: string;
+  revenue: Decimal;
+  cost: Decimal;
+}
+
+/**
+ * Split a cash sale's net revenue across its products. `Sale` has no per-product
+ * line price, so revenue is allocated proportionally by each product's `costPrice`
+ * (confirmed default — spec §6B). The LAST product absorbs the rounding residual so
+ * the allocated revenue sums EXACTLY to `netAmount`. If total cost is 0 (all
+ * give-aways) all revenue lands on the first (main) product. Each product's `cost`
+ * is its own `costPrice`.
+ */
+export function allocateCashSaleByCost(
+  netAmount: Decimal,
+  products: CashSaleProduct[],
+): CashSaleAllocation[] {
+  if (products.length === 0) return [];
+  const net = new Decimal(netAmount.toString());
+  const totalCost = products.reduce(
+    (s, p) => s.plus(new Decimal(p.costPrice.toString())),
+    new Decimal(0),
+  );
+
+  if (!totalCost.gt(0)) {
+    return products.map((p, i) => ({
+      productId: p.id,
+      revenue: i === 0 ? net : new Decimal(0),
+      cost: new Decimal(0),
+    }));
+  }
+
+  const allocations: CashSaleAllocation[] = [];
+  let allocated = new Decimal(0);
+  products.forEach((p, i) => {
+    const cost = new Decimal(p.costPrice.toString());
+    let revenue: Decimal;
+    if (i === products.length - 1) {
+      revenue = net.sub(allocated); // last absorbs residual → exact sum
+    } else {
+      revenue = net.mul(cost).div(totalCost).toDecimalPlaces(2, Decimal.ROUND_HALF_UP);
+      allocated = allocated.plus(revenue);
+    }
+    allocations.push({ productId: p.id, revenue, cost });
+  });
+  return allocations;
+}
+```
+
+- [ ] **Step 4: Run — expect PASS** (5 tests).
+
+Run: `npm --prefix apps/api test -- src/modules/sales/shop-cash-sale-allocation.util.spec.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add apps/api/src/modules/sales/shop-cash-sale-allocation.util.ts apps/api/src/modules/sales/shop-cash-sale-allocation.util.spec.ts
+git commit -m "feat(sales): add allocateCashSaleByCost — split cash-sale revenue by product cost"
+```
+
+---
+
+## Task 2: `ShopAccountResolver.resolveInflowCashAccount`
+
+**Files:**
+- Modify: `apps/api/src/modules/journal/shop-account-resolver.service.ts`
+- Test: `apps/api/src/modules/journal/shop-account-resolver.service.spec.ts`
+
+**Interfaces:**
+- Consumes: existing `resolveBranchCashAccount(branchId, tx?)` + `SHOP_RECEIVING_BANK`.
+- Produces: `resolveInflowCashAccount(branchId: string, paymentMethod: PaymentMethod | null | undefined, tx?: Prisma.TransactionClient): Promise<string>`
+
+- [ ] **Step 1: Add the failing tests** to `shop-account-resolver.service.spec.ts`:
+
+```typescript
+it('resolveInflowCashAccount: CASH → the branch till', async () => {
+  prisma.branch.findUnique.mockResolvedValue({ shopCashAccountCode: 'S11-1102' });
+  await expect(resolver.resolveInflowCashAccount('br-1', 'CASH')).resolves.toBe('S11-1102');
+});
+
+it('resolveInflowCashAccount: non-CASH (transfer/QR) → the receiving bank S11-1201', async () => {
+  await expect(resolver.resolveInflowCashAccount('br-1', 'BANK_TRANSFER')).resolves.toBe('S11-1201');
+  await expect(resolver.resolveInflowCashAccount('br-1', 'QR_EWALLET')).resolves.toBe('S11-1201');
+  expect(prisma.branch.findUnique).not.toHaveBeenCalled();
+});
+```
+
+- [ ] **Step 2: Run — expect FAIL** (method undefined).
+
+Run: `npm --prefix apps/api test -- src/modules/journal/shop-account-resolver.service.spec.ts`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement.** Add `PaymentMethod` to the `@prisma/client` import and this method to `ShopAccountResolver`:
+
+```typescript
+// import { Prisma, ProductCategory, PaymentMethod } from '@prisma/client';
+
+/**
+ * Resolve the SHOP cash/bank account that RECEIVES an inflow (cash sale, down
+ * payment). CASH → the branch's physical till (fail-closed); any electronic method
+ * (transfer/QR/etc.) → the single SHOP receiving bank S11-1201 (spec §5B).
+ */
+async resolveInflowCashAccount(
+  branchId: string,
+  paymentMethod: PaymentMethod | null | undefined,
+  tx?: Prisma.TransactionClient,
+): Promise<string> {
+  if (paymentMethod === 'CASH') {
+    return this.resolveBranchCashAccount(branchId, tx);
+  }
+  return ShopAccountResolver.SHOP_RECEIVING_BANK;
+}
+```
+
+- [ ] **Step 4: Run — expect PASS.**
+
+Run: `npm --prefix apps/api test -- src/modules/journal/shop-account-resolver.service.spec.ts`
+Expected: PASS (existing 4 + 2 new).
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add apps/api/src/modules/journal/shop-account-resolver.service.ts apps/api/src/modules/journal/shop-account-resolver.service.spec.ts
+git commit -m "feat(journal): ShopAccountResolver.resolveInflowCashAccount (CASH→till, else→receiving bank)"
+```
+
+---
+
+## Task 3: Wire `ShopCashSaleTemplate` per-product at `createCashSale`
+
+**Files:**
+- Modify: `apps/api/src/modules/sales/services/sale-writer.service.ts` (ctor + `createCashSale`, replace the `W-007` TODO ~:147)
+- Modify: `apps/api/src/modules/sales/sales.module.ts` (ensure `JournalModule` imported)
+- Test: `apps/api/src/modules/sales/services/sale-writer.service.spec.ts`
+
+**Interfaces:**
+- Consumes: `ShopCashSaleTemplate.execute(input, outerTx?)` where `input = { idempotencyKey, saleId, cashAccountCode, revenueAccountCode, revenueAmount: Decimal, cogsAccountCode, inventoryAccountCode, inventoryCost: Decimal, postedAt? }`; `allocateCashSaleByCost` (Task 1); `ShopAccountResolver.resolveInflowCashAccount` (Task 2) + `resolveProductAccounts`.
+
+- [ ] **Step 1: Write the failing tests** (`sale-writer.service.spec.ts`; mirror `contract-exchange.service.spec.ts` provider/mock-prisma setup; `$transaction = jest.fn(async (cb) => cb(tx))`). Cover: (a) single CASH product → one ShopCashSale JE with the product's category codes, key `shop-cash-sale:<saleId>:<productId>`, revenueAmount=netAmount, inventoryCost=costPrice, cashAccountCode=branch till; (b) bundle of 2 products (PHONE_NEW + ACCESSORY) → TWO JEs with per-product keys + cost-allocated revenue; (c) BANK_TRANSFER → cashAccountCode = `S11-1201`. Example assertion for (a):
+
+```typescript
+it('posts one ShopCashSale JE for a single CASH-paid product', async () => {
+  tx.product.findMany.mockResolvedValue([{ id: 'p1', category: 'PHONE_NEW', costPrice: new Decimal(7000) }]);
+  shopAccountResolver.resolveInflowCashAccount.mockResolvedValue('S11-1102');
+  shopAccountResolver.resolveProductAccounts.mockReturnValue({ inventoryAccountCode: 'S11-2001', cogsAccountCode: 'S50-1101', revenueAccountCode: 'S41-1101' });
+  await service.createCashSale({ productId: 'p1', branchId: 'br-1', customerId: 'c1', sellingPrice: 10000, bundleProductIds: [], paymentMethod: 'CASH' } as any, 'sp-1', 10000, 0);
+  expect(shopCashSaleTemplate.execute).toHaveBeenCalledTimes(1);
+  const input = shopCashSaleTemplate.execute.mock.calls[0][0];
+  expect(input).toMatchObject({ idempotencyKey: 'shop-cash-sale:sale-1:p1', saleId: 'sale-1', cashAccountCode: 'S11-1102', revenueAccountCode: 'S41-1101', cogsAccountCode: 'S50-1101', inventoryAccountCode: 'S11-2001' });
+  expect(input.revenueAmount.toString()).toBe('10000');
+  expect(input.inventoryCost.toString()).toBe('7000');
+  expect(shopCashSaleTemplate.execute.mock.calls[0][1]).toBeDefined(); // tx passed
+});
+```
+
+> Make `tx.sale.create` resolve `{ id: 'sale-1', ... }`, and stub `tx.product.update/updateMany`, `tx.commissionRule.findFirst`, `tx.salesCommission.create`, `verifyProductInStock`, `markBundleProductsSold`, `generateSaleNumber`. For (b) set `bundleProductIds:['p2']`, `tx.product.findMany` → `[{id:'p1',category:'PHONE_NEW',costPrice:D(6000)},{id:'p2',category:'ACCESSORY',costPrice:D(400)}]`, net 1000, and assert two execute calls with keys `...:p1`/`...:p2` and revenues `600`/`400` (resolveProductAccounts returns per-category — use `mockImplementation` keyed on the category arg).
+
+- [ ] **Step 2: Run — expect FAIL.**
+
+Run: `npm --prefix apps/api test -- src/modules/sales/services/sale-writer.service.spec.ts`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement.** Add imports + required ctor deps to `SaleWriterService`:
+
+```typescript
+import { Decimal } from '@prisma/client/runtime/library';
+import { PaymentMethod } from '@prisma/client';
+import { ShopCashSaleTemplate } from '../../journal/cpa-templates/shop-cash-sale.template';
+import { ShopAccountResolver } from '../../journal/shop-account-resolver.service';
+import { allocateCashSaleByCost } from '../shop-cash-sale-allocation.util';
+// constructor: add (after existing deps; required, no @Optional)
+//   private shopCashSaleTemplate: ShopCashSaleTemplate,
+//   private shopAccountResolver: ShopAccountResolver,
+```
+
+Replace the `W-007` TODO block in `createCashSale` (after the `sale.create` + product status update, inside the `$transaction`) with:
+
+```typescript
+      // SHOP-side: post one cash-sale JE per product (bundle-aware). Sale has no
+      // per-product price, so revenue is allocated proportionally by product cost.
+      const productIds = [dto.productId, ...(dto.bundleProductIds || [])];
+      const prods = await tx.product.findMany({
+        where: { id: { in: productIds } },
+        select: { id: true, category: true, costPrice: true },
+      });
+      const ordered = productIds
+        .map((id) => prods.find((p) => p.id === id))
+        .filter((p): p is (typeof prods)[number] => !!p);
+      const cashAccountCode = await this.shopAccountResolver.resolveInflowCashAccount(
+        dto.branchId,
+        dto.paymentMethod as PaymentMethod,
+        tx,
+      );
+      const allocations = allocateCashSaleByCost(
+        new Decimal(netAmount.toString()),
+        ordered.map((p) => ({ id: p.id, costPrice: new Decimal(p.costPrice.toString()) })),
+      );
+      for (const alloc of allocations) {
+        if (!alloc.revenue.gt(0)) continue; // template requires revenueAmount > 0
+        const prod = ordered.find((p) => p.id === alloc.productId)!;
+        const acc = this.shopAccountResolver.resolveProductAccounts(prod.category);
+        await this.shopCashSaleTemplate.execute(
+          {
+            idempotencyKey: `shop-cash-sale:${sale.id}:${alloc.productId}`,
+            saleId: sale.id,
+            cashAccountCode,
+            revenueAccountCode: acc.revenueAccountCode,
+            revenueAmount: alloc.revenue,
+            cogsAccountCode: acc.cogsAccountCode,
+            inventoryAccountCode: acc.inventoryAccountCode,
+            inventoryCost: alloc.cost,
+          },
+          tx,
+        );
+      }
+```
+
+- [ ] **Step 4: Ensure DI resolves.** Confirm `sales.module.ts` `imports` includes `JournalModule` (which exports `ShopCashSaleTemplate` + `ShopAccountResolver`); add it if missing. Then update EVERY TestingModule that constructs `SaleWriterService` (grep `rg -l "SaleWriterService" apps/api/src/modules/sales -g'*.spec.ts'`) to provide `{ provide: ShopCashSaleTemplate, useValue: { execute: jest.fn().mockResolvedValue({ entryNo:'JE-1', journalEntryId:'je-1' }) } }` and `{ provide: ShopAccountResolver, useValue: { resolveInflowCashAccount: jest.fn(), resolveProductAccounts: jest.fn() } }` (or add to positional `new SaleWriterService(...)` calls).
+
+- [ ] **Step 5: Run — expect PASS** (whole sales suite) + typecheck.
+
+Run: `npm --prefix apps/api test -- src/modules/sales && (cd apps/api && npx tsc --noEmit -p tsconfig.json)`
+Expected: all sales suites PASS; tsc exit 0.
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add apps/api/src/modules/sales/services/sale-writer.service.ts apps/api/src/modules/sales/services/sale-writer.service.spec.ts apps/api/src/modules/sales/sales.module.ts
+git commit -m "feat(sales): post ShopCashSale per product at cash sale (bundle-aware, cost-allocated)"
+```
+
+---
+
+## Acceptance
+- `apps/api` tsc 0; full `src/modules/sales` suite green; `shop-cash-sale-allocation.util.spec.ts` + resolver spec green.
+- A single-product CASH sale posts one balanced SHOP JE (Dr till / Cr S41 + Dr S50 / Cr S11-200x). A 2-category bundle posts two JEs whose revenues sum to `netAmount`. A BANK_TRANSFER sale debits `S11-1201`.
+- Re-recording the same sale (same `saleId`) does not double-post (template idempotency on `shop-cash-sale:<saleId>:<productId>`).
+
+## Open items (surface at review / to owner)
+- **Revenue base = `netAmount` (after discount)** — discount reduces SHOP revenue, no separate discount contra (non-VAT SHOP). Confirm acceptable vs. booking gross revenue + a discount account.
+- **`CREDIT_BALANCE` / `ONLINE_GATEWAY` payment methods** route to `S11-1201` like other non-cash methods. Confirm that's the right account for store-credit / gateway settlements, or refine `resolveInflowCashAccount`.
+- Allocation-by-cost is a proxy (no per-product price exists). If a per-item price source is ever added (e.g. a `SaleItem` line model), switch the allocation to actual line prices.


### PR DESCRIPTION
## Summary
**P2** of the SHOP-JE wiring: posts a SHOP **cash-sale** journal entry per product when a cash `Sale` is recorded, so `/shop/accounting` reflects cash-sale revenue + COGS. Built task-by-task via subagent-driven development; every per-task review + a final whole-branch review passed.

Spec §6/§6B/§5B · Plan: `docs/superpowers/plans/2026-06-23-shop-je-wiring-p2-cashsale.md`

> ⚠️ **Stacked on PR #1280 (P0+P1).** Base is `feat/shop-je-wiring` so the diff shows **P2 only**. **Do NOT merge before #1280** (X5 PEAK isolation must reach `main` before any SHOP JE deploys). After #1280 squash-merges to `main`, **rebase this branch onto `main`** (drops the now-redundant P1 commits), then merge. Merging deploys to prod.

## What landed (3 tasks)
- **`allocateCashSaleByCost`** util — splits a sale's `netAmount` across its products **proportionally by `Product.costPrice`** (the `Sale` model has no per-product line price), last product absorbs the rounding residual so the split sums **exactly** to `netAmount`; zero total cost → all on the main product.
- **`ShopAccountResolver.resolveInflowCashAccount`** — `CASH` → branch till (fail-closed); any other method → `S11-1201` (receiving bank).
- **Wiring** at `SaleWriterService.createCashSale` (replacing the `W-007` TODO) — one `ShopCashSaleTemplate` JE per product (key `shop-cash-sale:<saleId>:<productId>`), atomic inside the existing `$transaction`, category codes via `resolveProductAccounts`, revenue/cost from the allocation. `sales.module` now imports `JournalModule`.

## Test plan
- `apps/api` tsc 0; full `src/modules/sales` suite + allocation util + resolver specs: **10 suites / 109 tests pass** (`--runInBand`).
- A 2-category bundle posts two JEs whose revenues sum to `netAmount`; BANK_TRANSFER debits `S11-1201`; a zero-cost bundle item posts no JE (revenue 0); re-recording the same sale doesn't double-post.

## Review status
Per-task reviews clean (T1 allocation reviewed adversarially on opus; T2/T3 on sonnet). Final whole-branch review: **fix-then-ship**, no Critical — the two flagged items were **test-only** gaps (zero-revenue-skip wiring test + CREDIT_BALANCE/ONLINE_GATEWAY routing assertions), now added; production behavior was already correct. _(Final review ran on sonnet — opus was 529-overloaded.)_

## Deferred / owner-confirm (not blocking)
- Revenue base = `netAmount` (after discount), no discount-contra (non-VAT SHOP).
- `CREDIT_BALANCE` / `ONLINE_GATEWAY` route to `S11-1201` like other non-cash methods — confirm that's the right account for store-credit / gateway settlements.
- Minor: `ordered.find` O(n²) (bundles ≤5); `netAmount:number` boundary (pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
