### PR TITLE
feat(settings): IA redesign P2a — Outlet foundation + finance category migration

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -57,11 +57,16 @@ const SettingsLayout = lazy(() =>
 const SettingsIndexRedirect = lazy(() =>
   import('@/pages/settings/SettingsIndexRedirect').then((m) => ({ default: m.SettingsIndexRedirect })),
 );
+const SettingsCategoryRoute = lazy(() =>
+  import('@/pages/settings/SettingsCategoryRoute').then((m) => ({ default: m.SettingsCategoryRoute })),
+);
+const SettingsItemRoute = lazy(() =>
+  import('@/pages/settings/SettingsItemRoute').then((m) => ({ default: m.SettingsItemRoute })),
+);
 const StickersSettingsPage = lazy(() => import('@/pages/SettingsPage/StickersPage'));
 const CollectionsSettingsPage = lazy(() => import('@/pages/SettingsPage/CollectionsPage'));
 const GeneralSettingsPage = lazy(() => import('@/pages/SettingsPage/GeneralSettingsPage'));
 const DocumentConfigPage = lazy(() => import('@/pages/DocumentConfigPage'));
-const PaymentMethodSettingsPage = lazy(() => import('@/pages/PaymentMethodSettingsPage'));
 // SP5 — SHOP-side additions
 // SP1 hotfix #2: /defect-exchange restored as a real route to DefectExchangePage.
 // SP1's new IMEI wizard handles REPAIR only — exchange flow needs its own home.
@@ -82,7 +87,6 @@ const FinancialAuditPage = lazy(() => import('@/pages/FinancialAuditPage'));
 const PaymentCsvImportPage = lazy(() => import('@/pages/PaymentCsvImportPage'));
 const POSPage = lazy(() => import('@/pages/POSPage'));
 const SalesHistoryPage = lazy(() => import('@/pages/SalesHistoryPage'));
-const InterestConfigPage = lazy(() => import('@/pages/InterestConfigPage'));
 const PricingTemplatesPage = lazy(() => import('@/pages/PricingTemplatesPage'));
 const SuppliersPage = lazy(() => import('@/pages/SuppliersPage'));
 const StockOverviewPage = lazy(() => import('@/pages/StockPage/OverviewPage'));
@@ -215,8 +219,6 @@ const AiPerformancePage = lazy(() => import('@/pages/AiPerformancePage'));
 const AiPersonaPage = lazy(() => import('@/pages/AiPersonaPage'));
 const AiAdminPage = lazy(() => import('@/pages/AiAdminPage'));
 const IntegrationHubPage = lazy(() => import('@/pages/IntegrationHubPage'));
-// F-Phase — GFIN rate table admin (OWNER-only)
-const GfinConfigPage = lazy(() => import('@/pages/GfinConfigPage'));
 const MdmTestPage = lazy(() => import('@/pages/MdmTestPage'));
 const MdmDashboardPage = lazy(() => import('@/pages/MdmDashboardPage'));
 const BroadcastPage = lazy(() => import('@/pages/BroadcastPage'));
@@ -476,7 +478,7 @@ function App() {
           <Route path="/crm" element={<ProtectedRoute roles={['OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'SALES']}><CrmPipelinePage /></ProtectedRoute>} />
           <Route path="/ads" element={<ProtectedRoute roles={['OWNER']}><AdsTrackingPage /></ProtectedRoute>} />
           <Route path="/settings/channels" element={<ProtectedRoute roles={['OWNER']}><ChannelSettingsPage /></ProtectedRoute>} />
-          <Route path="/settings/payment-methods" element={<ProtectedRoute roles={['OWNER', 'FINANCE_MANAGER']}><PaymentMethodSettingsPage /></ProtectedRoute>} />
+          <Route path="/settings/payment-methods" element={<Navigate to="/settings/finance/payment-methods" replace />} />
           <Route path="/settings/stickers" element={<ProtectedRoute roles={['OWNER']}><StickersSettingsPage /></ProtectedRoute>} />
           <Route path="/settings/collections" element={<ProtectedRoute roles={['OWNER']}><CollectionsSettingsPage /></ProtectedRoute>} />
           <Route path="/settings/general" element={<ProtectedRoute roles={['OWNER']}><GeneralSettingsPage /></ProtectedRoute>} />
@@ -779,15 +781,11 @@ function App() {
                 <SettingsLayout />
               </ProtectedRoute>
             }
-          />
-          <Route
-            path="/settings/interest-config"
-            element={
-              <ProtectedRoute roles={['OWNER']}>
-                <InterestConfigPage />
-              </ProtectedRoute>
-            }
-          />
+          >
+            <Route index element={<SettingsCategoryRoute />} />
+            <Route path=":itemId" element={<SettingsItemRoute />} />
+          </Route>
+          <Route path="/settings/interest-config" element={<Navigate to="/settings/finance/interest" replace />} />
           <Route
             path="/settings/pricing-templates"
             element={
@@ -796,14 +794,7 @@ function App() {
               </ProtectedRoute>
             }
           />
-          <Route
-            path="/settings/gfin-rates"
-            element={
-              <ProtectedRoute roles={['OWNER']}>
-                <GfinConfigPage />
-              </ProtectedRoute>
-            }
-          />
+          <Route path="/settings/gfin-rates" element={<Navigate to="/settings/finance/gfin" replace />} />
           <Route
             path="/audit-logs"
             element={

--- a/apps/web/src/config/__tests__/settings-access.test.ts
+++ b/apps/web/src/config/__tests__/settings-access.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import {
-  visibleCategories, categoryById, visibleItems, firstVisibleCategoryId, searchSettings,
+  visibleCategories, categoryById, visibleItems, firstVisibleCategoryId, searchSettings, findItem,
 } from '../settings-access';
 
 describe('settings-access', () => {
@@ -41,5 +41,13 @@ describe('settings-access', () => {
 
   it('searchSettings query ว่าง → []', () => {
     expect(searchSettings('', 'OWNER')).toEqual([]);
+  });
+
+  it('findItem คืน category+item ที่ถูกต้อง', () => {
+    const r = findItem('finance', 'interest');
+    expect(r?.item.id).toBe('interest');
+    expect(r?.category.id).toBe('finance');
+    expect(findItem('finance', 'nope')).toBeUndefined();
+    expect(findItem('nope', 'interest')).toBeUndefined();
   });
 });

--- a/apps/web/src/config/menu.ts
+++ b/apps/web/src/config/menu.ts
@@ -744,7 +744,7 @@ const OWNER_CONFIG: RoleMenuConfig = {
         { label: 'บริษัท', path: '/settings/companies', icon: Building2 },
         { label: 'แบบสัญญา', path: '/contract-templates', icon: FileCheck },
         { label: 'ตั้งราคา', path: '/settings/pricing-templates', icon: CircleDollarSign },
-        { label: 'ตั้งค่า GFIN', path: '/settings/gfin-rates', icon: Calculator },
+        { label: 'ตั้งค่า GFIN', path: '/settings/finance/gfin', icon: Calculator },
         { label: 'โปรโมชัน', path: '/promotions', icon: BadgePercent },
         { label: 'PDPA', path: '/pdpa', icon: Shield },
       ],

--- a/apps/web/src/config/settings-access.ts
+++ b/apps/web/src/config/settings-access.ts
@@ -31,3 +31,12 @@ export function searchSettings(
   }
   return out;
 }
+
+export function findItem(
+  categoryId: string,
+  itemId: string,
+): { category: SettingsCategory; item: SettingsItem } | undefined {
+  const category = categoryById(categoryId);
+  const item = category?.items.find((i) => i.id === itemId);
+  return category && item ? { category, item } : undefined;
+}

--- a/apps/web/src/config/settings-registry.tsx
+++ b/apps/web/src/config/settings-registry.tsx
@@ -1,6 +1,9 @@
 import type { ComponentType } from 'react';
 import type { LucideIcon } from 'lucide-react';
 import { Building2, Users, BarChart3, Wallet, Smartphone, MessageSquare, Sparkles, ShieldCheck } from 'lucide-react';
+import InterestConfigPage from '@/pages/InterestConfigPage';
+import GfinConfigPage from '@/pages/GfinConfigPage';
+import PaymentMethodSettingsPage from '@/pages/PaymentMethodSettingsPage';
 // inline components (อยู่ที่เดิม — แค่ import มา render)
 import { CompanyTab } from '@/pages/SettingsPage/tabs/CompanyTab';
 import { ContactsTab } from '@/pages/SettingsPage/tabs/ContactsTab';
@@ -76,9 +79,9 @@ export const settingsRegistry: SettingsCategory[] = [
   {
     id: 'finance', label: 'การเงิน & สินเชื่อ', icon: Wallet, roles: ['OWNER', 'FINANCE_MANAGER'],
     items: [
-      { id: 'interest', label: 'ดอกเบี้ย', roles: ['OWNER'], kind: 'external', path: '/settings/interest-config' },
-      { id: 'gfin', label: 'GFIN', roles: ['OWNER'], kind: 'external', path: '/settings/gfin-rates' },
-      { id: 'payment-methods', label: 'ช่องทางชำระเงิน', roles: ['OWNER', 'FINANCE_MANAGER'], kind: 'external', path: '/settings/payment-methods' },
+      { id: 'interest', label: 'ดอกเบี้ย', roles: ['OWNER'], kind: 'route', component: InterestConfigPage, path: '/settings/finance/interest' },
+      { id: 'gfin', label: 'GFIN', roles: ['OWNER'], kind: 'route', component: GfinConfigPage, path: '/settings/finance/gfin' },
+      { id: 'payment-methods', label: 'ช่องทางชำระเงิน', roles: ['OWNER', 'FINANCE_MANAGER'], kind: 'route', component: PaymentMethodSettingsPage, path: '/settings/finance/payment-methods' },
     ],
   },
   {

--- a/apps/web/src/pages/settings/CategoryPage.tsx
+++ b/apps/web/src/pages/settings/CategoryPage.tsx
@@ -6,7 +6,7 @@ import type { SettingsItem, SettingsRole } from '@/config/settings-registry';
 
 const groupLabelClass = 'text-xs font-semibold uppercase tracking-wide text-muted-foreground leading-snug';
 
-function ItemSection({ item }: { item: SettingsItem }) {
+function ItemSection({ item, categoryId }: { item: SettingsItem; categoryId: string }) {
   if (item.kind === 'inline' && item.component) {
     const C = item.component;
     return (
@@ -15,10 +15,10 @@ function ItemSection({ item }: { item: SettingsItem }) {
       </div>
     );
   }
-  // external / route(P1=ลิงก์)
+  const to = item.kind === 'route' ? `/settings/${categoryId}/${item.id}` : (item.path ?? '#');
   return (
     <Link
-      to={item.path ?? '#'}
+      to={to}
       className="flex items-center justify-between rounded-xl border border-border/60 bg-card p-4 hover:bg-accent transition-colors"
     >
       <span className="text-sm font-medium text-foreground leading-snug">{item.label}</span>
@@ -48,7 +48,7 @@ export function CategoryPage({ categoryId }: { categoryId: string }) {
         <section key={g.name ?? gi} className="space-y-4">
           {g.name && <h3 className={groupLabelClass}>{g.name}</h3>}
           {g.items.map((item) => (
-            <ItemSection key={item.id} item={item} />
+            <ItemSection key={item.id} item={item} categoryId={cat.id} />
           ))}
         </section>
       ))}

--- a/apps/web/src/pages/settings/SettingsCategoryRoute.tsx
+++ b/apps/web/src/pages/settings/SettingsCategoryRoute.tsx
@@ -1,0 +1,7 @@
+import { useParams } from 'react-router';
+import { CategoryPage } from './CategoryPage';
+
+export function SettingsCategoryRoute() {
+  const { categoryId = '' } = useParams<{ categoryId: string }>();
+  return <CategoryPage categoryId={categoryId} />;
+}

--- a/apps/web/src/pages/settings/SettingsItemRoute.tsx
+++ b/apps/web/src/pages/settings/SettingsItemRoute.tsx
@@ -1,0 +1,18 @@
+import { useParams, Navigate } from 'react-router';
+import { useAuth } from '@/contexts/AuthContext';
+import { findItem } from '@/config/settings-access';
+import type { SettingsRole } from '@/config/settings-registry';
+
+export function SettingsItemRoute() {
+  const { user } = useAuth();
+  const role = (user?.role ?? '') as SettingsRole;
+  const { categoryId = '', itemId = '' } = useParams<{ categoryId: string; itemId: string }>();
+  const found = findItem(categoryId, itemId);
+
+  // ไม่พบ / ไม่ใช่ route / ไม่มี component / role ไม่ถึง → กลับหน้าหมวด
+  if (!found || found.item.kind !== 'route' || !found.item.component || !found.item.roles.includes(role)) {
+    return <Navigate to={`/settings/${categoryId}`} replace />;
+  }
+  const C = found.item.component;
+  return <C />;
+}

--- a/apps/web/src/pages/settings/SettingsLayout.tsx
+++ b/apps/web/src/pages/settings/SettingsLayout.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useParams, useNavigate, Link } from 'react-router';
+import { useParams, useNavigate, Link, Outlet } from 'react-router';
 import { Search } from 'lucide-react';
 import { useAuth } from '@/contexts/AuthContext';
 import { useIsMobile } from '@/hooks/useIsMobile';
@@ -7,7 +7,6 @@ import { useDocumentTitle } from '@/hooks/useDocumentTitle';
 import PageHeader from '@/components/ui/PageHeader';
 import { visibleCategories, visibleItems, searchSettings } from '@/config/settings-access';
 import type { SettingsRole } from '@/config/settings-registry';
-import { CategoryPage } from './CategoryPage';
 
 export function SettingsLayout() {
   useDocumentTitle('ตั้งค่าระบบ');
@@ -62,7 +61,7 @@ export function SettingsLayout() {
               <option key={c.id} value={c.id}>{c.label}</option>
             ))}
           </select>
-          <CategoryPage categoryId={categoryId} />
+          <Outlet />
         </div>
       ) : (
         <div className="flex gap-6">
@@ -88,7 +87,7 @@ export function SettingsLayout() {
             })}
           </nav>
           <div className="min-w-0 flex-1">
-            <CategoryPage categoryId={categoryId} />
+            <Outlet />
           </div>
         </div>
       )}

--- a/apps/web/src/pages/settings/__tests__/SettingsItemRoute.test.tsx
+++ b/apps/web/src/pages/settings/__tests__/SettingsItemRoute.test.tsx
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router';
+import { SettingsItemRoute } from '../SettingsItemRoute';
+
+let role = 'OWNER';
+vi.mock('@/contexts/AuthContext', () => ({ useAuth: () => ({ user: { role } }) }));
+vi.mock('@/pages/InterestConfigPage', () => ({ default: () => <div>interest-page</div> }));
+
+function renderAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="/settings/:categoryId/:itemId" element={<SettingsItemRoute />} />
+        <Route path="/settings/:categoryId" element={<div>category-fallback</div>} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('SettingsItemRoute', () => {
+  it('render component ของ route-item (interest)', () => {
+    role = 'OWNER';
+    renderAt('/settings/finance/interest');
+    expect(screen.getByText('interest-page')).toBeTruthy();
+  });
+
+  it('role ไม่มีสิทธิ์ → redirect ไปหน้าหมวด', () => {
+    role = 'FINANCE_MANAGER'; // interest = OWNER-only
+    renderAt('/settings/finance/interest');
+    expect(screen.getByText('category-fallback')).toBeTruthy();
+  });
+
+  it('item ไม่รู้จัก → redirect ไปหน้าหมวด', () => {
+    role = 'OWNER';
+    renderAt('/settings/finance/nope');
+    expect(screen.getByText('category-fallback')).toBeTruthy();
+  });
+});

--- a/apps/web/src/pages/settings/__tests__/SettingsLayout.test.tsx
+++ b/apps/web/src/pages/settings/__tests__/SettingsLayout.test.tsx
@@ -7,14 +7,18 @@ let role = 'OWNER';
 let mobile = false;
 vi.mock('@/contexts/AuthContext', () => ({ useAuth: () => ({ user: { role } }) }));
 vi.mock('@/hooks/useIsMobile', () => ({ useIsMobile: () => mobile }));
-// CategoryPage ตัวจริงจะ render inline components — mock ให้เบา
-vi.mock('../CategoryPage', () => ({ CategoryPage: ({ categoryId }: { categoryId: string }) => <div>cat:{categoryId}</div> }));
 
 function renderAt(path: string) {
+  // Extract categoryId from path for the index child stub
+  const match = path.match(/\/settings\/([^/]+)/);
+  const catId = match?.[1] ?? '';
   return render(
     <MemoryRouter initialEntries={[path]}>
       <Routes>
-        <Route path="/settings/:categoryId" element={<SettingsLayout />} />
+        <Route path="/settings/:categoryId" element={<SettingsLayout />}>
+          <Route index element={<div>cat:{catId}</div>} />
+          <Route path=":itemId" element={<div>item-child</div>} />
+        </Route>
       </Routes>
     </MemoryRouter>,
   );

--- a/apps/web/src/pages/settings/__tests__/finance-migration.test.tsx
+++ b/apps/web/src/pages/settings/__tests__/finance-migration.test.tsx
@@ -16,6 +16,8 @@ function App({ entry }: { entry: string }) {
     <MemoryRouter initialEntries={[entry]}>
       <Routes>
         <Route path="/settings/interest-config" element={<Navigate to="/settings/finance/interest" replace />} />
+        <Route path="/settings/gfin-rates" element={<Navigate to="/settings/finance/gfin" replace />} />
+        <Route path="/settings/payment-methods" element={<Navigate to="/settings/finance/payment-methods" replace />} />
         <Route path="/settings/:categoryId" element={<SettingsLayout />}>
           <Route index element={<SettingsCategoryRoute />} />
           <Route path=":itemId" element={<SettingsItemRoute />} />
@@ -36,5 +38,15 @@ describe('finance migration', () => {
   it('old /settings/interest-config → redirect ไป /settings/finance/interest', async () => {
     render(<App entry="/settings/interest-config" />);
     await waitFor(() => expect(screen.getByText('interest-page')).toBeTruthy());
+  });
+
+  it('old /settings/gfin-rates → redirect ไป /settings/finance/gfin', async () => {
+    render(<App entry="/settings/gfin-rates" />);
+    await waitFor(() => expect(screen.getByText('gfin-page')).toBeTruthy());
+  });
+
+  it('old /settings/payment-methods → redirect ไป /settings/finance/payment-methods', async () => {
+    render(<App entry="/settings/payment-methods" />);
+    await waitFor(() => expect(screen.getByText('payment-page')).toBeTruthy());
   });
 });

--- a/apps/web/src/pages/settings/__tests__/finance-migration.test.tsx
+++ b/apps/web/src/pages/settings/__tests__/finance-migration.test.tsx
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Routes, Route, Navigate } from 'react-router';
+import { SettingsLayout } from '../SettingsLayout';
+import { SettingsCategoryRoute } from '../SettingsCategoryRoute';
+import { SettingsItemRoute } from '../SettingsItemRoute';
+
+vi.mock('@/contexts/AuthContext', () => ({ useAuth: () => ({ user: { role: 'OWNER' } }) }));
+vi.mock('@/hooks/useIsMobile', () => ({ useIsMobile: () => false }));
+vi.mock('@/pages/InterestConfigPage', () => ({ default: () => <div>interest-page</div> }));
+vi.mock('@/pages/GfinConfigPage', () => ({ default: () => <div>gfin-page</div> }));
+vi.mock('@/pages/PaymentMethodSettingsPage', () => ({ default: () => <div>payment-page</div> }));
+
+function App({ entry }: { entry: string }) {
+  return (
+    <MemoryRouter initialEntries={[entry]}>
+      <Routes>
+        <Route path="/settings/interest-config" element={<Navigate to="/settings/finance/interest" replace />} />
+        <Route path="/settings/:categoryId" element={<SettingsLayout />}>
+          <Route index element={<SettingsCategoryRoute />} />
+          <Route path=":itemId" element={<SettingsItemRoute />} />
+        </Route>
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe('finance migration', () => {
+  it('/settings/finance/interest → render หน้า interest ใน panel (มี nav ข้างซ้าย)', () => {
+    render(<App entry="/settings/finance/interest" />);
+    expect(screen.getByText('interest-page')).toBeTruthy();
+    // panel nav ยังอยู่ (link หมวด finance)
+    expect(screen.getByRole('link', { name: /การเงิน/ })).toBeTruthy();
+  });
+
+  it('old /settings/interest-config → redirect ไป /settings/finance/interest', async () => {
+    render(<App entry="/settings/interest-config" />);
+    await waitFor(() => expect(screen.getByText('interest-page')).toBeTruthy());
+  });
+});

--- a/apps/web/src/pages/settings/__tests__/settings-routing.test.tsx
+++ b/apps/web/src/pages/settings/__tests__/settings-routing.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter, Routes, Route } from 'react-router';
 import { SettingsIndexRedirect } from '../SettingsIndexRedirect';
 import { SettingsLayout } from '../SettingsLayout';
+import { SettingsCategoryRoute } from '../SettingsCategoryRoute';
 
 let role = 'OWNER';
 vi.mock('@/contexts/AuthContext', () => ({ useAuth: () => ({ user: { role } }) }));
@@ -14,7 +15,9 @@ function App({ entry }: { entry: string }) {
     <MemoryRouter initialEntries={[entry]}>
       <Routes>
         <Route path="/settings" element={<SettingsIndexRedirect />} />
-        <Route path="/settings/:categoryId" element={<SettingsLayout />} />
+        <Route path="/settings/:categoryId" element={<SettingsLayout />}>
+          <Route index element={<SettingsCategoryRoute />} />
+        </Route>
       </Routes>
     </MemoryRouter>
   );

--- a/docs/superpowers/plans/2026-06-23-settings-ia-redesign-p2a-foundation-finance.md
+++ b/docs/superpowers/plans/2026-06-23-settings-ia-redesign-p2a-foundation-finance.md
@@ -1,0 +1,398 @@
+# Settings IA Redesign — P2a (Outlet Foundation + Finance migration) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** เปลี่ยน settings panel ให้ render หน้า config "ใต้ layout" ผ่าน react-router `<Outlet>` แล้วย้ายหมวด **finance** (ดอกเบี้ย/GFIN/ช่องทางชำระเงิน) เป็น URL ใหม่ `/settings/finance/<item>` + redirect ของเก่า — เป็น proof ของ pattern ที่หมวดอื่นจะตามใน P2b
+
+**Architecture:** P1 สร้าง panel ที่ render `<CategoryPage>` ตรงๆ. P2a เปลี่ยน `SettingsLayout` ให้ render `<Outlet>` แล้วผูก nested routes: `index → SettingsCategoryRoute` (หน้าหมวด) และ `:itemId → SettingsItemRoute` (หน้า config เต็มใน panel). route-item ใน registry เปลี่ยน `kind:'external'`→`'route'` + ใส่ `component` (หน้าเดิม) + path ใหม่. หน้า config ที่มีแท็บ/sub-nav ของตัวเอง (เช่น document-config) คงเป็น `external` เต็มจอ (P2b). ทั้งหมด registry-driven ไม่ duplicate route ต่อหน้า
+
+**Tech Stack:** React 18 + TS + Vite + react-router v7 + Tailwind + Vitest
+
+**Spec:** `docs/superpowers/specs/2026-06-23-settings-ia-redesign-design.md` (§4.3 routes, §5 mapping, structural fix: complex pages → external)
+**Builds on:** P1 (PR #1286) — `settings-registry`, `settings-access`, `SettingsLayout`, `CategoryPage`, `SettingsIndexRedirect`
+
+## Global Constraints
+
+- Design-token semantic classes only (no hardcoded hex/`text-gray-*`/`bg-white`); functional components + hooks; Thai uses `leading-snug`
+- Registry = single source of truth; role guard derives from registry (`item.roles`)
+- **ห้ามแตะ internals** ของหน้า config ที่ย้าย (InterestConfigPage, GfinConfigPage, PaymentMethodSettingsPage) — แค่ผูก route ใหม่ + redirect
+- หน้า config ที่มีแท็บ/sub-nav ของตัวเอง → `kind:'external'` เปิดเต็มจอ (ไม่ฝังใน Outlet) — finance ทั้ง 3 หน้าเป็นหน้าเดี่ยว เหมาะกับ `kind:'route'`
+- กัน URL เก่าพัง: redirect ทุก path เดิม + **แก้ internal links** ที่ชี้ path เก่า (ไม่พึ่ง redirect อย่างเดียว)
+- `/settings` + ลูกทั้งหมด guard `['OWNER','FINANCE_MANAGER','ACCOUNTANT']` (P1) — `SettingsItemRoute` กรองเพิ่มตาม `item.roles`
+- Commit ทีละ task; branch จะ stack ต่อจาก P1 (`feat/settings-ia-redesign`) หรือ branch ใหม่หลัง P1 merge
+
+---
+
+## File Structure
+
+- **Modify** `apps/web/src/pages/settings/SettingsLayout.tsx` — content area `<CategoryPage>` → `<Outlet/>`
+- **Create** `apps/web/src/pages/settings/SettingsCategoryRoute.tsx` — index child: อ่าน `:categoryId` → `<CategoryPage categoryId>`
+- **Create** `apps/web/src/pages/settings/SettingsItemRoute.tsx` — `:itemId` child: อ่าน `:categoryId/:itemId` → render `item.component` (kind route) + role guard
+- **Modify** `apps/web/src/config/settings-access.ts` — add `findItem(categoryId, itemId)`
+- **Modify** `apps/web/src/pages/settings/CategoryPage.tsx` — route-item → internal link `/settings/<cat>/<item>` (รับ categoryId เข้า ItemSection)
+- **Modify** `apps/web/src/config/settings-registry.tsx` — finance 3 items → `kind:'route'` + `component` + new path
+- **Modify** `apps/web/src/App.tsx` — nested routes under `/settings/:categoryId`; replace finance old routes with redirects
+- **Modify** `apps/web/src/config/menu.ts` — GFIN link → new path
+- **Modify** `apps/web/src/pages/SettingsPage/components/SystemSettings.tsx` — interest link → new path (IF still rendered; verify)
+
+---
+
+## Task 1: Outlet foundation + migrate finance/interest (proof)
+
+**Files:**
+- Modify: `apps/web/src/pages/settings/SettingsLayout.tsx`
+- Create: `apps/web/src/pages/settings/SettingsCategoryRoute.tsx`, `apps/web/src/pages/settings/SettingsItemRoute.tsx`
+- Modify: `apps/web/src/config/settings-access.ts`, `apps/web/src/config/settings-registry.tsx`, `apps/web/src/pages/settings/CategoryPage.tsx`, `apps/web/src/App.tsx`, `apps/web/src/pages/SettingsPage/components/SystemSettings.tsx`
+- Test: `apps/web/src/pages/settings/__tests__/SettingsItemRoute.test.tsx`, update `apps/web/src/config/__tests__/settings-access.test.ts`
+
+**Interfaces:**
+- Consumes (P1): `categoryById`, `visibleItems`, `CategoryPage({categoryId})`, registry types
+- Produces:
+  - `findItem(categoryId, itemId): { category: SettingsCategory; item: SettingsItem } | undefined`
+  - `SettingsCategoryRoute()` (reads `:categoryId`)
+  - `SettingsItemRoute()` (reads `:categoryId`,`:itemId`; renders `item.component` for kind `route`; else `<Navigate to="/settings/:categoryId" replace>`)
+
+- [ ] **Step 1: เพิ่ม `findItem` helper + test (RED)**
+
+ใน `apps/web/src/config/__tests__/settings-access.test.ts` เพิ่ม import `findItem` และ test:
+
+```ts
+  it('findItem คืน category+item ที่ถูกต้อง', () => {
+    const r = findItem('finance', 'interest');
+    expect(r?.item.id).toBe('interest');
+    expect(r?.category.id).toBe('finance');
+    expect(findItem('finance', 'nope')).toBeUndefined();
+    expect(findItem('nope', 'interest')).toBeUndefined();
+  });
+```
+
+Run: `cd apps/web && npx vitest run src/config/__tests__/settings-access.test.ts`
+Expected: FAIL — `findItem is not a function`
+
+- [ ] **Step 2: implement `findItem` (GREEN)**
+
+ต่อท้าย `apps/web/src/config/settings-access.ts`:
+
+```ts
+export function findItem(
+  categoryId: string,
+  itemId: string,
+): { category: SettingsCategory; item: SettingsItem } | undefined {
+  const category = categoryById(categoryId);
+  const item = category?.items.find((i) => i.id === itemId);
+  return category && item ? { category, item } : undefined;
+}
+```
+
+Run: `cd apps/web && npx vitest run src/config/__tests__/settings-access.test.ts`
+Expected: PASS
+
+- [ ] **Step 3: migrate finance items in registry → `kind:'route'` + component + new path**
+
+ใน `apps/web/src/config/settings-registry.tsx` เพิ่ม imports (ใกล้ imports อื่น):
+
+```tsx
+import InterestConfigPage from '@/pages/InterestConfigPage';
+import GfinConfigPage from '@/pages/GfinConfigPage';
+import PaymentMethodSettingsPage from '@/pages/PaymentMethodSettingsPage';
+```
+
+แทน 3 รายการ finance (เดิม kind:'external') ด้วย:
+
+```tsx
+      { id: 'interest', label: 'ดอกเบี้ย', roles: ['OWNER'], kind: 'route', component: InterestConfigPage, path: '/settings/finance/interest' },
+      { id: 'gfin', label: 'GFIN', roles: ['OWNER'], kind: 'route', component: GfinConfigPage, path: '/settings/finance/gfin' },
+      { id: 'payment-methods', label: 'ช่องทางชำระเงิน', roles: ['OWNER', 'FINANCE_MANAGER'], kind: 'route', component: PaymentMethodSettingsPage, path: '/settings/finance/payment-methods' },
+```
+
+> Note: `component` field already typed `ComponentType` (P1). `path` for kind:'route' is the NEW canonical path.
+
+- [ ] **Step 4: CategoryPage — route-items link to new path (pass categoryId into ItemSection)**
+
+แก้ `apps/web/src/pages/settings/CategoryPage.tsx`. เปลี่ยน `ItemSection` ให้รับ `categoryId` และแยก kind `route`:
+
+```tsx
+function ItemSection({ item, categoryId }: { item: SettingsItem; categoryId: string }) {
+  if (item.kind === 'inline' && item.component) {
+    const C = item.component;
+    return (
+      <div id={item.id} className="scroll-mt-20">
+        <C />
+      </div>
+    );
+  }
+  const to = item.kind === 'route' ? `/settings/${categoryId}/${item.id}` : (item.path ?? '#');
+  return (
+    <Link
+      to={to}
+      className="flex items-center justify-between rounded-xl border border-border/60 bg-card p-4 hover:bg-accent transition-colors"
+    >
+      <span className="text-sm font-medium text-foreground leading-snug">{item.label}</span>
+      <ChevronRight className="size-4 text-muted-foreground" />
+    </Link>
+  );
+}
+```
+
+และตรงที่ render เปลี่ยนเป็นส่ง categoryId:
+
+```tsx
+          {g.items.map((item) => (
+            <ItemSection key={item.id} item={item} categoryId={cat.id} />
+          ))}
+```
+
+> CategoryPage.test.tsx เดิมยังผ่าน (system หมวดไม่มี route-item; external ยังลิงก์ path เดิม). ไม่ต้องแก้เทสนั้น.
+
+- [ ] **Step 5: SettingsLayout → `<Outlet/>`**
+
+ใน `apps/web/src/pages/settings/SettingsLayout.tsx`:
+- เปลี่ยน import `import { useParams, useNavigate, Link } from 'react-router';` → เพิ่ม `Outlet`: `import { useParams, useNavigate, Link, Outlet } from 'react-router';`
+- ลบ import `import { CategoryPage } from './CategoryPage';`
+- แทน `<CategoryPage categoryId={categoryId} />` **ทั้ง 2 ที่** (mobile branch + desktop branch) ด้วย `<Outlet />`
+
+- [ ] **Step 6: SettingsCategoryRoute + SettingsItemRoute (with test, RED→GREEN)**
+
+สร้างเทส `apps/web/src/pages/settings/__tests__/SettingsItemRoute.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router';
+import { SettingsItemRoute } from '../SettingsItemRoute';
+
+let role = 'OWNER';
+vi.mock('@/contexts/AuthContext', () => ({ useAuth: () => ({ user: { role } }) }));
+vi.mock('@/pages/InterestConfigPage', () => ({ default: () => <div>interest-page</div> }));
+
+function renderAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="/settings/:categoryId/:itemId" element={<SettingsItemRoute />} />
+        <Route path="/settings/:categoryId" element={<div>category-fallback</div>} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('SettingsItemRoute', () => {
+  it('render component ของ route-item (interest)', () => {
+    role = 'OWNER';
+    renderAt('/settings/finance/interest');
+    expect(screen.getByText('interest-page')).toBeTruthy();
+  });
+
+  it('role ไม่มีสิทธิ์ → redirect ไปหน้าหมวด', () => {
+    role = 'FINANCE_MANAGER'; // interest = OWNER-only
+    renderAt('/settings/finance/interest');
+    expect(screen.getByText('category-fallback')).toBeTruthy();
+  });
+
+  it('item ไม่รู้จัก → redirect ไปหน้าหมวด', () => {
+    role = 'OWNER';
+    renderAt('/settings/finance/nope');
+    expect(screen.getByText('category-fallback')).toBeTruthy();
+  });
+});
+```
+
+Run: `cd apps/web && npx vitest run src/pages/settings/__tests__/SettingsItemRoute.test.tsx`
+Expected: FAIL — module not found
+
+สร้าง `apps/web/src/pages/settings/SettingsCategoryRoute.tsx`:
+
+```tsx
+import { useParams } from 'react-router';
+import { CategoryPage } from './CategoryPage';
+
+export function SettingsCategoryRoute() {
+  const { categoryId = '' } = useParams<{ categoryId: string }>();
+  return <CategoryPage categoryId={categoryId} />;
+}
+```
+
+สร้าง `apps/web/src/pages/settings/SettingsItemRoute.tsx`:
+
+```tsx
+import { useParams, Navigate } from 'react-router';
+import { useAuth } from '@/contexts/AuthContext';
+import { findItem } from '@/config/settings-access';
+import type { SettingsRole } from '@/config/settings-registry';
+
+export function SettingsItemRoute() {
+  const { user } = useAuth();
+  const role = (user?.role ?? '') as SettingsRole;
+  const { categoryId = '', itemId = '' } = useParams<{ categoryId: string; itemId: string }>();
+  const found = findItem(categoryId, itemId);
+
+  // ไม่พบ / ไม่ใช่ route / ไม่มี component / role ไม่ถึง → กลับหน้าหมวด
+  if (!found || found.item.kind !== 'route' || !found.item.component || !found.item.roles.includes(role)) {
+    return <Navigate to={`/settings/${categoryId}`} replace />;
+  }
+  const C = found.item.component;
+  return <C />;
+}
+```
+
+Run: `cd apps/web && npx vitest run src/pages/settings/__tests__/SettingsItemRoute.test.tsx`
+Expected: PASS (3 tests)
+
+- [ ] **Step 7: App.tsx — nested routes + finance redirects + remove old finance routes**
+
+ใน `apps/web/src/App.tsx`:
+
+(a) เพิ่ม lazy imports ของ 2 route components (ใกล้ของ P1):
+
+```tsx
+const SettingsCategoryRoute = lazy(() =>
+  import('@/pages/settings/SettingsCategoryRoute').then((m) => ({ default: m.SettingsCategoryRoute })),
+);
+const SettingsItemRoute = lazy(() =>
+  import('@/pages/settings/SettingsItemRoute').then((m) => ({ default: m.SettingsItemRoute })),
+);
+```
+
+(b) เปลี่ยน route `/settings/:categoryId` (P1) ให้มี children:
+
+```tsx
+          <Route
+            path="/settings/:categoryId"
+            element={
+              <ProtectedRoute roles={['OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT']}>
+                <SettingsLayout />
+              </ProtectedRoute>
+            }
+          >
+            <Route index element={<SettingsCategoryRoute />} />
+            <Route path=":itemId" element={<SettingsItemRoute />} />
+          </Route>
+```
+
+(c) แทน route เดิม 3 อันด้วย redirect (เก็บ `<Navigate>` — path ล้วน ไม่มี hash):
+- `/settings/interest-config` (App.tsx ~784) → `<Navigate to="/settings/finance/interest" replace />`
+- `/settings/gfin-rates` (~800) → `<Navigate to="/settings/finance/gfin" replace />`
+- `/settings/payment-methods` (~479) → `<Navigate to="/settings/finance/payment-methods" replace />`
+
+ตัวอย่าง (interest):
+
+```tsx
+          <Route path="/settings/interest-config" element={<Navigate to="/settings/finance/interest" replace />} />
+```
+
+> ลบ element เดิม (`<ProtectedRoute>...<InterestConfigPage/>...`) ออก. lazy import ของ 3 หน้านี้ยังคงไว้ (registry ใช้ผ่าน SettingsItemRoute) — จริงๆ registry import เองแล้ว ดังนั้น lazy import เดิมใน App.tsx ของ 3 หน้านี้ที่ไม่ถูกใช้แล้วให้ลบ (verify ไม่มี reference อื่น). ตรวจ: `InterestConfigPage`, `GfinConfigPage`, `PaymentMethodSettingsPage` — ถ้า App.tsx ไม่อ้างแล้ว ลบ lazy import 3 บรรทัด (App.tsx:64,85,219).
+
+- [ ] **Step 8: แก้ internal links → path ใหม่**
+
+(a) `apps/web/src/config/menu.ts:747`:
+```tsx
+        { label: 'ตั้งค่า GFIN', path: '/settings/finance/gfin', icon: Calculator },
+```
+
+(b) `apps/web/src/pages/SettingsPage/components/SystemSettings.tsx:173` — **verify ก่อน**ว่า SystemSettings ยังถูก render ที่ไหน (old hub ถูกลบใน P1): `grep -rn "SystemSettings" apps/web/src`. ถ้ายังถูกใช้ → เปลี่ยน `navigate('/settings/interest-config')` เป็น `navigate('/settings/finance/interest')`. ถ้าเป็น dead code (ไม่มีผู้ render) → ปล่อยไว้ + บันทึกใน report ว่าเป็น dead (P4 จะลบ).
+
+- [ ] **Step 9: routing test (RED→GREEN) — finance ผ่าน panel + redirect**
+
+สร้าง `apps/web/src/pages/settings/__tests__/finance-migration.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Routes, Route, Navigate } from 'react-router';
+import { SettingsLayout } from '../SettingsLayout';
+import { SettingsCategoryRoute } from '../SettingsCategoryRoute';
+import { SettingsItemRoute } from '../SettingsItemRoute';
+
+vi.mock('@/contexts/AuthContext', () => ({ useAuth: () => ({ user: { role: 'OWNER' } }) }));
+vi.mock('@/hooks/useIsMobile', () => ({ useIsMobile: () => false }));
+vi.mock('@/pages/InterestConfigPage', () => ({ default: () => <div>interest-page</div> }));
+vi.mock('@/pages/GfinConfigPage', () => ({ default: () => <div>gfin-page</div> }));
+vi.mock('@/pages/PaymentMethodSettingsPage', () => ({ default: () => <div>payment-page</div> }));
+
+function App({ entry }: { entry: string }) {
+  return (
+    <MemoryRouter initialEntries={[entry]}>
+      <Routes>
+        <Route path="/settings/interest-config" element={<Navigate to="/settings/finance/interest" replace />} />
+        <Route path="/settings/:categoryId" element={<SettingsLayout />}>
+          <Route index element={<SettingsCategoryRoute />} />
+          <Route path=":itemId" element={<SettingsItemRoute />} />
+        </Route>
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe('finance migration', () => {
+  it('/settings/finance/interest → render หน้า interest ใน panel (มี nav ข้างซ้าย)', () => {
+    render(<App entry="/settings/finance/interest" />);
+    expect(screen.getByText('interest-page')).toBeTruthy();
+    // panel nav ยังอยู่ (link หมวด finance)
+    expect(screen.getByRole('link', { name: /การเงิน/ })).toBeTruthy();
+  });
+
+  it('old /settings/interest-config → redirect ไป /settings/finance/interest', async () => {
+    render(<App entry="/settings/interest-config" />);
+    await waitFor(() => expect(screen.getByText('interest-page')).toBeTruthy());
+  });
+});
+```
+
+Run: `cd apps/web && npx vitest run src/pages/settings/__tests__/finance-migration.test.tsx`
+Expected: PASS (2 tests)
+
+- [ ] **Step 10: type-check + commit**
+
+Run: `./tools/check-types.sh web`
+Expected: 0 errors
+
+```bash
+git add apps/web/src/pages/settings/ apps/web/src/config/ apps/web/src/App.tsx apps/web/src/config/menu.ts apps/web/src/pages/SettingsPage/components/SystemSettings.tsx
+git commit -m "feat(settings): P2a Outlet foundation + migrate finance category to /settings/finance/*"
+```
+
+---
+
+## Task 2: Verification (finance fully in-panel + no regressions)
+
+**Files:** ไม่มี (รันตรวจ)
+
+- [ ] **Step 1: type-check ทั้ง web**
+
+Run: `./tools/check-types.sh web`
+Expected: 0 errors
+
+- [ ] **Step 2: settings + config tests**
+
+Run: `cd apps/web && npx vitest run src/pages/settings src/config`
+Expected: PASS ทั้งหมด (รวม SettingsItemRoute 3, finance-migration 2, settings-access +1)
+
+- [ ] **Step 3: grep ยืนยันไม่มี internal link ชี้ finance path เก่า (นอกจาก redirect/comment)**
+
+Run: `cd "/d/BESTCHOICE APP/BESTCHOICE" && grep -rn "settings/interest-config\|settings/gfin-rates\|settings/payment-methods" apps/web/src --include=*.ts --include=*.tsx | grep -v "Navigate to" | grep -vi "//"`
+Expected: ไม่มีผลลัพธ์ (หรือมีแต่ comment ที่ยอมรับได้ — รายงานสิ่งที่เจอ)
+
+- [ ] **Step 4: smoke ด้วยตา (ถ้ารัน dev ได้)**
+
+`/settings/finance` → เห็นการ์ด 3 ลิงก์ (ดอกเบี้ย/GFIN/ช่องทางชำระเงิน). คลิก "ดอกเบี้ย" → URL `/settings/finance/interest`, หน้า InterestConfig render **ในpanel** (nav ซ้ายยังอยู่). เปิด `/settings/interest-config` (bookmark เก่า) → เด้งไป `/settings/finance/interest`.
+
+---
+
+## Self-Review (ผู้เขียนแผนตรวจเอง)
+
+**Spec coverage (P2a ส่วน):**
+- §4.3 `/settings/:categoryId/:itemId` → SettingsLayout + Outlet → Task 1 Step 5-7 ✓
+- §5 finance items → kind:'route' + new path → Task 1 Step 3 ✓; redirect เก่า → Step 7c ✓
+- structural fix (route-item ใน panel ผ่าน Outlet; หน้ามีแท็บ→external) → finance เป็นหน้าเดี่ยว เหมาะ route ✓ (document-config ฯลฯ ยัง external — P2b)
+- internal-link update (ไม่พึ่ง redirect) → Step 8 ✓
+- role guard ระดับ item → SettingsItemRoute ✓
+
+**Placeholder scan:** Step 8b มีเงื่อนไข "verify ว่า SystemSettings ยัง render ไหม" — เป็น verify step ที่มีคำสั่ง grep + การกระทำชัดทั้ง 2 ทาง (live→แก้ link; dead→บันทึก) ไม่ใช่ placeholder ✓ ไม่มี TBD อื่น
+
+**Type consistency:** `findItem` signature (access.ts) ตรงกับที่ SettingsItemRoute เรียก; `SettingsCategoryRoute`/`SettingsItemRoute` named exports ตรงกับ lazy import ใน App.tsx; `CategoryPage({categoryId})` prop เดิมคงไว้ (SettingsCategoryRoute ส่งให้); registry route-item มี `component` (ComponentType, P1 type) + `path` ✓
+
+## Out of scope (P2b — แผนแยกถัดไป, pattern เดียวกัน)
+- ย้ายหมวดที่เหลือทีละหมวด: accounting (chart/peak-sync/e-tax — document-config คง external เพราะ 9 แท็บ), products (pricing/stickers + promotions/contract-templates คง external operational), comms (line-oa/rich-menu/greeting/sms/channels/dunning/collections), ai (5 หน้า — ตรวจหน้าที่มีแท็บใน → external), company (entities), access (account-roles), system (integrations/mdm)
+- operational external (users/branches/promotions/contract-templates/audit-logs/system-status) — คง path เดิม (spec §5)
+- scroll-to-section wiring (carry จาก P1) — ทำพร้อม P2b หรือ P3
+- P3 sidebar collapse + CommandPalette index · P4 dedup PDPA / ลบ doc-config dup / เลิก general


### PR DESCRIPTION
## สรุป

**P2a** ของการรื้อ IA `/settings` (ต่อจาก P1 #1286 ที่ merge แล้ว) — ทำให้หน้า config render **ในpanel** ผ่าน react-router `<Outlet>` แล้วย้ายหมวด **finance** เป็น URL ใหม่ `/settings/finance/*`

## สิ่งที่ทำ (TDD, review = ship)
- `SettingsLayout` → render `<Outlet/>` (nav shell คงอยู่ทั้ง desktop + mobile)
- เพิ่ม `SettingsCategoryRoute` (index → CategoryPage) + `SettingsItemRoute` (`:itemId` → render component ของ route-item, role-guarded) + `findItem` helper
- finance 3 หน้า → `kind:'route'` + path ใหม่: `/settings/finance/{interest,gfin,payment-methods}`
- redirect path เก่าทั้ง 3 + แก้ internal links (menu GFIN, ETaxInvoice ไม่เกี่ยว — เฉพาะ finance)
- **infra generic** — หมวดอื่นที่เหลือ (P2b) แค่เปลี่ยน registry + redirect ไม่ต้องแก้ routing อีก

## เทส
- ✅ settings + config **80/80**, web type-check 0 errors
- finance-migration test: render ในpanel + redirect ครบ 3 path
- Final review (Opus): **ship**

## เอกสาร
Plan: `docs/superpowers/plans/2026-06-23-settings-ia-redesign-p2a-foundation-finance.md`

## ถัดไป
P2b (ย้าย 20 หน้าที่เหลือ — plan พร้อมแล้ว, pattern เดียวกับ finance) → P3 (sidebar + CommandPalette) → P4 (cleanup: ลบ SystemSettings dead code, dedup PDPA, ลบ document-config dup route, docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)