### PR TITLE
feat(settings): IA redesign P2b — migrate remaining 20 config pages into the panel

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -207,12 +207,7 @@ const ETaxPage = lazy(() => import('@/pages/finance/ETaxPage'));
 const VatAutoJournalPage = lazy(() => import('@/pages/finance/VatAutoJournalPage'));
 const EReceiptAutoPage = lazy(() => import('@/pages/finance/EReceiptAutoPage'));
 const PeakExportPage = lazy(() => import('@/pages/PeakExportPage'));
-const AiSettingsPage = lazy(() => import('@/pages/AiSettingsPage'));
-const AiTrainingPage = lazy(() => import('@/pages/AiTrainingPage'));
-const AiPerformancePage = lazy(() => import('@/pages/AiPerformancePage'));
-// SP — AI Persona viewer (Phase A read-only)
-const AiPersonaPage = lazy(() => import('@/pages/AiPersonaPage'));
-const AiAdminPage = lazy(() => import('@/pages/AiAdminPage'));
+// AI pages moved to settings-registry (kind:'route') — lazy imports removed
 const IntegrationHubPage = lazy(() => import('@/pages/IntegrationHubPage'));
 const MdmTestPage = lazy(() => import('@/pages/MdmTestPage'));
 const MdmDashboardPage = lazy(() => import('@/pages/MdmDashboardPage'));
@@ -1151,46 +1146,11 @@ function App() {
               </ProtectedRoute>
             }
           />
-          <Route
-            path="/settings/ai-chat"
-            element={
-              <ProtectedRoute roles={['OWNER']}>
-                <AiSettingsPage />
-              </ProtectedRoute>
-            }
-          />
-          <Route
-            path="/settings/ai-training"
-            element={
-              <ProtectedRoute roles={['OWNER']}>
-                <AiTrainingPage />
-              </ProtectedRoute>
-            }
-          />
-          <Route
-            path="/settings/ai-performance"
-            element={
-              <ProtectedRoute roles={['OWNER']}>
-                <AiPerformancePage />
-              </ProtectedRoute>
-            }
-          />
-          <Route
-            path="/settings/ai-admin"
-            element={
-              <ProtectedRoute roles={['OWNER']}>
-                <AiAdminPage />
-              </ProtectedRoute>
-            }
-          />
-          <Route
-            path="/settings/ai-persona"
-            element={
-              <ProtectedRoute roles={['OWNER']}>
-                <AiPersonaPage />
-              </ProtectedRoute>
-            }
-          />
+          <Route path="/settings/ai-chat" element={<Navigate to="/settings/ai/assistant" replace />} />
+          <Route path="/settings/ai-training" element={<Navigate to="/settings/ai/training" replace />} />
+          <Route path="/settings/ai-performance" element={<Navigate to="/settings/ai/performance" replace />} />
+          <Route path="/settings/ai-admin" element={<Navigate to="/settings/ai/admin" replace />} />
+          <Route path="/settings/ai-persona" element={<Navigate to="/settings/ai/persona" replace />} />
           <Route
             path="/settings/integrations"
             element={

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -141,9 +141,6 @@ const WhtReportPage = lazy(() =>
 const ETaxInvoicePage = lazy(() =>
   import('@/pages/ETaxInvoicePage').then((m) => ({ default: m.ETaxInvoicePage })),
 );
-const ETaxConfigPage = lazy(() =>
-  import('@/pages/ETaxConfigPage').then((m) => ({ default: m.ETaxConfigPage })),
-);
 const CommissionsPage = lazy(() => import('@/pages/CommissionsPage'));
 const TradeInPage = lazy(() => import('@/pages/TradeInPage'));
 const PromotionsPage = lazy(() => import('@/pages/PromotionsPage'));
@@ -158,7 +155,6 @@ const AssetJournalPage = lazy(() => import('@/pages/assets/AssetJournalPage'));
 const AssetSummaryReportPage = lazy(() => import('@/pages/assets/AssetSummaryReportPage'));
 const AssetTransfersListPage = lazy(() => import('@/pages/transfers/AssetTransfersListPage'));
 const DepreciationPage = lazy(() => import('@/pages/depreciation/DepreciationPage'));
-const ChartOfAccountsPage = lazy(() => import('@/pages/ChartOfAccountsPage'));
 const BankAccountsPage = lazy(() => import('@/pages/BankAccountsPage'));
 // D1.1.1.4 — Admin UI for account_role_map (OWNER-only).
 const AccountRolesPage = lazy(() => import('@/pages/AccountRolesPage'));
@@ -210,7 +206,6 @@ const WhtPage = lazy(() => import('@/pages/finance/WhtPage'));
 const ETaxPage = lazy(() => import('@/pages/finance/ETaxPage'));
 const VatAutoJournalPage = lazy(() => import('@/pages/finance/VatAutoJournalPage'));
 const EReceiptAutoPage = lazy(() => import('@/pages/finance/EReceiptAutoPage'));
-const PeakSyncPage = lazy(() => import('@/pages/PeakSyncPage'));
 const PeakExportPage = lazy(() => import('@/pages/PeakExportPage'));
 const AiSettingsPage = lazy(() => import('@/pages/AiSettingsPage'));
 const AiTrainingPage = lazy(() => import('@/pages/AiTrainingPage'));
@@ -928,15 +923,8 @@ function App() {
               </ProtectedRoute>
             }
           />
-          {/* P2-SP5 — OWNER-only e-Tax cert + RD creds configuration */}
-          <Route
-            path="/settings/e-tax-config"
-            element={
-              <ProtectedRoute roles={['OWNER']}>
-                <ETaxConfigPage />
-              </ProtectedRoute>
-            }
-          />
+          {/* P2b — e-Tax moved to /settings/accounting/e-tax */}
+          <Route path="/settings/e-tax-config" element={<Navigate to="/settings/accounting/e-tax" replace />} />
           {/* Backwards-compat: legacy /tax-reports → /finance/vat */}
           <Route path="/tax-reports" element={<Navigate to="/finance/vat" replace />} />
           <Route
@@ -963,14 +951,8 @@ function App() {
               </ProtectedRoute>
             }
           />
-          <Route
-            path="/settings/peak-sync"
-            element={
-              <ProtectedRoute roles={['OWNER', 'ACCOUNTANT']}>
-                <PeakSyncPage />
-              </ProtectedRoute>
-            }
-          />
+          {/* P2b — PEAK sync moved to /settings/accounting/peak-sync */}
+          <Route path="/settings/peak-sync" element={<Navigate to="/settings/accounting/peak-sync" replace />} />
           <Route
             path="/finance/peak-export"
             element={
@@ -1133,14 +1115,8 @@ function App() {
               </ProtectedRoute>
             }
           />
-          <Route
-            path="/settings/chart-of-accounts"
-            element={
-              <ProtectedRoute roles={['OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT']}>
-                <ChartOfAccountsPage />
-              </ProtectedRoute>
-            }
-          />
+          {/* P2b — Chart of Accounts moved to /settings/accounting/chart */}
+          <Route path="/settings/chart-of-accounts" element={<Navigate to="/settings/accounting/chart" replace />} />
           {/* SP6 — Bank/Cash account directory (closes /finance/bank-accounts placeholder). */}
           <Route
             path="/finance/bank-accounts"

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -64,7 +64,7 @@ const SettingsItemRoute = lazy(() =>
   import('@/pages/settings/SettingsItemRoute').then((m) => ({ default: m.SettingsItemRoute })),
 );
 const StickersSettingsPage = lazy(() => import('@/pages/SettingsPage/StickersPage'));
-const CollectionsSettingsPage = lazy(() => import('@/pages/SettingsPage/CollectionsPage'));
+// CollectionsSettingsPage moved to settings-registry (P2b comms migration)
 const GeneralSettingsPage = lazy(() => import('@/pages/SettingsPage/GeneralSettingsPage'));
 const DocumentConfigPage = lazy(() => import('@/pages/DocumentConfigPage'));
 // SP5 — SHOP-side additions
@@ -116,7 +116,7 @@ const LiffFinanceVerify = lazy(() => import('@/pages/liff/LiffFinanceVerify'));
 const LiffBranches = lazy(() => import('@/pages/liff/LiffBranches'));
 const LiffReceipts = lazy(() => import('@/pages/liff/LiffReceipts'));
 const LiffNotificationSettings = lazy(() => import('@/pages/liff/LiffNotificationSettings'));
-const LineOaSettingsPage = lazy(() => import('@/pages/LineOaSettingsPage'));
+// LineOaSettingsPage moved to settings-registry (P2b comms migration)
 const FinanceReceivablePage = lazy(() => import('@/pages/FinanceReceivablePage'));
 const FinancePortfolioPage = lazy(() => import('@/pages/FinancePortfolioPage'));
 const ExternalFinanceCompanyDetailPage = lazy(
@@ -163,7 +163,7 @@ const UnifiedInboxPage = lazy(() => import('@/pages/UnifiedInboxPage'));
 const ChatInboxPage = lazy(() => import('@/pages/chat/ChatInboxPage'));
 const CrmPipelinePage = lazy(() => import('@/pages/CrmPipelinePage'));
 const AdsTrackingPage = lazy(() => import('@/pages/AdsTrackingPage'));
-const ChannelSettingsPage = lazy(() => import('@/pages/ChannelSettingsPage'));
+// ChannelSettingsPage moved to settings-registry (P2b comms migration)
 const ChatbotFinanceAnalyticsPage = lazy(() => import('@/pages/ChatbotFinanceAnalyticsPage'));
 const ChatbotFinanceSessionsPage = lazy(() => import('@/pages/ChatbotFinanceSessionsPage'));
 const ChatbotFinanceKnowledgePage = lazy(() => import('@/pages/ChatbotFinanceKnowledgePage'));
@@ -175,8 +175,8 @@ const CannedResponseAdminPage = lazy(() => import('@/pages/CannedResponseAdminPa
 const CollectionDashboardPage = lazy(() => import('@/pages/CollectionDashboardPage'));
 const CollectionsPage = lazy(() => import('@/pages/CollectionsPage'));
 const LettersPage = lazy(() => import('./pages/LettersPage'));
-const DunningSettingsPage = lazy(() => import('@/pages/DunningSettingsPage'));
-const SmsTemplatesPage = lazy(() => import('@/pages/SmsTemplatesPage'));
+// DunningSettingsPage moved to settings-registry (P2b comms migration)
+// SmsTemplatesPage moved to settings-registry (P2b comms migration)
 const MonthlyClosePage = lazy(() => import('@/pages/MonthlyClosePage'));
 const YearEndClosingPage = lazy(() => import('@/pages/YearEndClosingPage'));
 // P3-SP5 — SHOP-side accounting (Trial Balance + P&L scoped to SHOP chart)
@@ -218,7 +218,7 @@ const MdmTestPage = lazy(() => import('@/pages/MdmTestPage'));
 const MdmDashboardPage = lazy(() => import('@/pages/MdmDashboardPage'));
 const BroadcastPage = lazy(() => import('@/pages/BroadcastPage'));
 const RichMenuPage = lazy(() => import('@/pages/RichMenuPage'));
-const LineGreetingPage = lazy(() => import('@/pages/LineGreetingPage'));
+// LineGreetingPage moved to settings-registry (P2b comms migration)
 const CustomerIntakePage = lazy(() => import('@/pages/CustomerIntakePage'));
 const OnlineOrdersPage = lazy(() => import('@/pages/OnlineOrdersPage'));
 const InstallmentApplicationsPage = lazy(() => import('@/pages/InstallmentApplicationsPage'));
@@ -472,10 +472,12 @@ function App() {
           <Route path="/chat" element={<ProtectedRoute roles={['OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'SALES']}><ChatInboxPage /></ProtectedRoute>} />
           <Route path="/crm" element={<ProtectedRoute roles={['OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'SALES']}><CrmPipelinePage /></ProtectedRoute>} />
           <Route path="/ads" element={<ProtectedRoute roles={['OWNER']}><AdsTrackingPage /></ProtectedRoute>} />
-          <Route path="/settings/channels" element={<ProtectedRoute roles={['OWNER']}><ChannelSettingsPage /></ProtectedRoute>} />
+          {/* P2b — channels moved to /settings/comms/channels */}
+          <Route path="/settings/channels" element={<Navigate to="/settings/comms/channels" replace />} />
           <Route path="/settings/payment-methods" element={<Navigate to="/settings/finance/payment-methods" replace />} />
           <Route path="/settings/stickers" element={<ProtectedRoute roles={['OWNER']}><StickersSettingsPage /></ProtectedRoute>} />
-          <Route path="/settings/collections" element={<ProtectedRoute roles={['OWNER']}><CollectionsSettingsPage /></ProtectedRoute>} />
+          {/* P2b — collections moved to /settings/comms/collections */}
+          <Route path="/settings/collections" element={<Navigate to="/settings/comms/collections" replace />} />
           <Route path="/settings/general" element={<ProtectedRoute roles={['OWNER']}><GeneralSettingsPage /></ProtectedRoute>} />
           <Route path="/settings/document-config" element={<ProtectedRoute roles={['OWNER']}><DocumentConfigPage /></ProtectedRoute>} />
           <Route path="/chatbot-finance" element={<ProtectedRoute roles={['OWNER', 'FINANCE_MANAGER']}><ChatbotFinanceAnalyticsPage /></ProtectedRoute>} />
@@ -882,14 +884,8 @@ function App() {
               </ProtectedRoute>
             }
           />
-          <Route
-            path="/settings/line-oa"
-            element={
-              <ProtectedRoute roles={['OWNER']}>
-                <LineOaSettingsPage />
-              </ProtectedRoute>
-            }
-          />
+          {/* P2b — line-oa moved to /settings/comms/line-oa */}
+          <Route path="/settings/line-oa" element={<Navigate to="/settings/comms/line-oa" replace />} />
           {/* P4-SP2 — Tax UI (finance-tax endpoints replace SP3 placeholders) */}
           <Route
             path="/finance/vat"
@@ -935,22 +931,10 @@ function App() {
               </ProtectedRoute>
             }
           />
-          <Route
-            path="/settings/dunning"
-            element={
-              <ProtectedRoute roles={['OWNER']}>
-                <DunningSettingsPage />
-              </ProtectedRoute>
-            }
-          />
-          <Route
-            path="/settings/sms-templates"
-            element={
-              <ProtectedRoute roles={['OWNER', 'FINANCE_MANAGER']}>
-                <SmsTemplatesPage />
-              </ProtectedRoute>
-            }
-          />
+          {/* P2b — dunning moved to /settings/comms/dunning */}
+          <Route path="/settings/dunning" element={<Navigate to="/settings/comms/dunning" replace />} />
+          {/* P2b — sms-templates moved to /settings/comms/sms */}
+          <Route path="/settings/sms-templates" element={<Navigate to="/settings/comms/sms" replace />} />
           {/* P2b — PEAK sync moved to /settings/accounting/peak-sync */}
           <Route path="/settings/peak-sync" element={<Navigate to="/settings/accounting/peak-sync" replace />} />
           <Route
@@ -1247,14 +1231,8 @@ function App() {
               </ProtectedRoute>
             }
           />
-          <Route
-            path="/settings/line-greeting"
-            element={
-              <ProtectedRoute roles={['OWNER']}>
-                <LineGreetingPage />
-              </ProtectedRoute>
-            }
-          />
+          {/* P2b — line-greeting moved to /settings/comms/greeting */}
+          <Route path="/settings/line-greeting" element={<Navigate to="/settings/comms/greeting" replace />} />
           <Route
             path="/profile"
             element={

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -63,7 +63,7 @@ const SettingsCategoryRoute = lazy(() =>
 const SettingsItemRoute = lazy(() =>
   import('@/pages/settings/SettingsItemRoute').then((m) => ({ default: m.SettingsItemRoute })),
 );
-const StickersSettingsPage = lazy(() => import('@/pages/SettingsPage/StickersPage'));
+// StickersSettingsPage moved to settings-registry (P2b products migration)
 // CollectionsSettingsPage moved to settings-registry (P2b comms migration)
 const GeneralSettingsPage = lazy(() => import('@/pages/SettingsPage/GeneralSettingsPage'));
 const DocumentConfigPage = lazy(() => import('@/pages/DocumentConfigPage'));
@@ -87,7 +87,7 @@ const FinancialAuditPage = lazy(() => import('@/pages/FinancialAuditPage'));
 const PaymentCsvImportPage = lazy(() => import('@/pages/PaymentCsvImportPage'));
 const POSPage = lazy(() => import('@/pages/POSPage'));
 const SalesHistoryPage = lazy(() => import('@/pages/SalesHistoryPage'));
-const PricingTemplatesPage = lazy(() => import('@/pages/PricingTemplatesPage'));
+// PricingTemplatesPage moved to settings-registry (P2b products migration)
 const SuppliersPage = lazy(() => import('@/pages/SuppliersPage'));
 const StockOverviewPage = lazy(() => import('@/pages/StockPage/OverviewPage'));
 const StockProductsPage = lazy(() => import('@/pages/StockPage/ProductsPage'));
@@ -470,7 +470,8 @@ function App() {
           {/* P2b — channels moved to /settings/comms/channels */}
           <Route path="/settings/channels" element={<Navigate to="/settings/comms/channels" replace />} />
           <Route path="/settings/payment-methods" element={<Navigate to="/settings/finance/payment-methods" replace />} />
-          <Route path="/settings/stickers" element={<ProtectedRoute roles={['OWNER']}><StickersSettingsPage /></ProtectedRoute>} />
+          {/* P2b — stickers moved to /settings/products/stickers */}
+          <Route path="/settings/stickers" element={<Navigate to="/settings/products/stickers" replace />} />
           {/* P2b — collections moved to /settings/comms/collections */}
           <Route path="/settings/collections" element={<Navigate to="/settings/comms/collections" replace />} />
           <Route path="/settings/general" element={<ProtectedRoute roles={['OWNER']}><GeneralSettingsPage /></ProtectedRoute>} />
@@ -778,14 +779,8 @@ function App() {
             <Route path=":itemId" element={<SettingsItemRoute />} />
           </Route>
           <Route path="/settings/interest-config" element={<Navigate to="/settings/finance/interest" replace />} />
-          <Route
-            path="/settings/pricing-templates"
-            element={
-              <ProtectedRoute roles={['OWNER']}>
-                <PricingTemplatesPage />
-              </ProtectedRoute>
-            }
-          />
+          {/* P2b — pricing-templates moved to /settings/products/pricing */}
+          <Route path="/settings/pricing-templates" element={<Navigate to="/settings/products/pricing" replace />} />
           <Route path="/settings/gfin-rates" element={<Navigate to="/settings/finance/gfin" replace />} />
           <Route
             path="/audit-logs"

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -130,7 +130,7 @@ const ExpenseDocumentNewPage = lazy(() => import('@/pages/ExpenseDocumentNewPage
 const ExpenseFavoritesPage = lazy(() => import('@/pages/ExpenseFavoritesPage'));
 const ExpenseDailySummaryPage = lazy(() => import('@/pages/ExpenseDailySummaryPage'));
 const ProfitLossPage = lazy(() => import('@/pages/ProfitLossPage'));
-const CompanySettingsPage = lazy(() => import('@/pages/CompanySettingsPage'));
+// CompanySettingsPage moved to settings-registry (kind:'route') — lazy import removed
 // SP3 — split /tax-reports into 3 dedicated pages (VAT / WHT / e-Tax)
 const VatReportPage = lazy(() =>
   import('@/pages/VatReportPage').then((m) => ({ default: m.VatReportPage })),
@@ -156,8 +156,7 @@ const AssetSummaryReportPage = lazy(() => import('@/pages/assets/AssetSummaryRep
 const AssetTransfersListPage = lazy(() => import('@/pages/transfers/AssetTransfersListPage'));
 const DepreciationPage = lazy(() => import('@/pages/depreciation/DepreciationPage'));
 const BankAccountsPage = lazy(() => import('@/pages/BankAccountsPage'));
-// D1.1.1.4 — Admin UI for account_role_map (OWNER-only).
-const AccountRolesPage = lazy(() => import('@/pages/AccountRolesPage'));
+// D1.1.1.4 — AccountRolesPage moved to settings-registry (kind:'route') — lazy import removed
 const TodosPage = lazy(() => import('@/pages/TodosPage'));
 const UnifiedInboxPage = lazy(() => import('@/pages/UnifiedInboxPage'));
 const ChatInboxPage = lazy(() => import('@/pages/chat/ChatInboxPage'));
@@ -207,9 +206,7 @@ const ETaxPage = lazy(() => import('@/pages/finance/ETaxPage'));
 const VatAutoJournalPage = lazy(() => import('@/pages/finance/VatAutoJournalPage'));
 const EReceiptAutoPage = lazy(() => import('@/pages/finance/EReceiptAutoPage'));
 const PeakExportPage = lazy(() => import('@/pages/PeakExportPage'));
-// AI pages moved to settings-registry (kind:'route') — lazy imports removed
-const IntegrationHubPage = lazy(() => import('@/pages/IntegrationHubPage'));
-const MdmTestPage = lazy(() => import('@/pages/MdmTestPage'));
+// IntegrationHubPage + MdmTestPage moved to settings-registry (kind:'route') — lazy imports removed
 const MdmDashboardPage = lazy(() => import('@/pages/MdmDashboardPage'));
 const BroadcastPage = lazy(() => import('@/pages/BroadcastPage'));
 const RichMenuPage = lazy(() => import('@/pages/RichMenuPage'));
@@ -913,14 +910,8 @@ function App() {
           <Route path="/settings/e-tax-config" element={<Navigate to="/settings/accounting/e-tax" replace />} />
           {/* Backwards-compat: legacy /tax-reports → /finance/vat */}
           <Route path="/tax-reports" element={<Navigate to="/finance/vat" replace />} />
-          <Route
-            path="/settings/companies"
-            element={
-              <ProtectedRoute roles={['OWNER']}>
-                <CompanySettingsPage />
-              </ProtectedRoute>
-            }
-          />
+          {/* P2b — companies moved to /settings/company/entities */}
+          <Route path="/settings/companies" element={<Navigate to="/settings/company/entities" replace />} />
           {/* P2b — dunning moved to /settings/comms/dunning */}
           <Route path="/settings/dunning" element={<Navigate to="/settings/comms/dunning" replace />} />
           {/* P2b — sms-templates moved to /settings/comms/sms */}
@@ -1101,14 +1092,8 @@ function App() {
             }
           />
           {/* D1.1.1.4 — Admin UI for account_role_map (OWNER-only). */}
-          <Route
-            path="/settings/account-roles"
-            element={
-              <ProtectedRoute roles={['OWNER']}>
-                <AccountRolesPage />
-              </ProtectedRoute>
-            }
-          />
+          {/* P2b — account-roles moved to /settings/access/account-roles */}
+          <Route path="/settings/account-roles" element={<Navigate to="/settings/access/account-roles" replace />} />
           <Route
             path="/analytics"
             element={
@@ -1146,22 +1131,10 @@ function App() {
           <Route path="/settings/ai-performance" element={<Navigate to="/settings/ai/performance" replace />} />
           <Route path="/settings/ai-admin" element={<Navigate to="/settings/ai/admin" replace />} />
           <Route path="/settings/ai-persona" element={<Navigate to="/settings/ai/persona" replace />} />
-          <Route
-            path="/settings/integrations"
-            element={
-              <ProtectedRoute roles={['OWNER', 'ACCOUNTANT']}>
-                <IntegrationHubPage />
-              </ProtectedRoute>
-            }
-          />
-          <Route
-            path="/settings/mdm-test"
-            element={
-              <ProtectedRoute roles={['OWNER']}>
-                <MdmTestPage />
-              </ProtectedRoute>
-            }
-          />
+          {/* P2b — integrations moved to /settings/system/integrations */}
+          <Route path="/settings/integrations" element={<Navigate to="/settings/system/integrations" replace />} />
+          {/* P2b — mdm-test moved to /settings/system/mdm */}
+          <Route path="/settings/mdm-test" element={<Navigate to="/settings/system/mdm" replace />} />
           <Route
             path="/mdm"
             element={

--- a/apps/web/src/config/menu.ts
+++ b/apps/web/src/config/menu.ts
@@ -785,7 +785,7 @@ const OWNER_CONFIG: RoleMenuConfig = {
       icon: Bell,
       zone: 'fin',
       items: [
-        { label: 'Dunning (เตือนค่างวด)', path: '/settings/dunning', icon: Bell },
+        { label: 'Dunning (เตือนค่างวด)', path: '/settings/comms/dunning', icon: Bell },
         // P4-SP2 — auto e-receipt config (e_receipt_auto SystemConfig key)
         { label: 'ใบเสร็จอิเล็กทรอนิกส์อัตโนมัติ', path: '/finance/e-receipt-auto', icon: FileText },
       ],

--- a/apps/web/src/config/menu.ts
+++ b/apps/web/src/config/menu.ts
@@ -743,7 +743,7 @@ const OWNER_CONFIG: RoleMenuConfig = {
         { label: 'สาขา', path: '/branches', icon: Building2 },
         { label: 'บริษัท', path: '/settings/companies', icon: Building2 },
         { label: 'แบบสัญญา', path: '/contract-templates', icon: FileCheck },
-        { label: 'ตั้งราคา', path: '/settings/pricing-templates', icon: CircleDollarSign },
+        { label: 'ตั้งราคา', path: '/settings/products/pricing', icon: CircleDollarSign },
         { label: 'ตั้งค่า GFIN', path: '/settings/finance/gfin', icon: Calculator },
         { label: 'โปรโมชัน', path: '/promotions', icon: BadgePercent },
         { label: 'PDPA', path: '/pdpa', icon: Shield },

--- a/apps/web/src/config/menu.ts
+++ b/apps/web/src/config/menu.ts
@@ -738,10 +738,10 @@ const OWNER_CONFIG: RoleMenuConfig = {
       zone: 'settings',
       items: [
         { label: 'ตั้งค่าระบบ', path: '/settings', icon: Settings },
-        { label: 'บัญชีตาม Role', path: '/settings/account-roles', icon: ClipboardList },
+        { label: 'บัญชีตาม Role', path: '/settings/access/account-roles', icon: ClipboardList },
         { label: 'ผู้ใช้ / พนักงาน', path: '/users', icon: UserCog },
         { label: 'สาขา', path: '/branches', icon: Building2 },
-        { label: 'บริษัท', path: '/settings/companies', icon: Building2 },
+        { label: 'บริษัท', path: '/settings/company/entities', icon: Building2 },
         { label: 'แบบสัญญา', path: '/contract-templates', icon: FileCheck },
         { label: 'ตั้งราคา', path: '/settings/products/pricing', icon: CircleDollarSign },
         { label: 'ตั้งค่า GFIN', path: '/settings/finance/gfin', icon: Calculator },
@@ -775,7 +775,7 @@ const OWNER_CONFIG: RoleMenuConfig = {
       zone: 'fin',
       items: [
         { label: 'LINE OA', path: '/settings/rich-menu', icon: MessageSquareMore },
-        { label: 'การเชื่อมต่อ (PaySolutions / สรรพากร ฯลฯ)', path: '/settings/integrations', icon: Plug },
+        { label: 'การเชื่อมต่อ (PaySolutions / สรรพากร ฯลฯ)', path: '/settings/system/integrations', icon: Plug },
       ],
     },
     {
@@ -908,7 +908,7 @@ const ZONE_CONFIG: Record<string, RoleZoneConfig> = {
       ],
       settings: [
         { label: 'ผู้ใช้ / พนักงาน', path: '/users', icon: UserCog },
-        { label: 'บริษัท', path: '/settings/companies', icon: Building2 },
+        { label: 'บริษัท', path: '/settings/company/entities', icon: Building2 },
         { label: 'สาขา', path: '/branches', icon: Building2 },
         { label: 'ตั้งค่า', path: '/settings', icon: Settings },
         { label: 'เพิ่มเติม', path: '#more', icon: MoreHorizontal, action: 'sidebar' },

--- a/apps/web/src/config/menu.ts
+++ b/apps/web/src/config/menu.ts
@@ -758,11 +758,11 @@ const OWNER_CONFIG: RoleMenuConfig = {
       icon: Sparkles,
       zone: 'settings',
       items: [
-        { label: 'AI Admin', path: '/settings/ai-admin', icon: Sparkles },
-        { label: 'AI Persona', path: '/settings/ai-persona', icon: Sparkles },
-        { label: 'AI Assistant', path: '/settings/ai-chat', icon: Sparkles },
-        { label: 'AI Training', path: '/settings/ai-training', icon: Sparkles },
-        { label: 'AI Performance', path: '/settings/ai-performance', icon: Sparkles },
+        { label: 'AI Admin', path: '/settings/ai/admin', icon: Sparkles },
+        { label: 'AI Persona', path: '/settings/ai/persona', icon: Sparkles },
+        { label: 'AI Assistant', path: '/settings/ai/assistant', icon: Sparkles },
+        { label: 'AI Training', path: '/settings/ai/training', icon: Sparkles },
+        { label: 'AI Performance', path: '/settings/ai/performance', icon: Sparkles },
       ],
     },
     {

--- a/apps/web/src/config/menu.ts
+++ b/apps/web/src/config/menu.ts
@@ -436,9 +436,9 @@ const ACCOUNTANT_CONFIG: RoleMenuConfig = {
         { label: 'ปิดบัญชีสิ้นปี', path: '/finance/year-end-closing', icon: CalendarDays },
         { label: 'งวดบัญชี', path: '/accounting/periods', icon: CalendarDays },
         { label: 'ชำระเงินระหว่างบริษัท', path: '/accounting/intercompany', icon: ClipboardList },
-        { label: 'ผังบัญชี', path: '/settings/chart-of-accounts', icon: ClipboardList },
+        { label: 'ผังบัญชี', path: '/settings/accounting/chart', icon: ClipboardList },
         { label: 'ตรวจสอบบัญชี', path: '/financial-audit', icon: ClipboardList },
-        { label: 'PEAK Sync', path: '/settings/peak-sync', icon: Plug },
+        { label: 'PEAK Sync', path: '/settings/accounting/peak-sync', icon: Plug },
         { label: 'ส่งออก PEAK CSV', path: '/finance/peak-export', icon: Plug },
       ],
     },
@@ -656,7 +656,7 @@ const OWNER_CONFIG: RoleMenuConfig = {
       icon: Landmark,
       zone: 'fin',
       items: [
-        { label: 'ผังบัญชี', path: '/settings/chart-of-accounts', icon: ClipboardList },
+        { label: 'ผังบัญชี', path: '/settings/accounting/chart', icon: ClipboardList },
         // SP6 — Bank/Cash account directory (mirrors CoA 11-1101..1203)
         { label: 'บัญชีเงินสด/ธนาคาร', path: '/finance/bank-accounts', icon: Landmark },
       ],

--- a/apps/web/src/config/settings-registry.tsx
+++ b/apps/web/src/config/settings-registry.tsx
@@ -7,6 +7,11 @@ import SmsTemplatesPage from '@/pages/SmsTemplatesPage';
 import ChannelSettingsPage from '@/pages/ChannelSettingsPage';
 import DunningSettingsPage from '@/pages/DunningSettingsPage';
 import CollectionsSettingsPage from '@/pages/SettingsPage/CollectionsPage';
+import AiAdminPage from '@/pages/AiAdminPage';
+import AiPersonaPage from '@/pages/AiPersonaPage';
+import AiSettingsPage from '@/pages/AiSettingsPage';
+import AiTrainingPage from '@/pages/AiTrainingPage';
+import AiPerformancePage from '@/pages/AiPerformancePage';
 import InterestConfigPage from '@/pages/InterestConfigPage';
 import GfinConfigPage from '@/pages/GfinConfigPage';
 import PaymentMethodSettingsPage from '@/pages/PaymentMethodSettingsPage';
@@ -117,11 +122,11 @@ export const settingsRegistry: SettingsCategory[] = [
   {
     id: 'ai', label: 'AI', icon: Sparkles, roles: ['OWNER'],
     items: [
-      { id: 'ai-admin', label: 'AI Admin', roles: ['OWNER'], kind: 'external', path: '/settings/ai-admin' },
-      { id: 'ai-persona', label: 'AI Persona', roles: ['OWNER'], kind: 'external', path: '/settings/ai-persona' },
-      { id: 'ai-assistant', label: 'AI Assistant', roles: ['OWNER'], kind: 'external', path: '/settings/ai-chat' },
-      { id: 'ai-training', label: 'AI Training', roles: ['OWNER'], kind: 'external', path: '/settings/ai-training' },
-      { id: 'ai-performance', label: 'AI Performance', roles: ['OWNER'], kind: 'external', path: '/settings/ai-performance' },
+      { id: 'admin', label: 'AI Admin', roles: ['OWNER'], kind: 'route', component: AiAdminPage, path: '/settings/ai/admin' },
+      { id: 'persona', label: 'AI Persona', roles: ['OWNER'], kind: 'route', component: AiPersonaPage, path: '/settings/ai/persona' },
+      { id: 'assistant', label: 'AI Assistant', roles: ['OWNER'], kind: 'route', component: AiSettingsPage, path: '/settings/ai/assistant' },
+      { id: 'training', label: 'AI Training', roles: ['OWNER'], kind: 'route', component: AiTrainingPage, path: '/settings/ai/training' },
+      { id: 'performance', label: 'AI Performance', roles: ['OWNER'], kind: 'route', component: AiPerformancePage, path: '/settings/ai/performance' },
     ],
   },
   {

--- a/apps/web/src/config/settings-registry.tsx
+++ b/apps/web/src/config/settings-registry.tsx
@@ -7,6 +7,8 @@ import SmsTemplatesPage from '@/pages/SmsTemplatesPage';
 import ChannelSettingsPage from '@/pages/ChannelSettingsPage';
 import DunningSettingsPage from '@/pages/DunningSettingsPage';
 import CollectionsSettingsPage from '@/pages/SettingsPage/CollectionsPage';
+import PricingTemplatesPage from '@/pages/PricingTemplatesPage';
+import StickersSettingsPage from '@/pages/SettingsPage/StickersPage';
 import AiAdminPage from '@/pages/AiAdminPage';
 import AiPersonaPage from '@/pages/AiPersonaPage';
 import AiSettingsPage from '@/pages/AiSettingsPage';
@@ -101,8 +103,8 @@ export const settingsRegistry: SettingsCategory[] = [
   {
     id: 'products', label: 'สินค้า & การขาย', icon: Smartphone, roles: ['OWNER'],
     items: [
-      { id: 'pricing', label: 'ตั้งราคา', roles: ['OWNER'], kind: 'external', path: '/settings/pricing-templates' },
-      { id: 'stickers', label: 'สติกเกอร์ฉลาก', roles: ['OWNER'], kind: 'external', path: '/settings/stickers' },
+      { id: 'pricing', label: 'ตั้งราคา', roles: ['OWNER'], kind: 'route', component: PricingTemplatesPage, path: '/settings/products/pricing' },
+      { id: 'stickers', label: 'สติกเกอร์ฉลาก', roles: ['OWNER'], kind: 'route', component: StickersSettingsPage, path: '/settings/products/stickers' },
       { id: 'promotions', label: 'โปรโมชัน', roles: ['OWNER'], kind: 'external', path: '/promotions' },
       { id: 'contract-templates', label: 'แบบสัญญา', roles: ['OWNER'], kind: 'external', path: '/contract-templates' },
     ],

--- a/apps/web/src/config/settings-registry.tsx
+++ b/apps/web/src/config/settings-registry.tsx
@@ -4,6 +4,9 @@ import { Building2, Users, BarChart3, Wallet, Smartphone, MessageSquare, Sparkle
 import InterestConfigPage from '@/pages/InterestConfigPage';
 import GfinConfigPage from '@/pages/GfinConfigPage';
 import PaymentMethodSettingsPage from '@/pages/PaymentMethodSettingsPage';
+import ChartOfAccountsPage from '@/pages/ChartOfAccountsPage';
+import PeakSyncPage from '@/pages/PeakSyncPage';
+import { ETaxConfigPage } from '@/pages/ETaxConfigPage';
 // inline components (อยู่ที่เดิม — แค่ import มา render)
 import { CompanyTab } from '@/pages/SettingsPage/tabs/CompanyTab';
 import { ContactsTab } from '@/pages/SettingsPage/tabs/ContactsTab';
@@ -70,9 +73,9 @@ export const settingsRegistry: SettingsCategory[] = [
       { id: 'vat', label: 'VAT', group: 'ภาษี', roles: ['OWNER'], kind: 'inline', component: VatTab, keywords: ['ภาษี', '7%', 'มูลค่าเพิ่ม'] },
       { id: 'periods', label: 'งวดบัญชี', group: 'บัญชี', roles: ['OWNER'], kind: 'inline', component: PeriodsTab, keywords: ['ปิดงวด', 'period'] },
       { id: 'peak-mapping', label: 'PEAK mapping', group: 'บัญชี', roles: ALL, kind: 'inline', component: PeakMappingTab, keywords: ['peak'] },
-      { id: 'chart', label: 'ผังบัญชี', group: 'บัญชี', roles: ALL, kind: 'external', path: '/settings/chart-of-accounts' },
-      { id: 'peak-sync', label: 'PEAK sync', group: 'บัญชี', roles: ['OWNER', 'ACCOUNTANT'], kind: 'external', path: '/settings/peak-sync' },
-      { id: 'e-tax', label: 'e-Tax', group: 'ภาษี', roles: ['OWNER'], kind: 'external', path: '/settings/e-tax-config' },
+      { id: 'chart', label: 'ผังบัญชี', group: 'บัญชี', roles: ALL, kind: 'route', component: ChartOfAccountsPage, path: '/settings/accounting/chart' },
+      { id: 'peak-sync', label: 'PEAK sync', group: 'บัญชี', roles: ['OWNER', 'ACCOUNTANT'], kind: 'route', component: PeakSyncPage, path: '/settings/accounting/peak-sync' },
+      { id: 'e-tax', label: 'e-Tax', group: 'ภาษี', roles: ['OWNER'], kind: 'route', component: ETaxConfigPage, path: '/settings/accounting/e-tax' },
       { id: 'documents', label: 'เลขที่/รูปแบบเอกสาร', group: 'บัญชี', roles: ['OWNER'], kind: 'external', path: '/settings/document-config' },
     ],
   },

--- a/apps/web/src/config/settings-registry.tsx
+++ b/apps/web/src/config/settings-registry.tsx
@@ -1,6 +1,12 @@
 import type { ComponentType } from 'react';
 import type { LucideIcon } from 'lucide-react';
 import { Building2, Users, BarChart3, Wallet, Smartphone, MessageSquare, Sparkles, ShieldCheck } from 'lucide-react';
+import LineOaSettingsPage from '@/pages/LineOaSettingsPage';
+import LineGreetingPage from '@/pages/LineGreetingPage';
+import SmsTemplatesPage from '@/pages/SmsTemplatesPage';
+import ChannelSettingsPage from '@/pages/ChannelSettingsPage';
+import DunningSettingsPage from '@/pages/DunningSettingsPage';
+import CollectionsSettingsPage from '@/pages/SettingsPage/CollectionsPage';
 import InterestConfigPage from '@/pages/InterestConfigPage';
 import GfinConfigPage from '@/pages/GfinConfigPage';
 import PaymentMethodSettingsPage from '@/pages/PaymentMethodSettingsPage';
@@ -99,13 +105,13 @@ export const settingsRegistry: SettingsCategory[] = [
   {
     id: 'comms', label: 'สื่อสารลูกค้า', icon: MessageSquare, roles: ['OWNER', 'FINANCE_MANAGER'],
     items: [
-      { id: 'line-oa', label: 'LINE OA', roles: ['OWNER'], kind: 'external', path: '/settings/line-oa' },
+      { id: 'line-oa', label: 'LINE OA', roles: ['OWNER'], kind: 'route', component: LineOaSettingsPage, path: '/settings/comms/line-oa' },
       { id: 'rich-menu', label: 'Rich Menu', roles: ['OWNER'], kind: 'external', path: '/settings/rich-menu' },
-      { id: 'greeting', label: 'ข้อความทักทาย', roles: ['OWNER'], kind: 'external', path: '/settings/line-greeting' },
-      { id: 'sms', label: 'SMS templates', roles: ['OWNER', 'FINANCE_MANAGER'], kind: 'external', path: '/settings/sms-templates' },
-      { id: 'channels', label: 'ช่องทาง', roles: ['OWNER'], kind: 'external', path: '/settings/channels' },
-      { id: 'dunning', label: 'Dunning', roles: ['OWNER'], kind: 'external', path: '/settings/dunning' },
-      { id: 'collections', label: 'ตั้งค่า collections', roles: ['OWNER'], kind: 'external', path: '/settings/collections' },
+      { id: 'greeting', label: 'ข้อความทักทาย', roles: ['OWNER'], kind: 'route', component: LineGreetingPage, path: '/settings/comms/greeting' },
+      { id: 'sms', label: 'SMS templates', roles: ['OWNER', 'FINANCE_MANAGER'], kind: 'route', component: SmsTemplatesPage, path: '/settings/comms/sms' },
+      { id: 'channels', label: 'ช่องทาง', roles: ['OWNER'], kind: 'route', component: ChannelSettingsPage, path: '/settings/comms/channels' },
+      { id: 'dunning', label: 'Dunning', roles: ['OWNER'], kind: 'route', component: DunningSettingsPage, path: '/settings/comms/dunning' },
+      { id: 'collections', label: 'ตั้งค่า collections', roles: ['OWNER'], kind: 'route', component: CollectionsSettingsPage, path: '/settings/comms/collections' },
     ],
   },
   {

--- a/apps/web/src/config/settings-registry.tsx
+++ b/apps/web/src/config/settings-registry.tsx
@@ -1,6 +1,10 @@
 import type { ComponentType } from 'react';
 import type { LucideIcon } from 'lucide-react';
 import { Building2, Users, BarChart3, Wallet, Smartphone, MessageSquare, Sparkles, ShieldCheck } from 'lucide-react';
+import CompanySettingsPage from '@/pages/CompanySettingsPage';
+import AccountRolesPage from '@/pages/AccountRolesPage';
+import IntegrationHubPage from '@/pages/IntegrationHubPage';
+import MdmTestPage from '@/pages/MdmTestPage';
 import LineOaSettingsPage from '@/pages/LineOaSettingsPage';
 import LineGreetingPage from '@/pages/LineGreetingPage';
 import SmsTemplatesPage from '@/pages/SmsTemplatesPage';
@@ -64,7 +68,7 @@ export const settingsRegistry: SettingsCategory[] = [
     items: [
       { id: 'company-info', label: 'ข้อมูลบริษัท', group: 'บริษัท', roles: ['OWNER'], kind: 'inline', component: CompanyTab, keywords: ['ที่อยู่', 'โลโก้', 'ผู้เซ็น', 'tax id'] },
       { id: 'contacts', label: 'สมุดผู้ติดต่อ', group: 'บริษัท', roles: ALL, kind: 'inline', component: ContactsTab, keywords: ['ลูกค้า', 'ผู้ขาย', 'supplier'] },
-      { id: 'entities', label: 'บริษัทในเครือ', group: 'บริษัท', roles: ['OWNER'], kind: 'external', path: '/settings/companies' },
+      { id: 'entities', label: 'บริษัทในเครือ', group: 'บริษัท', roles: ['OWNER'], kind: 'route', component: CompanySettingsPage, path: '/settings/company/entities' },
       { id: 'branches', label: 'สาขา', group: 'สาขา', roles: ['OWNER'], kind: 'external', path: '/branches' },
     ],
   },
@@ -72,7 +76,7 @@ export const settingsRegistry: SettingsCategory[] = [
     id: 'access', label: 'ผู้ใช้ & สิทธิ์', icon: Users, roles: ['OWNER'],
     items: [
       { id: 'users', label: 'ผู้ใช้ / พนักงาน', group: 'ผู้ใช้', roles: ['OWNER'], kind: 'external', path: '/users' },
-      { id: 'account-roles', label: 'บัญชีตาม Role', group: 'ผู้ใช้', roles: ['OWNER'], kind: 'external', path: '/settings/account-roles' },
+      { id: 'account-roles', label: 'บัญชีตาม Role', group: 'ผู้ใช้', roles: ['OWNER'], kind: 'route', component: AccountRolesPage, path: '/settings/access/account-roles' },
       { id: 'maker-checker', label: 'ระบบอนุมัติ 2 ชั้น (Maker-Checker)', group: 'การอนุมัติ & สิทธิ์', roles: ['OWNER'], kind: 'inline', component: MakerCheckerToggle, keywords: ['อนุมัติ', 'maker', 'checker'] },
       { id: 'reverse-permission', label: 'สิทธิ์กลับรายการ', group: 'การอนุมัติ & สิทธิ์', roles: ['OWNER'], kind: 'inline', component: ReversePermissionCard, keywords: ['reverse', 'กลับรายการ', 'void'] },
       { id: 'reverse-reasons', label: 'เหตุผลกลับรายการ', group: 'การอนุมัติ & สิทธิ์', roles: ['OWNER'], kind: 'inline', component: ReverseReasonsManagementCard },
@@ -137,8 +141,8 @@ export const settingsRegistry: SettingsCategory[] = [
       { id: 'test-mode', label: 'โหมดทดสอบ', group: 'ความปลอดภัย', roles: ['OWNER'], kind: 'inline', component: TestModeToggle, keywords: ['test', 'otp', '2fa', 'เครดิต'] },
       { id: 'pdpa', label: 'PDPA', group: 'ความปลอดภัย', roles: ['OWNER'], kind: 'inline', component: PdpaTab, keywords: ['pdpa', 'ข้อมูลส่วนบุคคล', 'encryption'] },
       { id: 'backup', label: 'สำรองข้อมูล', group: 'ข้อมูล', roles: ['OWNER'], kind: 'inline', component: OffsiteBackupTab, keywords: ['backup', 'สำรอง'] },
-      { id: 'integrations', label: 'การเชื่อมต่อ', group: 'เชื่อมต่อ', roles: ['OWNER', 'ACCOUNTANT'], kind: 'external', path: '/settings/integrations' },
-      { id: 'mdm', label: 'MDM', group: 'เชื่อมต่อ', roles: ['OWNER'], kind: 'external', path: '/settings/mdm-test' },
+      { id: 'integrations', label: 'การเชื่อมต่อ', group: 'เชื่อมต่อ', roles: ['OWNER', 'ACCOUNTANT'], kind: 'route', component: IntegrationHubPage, path: '/settings/system/integrations' },
+      { id: 'mdm', label: 'MDM', group: 'เชื่อมต่อ', roles: ['OWNER'], kind: 'route', component: MdmTestPage, path: '/settings/system/mdm' },
       { id: 'audit-log', label: 'Audit Log', group: 'ข้อมูล', roles: ['OWNER'], kind: 'external', path: '/audit-logs' },
       { id: 'system-status', label: 'System Status', group: 'ข้อมูล', roles: ['OWNER'], kind: 'external', path: '/system-status' },
     ],

--- a/apps/web/src/pages/AiAdminPage.tsx
+++ b/apps/web/src/pages/AiAdminPage.tsx
@@ -200,7 +200,7 @@ export default function AiAdminPage() {
       {/* Shortcut tiles to other AI pages */}
       <div className="grid grid-cols-1 md:grid-cols-3 gap-3 mb-6">
         <Link
-          to="/settings/ai-performance"
+          to="/settings/ai/performance"
           className="bg-card rounded-xl p-4 shadow-sm hover:bg-accent/50 transition-colors flex items-center justify-between"
         >
           <div className="flex items-center gap-3">
@@ -213,7 +213,7 @@ export default function AiAdminPage() {
           <ArrowRight className="w-4 h-4 text-muted-foreground" />
         </Link>
         <Link
-          to="/settings/ai-training"
+          to="/settings/ai/training"
           className="bg-card rounded-xl p-4 shadow-sm hover:bg-accent/50 transition-colors flex items-center justify-between"
         >
           <div className="flex items-center gap-3">
@@ -226,7 +226,7 @@ export default function AiAdminPage() {
           <ArrowRight className="w-4 h-4 text-muted-foreground" />
         </Link>
         <Link
-          to="/settings/ai-chat"
+          to="/settings/ai/assistant"
           className="bg-card rounded-xl p-4 shadow-sm hover:bg-accent/50 transition-colors flex items-center justify-between"
         >
           <div className="flex items-center gap-3">

--- a/apps/web/src/pages/DunningSettingsPage.tsx
+++ b/apps/web/src/pages/DunningSettingsPage.tsx
@@ -366,7 +366,7 @@ export default function DunningSettingsPage() {
         action={
           <div className="flex items-center gap-2">
             <a
-              href="/settings/sms-templates"
+              href="/settings/comms/sms"
               className="text-xs px-3 py-2 rounded-md border border-border hover:bg-accent text-foreground"
             >
               จัดการ SMS Template

--- a/apps/web/src/pages/ETaxInvoicePage.tsx
+++ b/apps/web/src/pages/ETaxInvoicePage.tsx
@@ -209,7 +209,7 @@ export function ETaxInvoicePage() {
         action={
           <div className="flex gap-2">
             <Button variant="ghost" asChild>
-              <Link to="/settings/e-tax-config" aria-label="ตั้งค่า e-Tax">
+              <Link to="/settings/accounting/e-tax" aria-label="ตั้งค่า e-Tax">
                 <SettingsIcon className="size-4 mr-2" aria-hidden />
                 ตั้งค่า
               </Link>

--- a/apps/web/src/pages/settings/__tests__/accounting-migration.test.tsx
+++ b/apps/web/src/pages/settings/__tests__/accounting-migration.test.tsx
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Routes, Route, Navigate } from 'react-router';
+import { SettingsLayout } from '../SettingsLayout';
+import { SettingsCategoryRoute } from '../SettingsCategoryRoute';
+import { SettingsItemRoute } from '../SettingsItemRoute';
+
+vi.mock('@/contexts/AuthContext', () => ({ useAuth: () => ({ user: { role: 'OWNER' } }) }));
+vi.mock('@/hooks/useIsMobile', () => ({ useIsMobile: () => false }));
+vi.mock('@/pages/ChartOfAccountsPage', () => ({ default: () => <div>chart-page</div> }));
+vi.mock('@/pages/PeakSyncPage', () => ({ default: () => <div>peak-sync-page</div> }));
+vi.mock('@/pages/ETaxConfigPage', () => ({ ETaxConfigPage: () => <div>e-tax-page</div> }));
+
+function App({ entry }: { entry: string }) {
+  return (
+    <MemoryRouter initialEntries={[entry]}>
+      <Routes>
+        <Route path="/settings/chart-of-accounts" element={<Navigate to="/settings/accounting/chart" replace />} />
+        <Route path="/settings/peak-sync" element={<Navigate to="/settings/accounting/peak-sync" replace />} />
+        <Route path="/settings/e-tax-config" element={<Navigate to="/settings/accounting/e-tax" replace />} />
+        <Route path="/settings/:categoryId" element={<SettingsLayout />}>
+          <Route index element={<SettingsCategoryRoute />} />
+          <Route path=":itemId" element={<SettingsItemRoute />} />
+        </Route>
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe('accounting migration', () => {
+  it('/settings/accounting/chart → render หน้า chart ใน panel (มี nav ข้างซ้าย)', () => {
+    render(<App entry="/settings/accounting/chart" />);
+    expect(screen.getByText('chart-page')).toBeTruthy();
+    // panel nav ยังอยู่ (link หมวด accounting)
+    expect(screen.getByRole('link', { name: /บัญชี/ })).toBeTruthy();
+  });
+
+  it('old /settings/chart-of-accounts → redirect ไป /settings/accounting/chart', async () => {
+    render(<App entry="/settings/chart-of-accounts" />);
+    await waitFor(() => expect(screen.getByText('chart-page')).toBeTruthy());
+  });
+
+  it('old /settings/peak-sync → redirect ไป /settings/accounting/peak-sync', async () => {
+    render(<App entry="/settings/peak-sync" />);
+    await waitFor(() => expect(screen.getByText('peak-sync-page')).toBeTruthy());
+  });
+
+  it('old /settings/e-tax-config → redirect ไป /settings/accounting/e-tax', async () => {
+    render(<App entry="/settings/e-tax-config" />);
+    await waitFor(() => expect(screen.getByText('e-tax-page')).toBeTruthy());
+  });
+});

--- a/apps/web/src/pages/settings/__tests__/ai-migration.test.tsx
+++ b/apps/web/src/pages/settings/__tests__/ai-migration.test.tsx
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Routes, Route, Navigate } from 'react-router';
+import { SettingsLayout } from '../SettingsLayout';
+import { SettingsCategoryRoute } from '../SettingsCategoryRoute';
+import { SettingsItemRoute } from '../SettingsItemRoute';
+
+vi.mock('@/contexts/AuthContext', () => ({ useAuth: () => ({ user: { role: 'OWNER' } }) }));
+vi.mock('@/hooks/useIsMobile', () => ({ useIsMobile: () => false }));
+vi.mock('@/pages/AiAdminPage', () => ({ default: () => <div>admin-page</div> }));
+vi.mock('@/pages/AiPersonaPage', () => ({ default: () => <div>persona-page</div> }));
+vi.mock('@/pages/AiSettingsPage', () => ({ default: () => <div>assistant-page</div> }));
+vi.mock('@/pages/AiTrainingPage', () => ({ default: () => <div>training-page</div> }));
+vi.mock('@/pages/AiPerformancePage', () => ({ default: () => <div>performance-page</div> }));
+
+function App({ entry }: { entry: string }) {
+  return (
+    <MemoryRouter initialEntries={[entry]}>
+      <Routes>
+        <Route path="/settings/ai-admin" element={<Navigate to="/settings/ai/admin" replace />} />
+        <Route path="/settings/ai-persona" element={<Navigate to="/settings/ai/persona" replace />} />
+        <Route path="/settings/ai-chat" element={<Navigate to="/settings/ai/assistant" replace />} />
+        <Route path="/settings/ai-training" element={<Navigate to="/settings/ai/training" replace />} />
+        <Route path="/settings/ai-performance" element={<Navigate to="/settings/ai/performance" replace />} />
+        <Route path="/settings/:categoryId" element={<SettingsLayout />}>
+          <Route index element={<SettingsCategoryRoute />} />
+          <Route path=":itemId" element={<SettingsItemRoute />} />
+        </Route>
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe('ai migration', () => {
+  it('/settings/ai/admin → render หน้า admin ใน panel (มี nav ข้างซ้าย)', () => {
+    render(<App entry="/settings/ai/admin" />);
+    expect(screen.getByText('admin-page')).toBeTruthy();
+    // panel nav ยังอยู่ (link หมวด ai)
+    expect(screen.getByRole('link', { name: /AI/ })).toBeTruthy();
+  });
+
+  it('old /settings/ai-admin → redirect ไป /settings/ai/admin', async () => {
+    render(<App entry="/settings/ai-admin" />);
+    await waitFor(() => expect(screen.getByText('admin-page')).toBeTruthy());
+  });
+
+  it('old /settings/ai-persona → redirect ไป /settings/ai/persona', async () => {
+    render(<App entry="/settings/ai-persona" />);
+    await waitFor(() => expect(screen.getByText('persona-page')).toBeTruthy());
+  });
+
+  it('old /settings/ai-chat → redirect ไป /settings/ai/assistant', async () => {
+    render(<App entry="/settings/ai-chat" />);
+    await waitFor(() => expect(screen.getByText('assistant-page')).toBeTruthy());
+  });
+
+  it('old /settings/ai-training → redirect ไป /settings/ai/training', async () => {
+    render(<App entry="/settings/ai-training" />);
+    await waitFor(() => expect(screen.getByText('training-page')).toBeTruthy());
+  });
+
+  it('old /settings/ai-performance → redirect ไป /settings/ai/performance', async () => {
+    render(<App entry="/settings/ai-performance" />);
+    await waitFor(() => expect(screen.getByText('performance-page')).toBeTruthy());
+  });
+});

--- a/apps/web/src/pages/settings/__tests__/comms-migration.test.tsx
+++ b/apps/web/src/pages/settings/__tests__/comms-migration.test.tsx
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Routes, Route, Navigate } from 'react-router';
+import { SettingsLayout } from '../SettingsLayout';
+import { SettingsCategoryRoute } from '../SettingsCategoryRoute';
+import { SettingsItemRoute } from '../SettingsItemRoute';
+
+vi.mock('@/contexts/AuthContext', () => ({ useAuth: () => ({ user: { role: 'OWNER' } }) }));
+vi.mock('@/hooks/useIsMobile', () => ({ useIsMobile: () => false }));
+vi.mock('@/pages/LineOaSettingsPage', () => ({ default: () => <div>line-oa-page</div> }));
+vi.mock('@/pages/LineGreetingPage', () => ({ default: () => <div>greeting-page</div> }));
+vi.mock('@/pages/SmsTemplatesPage', () => ({ default: () => <div>sms-page</div> }));
+vi.mock('@/pages/ChannelSettingsPage', () => ({ default: () => <div>channels-page</div> }));
+vi.mock('@/pages/DunningSettingsPage', () => ({ default: () => <div>dunning-page</div> }));
+vi.mock('@/pages/SettingsPage/CollectionsPage', () => ({ default: () => <div>collections-page</div> }));
+
+function App({ entry }: { entry: string }) {
+  return (
+    <MemoryRouter initialEntries={[entry]}>
+      <Routes>
+        <Route path="/settings/line-oa" element={<Navigate to="/settings/comms/line-oa" replace />} />
+        <Route path="/settings/line-greeting" element={<Navigate to="/settings/comms/greeting" replace />} />
+        <Route path="/settings/sms-templates" element={<Navigate to="/settings/comms/sms" replace />} />
+        <Route path="/settings/channels" element={<Navigate to="/settings/comms/channels" replace />} />
+        <Route path="/settings/dunning" element={<Navigate to="/settings/comms/dunning" replace />} />
+        <Route path="/settings/collections" element={<Navigate to="/settings/comms/collections" replace />} />
+        <Route path="/settings/:categoryId" element={<SettingsLayout />}>
+          <Route index element={<SettingsCategoryRoute />} />
+          <Route path=":itemId" element={<SettingsItemRoute />} />
+        </Route>
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe('comms migration', () => {
+  it('/settings/comms/line-oa → render หน้า line-oa ใน panel (มี nav ข้างซ้าย)', () => {
+    render(<App entry="/settings/comms/line-oa" />);
+    expect(screen.getByText('line-oa-page')).toBeTruthy();
+    // panel nav ยังอยู่ (link หมวด comms)
+    expect(screen.getByRole('link', { name: /สื่อสาร/ })).toBeTruthy();
+  });
+
+  it('old /settings/line-oa → redirect ไป /settings/comms/line-oa', async () => {
+    render(<App entry="/settings/line-oa" />);
+    await waitFor(() => expect(screen.getByText('line-oa-page')).toBeTruthy());
+  });
+
+  it('old /settings/line-greeting → redirect ไป /settings/comms/greeting', async () => {
+    render(<App entry="/settings/line-greeting" />);
+    await waitFor(() => expect(screen.getByText('greeting-page')).toBeTruthy());
+  });
+
+  it('old /settings/sms-templates → redirect ไป /settings/comms/sms', async () => {
+    render(<App entry="/settings/sms-templates" />);
+    await waitFor(() => expect(screen.getByText('sms-page')).toBeTruthy());
+  });
+
+  it('old /settings/channels → redirect ไป /settings/comms/channels', async () => {
+    render(<App entry="/settings/channels" />);
+    await waitFor(() => expect(screen.getByText('channels-page')).toBeTruthy());
+  });
+
+  it('old /settings/dunning → redirect ไป /settings/comms/dunning', async () => {
+    render(<App entry="/settings/dunning" />);
+    await waitFor(() => expect(screen.getByText('dunning-page')).toBeTruthy());
+  });
+
+  it('old /settings/collections → redirect ไป /settings/comms/collections', async () => {
+    render(<App entry="/settings/collections" />);
+    await waitFor(() => expect(screen.getByText('collections-page')).toBeTruthy());
+  });
+});

--- a/apps/web/src/pages/settings/__tests__/company-access-system-migration.test.tsx
+++ b/apps/web/src/pages/settings/__tests__/company-access-system-migration.test.tsx
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Routes, Route, Navigate } from 'react-router';
+import { SettingsLayout } from '../SettingsLayout';
+import { SettingsCategoryRoute } from '../SettingsCategoryRoute';
+import { SettingsItemRoute } from '../SettingsItemRoute';
+
+vi.mock('@/contexts/AuthContext', () => ({ useAuth: () => ({ user: { role: 'OWNER' } }) }));
+vi.mock('@/hooks/useIsMobile', () => ({ useIsMobile: () => false }));
+vi.mock('@/pages/CompanySettingsPage', () => ({ default: () => <div>entities-page</div> }));
+vi.mock('@/pages/AccountRolesPage', () => ({ default: () => <div>account-roles-page</div> }));
+vi.mock('@/pages/IntegrationHubPage', () => ({ default: () => <div>integrations-page</div> }));
+vi.mock('@/pages/MdmTestPage', () => ({ default: () => <div>mdm-page</div> }));
+
+function App({ entry }: { entry: string }) {
+  return (
+    <MemoryRouter initialEntries={[entry]}>
+      <Routes>
+        {/* redirects from old paths */}
+        <Route path="/settings/companies" element={<Navigate to="/settings/company/entities" replace />} />
+        <Route path="/settings/account-roles" element={<Navigate to="/settings/access/account-roles" replace />} />
+        <Route path="/settings/integrations" element={<Navigate to="/settings/system/integrations" replace />} />
+        <Route path="/settings/mdm-test" element={<Navigate to="/settings/system/mdm" replace />} />
+        <Route path="/settings/:categoryId" element={<SettingsLayout />}>
+          <Route index element={<SettingsCategoryRoute />} />
+          <Route path=":itemId" element={<SettingsItemRoute />} />
+        </Route>
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe('company/access/system migration', () => {
+  it('/settings/company/entities → render หน้า entities ใน panel (มี nav ข้างซ้าย)', () => {
+    render(<App entry="/settings/company/entities" />);
+    expect(screen.getByText('entities-page')).toBeTruthy();
+    // panel nav ยังอยู่ (link หมวด company)
+    expect(screen.getByRole('link', { name: /บริษัท/ })).toBeTruthy();
+  });
+
+  it('/settings/access/account-roles → render หน้า account-roles ใน panel', () => {
+    render(<App entry="/settings/access/account-roles" />);
+    expect(screen.getByText('account-roles-page')).toBeTruthy();
+    expect(screen.getByRole('link', { name: /ผู้ใช้/ })).toBeTruthy();
+  });
+
+  it('/settings/system/integrations → render หน้า integrations ใน panel', () => {
+    render(<App entry="/settings/system/integrations" />);
+    expect(screen.getByText('integrations-page')).toBeTruthy();
+    expect(screen.getByRole('link', { name: /ระบบ/ })).toBeTruthy();
+  });
+
+  it('old /settings/companies → redirect ไป /settings/company/entities', async () => {
+    render(<App entry="/settings/companies" />);
+    await waitFor(() => expect(screen.getByText('entities-page')).toBeTruthy());
+  });
+
+  it('old /settings/account-roles → redirect ไป /settings/access/account-roles', async () => {
+    render(<App entry="/settings/account-roles" />);
+    await waitFor(() => expect(screen.getByText('account-roles-page')).toBeTruthy());
+  });
+
+  it('old /settings/integrations → redirect ไป /settings/system/integrations', async () => {
+    render(<App entry="/settings/integrations" />);
+    await waitFor(() => expect(screen.getByText('integrations-page')).toBeTruthy());
+  });
+
+  it('old /settings/mdm-test → redirect ไป /settings/system/mdm', async () => {
+    render(<App entry="/settings/mdm-test" />);
+    await waitFor(() => expect(screen.getByText('mdm-page')).toBeTruthy());
+  });
+});

--- a/apps/web/src/pages/settings/__tests__/company-access-system-migration.test.tsx
+++ b/apps/web/src/pages/settings/__tests__/company-access-system-migration.test.tsx
@@ -50,6 +50,12 @@ describe('company/access/system migration', () => {
     expect(screen.getByRole('link', { name: /ระบบ/ })).toBeTruthy();
   });
 
+  it('/settings/system/mdm → render หน้า mdm ใน panel', () => {
+    render(<App entry="/settings/system/mdm" />);
+    expect(screen.getByText('mdm-page')).toBeTruthy();
+    expect(screen.getByRole('link', { name: /ระบบ/ })).toBeTruthy();
+  });
+
   it('old /settings/companies → redirect ไป /settings/company/entities', async () => {
     render(<App entry="/settings/companies" />);
     await waitFor(() => expect(screen.getByText('entities-page')).toBeTruthy());

--- a/apps/web/src/pages/settings/__tests__/products-migration.test.tsx
+++ b/apps/web/src/pages/settings/__tests__/products-migration.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Routes, Route, Navigate } from 'react-router';
+import { SettingsLayout } from '../SettingsLayout';
+import { SettingsCategoryRoute } from '../SettingsCategoryRoute';
+import { SettingsItemRoute } from '../SettingsItemRoute';
+
+vi.mock('@/contexts/AuthContext', () => ({ useAuth: () => ({ user: { role: 'OWNER' } }) }));
+vi.mock('@/hooks/useIsMobile', () => ({ useIsMobile: () => false }));
+vi.mock('@/pages/PricingTemplatesPage', () => ({ default: () => <div>pricing-page</div> }));
+vi.mock('@/pages/SettingsPage/StickersPage', () => ({ default: () => <div>stickers-page</div> }));
+
+function App({ entry }: { entry: string }) {
+  return (
+    <MemoryRouter initialEntries={[entry]}>
+      <Routes>
+        <Route path="/settings/pricing-templates" element={<Navigate to="/settings/products/pricing" replace />} />
+        <Route path="/settings/stickers" element={<Navigate to="/settings/products/stickers" replace />} />
+        <Route path="/settings/:categoryId" element={<SettingsLayout />}>
+          <Route index element={<SettingsCategoryRoute />} />
+          <Route path=":itemId" element={<SettingsItemRoute />} />
+        </Route>
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe('products migration', () => {
+  it('/settings/products/pricing → render หน้า pricing ใน panel (มี nav ข้างซ้าย)', () => {
+    render(<App entry="/settings/products/pricing" />);
+    expect(screen.getByText('pricing-page')).toBeTruthy();
+    // panel nav ยังอยู่ (link หมวด products)
+    expect(screen.getByRole('link', { name: /สินค้า/ })).toBeTruthy();
+  });
+
+  it('old /settings/pricing-templates → redirect ไป /settings/products/pricing', async () => {
+    render(<App entry="/settings/pricing-templates" />);
+    await waitFor(() => expect(screen.getByText('pricing-page')).toBeTruthy());
+  });
+
+  it('old /settings/stickers → redirect ไป /settings/products/stickers', async () => {
+    render(<App entry="/settings/stickers" />);
+    await waitFor(() => expect(screen.getByText('stickers-page')).toBeTruthy());
+  });
+});

--- a/docs/superpowers/plans/2026-06-23-settings-ia-redesign-p2b-remaining-categories.md
+++ b/docs/superpowers/plans/2026-06-23-settings-ia-redesign-p2b-remaining-categories.md
@@ -1,0 +1,234 @@
+# Settings IA Redesign — P2b (Remaining Category Migrations) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** ย้ายหน้า config ที่เหลือทั้งหมด (20 หน้า ใน 7 หมวด) เข้า settings panel เป็น `/settings/<หมวด>/<รายการ>` ตาม pattern ที่ P2a พิสูจน์กับ finance — โดยหน้าที่มีแท็บในตัว (DocumentConfig, RichMenu) คงเป็น external เต็มจอ
+
+**Architecture:** P2a สร้าง infra ครบแล้ว — `SettingsItemRoute` render `item.component` ของ route-item ใดๆ แบบ generic, `SettingsCategoryRoute` เป็น index, nested routes ใต้ `/settings/:categoryId`. P2b จึง **ไม่ต้องแก้ infra** — แค่: (1) เปลี่ยน registry item จาก `kind:'external'`→`'route'` + ใส่ `component` + path ใหม่; (2) เพิ่ม redirect path เก่า→ใหม่ + ลบ route เดิมใน App.tsx; (3) แก้ internal links. ทุกหมวดใช้ **Migration Recipe เดียวกัน** (ด้านล่าง) ต่างกันแค่ข้อมูลในตารางของแต่ละหมวด
+
+**Tech Stack:** React 18 + TS + Vite + react-router v7 + Tailwind + Vitest
+
+**Spec:** `docs/superpowers/specs/2026-06-23-settings-ia-redesign-design.md` · **Builds on:** P2a (Outlet foundation + finance)
+
+**Sequencing note:** ทุก task แก้ไฟล์ร่วมกัน 2 ไฟล์ (`settings-registry.tsx` + `App.tsx`) → **ต้องทำเรียงลำดับ (sequential)** ห้ามขนาน (จะ conflict). subagent-driven ทีละ task เหมาะสุด
+
+## Global Constraints
+
+- Design-token classes only; functional components + hooks; Thai `leading-snug`
+- Registry = single source of truth; role guard จาก `item.roles` (มีอยู่แล้วใน SettingsItemRoute)
+- **ห้ามแตะ internals** ของหน้าที่ย้าย — แค่ import + ผูก route + redirect
+- หน้าที่มี **แท็บ/sub-nav ของตัวเอง คง `kind:'external'`** (path เดิม): DocumentConfigPage, RichMenuPage — ห้ามเปลี่ยนเป็น route
+- หน้า operational คง external path เดิม (ไม่อยู่ใน P2b): promotions, contract-templates, branches, users, audit-logs, system-status
+- redirect ใช้ react-router `<Navigate replace>`; แก้ internal links (ไม่พึ่ง redirect อย่างเดียว)
+- `ETaxConfigPage` เป็น **named export** — registry ต้อง `import { ETaxConfigPage }` (ไม่ใช่ default)
+- Commit ทีละ task (= ทีละหมวด); branch stack ต่อจาก P2a
+
+---
+
+## Migration Recipe (ใช้กับทุกหมวด — แทนค่าจากตารางของหมวดนั้น)
+
+สำหรับหมวด `<cat>` ที่มี route-items ชุดหนึ่ง (แต่ละตัวมี: `id`, `Component`, `import`, `oldPath`, `newPath = /settings/<cat>/<id>`):
+
+**R1. registry** (`apps/web/src/config/settings-registry.tsx`): เพิ่ม import ของแต่ละ Component (default: `import X from '@/pages/X'`; named: `import { X } from '@/pages/X'`). เปลี่ยนแต่ละ item ในหมวดจาก
+`{ id, label, roles, kind: 'external', path: '<oldPath>' }`
+เป็น
+`{ id, label, roles, kind: 'route', component: <Component>, path: '<newPath>' }`
+(รายการที่ระบุว่า **คง external** → ไม่แตะ)
+
+**R2. App.tsx redirects**: แทน `<Route path="<oldPath>" element={<ProtectedRoute roles={...}><Component/></ProtectedRoute>}/>` ด้วย
+`<Route path="<oldPath>" element={<Navigate to="<newPath>" replace />} />`
+แล้วลบ lazy import ของ Component นั้นใน App.tsx ถ้าไม่มีที่อื่นอ้าง (verify ด้วย grep) — เพราะ registry import เองแล้ว
+
+**R3. internal links**: แก้ทุกลิงก์ภายในที่ชี้ `<oldPath>` → `<newPath>` (จากตาราง "internal links" ของหมวด). ใช้ `<Link to>`/`<a href>`/`navigate()` ตามของเดิม
+
+**R4. test** (`apps/web/src/pages/settings/__tests__/<cat>-migration.test.tsx`): ตาม template นี้ (แทน page mocks + assertions ตามตาราง):
+
+```tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Routes, Route, Navigate } from 'react-router';
+import { SettingsLayout } from '../SettingsLayout';
+import { SettingsCategoryRoute } from '../SettingsCategoryRoute';
+import { SettingsItemRoute } from '../SettingsItemRoute';
+
+vi.mock('@/contexts/AuthContext', () => ({ useAuth: () => ({ user: { role: 'OWNER' } }) }));
+vi.mock('@/hooks/useIsMobile', () => ({ useIsMobile: () => false }));
+// --- mock each migrated page of this category (one line each):
+// vi.mock('@/pages/<Component path>', () => ({ default: () => <div><id>-page</div> }));
+//   (named export → mock { <Name>: () => ... } instead of { default })
+
+function App({ entry }: { entry: string }) {
+  return (
+    <MemoryRouter initialEntries={[entry]}>
+      <Routes>
+        {/* one redirect <Route> per migrated item: */}
+        {/* <Route path="<oldPath>" element={<Navigate to="<newPath>" replace />} /> */}
+        <Route path="/settings/:categoryId" element={<SettingsLayout />}>
+          <Route index element={<SettingsCategoryRoute />} />
+          <Route path=":itemId" element={<SettingsItemRoute />} />
+        </Route>
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe('<cat> migration', () => {
+  it('render <firstItem> ใน panel', () => {
+    render(<App entry="/settings/<cat>/<firstId>" />);
+    expect(screen.getByText('<firstId>-page')).toBeTruthy();
+    expect(screen.getByRole('link', { name: /<categoryThaiLabel>/ })).toBeTruthy(); // nav ยังอยู่
+  });
+  // one redirect test per migrated item:
+  it('old <oldPath> → redirect', async () => {
+    render(<App entry="<oldPath>" />);
+    await waitFor(() => expect(screen.getByText('<id>-page')).toBeTruthy());
+  });
+});
+```
+
+**R5. verify**: `cd apps/web && npx vitest run src/pages/settings src/config` (เขียว) + `./tools/check-types.sh web` (0 errors) + grep ยืนยันไม่มี internal link ค้างที่ `<oldPath>` (นอก redirect/comment)
+
+**R6. commit**: `git commit -m "feat(settings): P2b migrate <cat> category to /settings/<cat>/*"`
+
+> **กฎสำคัญ**: รายการ kind:'external' ที่ระบุ "คง" — **ห้าม**เปลี่ยน. ตรวจ export style (default vs named) ให้ตรงก่อน import.
+
+---
+
+## Task 1: หมวด accounting (chart, peak-sync, e-tax → route; document-config คง external)
+
+**Files:** `settings-registry.tsx`, `App.tsx`, `apps/web/src/pages/ETaxInvoicePage.tsx`, test `__tests__/accounting-migration.test.tsx`
+
+**ตารางหมวด accounting:**
+
+| id | Component (export) | import | oldPath | newPath | roles | kind |
+|---|---|---|---|---|---|---|
+| chart | ChartOfAccountsPage (default) | `import ChartOfAccountsPage from '@/pages/ChartOfAccountsPage'` | /settings/chart-of-accounts | /settings/accounting/chart | OWNER,FM,ACC | route |
+| peak-sync | PeakSyncPage (default) | `import PeakSyncPage from '@/pages/PeakSyncPage'` | /settings/peak-sync | /settings/accounting/peak-sync | OWNER,ACC | route |
+| e-tax | **ETaxConfigPage (named)** | `import { ETaxConfigPage } from '@/pages/ETaxConfigPage'` | /settings/e-tax-config | /settings/accounting/e-tax | OWNER | route |
+| documents | — | — | — | — | OWNER | **คง external** (9 แท็บ) |
+
+**internal links:** `apps/web/src/pages/ETaxInvoicePage.tsx:212` `<Link to="/settings/e-tax-config">` → `/settings/accounting/e-tax`
+
+- [ ] **Step 1:** ใช้ Recipe R4 เขียน `accounting-migration.test.tsx` ก่อน (mock 3 หน้า: ChartOfAccountsPage/PeakSyncPage default, ETaxConfigPage named → `vi.mock('@/pages/ETaxConfigPage', () => ({ ETaxConfigPage: () => <div>e-tax-page</div> }))`; firstItem=chart; 3 redirect tests). รัน → FAIL (path ยังเก่า/หน้ายังไม่ใช่ route)
+- [ ] **Step 2:** Recipe R1 — registry: import 3 หน้า (e-tax แบบ named) + เปลี่ยน chart/peak-sync/e-tax เป็น kind:'route'. **อย่าแตะ documents** (คง external)
+- [ ] **Step 3:** Recipe R2 — App.tsx: redirect 3 path เก่า (chart-of-accounts, peak-sync, e-tax-config) + ลบ lazy import 3 ตัว (verify ไม่มีที่อื่นอ้าง). **อย่าแตะ document-config route**
+- [ ] **Step 4:** Recipe R3 — แก้ ETaxInvoicePage.tsx:212 → `/settings/accounting/e-tax`
+- [ ] **Step 5:** Recipe R5 verify (vitest settings+config เขียว, check-types 0, grep clean) → Recipe R6 commit
+
+---
+
+## Task 2: หมวด comms (line-oa, greeting, sms, channels, dunning, collections → route; rich-menu คง external)
+
+**Files:** `settings-registry.tsx`, `App.tsx`, `apps/web/src/pages/DunningSettingsPage.tsx`, test `__tests__/comms-migration.test.tsx`
+
+| id | Component (export) | import | oldPath | newPath | roles | kind |
+|---|---|---|---|---|---|---|
+| line-oa | LineOaSettingsPage (default) | `import LineOaSettingsPage from '@/pages/LineOaSettingsPage'` | /settings/line-oa | /settings/comms/line-oa | OWNER | route |
+| greeting | LineGreetingPage (default) | `import LineGreetingPage from '@/pages/LineGreetingPage'` | /settings/line-greeting | /settings/comms/greeting | OWNER | route |
+| sms | SmsTemplatesPage (default) | `import SmsTemplatesPage from '@/pages/SmsTemplatesPage'` | /settings/sms-templates | /settings/comms/sms | OWNER,FM | route |
+| channels | ChannelSettingsPage (default) | `import ChannelSettingsPage from '@/pages/ChannelSettingsPage'` | /settings/channels | /settings/comms/channels | OWNER | route |
+| dunning | DunningSettingsPage (default) | `import DunningSettingsPage from '@/pages/DunningSettingsPage'` | /settings/dunning | /settings/comms/dunning | OWNER | route |
+| collections | CollectionsSettingsPage = `CollectionsPage` (default) | `import CollectionsSettingsPage from '@/pages/SettingsPage/CollectionsPage'` | /settings/collections | /settings/comms/collections | OWNER | route |
+| rich-menu | — | — | — | — | OWNER | **คง external** (2-axis tabs) |
+
+**internal links:** `apps/web/src/pages/DunningSettingsPage.tsx:369` `<a href="/settings/sms-templates">` → `/settings/comms/sms`
+
+- [ ] **Step 1:** R4 test `comms-migration.test.tsx` (mock 6 หน้า default; firstItem=line-oa; 6 redirect tests). รัน → FAIL
+- [ ] **Step 2:** R1 registry — import 6 หน้า + เปลี่ยนเป็น route. **อย่าแตะ rich-menu**
+- [ ] **Step 3:** R2 App.tsx — redirect 6 path เก่า + ลบ lazy imports (verify). **อย่าแตะ rich-menu route**
+- [ ] **Step 4:** R3 — DunningSettingsPage.tsx:369 → `/settings/comms/sms`
+- [ ] **Step 5:** R5 verify → R6 commit
+
+---
+
+## Task 3: หมวด ai (ทั้ง 5 หน้า → route; rename id ตัด prefix "ai-")
+
+**Files:** `settings-registry.tsx`, `App.tsx`, `apps/web/src/pages/AiAdminPage.tsx`, test `__tests__/ai-migration.test.tsx`
+
+> ปรับ id ให้ URL สะอาด: `ai-admin`→`admin`, `ai-persona`→`persona`, `ai-assistant`→`assistant`, `ai-training`→`training`, `ai-performance`→`performance` (id ใช้แค่ภายใน registry+search — ปลอดภัย). newPath = `/settings/ai/<newId>`
+
+| newId | Component (default) | import | oldPath | newPath | roles |
+|---|---|---|---|---|---|
+| admin | AiAdminPage | `import AiAdminPage from '@/pages/AiAdminPage'` | /settings/ai-admin | /settings/ai/admin | OWNER |
+| persona | AiPersonaPage | `import AiPersonaPage from '@/pages/AiPersonaPage'` | /settings/ai-persona | /settings/ai/persona | OWNER |
+| assistant | AiSettingsPage | `import AiSettingsPage from '@/pages/AiSettingsPage'` | /settings/ai-chat | /settings/ai/assistant | OWNER |
+| training | AiTrainingPage | `import AiTrainingPage from '@/pages/AiTrainingPage'` | /settings/ai-training | /settings/ai/training | OWNER |
+| performance | AiPerformancePage | `import AiPerformancePage from '@/pages/AiPerformancePage'` | /settings/ai-performance | /settings/ai/performance | OWNER |
+
+**internal links (ใน AiAdminPage.tsx):** `:203` → `/settings/ai/performance` · `:216` → `/settings/ai/training` · `:229` → `/settings/ai/assistant`
+
+- [ ] **Step 1:** R4 test `ai-migration.test.tsx` (mock 5 หน้า; firstItem=admin → entry `/settings/ai/admin`; 5 redirect tests จาก oldPath). รัน → FAIL
+- [ ] **Step 2:** R1 registry — import 5 หน้า + เปลี่ยน 5 item เป็น kind:'route' + **เปลี่ยน id** ตามตาราง (อัปเดต keywords ถ้ามี)
+- [ ] **Step 3:** R2 App.tsx — redirect 5 path เก่า + ลบ lazy imports 5 ตัว (verify)
+- [ ] **Step 4:** R3 — AiAdminPage.tsx 3 ลิงก์ (:203/:216/:229) → path ใหม่
+- [ ] **Step 5:** R5 verify → R6 commit
+
+---
+
+## Task 4: หมวด products (pricing, stickers → route; promotions, contract-templates คง external operational)
+
+**Files:** `settings-registry.tsx`, `App.tsx`, test `__tests__/products-migration.test.tsx`
+
+| id | Component (default) | import | oldPath | newPath | roles |
+|---|---|---|---|---|---|
+| pricing | PricingTemplatesPage | `import PricingTemplatesPage from '@/pages/PricingTemplatesPage'` | /settings/pricing-templates | /settings/products/pricing | OWNER |
+| stickers | StickersSettingsPage = `StickersPage` (default) | `import StickersSettingsPage from '@/pages/SettingsPage/StickersPage'` | /settings/stickers | /settings/products/stickers | OWNER |
+
+> **คง external:** promotions (/promotions), contract-templates (/contract-templates) — operational, ห้ามแตะ
+
+**internal links:** ไม่มี (registry only ตาม Explore)
+
+- [ ] **Step 1:** R4 test `products-migration.test.tsx` (mock 2 หน้า; firstItem=pricing; 2 redirect tests). รัน → FAIL
+- [ ] **Step 2:** R1 registry — import 2 หน้า + route. **อย่าแตะ promotions/contract-templates**
+- [ ] **Step 3:** R2 App.tsx — redirect 2 path เก่า (pricing-templates, stickers) + ลบ lazy imports
+- [ ] **Step 4:** R5 verify → R6 commit (ไม่มี R3 internal links)
+
+---
+
+## Task 5: หมวด company + access + system (รวม task เดียว — รายการน้อย, ไม่มี external ปน)
+
+**Files:** `settings-registry.tsx`, `App.tsx`, test `__tests__/company-access-system-migration.test.tsx`
+
+| หมวด | id | Component (default) | import | oldPath | newPath | roles |
+|---|---|---|---|---|---|---|
+| company | entities | CompanySettingsPage | `import CompanySettingsPage from '@/pages/CompanySettingsPage'` | /settings/companies | /settings/company/entities | OWNER |
+| access | account-roles | AccountRolesPage | `import AccountRolesPage from '@/pages/AccountRolesPage'` | /settings/account-roles | /settings/access/account-roles | OWNER |
+| system | integrations | IntegrationHubPage | `import IntegrationHubPage from '@/pages/IntegrationHubPage'` | /settings/integrations | /settings/system/integrations | OWNER,ACC |
+| system | mdm | MdmTestPage | `import MdmTestPage from '@/pages/MdmTestPage'` | /settings/mdm-test | /settings/system/mdm | OWNER |
+
+> **คง external (system):** audit-log (/audit-logs), system-status (/system-status) — operational. **คง external (company):** branches (/branches). **คง external (access):** users (/users).
+
+**internal links:** ไม่มี (registry only ตาม Explore)
+
+- [ ] **Step 1:** R4 test `company-access-system-migration.test.tsx` (mock 4 หน้า; 1 in-panel test ต่อหมวด เช่น entry `/settings/company/entities`→company-entities-page + nav "บริษัท & สาขา"; 4 redirect tests). รัน → FAIL
+- [ ] **Step 2:** R1 registry — import 4 หน้า + เปลี่ยน 4 item (entities/account-roles/integrations/mdm) เป็น route. **อย่าแตะ** branches/users/audit-log/system-status
+- [ ] **Step 3:** R2 App.tsx — redirect 4 path เก่า (companies, account-roles, integrations, mdm-test) + ลบ lazy imports
+- [ ] **Step 4:** R5 verify → R6 commit
+
+---
+
+## Task 6: Verification รวม P2b
+
+**Files:** ไม่มี (รันตรวจ)
+
+- [ ] **Step 1:** `./tools/check-types.sh web` → 0 errors
+- [ ] **Step 2:** `cd apps/web && npx vitest run src/pages/settings src/config` → เขียวทั้งหมด
+- [ ] **Step 3:** grep ยืนยันไม่มี internal link ค้างที่ path เก่า (นอก redirect/comment):
+  Run: `cd "/d/BESTCHOICE APP/BESTCHOICE" && grep -rn "settings/chart-of-accounts\|settings/peak-sync\|settings/e-tax-config\|settings/line-oa\|settings/line-greeting\|settings/sms-templates\|settings/channels\|settings/dunning\|settings/collections\|settings/ai-\|settings/pricing-templates\|settings/stickers\|settings/companies\|settings/account-roles\|settings/integrations\|settings/mdm-test" apps/web/src --include=*.tsx --include=*.ts | grep -v "Navigate to" | grep -v "\.test\." | grep -vE "/\*|\*/|//"`
+  Expected: ไม่มี (หรือมีแต่ comment — รายงาน)
+- [ ] **Step 4:** smoke ด้วยตา (ถ้ารัน dev ได้): สุ่ม 3 หน้าต่างหมวด (เช่น `/settings/accounting/chart`, `/settings/comms/sms`, `/settings/ai/admin`) → render ในpanel มี nav ซ้าย. `/settings/accounting/documents` + `/settings/comms` rich-menu → ยังเป็นลิงก์ออกเต็มจอ. bookmark เก่า (เช่น `/settings/ai-admin`) → เด้งไปใหม่
+
+---
+
+## Self-Review (ผู้เขียนแผนตรวจเอง)
+
+**Spec coverage:** §5 mapping — route candidates 20 หน้า → route (Task 1-5); external 2 หน้า (document-config, rich-menu) คงไว้ ✓; operational external คงไว้ ✓. §10 P2 "ย้ายทีละหมวด + redirects + internal links" ✓. structural fix (หน้ามีแท็บ→external) → document-config + rich-menu external ✓
+
+**Placeholder scan:** Recipe เป็น procedure ที่ใช้ร่วม (DRY) ไม่ใช่ "see Task N"; แต่ละ task มีข้อมูลครบ (id/component/export/path/roles/links) + test template + verify/commit. ไม่มี TBD. "ลบ lazy import ถ้าไม่มีที่อื่นอ้าง (verify grep)" เป็น verify-step มีคำสั่งชัด ✓
+
+**Type consistency:** ใช้ infra P2a (`SettingsItemRoute`/`SettingsCategoryRoute`/`SettingsLayout` Outlet) ตามจริง; `kind:'route'`+`component`+`path` ตรง schema P1; ETaxConfigPage named-import ระบุชัด; ai id rename สอดคล้องทั้ง registry+links+test ✓
+
+## Out of scope (P3, P4)
+- **P3:** ยุบ sidebar settings zone เหลือ "ตั้งค่าระบบ" + กลุ่ม "จัดการ" (operational) + index settings เข้า CommandPalette + wire scroll-to-section (carry จาก P1)
+- **P4:** dedup PDPA (/pdpa + #pdpa), ลบ route ซ้ำ document-config (App.tsx ComingSoon dead), ลบ SystemSettings.tsx dead code, เลิกหน้า general (กระจาย field), อัปเดต docs (accounting.md/CLAUDE.md)
+- bundle optimization (registry static-imports หน้า config — ทำ dynamic ทีหลังถ้าจำเป็น)


### PR DESCRIPTION
## สรุป

**P2b** (ต่อจาก P2a #1287 ที่ merge แล้ว) — ย้ายหน้า config ที่เหลือ **20 หน้า ใน 5 หมวด** เข้า settings panel เป็น `/settings/<หมวด>/<รายการ>` ตาม pattern finance/P2a

## ย้ายเข้า panel (kind:'route')
- **accounting**: chart, peak-sync, e-tax (ETaxConfigPage named export)
- **comms**: line-oa, greeting, sms, channels, dunning, collections
- **ai**: admin, persona, assistant, training, performance (+ rename id ตัด `ai-` prefix)
- **products**: pricing, stickers
- **company/access/system**: entities, account-roles, integrations, mdm

## คงเป็น external เต็มจอ (มีแท็บในตัว / operational)
- **document-config** (9 แท็บ), **rich-menu** (2-axis tabs)
- operational: users, branches, promotions, contract-templates, audit-logs, system-status

## กลไก
- ทุก path เก่า → `<Navigate replace>` redirect (กัน bookmark พัง)
- แก้ internal links ทั้งหมด: menu.ts (sidebar) + ETaxInvoice + DunningSettings + AiAdmin (ไม่พึ่ง redirect)
- ลบ lazy imports ที่ไม่ใช้ใน App.tsx (registry import เอง)
- **ไม่เพิ่ม routing infra** — ใช้ `SettingsItemRoute` ของ P2a แบบ generic

## เทส
- ✅ settings + config **108/108**, web type-check 0 errors
- ทุกหมวดมี migration test (render ในpanel + redirect ครบ)
- grep: ไม่มี stale router link เหลือ (เหลือแค่ JSDoc comment + backend api call ที่ถูกต้อง)
- 6 tasks subagent-driven, review ทุก task, Final review (Opus) = **ship**

## ถัดไป
P3 (ยุบ sidebar เหลือ "ตั้งค่าระบบ" + กลุ่ม "จัดการ" + CommandPalette + scroll-to-section) → P4 (cleanup: ลบ SystemSettings dead code, ลบ document-config dup route, dedup PDPA, JSDoc/`<a href>` tidy, docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)