### PR TITLE
feat(settings): sidebar-driven settings navigation (one nav set)

### DIFF
--- a/apps/web/src/config/menu.test.ts
+++ b/apps/web/src/config/menu.test.ts
@@ -37,7 +37,7 @@ describe('getSidebarForRole — populated ZONE_CONFIG', () => {
     expect(sections.every((s) => s.zone === 'fin')).toBe(true);
   });
 
-  it('OWNER + settings returns settings sections', () => {
+  it('OWNER + settings returns registry-driven settings sections', () => {
     const sections = getSidebarForRole('OWNER', 'settings');
     expect(sections.length).toBeGreaterThan(0);
     expect(sections.every((s) => s.zone === 'settings')).toBe(true);
@@ -100,50 +100,33 @@ describe('getSidebarForRole — populated ZONE_CONFIG', () => {
     expect(keys).toContain('owner-fin-notifications');
   });
 
-  it('OWNER settings sections have expected keys', () => {
+  it('OWNER settings zone is now registry-driven (P5): one section keyed "settings"', () => {
     const keys = getSidebarForRole('OWNER', 'settings').map((s) => s.key);
-    // owner-doc-config moved to FIN zone per CSV §8
-    expect(keys).toContain('owner-settings');
-    expect(keys).toContain('owner-settings-extra');
-    // owner-ai removed (P3 collapse — reachable via settings panel)
-    expect(keys).not.toContain('owner-ai');
+    // P5: old static keys removed; replaced by single registry section
+    expect(keys).toEqual(['settings']);
+    expect(keys).not.toContain('owner-settings');
+    expect(keys).not.toContain('owner-settings-extra');
+    expect(keys).not.toContain('owner-fin-master');
   });
 
-  it('OWNER settings zone contains panel entry + operational quick-links (P3 collapse)', () => {
+  it('OWNER settings zone paths are all /settings/<catId> (P5 registry-driven)', () => {
     const sections = getSidebarForRole('OWNER', 'settings');
     const allPaths = sections.flatMap((s) => s.items.map((i) => i.path));
-    // Must contain the panel entry and operational paths
-    expect(allPaths).toContain('/settings');
-    expect(allPaths).toContain('/users');
-    expect(allPaths).toContain('/branches');
-    // Must NOT contain config deep-links (now reachable only via the panel)
-    expect(allPaths).not.toContain('/settings/ai/admin');
-    expect(allPaths).not.toContain('/settings/finance/gfin');
-    expect(allPaths).not.toContain('/settings/access/account-roles');
-    expect(allPaths).not.toContain('/settings/products/pricing');
-    expect(allPaths).not.toContain('/settings/company/entities');
-  });
-
-  it('OWNER settings owner-settings items match collapsed list exactly (P3)', () => {
-    const sections = getSidebarForRole('OWNER', 'settings');
-    const settingsSection = sections.find((s) => s.key === 'owner-settings');
-    expect(settingsSection).toBeDefined();
-    const paths = settingsSection!.items.map((i) => i.path);
-    expect(paths).toEqual([
-      '/settings',
-      '/users',
-      '/branches',
-      '/contract-templates',
-      '/promotions',
-      '/pdpa',
-    ]);
-  });
-
-  it('PDPA label is disambiguated in owner-settings (P3)', () => {
-    const sections = getSidebarForRole('OWNER', 'settings');
-    const settingsSection = sections.find((s) => s.key === 'owner-settings');
-    const pdpaItem = settingsSection?.items.find((i) => i.path === '/pdpa');
-    expect(pdpaItem?.label).toBe('PDPA (คำยินยอม/DSAR)');
+    // All paths are /settings/<categoryId> — registry-driven
+    expect(allPaths.every((p) => p.startsWith('/settings/'))).toBe(true);
+    // operational quick-links removed (now inside the panel)
+    expect(allPaths).not.toContain('/users');
+    expect(allPaths).not.toContain('/branches');
+    expect(allPaths).not.toContain('/settings');  // bare root not listed
+    // all 8 registry categories visible to OWNER
+    expect(allPaths).toContain('/settings/company');
+    expect(allPaths).toContain('/settings/access');
+    expect(allPaths).toContain('/settings/accounting');
+    expect(allPaths).toContain('/settings/finance');
+    expect(allPaths).toContain('/settings/products');
+    expect(allPaths).toContain('/settings/comms');
+    expect(allPaths).toContain('/settings/ai');
+    expect(allPaths).toContain('/settings/system');
   });
 
   it('FINANCE_MANAGER fin sections include payments (regression for fm-payments zone fix)', () => {
@@ -205,40 +188,65 @@ describe('VIEWER role (Owner Q4 2026-05-17)', () => {
   });
 });
 
-describe('Master data moved into settings zone (Option B, 2026-06-13)', () => {
-  it('ข้อมูลหลัก section lives in the settings zone for OWNER/FM/ACC', () => {
-    expect(getSidebarForRole('OWNER', 'settings').map((s) => s.key)).toContain('owner-fin-master');
-    expect(getSidebarForRole('FINANCE_MANAGER', 'settings').map((s) => s.key)).toContain(
-      'fm-fin-master',
-    );
-    expect(getSidebarForRole('ACCOUNTANT', 'settings').map((s) => s.key)).toContain('acc-fin-master');
+describe('Master data moved into settings zone (Option B, 2026-06-13) — now registry-driven (P5)', () => {
+  it('settings zone for OWNER/FM/ACC is registry-driven (single section keyed "settings")', () => {
+    // P5: old static "ข้อมูลหลัก" sections replaced by registry-driven section
+    expect(getSidebarForRole('OWNER', 'settings').map((s) => s.key)).toEqual(['settings']);
+    expect(getSidebarForRole('FINANCE_MANAGER', 'settings').map((s) => s.key)).toEqual(['settings']);
+    expect(getSidebarForRole('ACCOUNTANT', 'settings').map((s) => s.key)).toEqual(['settings']);
   });
 
-  it('ข้อมูลหลัก is no longer in the fin zone', () => {
+  it('ข้อมูลหลัก static sections no longer exist in any zone', () => {
+    // Removed in P5 — contacts now reachable via /settings/company
     expect(getSidebarForRole('OWNER', 'fin').map((s) => s.key)).not.toContain('owner-fin-master');
-    expect(getSidebarForRole('FINANCE_MANAGER', 'fin').map((s) => s.key)).not.toContain(
-      'fm-fin-master',
-    );
+    expect(getSidebarForRole('FINANCE_MANAGER', 'fin').map((s) => s.key)).not.toContain('fm-fin-master');
     expect(getSidebarForRole('ACCOUNTANT', 'fin').map((s) => s.key)).not.toContain('acc-fin-master');
+    expect(getSidebarForRole('OWNER', 'settings').map((s) => s.key)).not.toContain('owner-fin-master');
+    expect(getSidebarForRole('FINANCE_MANAGER', 'settings').map((s) => s.key)).not.toContain('fm-fin-master');
+    expect(getSidebarForRole('ACCOUNTANT', 'settings').map((s) => s.key)).not.toContain('acc-fin-master');
   });
 
-  it('FM/ACC now have settings-zone access (gear)', () => {
+  it('FM/ACC still have settings-zone access (gear)', () => {
     expect(getZoneConfigForRole('FINANCE_MANAGER')?.showSettingsGear).toBe(true);
     expect(getZoneConfigForRole('ACCOUNTANT')?.showSettingsGear).toBe(true);
   });
 
-  it('FM sees only ผู้ติดต่อ; ACC sees ผู้ติดต่อ เท่านั้น (พนักงาน tab ถูกรวมใน /users แล้ว)', () => {
+  it('FM/ACC settings zone includes /settings/company (contacts reachable via registry)', () => {
     const fmPaths = getSidebarForRole('FINANCE_MANAGER', 'settings').flatMap((s) =>
       s.items.map((i) => i.path),
     );
-    expect(fmPaths).toContain('/settings#contacts');
-    expect(fmPaths).not.toContain('/settings#employees');
+    // contacts is now under /settings/company (registry-driven)
+    expect(fmPaths).toContain('/settings/company');
+    expect(fmPaths).not.toContain('/settings#contacts');  // old hash-link gone
 
     const accPaths = getSidebarForRole('ACCOUNTANT', 'settings').flatMap((s) =>
       s.items.map((i) => i.path),
     );
-    expect(accPaths).toContain('/settings#contacts');
-    expect(accPaths).not.toContain('/settings#employees');
+    expect(accPaths).toContain('/settings/company');
+    expect(accPaths).not.toContain('/settings#contacts');  // old hash-link gone
+  });
+});
+
+describe('P5 Task 1 — registry-driven settings-zone sidebar', () => {
+  it('OWNER settings zone = registry categories (8), as links to /settings/<cat>', () => {
+    const secs = getSidebarForRole('OWNER', 'settings');
+    const paths = secs.flatMap((s) => s.items.map((i) => i.path));
+    expect(paths).toContain('/settings/company');
+    expect(paths).toContain('/settings/system');
+    expect(paths.every((p) => p.startsWith('/settings/'))).toBe(true);
+    expect(paths).not.toContain('/users');      // operational no longer a sidebar quick-link
+    expect(paths).not.toContain('/settings');   // bare panel root not listed; categories are
+  });
+
+  it('FINANCE_MANAGER settings zone = its visible categories (subset, no AI)', () => {
+    const paths = getSidebarForRole('FINANCE_MANAGER', 'settings').flatMap((s) => s.items.map((i) => i.path));
+    expect(paths).toContain('/settings/company');     // contacts
+    expect(paths).not.toContain('/settings/ai');      // OWNER-only
+  });
+
+  it('resolveZoneForPath maps any /settings/* to settings zone (OWNER)', () => {
+    expect(resolveZoneForPath('OWNER', '/settings/accounting')).toBe('settings');
+    expect(resolveZoneForPath('OWNER', '/settings/accounting/chart')).toBe('settings');
   });
 });
 

--- a/apps/web/src/config/menu.test.ts
+++ b/apps/web/src/config/menu.test.ts
@@ -250,6 +250,28 @@ describe('P5 Task 1 — registry-driven settings-zone sidebar', () => {
   });
 });
 
+describe('FM/ACC bottomNav contacts shortcut — stale hash fix (2026-06-24)', () => {
+  it('FM/ACC bottomNav settings zone does not contain stale /settings#contacts', () => {
+    for (const role of ['FINANCE_MANAGER', 'ACCOUNTANT']) {
+      const bn = getZoneConfigForRole(role)?.bottomNav.settings ?? [];
+      const paths = bn.map((i) => i.path);
+      expect(paths).not.toContain('/settings#contacts');
+    }
+  });
+
+  it('FM bottomNav contacts shortcut now points to /settings/company', () => {
+    const bn = getZoneConfigForRole('FINANCE_MANAGER')?.bottomNav.settings ?? [];
+    const paths = bn.map((i) => i.path);
+    expect(paths).toContain('/settings/company');
+  });
+
+  it('ACC bottomNav contacts shortcut now points to /settings/company', () => {
+    const bn = getZoneConfigForRole('ACCOUNTANT')?.bottomNav.settings ?? [];
+    const paths = bn.map((i) => i.path);
+    expect(paths).toContain('/settings/company');
+  });
+});
+
 describe('resolveZoneForPath — hash-aware (regression: FM/ACC must not bounce off /settings)', () => {
   it('/settings resolves to the settings zone for OWNER/FM/ACC', () => {
     expect(resolveZoneForPath('OWNER', '/settings')).toBe('settings');

--- a/apps/web/src/config/menu.ts
+++ b/apps/web/src/config/menu.ts
@@ -1,4 +1,6 @@
 import type { LucideIcon } from 'lucide-react';
+import { visibleCategories } from './settings-access';
+import type { SettingsRole } from './settings-registry';
 import {
   ShoppingCart,
   Users,
@@ -295,15 +297,6 @@ const FINANCE_MANAGER_CONFIG: RoleMenuConfig = {
       ],
     },
     {
-      key: 'fm-fin-master',
-      label: 'ข้อมูลหลัก',
-      icon: BookUser,
-      zone: 'settings',
-      items: [
-        { label: 'สมุดผู้ติดต่อ', path: '/settings#contacts', icon: BookUser },
-      ],
-    },
-    {
       key: 'fm-fin-daily',
       label: 'งานประจำวัน (การเงิน)',
       icon: HandCoins,
@@ -390,15 +383,6 @@ const FINANCE_MANAGER_CONFIG: RoleMenuConfig = {
 
 const ACCOUNTANT_CONFIG: RoleMenuConfig = {
   sidebar: [
-    {
-      key: 'acc-fin-master',
-      label: 'ข้อมูลหลัก',
-      icon: BookUser,
-      zone: 'settings',
-      items: [
-        { label: 'สมุดผู้ติดต่อ', path: '/settings#contacts', icon: BookUser },
-      ],
-    },
     {
       key: 'acc-daily',
       label: 'งานประจำวัน',
@@ -558,15 +542,6 @@ const OWNER_CONFIG: RoleMenuConfig = {
      * OWNER sees them from both zones; FM/ACC already have them in FIN.
      * Asset menu items embedded as sub-group inside "รายจ่าย" → ซื้อทรัพย์สิน
      * (mirrors `assetMenuSection.items` — kept in sync manually). */
-    {
-      key: 'owner-fin-master',
-      label: 'ข้อมูลหลัก',
-      icon: BookUser,
-      zone: 'settings',
-      items: [
-        { label: 'สมุดผู้ติดต่อ', path: '/settings#contacts', icon: BookUser },
-      ],
-    },
     {
       key: 'owner-fin-revenue',
       label: 'รายรับ',
@@ -731,20 +706,6 @@ const OWNER_CONFIG: RoleMenuConfig = {
       ],
     },
     {
-      key: 'owner-settings',
-      label: 'ตั้งค่า',
-      icon: Settings,
-      zone: 'settings',
-      items: [
-        { label: 'ตั้งค่าระบบ', path: '/settings', icon: Settings },
-        { label: 'ผู้ใช้ / พนักงาน', path: '/users', icon: UserCog },
-        { label: 'สาขา', path: '/branches', icon: Building2 },
-        { label: 'แบบสัญญา', path: '/contract-templates', icon: FileCheck },
-        { label: 'โปรโมชัน', path: '/promotions', icon: BadgePercent },
-        { label: 'PDPA (คำยินยอม/DSAR)', path: '/pdpa', icon: Shield },
-      ],
-    },
-    {
       // CSV §9 — split from old "เครื่องมือไฟแนนซ์" — Dunning moved to its
       // own section (#10) since it's customer-facing notifications, not
       // an integration target.
@@ -767,15 +728,6 @@ const OWNER_CONFIG: RoleMenuConfig = {
         { label: 'Dunning (เตือนค่างวด)', path: '/settings/comms/dunning', icon: Bell },
         // P4-SP2 — auto e-receipt config (e_receipt_auto SystemConfig key)
         { label: 'ใบเสร็จอิเล็กทรอนิกส์อัตโนมัติ', path: '/finance/e-receipt-auto', icon: FileText },
-      ],
-    },
-    {
-      key: 'owner-settings-extra',
-      label: 'บันทึกระบบ',
-      icon: ScrollText,
-      zone: 'settings',
-      items: [
-        { label: 'Audit Log', path: '/audit-logs', icon: ScrollText },
       ],
     },
   ],
@@ -969,6 +921,21 @@ const ZONE_CONFIG: Record<string, RoleZoneConfig> = {
   },
 };
 
+/** Build the settings-zone sidebar from the registry (role-filtered categories). */
+function buildSettingsZoneSections(role: string): MenuSection[] {
+  const cats = visibleCategories(role as SettingsRole);
+  if (cats.length === 0) return [];
+  return [
+    {
+      key: 'settings',
+      label: 'ตั้งค่าระบบ',
+      icon: Settings,
+      zone: 'settings' as const,
+      items: cats.map((c) => ({ label: c.label, path: `/settings/${c.id}`, icon: c.icon })),
+    },
+  ];
+}
+
 /**
  * Filter sections for the role's current zone.
  * Returns empty array if role/zone combo invalid (caller handles fallback).
@@ -977,9 +944,7 @@ export function getSidebarForRole(role: string, currentZone: Zone): MenuSection[
   const config = ZONE_CONFIG[role];
   if (!config) return [];
   if (currentZone === 'settings') {
-    return config.showSettingsGear
-      ? config.sections.filter((s) => s.zone === 'settings')
-      : [];
+    return config.showSettingsGear ? buildSettingsZoneSections(role) : [];
   }
   if (!config.zones.includes(currentZone)) return [];
   return config.sections.filter((s) => s.zone === currentZone);
@@ -995,6 +960,10 @@ const ZONE_LOOKUP_ORDER: Zone[] = ['shop', 'fin', 'settings'];
  * the role's accessible zones (caller decides pass-through vs redirect).
  */
 export function resolveZoneForPath(role: string, path: string): Zone | null {
+  if (path === '/settings' || path.startsWith('/settings/') || path.startsWith('/settings#')) {
+    const cfg = ZONE_CONFIG[role];
+    if (cfg?.showSettingsGear) return 'settings';
+  }
   const matches = (menuPath: string) => menuPath === path || menuPath.split('#')[0] === path;
   for (const z of ZONE_LOOKUP_ORDER) {
     const sections = getSidebarForRole(role, z);

--- a/apps/web/src/config/menu.ts
+++ b/apps/web/src/config/menu.ts
@@ -878,7 +878,7 @@ const ZONE_CONFIG: Record<string, RoleZoneConfig> = {
       ],
       fin: FINANCE_MANAGER_CONFIG.bottomNav,
       settings: [
-        { label: 'ผู้ติดต่อ', path: '/settings#contacts', icon: BookUser },
+        { label: 'ผู้ติดต่อ', path: '/settings/company', icon: BookUser },
         { label: 'เพิ่มเติม', path: '#more', icon: MoreHorizontal, action: 'sidebar' },
       ],
     },
@@ -903,7 +903,7 @@ const ZONE_CONFIG: Record<string, RoleZoneConfig> = {
       shop: [],
       fin: ACCOUNTANT_CONFIG.bottomNav,
       settings: [
-        { label: 'ผู้ติดต่อ', path: '/settings#contacts', icon: BookUser },
+        { label: 'ผู้ติดต่อ', path: '/settings/company', icon: BookUser },
         { label: 'เพิ่มเติม', path: '#more', icon: MoreHorizontal, action: 'sidebar' },
       ],
     },

--- a/apps/web/src/pages/settings/CategoryPage.tsx
+++ b/apps/web/src/pages/settings/CategoryPage.tsx
@@ -57,6 +57,7 @@ export function CategoryPage({ categoryId }: { categoryId: string }) {
 
   return (
     <div className="space-y-6">
+      <h2 className="text-lg font-semibold text-foreground leading-snug mb-4">{cat.label}</h2>
       {groups.map((g, gi) => (
         <section key={g.name ?? gi} className="space-y-4">
           {g.name && <h3 className={groupLabelClass}>{g.name}</h3>}

--- a/apps/web/src/pages/settings/CategoryPage.tsx
+++ b/apps/web/src/pages/settings/CategoryPage.tsx
@@ -59,7 +59,7 @@ export function CategoryPage({ categoryId }: { categoryId: string }) {
     <div className="space-y-6">
       <h2 className="text-lg font-semibold text-foreground leading-snug mb-4">{cat.label}</h2>
       {groups.map((g, gi) => (
-        <section key={g.name ?? gi} className="space-y-4">
+        <section key={`${g.name ?? ''}-${gi}`} className="space-y-4">
           {g.name && <h3 className={groupLabelClass}>{g.name}</h3>}
           {g.items.map((item) => (
             <ItemSection key={item.id} item={item} categoryId={cat.id} />

--- a/apps/web/src/pages/settings/SettingsLayout.tsx
+++ b/apps/web/src/pages/settings/SettingsLayout.tsx
@@ -1,11 +1,11 @@
 import { useState } from 'react';
-import { useParams, useNavigate, Link, Outlet } from 'react-router';
+import { useParams, useNavigate, Outlet } from 'react-router';
 import { Search } from 'lucide-react';
 import { useAuth } from '@/contexts/AuthContext';
 import { useIsMobile } from '@/hooks/useIsMobile';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
 import PageHeader from '@/components/ui/PageHeader';
-import { visibleCategories, visibleItems, searchSettings } from '@/config/settings-access';
+import { visibleCategories, searchSettings } from '@/config/settings-access';
 import type { SettingsRole } from '@/config/settings-registry';
 
 export function SettingsLayout() {
@@ -64,31 +64,8 @@ export function SettingsLayout() {
           <Outlet />
         </div>
       ) : (
-        <div className="flex gap-6">
-          <nav className="w-60 shrink-0 space-y-1">
-            {cats.map((c) => {
-              const active = c.id === categoryId;
-              const Icon = c.icon;
-              return (
-                <Link
-                  key={c.id}
-                  to={`/settings/${c.id}`}
-                  className={`flex items-center justify-between rounded-lg px-3 py-2 text-sm transition-colors ${
-                    active ? 'bg-accent font-semibold text-foreground' : 'text-muted-foreground hover:bg-accent/60'
-                  }`}
-                >
-                  <span className="flex items-center gap-2 leading-snug">
-                    <Icon className="size-4" />
-                    {c.label}
-                  </span>
-                  <span className="text-xs text-muted-foreground">{visibleItems(c, role).length}</span>
-                </Link>
-              );
-            })}
-          </nav>
-          <div className="min-w-0 flex-1">
-            <Outlet />
-          </div>
+        <div className="min-w-0">
+          <Outlet />
         </div>
       )}
     </div>

--- a/apps/web/src/pages/settings/__tests__/CategoryPage.test.tsx
+++ b/apps/web/src/pages/settings/__tests__/CategoryPage.test.tsx
@@ -24,6 +24,12 @@ describe('CategoryPage', () => {
     expect(scrollSpy).toHaveBeenCalled();
   });
 
+  it('แสดง heading ชื่อหมวดที่ด้านบน (ช่วยบอก orientation ตอน sidebar ขับ category)', () => {
+    role = 'OWNER';
+    renderCat('system');
+    expect(screen.getByRole('heading', { name: 'ระบบ & ความปลอดภัย' })).toBeTruthy();
+  });
+
   it('render inline component sections ของหมวด (system)', () => {
     role = 'OWNER';
     renderCat('system');

--- a/apps/web/src/pages/settings/__tests__/CategoryPage.test.tsx
+++ b/apps/web/src/pages/settings/__tests__/CategoryPage.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
 import { CategoryPage } from '../CategoryPage';
@@ -15,6 +15,17 @@ function renderCat(id: string) {
 }
 
 describe('CategoryPage', () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    // Capture console.error to detect React duplicate-key warnings
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
   it('scrolls to the section matching the URL hash on mount', () => {
     const scrollSpy = vi.fn();
     window.HTMLElement.prototype.scrollIntoView = scrollSpy;
@@ -36,6 +47,16 @@ describe('CategoryPage', () => {
     expect(screen.getByText('test-mode-body')).toBeTruthy();
     expect(screen.getByText('pdpa-body')).toBeTruthy();
     expect(screen.getByText('backup-body')).toBeTruthy();
+  });
+
+  it('no duplicate-key warning on system category with non-contiguous "ข้อมูล" groups', () => {
+    role = 'OWNER';
+    renderCat('system');
+    // Assert no console.error calls with "duplicate key" warning
+    const duplicateKeyWarnings = consoleErrorSpy.mock.calls.filter(
+      (call: unknown[]) => String(call[0]).includes('Encountered two children with the same key'),
+    );
+    expect(duplicateKeyWarnings).toHaveLength(0);
   });
 
   it('render external item เป็นลิงก์', () => {

--- a/apps/web/src/pages/settings/__tests__/SettingsLayout.test.tsx
+++ b/apps/web/src/pages/settings/__tests__/SettingsLayout.test.tsx
@@ -27,16 +27,18 @@ function renderAt(path: string) {
 describe('SettingsLayout', () => {
   beforeEach(() => { role = 'OWNER'; mobile = false; });
 
-  it('desktop: เมนูซ้ายแสดงหมวดที่ role เห็น + render หมวดที่ active', () => {
+  it('desktop: ไม่มีเมนูซ้าย (sidebar หลักขับ category แล้ว) + Outlet content ยังแสดง', () => {
     renderAt('/settings/system');
-    expect(screen.getByRole('link', { name: /ระบบ & ความปลอดภัย/ })).toBeTruthy();
+    // The left category nav links must NOT be rendered on desktop
+    expect(screen.queryByRole('link', { name: /ระบบ & ความปลอดภัย/ })).toBeNull();
+    // Outlet content still renders
     expect(screen.getByText('cat:system')).toBeTruthy();
   });
 
-  it('FM เห็นเฉพาะหมวดของตัวเอง (ไม่มี AI)', () => {
-    role = 'FINANCE_MANAGER';
+  it('desktop: ช่องค้นหายังมีอยู่ + Outlet แสดงเนื้อหา', () => {
     renderAt('/settings/company');
-    expect(screen.queryByRole('link', { name: /^AI$/ })).toBeNull();
+    expect(screen.getByPlaceholderText(/ค้นหา/)).toBeTruthy();
+    expect(screen.getByText('cat:company')).toBeTruthy();
   });
 
   it('mobile: render <select> หมวดแทน sidebar', () => {

--- a/apps/web/src/pages/settings/__tests__/accounting-migration.test.tsx
+++ b/apps/web/src/pages/settings/__tests__/accounting-migration.test.tsx
@@ -28,11 +28,11 @@ function App({ entry }: { entry: string }) {
 }
 
 describe('accounting migration', () => {
-  it('/settings/accounting/chart → render หน้า chart ใน panel (มี nav ข้างซ้าย)', () => {
+  it('/settings/accounting/chart → render หน้า chart ใน panel (sidebar ขับ category แล้ว — ไม่มี nav ข้างซ้าย)', () => {
     render(<App entry="/settings/accounting/chart" />);
     expect(screen.getByText('chart-page')).toBeTruthy();
-    // panel nav ยังอยู่ (link หมวด accounting)
-    expect(screen.getByRole('link', { name: /บัญชี/ })).toBeTruthy();
+    // desktop left category nav is removed — sidebar drives category selection now
+    expect(screen.queryByRole('link', { name: /บัญชี/ })).toBeNull();
   });
 
   it('old /settings/chart-of-accounts → redirect ไป /settings/accounting/chart', async () => {

--- a/apps/web/src/pages/settings/__tests__/ai-migration.test.tsx
+++ b/apps/web/src/pages/settings/__tests__/ai-migration.test.tsx
@@ -32,11 +32,11 @@ function App({ entry }: { entry: string }) {
 }
 
 describe('ai migration', () => {
-  it('/settings/ai/admin → render หน้า admin ใน panel (มี nav ข้างซ้าย)', () => {
+  it('/settings/ai/admin → render หน้า admin ใน panel (sidebar ขับ category แล้ว — ไม่มี nav ข้างซ้าย)', () => {
     render(<App entry="/settings/ai/admin" />);
     expect(screen.getByText('admin-page')).toBeTruthy();
-    // panel nav ยังอยู่ (link หมวด ai)
-    expect(screen.getByRole('link', { name: /AI/ })).toBeTruthy();
+    // desktop left category nav is removed — sidebar drives category selection now
+    expect(screen.queryByRole('link', { name: /AI/ })).toBeNull();
   });
 
   it('old /settings/ai-admin → redirect ไป /settings/ai/admin', async () => {

--- a/apps/web/src/pages/settings/__tests__/comms-migration.test.tsx
+++ b/apps/web/src/pages/settings/__tests__/comms-migration.test.tsx
@@ -34,11 +34,11 @@ function App({ entry }: { entry: string }) {
 }
 
 describe('comms migration', () => {
-  it('/settings/comms/line-oa → render หน้า line-oa ใน panel (มี nav ข้างซ้าย)', () => {
+  it('/settings/comms/line-oa → render หน้า line-oa ใน panel (sidebar ขับ category แล้ว — ไม่มี nav ข้างซ้าย)', () => {
     render(<App entry="/settings/comms/line-oa" />);
     expect(screen.getByText('line-oa-page')).toBeTruthy();
-    // panel nav ยังอยู่ (link หมวด comms)
-    expect(screen.getByRole('link', { name: /สื่อสาร/ })).toBeTruthy();
+    // desktop left category nav is removed — sidebar drives category selection now
+    expect(screen.queryByRole('link', { name: /สื่อสาร/ })).toBeNull();
   });
 
   it('old /settings/line-oa → redirect ไป /settings/comms/line-oa', async () => {

--- a/apps/web/src/pages/settings/__tests__/company-access-system-migration.test.tsx
+++ b/apps/web/src/pages/settings/__tests__/company-access-system-migration.test.tsx
@@ -31,29 +31,29 @@ function App({ entry }: { entry: string }) {
 }
 
 describe('company/access/system migration', () => {
-  it('/settings/company/entities → render หน้า entities ใน panel (มี nav ข้างซ้าย)', () => {
+  it('/settings/company/entities → render หน้า entities ใน panel (sidebar ขับ category แล้ว — ไม่มี nav ข้างซ้าย)', () => {
     render(<App entry="/settings/company/entities" />);
     expect(screen.getByText('entities-page')).toBeTruthy();
-    // panel nav ยังอยู่ (link หมวด company)
-    expect(screen.getByRole('link', { name: /บริษัท/ })).toBeTruthy();
+    // desktop left category nav is removed — sidebar drives category selection now
+    expect(screen.queryByRole('link', { name: /บริษัท/ })).toBeNull();
   });
 
   it('/settings/access/account-roles → render หน้า account-roles ใน panel', () => {
     render(<App entry="/settings/access/account-roles" />);
     expect(screen.getByText('account-roles-page')).toBeTruthy();
-    expect(screen.getByRole('link', { name: /ผู้ใช้/ })).toBeTruthy();
+    expect(screen.queryByRole('link', { name: /ผู้ใช้/ })).toBeNull();
   });
 
   it('/settings/system/integrations → render หน้า integrations ใน panel', () => {
     render(<App entry="/settings/system/integrations" />);
     expect(screen.getByText('integrations-page')).toBeTruthy();
-    expect(screen.getByRole('link', { name: /ระบบ/ })).toBeTruthy();
+    expect(screen.queryByRole('link', { name: /ระบบ/ })).toBeNull();
   });
 
   it('/settings/system/mdm → render หน้า mdm ใน panel', () => {
     render(<App entry="/settings/system/mdm" />);
     expect(screen.getByText('mdm-page')).toBeTruthy();
-    expect(screen.getByRole('link', { name: /ระบบ/ })).toBeTruthy();
+    expect(screen.queryByRole('link', { name: /ระบบ/ })).toBeNull();
   });
 
   it('old /settings/companies → redirect ไป /settings/company/entities', async () => {

--- a/apps/web/src/pages/settings/__tests__/finance-migration.test.tsx
+++ b/apps/web/src/pages/settings/__tests__/finance-migration.test.tsx
@@ -28,11 +28,11 @@ function App({ entry }: { entry: string }) {
 }
 
 describe('finance migration', () => {
-  it('/settings/finance/interest → render หน้า interest ใน panel (มี nav ข้างซ้าย)', () => {
+  it('/settings/finance/interest → render หน้า interest ใน panel (sidebar ขับ category แล้ว — ไม่มี nav ข้างซ้าย)', () => {
     render(<App entry="/settings/finance/interest" />);
     expect(screen.getByText('interest-page')).toBeTruthy();
-    // panel nav ยังอยู่ (link หมวด finance)
-    expect(screen.getByRole('link', { name: /การเงิน/ })).toBeTruthy();
+    // desktop left category nav is removed — sidebar drives category selection now
+    expect(screen.queryByRole('link', { name: /การเงิน/ })).toBeNull();
   });
 
   it('old /settings/interest-config → redirect ไป /settings/finance/interest', async () => {

--- a/apps/web/src/pages/settings/__tests__/products-migration.test.tsx
+++ b/apps/web/src/pages/settings/__tests__/products-migration.test.tsx
@@ -26,11 +26,11 @@ function App({ entry }: { entry: string }) {
 }
 
 describe('products migration', () => {
-  it('/settings/products/pricing → render หน้า pricing ใน panel (มี nav ข้างซ้าย)', () => {
+  it('/settings/products/pricing → render หน้า pricing ใน panel (sidebar ขับ category แล้ว — ไม่มี nav ข้างซ้าย)', () => {
     render(<App entry="/settings/products/pricing" />);
     expect(screen.getByText('pricing-page')).toBeTruthy();
-    // panel nav ยังอยู่ (link หมวด products)
-    expect(screen.getByRole('link', { name: /สินค้า/ })).toBeTruthy();
+    // desktop left category nav is removed — sidebar drives category selection now
+    expect(screen.queryByRole('link', { name: /สินค้า/ })).toBeNull();
   });
 
   it('old /settings/pricing-templates → redirect ไป /settings/products/pricing', async () => {

--- a/docs/superpowers/plans/2026-06-24-settings-sidebar-driven-nav.md
+++ b/docs/superpowers/plans/2026-06-24-settings-sidebar-driven-nav.md
@@ -1,0 +1,166 @@
+# Settings — Sidebar-Driven Navigation (P5) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** ทำให้ navigation ของ settings เป็น "ชุดเดียว" — sidebar (gear zone) แสดง 8 หมวดจาก settings-registry แทนรายการแบนๆ เดิม, และ panel เอา sub-nav ซ้ายออก (เหลือ content + search; มือถือคง dropdown). คลิกหมวดใน sidebar → `/settings/<cat>` → panel โชว์เนื้อหาหมวดนั้น
+
+**Architecture:** sidebar gear-zone เดิม render `MenuSection[]` ที่ `zone:'settings'` (static ใน menu.ts). เปลี่ยนเป็น registry-driven: `getSidebarForRole(role,'settings')` คืน section เดียว "ตั้งค่าระบบ" ที่ items = `visibleCategories(role)` → `{label, path:/settings/<cat.id>, icon: cat.icon}`. Panel (`SettingsLayout`) ตัด sub-nav ซ้ายเดสก์ท็อปออก. ทำให้ navigation ไม่ซ้อน 2 ชั้น และขับด้วย registry เดียวกับ panel
+
+**Tech Stack:** React 18 + TS + Vite + react-router v7 + Tailwind + Vitest
+
+**Confirmed design (user, 2026-06-24):** sidebar = 8 categories (registry) · panel drops left sub-nav · operational reached via category → panel (accepted 2-click trade-off)
+
+## Global Constraints
+- Design tokens; functional+hooks; registry (`@/config/settings-registry` + `@/config/settings-access`) = source of truth
+- Role filtering via `visibleCategories(role)` (handles OWNER/FM/ACC automatically); roles without settings gear → empty
+- `/settings/*` (any depth) must resolve to the `settings` zone so the gear stays active + correct category highlights
+- Don't break other zones (shop/fin) or non-settings sidebar sections
+- Commit per task; branch `feat/settings-sidebar-driven-nav` (off main @ 11175ae9)
+
+---
+
+## File Structure
+- **Modify** `apps/web/src/config/menu.ts` — registry-driven settings-zone section (helper + `getSidebarForRole` + `resolveZoneForPath`); remove now-dead static `zone:'settings'` sections from role configs
+- **Modify** `apps/web/src/config/menu.test.ts` — assert settings zone = registry categories
+- **Modify** `apps/web/src/components/layout/Sidebar.tsx` — ensure category link active-state uses prefix match for `/settings/<cat>`
+- **Modify** `apps/web/src/pages/settings/SettingsLayout.tsx` — remove desktop left sub-nav (keep header + search + Outlet); keep mobile dropdown
+- **Modify** `apps/web/src/pages/settings/CategoryPage.tsx` — add category-label heading (orientation, since sidebar drives selection)
+- Tests: `SettingsLayout.test.tsx`, `CategoryPage.test.tsx`, `menu.test.ts`
+
+---
+
+## Task 1: Registry-driven settings-zone sidebar (menu.ts)
+
+**Files:** Modify `apps/web/src/config/menu.ts`, `apps/web/src/config/menu.test.ts`
+
+**Interfaces:**
+- Consumes: `visibleCategories` (`@/config/settings-access`), `settingsRegistry` types, `Settings` icon
+- Produces: `getSidebarForRole(role,'settings')` returns ONE section `{ key:'settings', label:'ตั้งค่าระบบ', icon: Settings, zone:'settings', items:[{label, path:'/settings/<catId>', icon: cat.icon}] }` per role; `resolveZoneForPath` returns `'settings'` for any `/settings*` path (gear roles)
+
+- [ ] **Step 1: test (RED)** — in `menu.test.ts` add:
+```ts
+import { getSidebarForRole, resolveZoneForPath } from './menu';
+// ...
+it('OWNER settings zone = registry categories (8), as links to /settings/<cat>', () => {
+  const secs = getSidebarForRole('OWNER', 'settings');
+  const paths = secs.flatMap((s) => s.items.map((i) => i.path));
+  expect(paths).toContain('/settings/company');
+  expect(paths).toContain('/settings/system');
+  expect(paths.every((p) => p.startsWith('/settings/'))).toBe(true);
+  expect(paths).not.toContain('/users');      // operational no longer a sidebar quick-link
+  expect(paths).not.toContain('/settings');   // bare panel root not listed; categories are
+});
+it('FINANCE_MANAGER settings zone = its visible categories (subset, no AI)', () => {
+  const paths = getSidebarForRole('FINANCE_MANAGER', 'settings').flatMap((s) => s.items.map((i) => i.path));
+  expect(paths).toContain('/settings/company');     // contacts
+  expect(paths).not.toContain('/settings/ai');      // OWNER-only
+});
+it('resolveZoneForPath maps any /settings/* to settings zone (OWNER)', () => {
+  expect(resolveZoneForPath('OWNER', '/settings/accounting')).toBe('settings');
+  expect(resolveZoneForPath('OWNER', '/settings/accounting/chart')).toBe('settings');
+});
+```
+Run: `cd apps/web && npx vitest run src/config/menu.test.ts` → FAIL
+
+- [ ] **Step 2: helper + getSidebarForRole** — in `menu.ts`, add imports `import { visibleCategories } from './settings-access';` and `import type { SettingsRole } from './settings-registry';` (Settings icon already imported). Add helper near getSidebarForRole:
+```ts
+function buildSettingsZoneSections(role: string): MenuSection[] {
+  const cats = visibleCategories(role as SettingsRole);
+  if (cats.length === 0) return [];
+  return [{
+    key: 'settings',
+    label: 'ตั้งค่าระบบ',
+    icon: Settings,
+    zone: 'settings',
+    items: cats.map((c) => ({ label: c.label, path: `/settings/${c.id}`, icon: c.icon })),
+  }];
+}
+```
+Change the settings branch of `getSidebarForRole`:
+```ts
+  if (currentZone === 'settings') {
+    return config.showSettingsGear ? buildSettingsZoneSections(role) : [];
+  }
+```
+
+- [ ] **Step 3: resolveZoneForPath** — make `/settings*` resolve to settings zone. At the top of `resolveZoneForPath`, before the loop:
+```ts
+  if (path === '/settings' || path.startsWith('/settings/') || path.startsWith('/settings#')) {
+    const cfg = ZONE_CONFIG[role];
+    if (cfg?.showSettingsGear) return 'settings';
+  }
+```
+(keeps the existing loop for non-settings paths)
+
+- [ ] **Step 4: remove dead static settings sections** — in each role config (`OWNER_CONFIG`, `FINANCE_MANAGER_CONFIG`, `ACCOUNTANT_CONFIG`, others) delete the `MenuSection` objects with `zone: 'settings'` (they're no longer rendered — `getSidebarForRole` computes them). Verify by grep that no other code reads those specific section keys. KEEP non-settings sections untouched. (If a settings section also contained a `#contacts` deep-link relied on elsewhere, it's now covered by the company category — confirm contacts reachable via `/settings/company`.)
+
+- [ ] **Step 5: green + type-check** — `cd apps/web && npx vitest run src/config/menu.test.ts` PASS; `./tools/check-types.sh web` 0 errors. Fix any menu.test assertions that referenced removed static settings paths (update to the registry-driven expectations).
+
+- [ ] **Step 6: commit** — `git add apps/web/src/config/menu.ts apps/web/src/config/menu.test.ts && git commit -m "feat(settings): registry-driven settings-zone sidebar (8 categories replace flat list)"`
+
+---
+
+## Task 2: Sidebar category active-state (prefix match)
+
+**Files:** Modify `apps/web/src/components/layout/Sidebar.tsx` (only if needed); Test via existing sidebar e2e/unit if present
+
+- [ ] **Step 1: read `isItemActive` in Sidebar.tsx** — determine if it exact-matches or prefix-matches `item.path` against the current pathname. The category links are `/settings/<cat>`; when on `/settings/<cat>/<item>` or `/settings/<cat>#x`, the category link should still show active.
+
+- [ ] **Step 2: if exact-only, add prefix handling for settings categories** — make a `/settings/<cat>` item active when `pathname === item.path || pathname.startsWith(item.path + '/')`. Keep existing behavior for non-settings items (don't broaden globally — scope the prefix rule to paths starting `/settings/`). Example guard inside `isItemActive`:
+```ts
+// settings category links: active on the category root and any of its item sub-routes
+if (path.startsWith('/settings/')) {
+  return pathname === path || pathname.startsWith(path + '/');
+}
+```
+(place before the existing exact-match return; verify `pathname` source in the function)
+
+- [ ] **Step 3: verify** — `./tools/check-types.sh web` 0 errors. If a Sidebar unit test exists, run it; else note manual smoke (active highlight on /settings/accounting and /settings/accounting/chart).
+
+- [ ] **Step 4: commit** — `git add apps/web/src/components/layout/Sidebar.tsx && git commit -m "fix(settings): sidebar category link active on its sub-routes (prefix match)"`
+
+> If `isItemActive` already prefix-matches correctly, skip Steps 2/4 and note "no change needed" in the report.
+
+---
+
+## Task 3: Panel — drop desktop sub-nav + category heading
+
+**Files:** Modify `apps/web/src/pages/settings/SettingsLayout.tsx`, `apps/web/src/pages/settings/CategoryPage.tsx`; Tests `SettingsLayout.test.tsx`, `CategoryPage.test.tsx`
+
+**Interfaces:** Consumes existing layout/page. Produces: desktop SettingsLayout = header + search + `<Outlet/>` (NO left category nav); mobile = header + search + `<select>` dropdown + `<Outlet/>`. CategoryPage renders the category label as an `<h2>` heading.
+
+- [ ] **Step 1: tests (RED)** —
+  - `SettingsLayout.test.tsx`: change/add a desktop test asserting the left category `<nav>` is GONE (e.g. the category nav links are not rendered on desktop) while the search input + Outlet content still render. Keep the mobile test asserting the `<select>` exists.
+  - `CategoryPage.test.tsx`: add a test asserting the category label heading renders (e.g. `getByRole('heading', { name: 'ระบบ & ความปลอดภัย' })` for `system`).
+  Run both → FAIL.
+
+- [ ] **Step 2: SettingsLayout** — remove the desktop left `<nav>` block (the category list). Desktop branch becomes: `<div>{search}{<Outlet/>}</div>` (full-width content). Keep the mobile branch (`useIsMobile`) with the `<select>` dropdown + `<Outlet/>`. Remove now-unused imports (e.g. category `Link` mapping, `visibleItems` count if only used there — verify). Keep `searchSettings` + search box. Keep `visibleCategories` only if still used (mobile select uses it — keep for mobile).
+
+- [ ] **Step 3: CategoryPage heading** — at the top of the rendered output (inside the existing return, before the groups), add:
+```tsx
+<h2 className="text-lg font-semibold text-foreground leading-snug mb-4">{cat.label}</h2>
+```
+(`cat` is already resolved; this gives orientation now that the sidebar drives selection)
+
+- [ ] **Step 4: green + type-check** — run both test files + `cd apps/web && npx vitest run src/pages/settings` (green) + `./tools/check-types.sh web` (0).
+
+- [ ] **Step 5: commit** — `git add apps/web/src/pages/settings/ && git commit -m "feat(settings): panel drops desktop sub-nav (sidebar drives categories) + category heading"`
+
+---
+
+## Task 4: Verification
+- [ ] **Step 1:** `./tools/check-types.sh web` → 0
+- [ ] **Step 2:** `cd apps/web && npx vitest run src/pages/settings src/config src/components` → green
+- [ ] **Step 3: smoke (if dev runs):** gear-zone sidebar shows 8 categories (OWNER) / subset (FM/ACC); click "บัญชี & ภาษี" → `/settings/accounting`, sidebar highlights it, panel shows content WITHOUT its own left nav; `/settings/accounting/chart` keeps sidebar highlight; mobile (narrow) → panel dropdown works; CommandPalette search still jumps; `/settings/company` shows contacts.
+
+---
+
+## Self-Review
+**Coverage:** sidebar = 8 categories (registry-driven, role-filtered) → Task 1; active-state on sub-routes → Task 2; panel sub-nav removed + heading → Task 3; zone resolution for /settings/* → Task 1 Step 3.
+**Placeholder scan:** helper code + getSidebarForRole/resolveZoneForPath edits + SettingsLayout/CategoryPage edits all concrete. Task 2 conditional (skip if isItemActive already prefix) is a verify-with-action, not a placeholder.
+**Type consistency:** `buildSettingsZoneSections(role): MenuSection[]`; uses `visibleCategories(role as SettingsRole)`; category items `{label,path,icon}` match `MenuItem`.
+
+## Notes / trade-offs (user-accepted)
+- operational pages (/users, /branches, /promotions, /contract-templates) now reached via category → panel link (2-click) instead of sidebar quick-link. User confirmed the unified-nav preference over quick-access.
+- Mobile keeps the panel's `<select>` dropdown (sidebar is a drawer on mobile).
+- CommandPalette still indexes all settings (global search/jump) — unchanged.


### PR DESCRIPTION
## สรุป

ปรับ navigation ของ settings ให้เป็น **ชุดเดียว** ตามที่เจ้าของขอ — แก้อาการ "เมนูซ้อนเมนู" (sidebar gear-zone โชว์ลิสต์แบนๆ + panel มี sub-nav ของตัวเองอีกชุด)

### เปลี่ยนอะไร
- **Sidebar (gear zone) = 8 หมวดจาก registry** — `getSidebarForRole(role,'settings')` คืน section เดียว "ตั้งค่าระบบ" ที่ items = `visibleCategories(role)` → ลิงก์ `/settings/<หมวด>` (กรองตาม role อัตโนมัติ). ลบ static settings sections เก่า 5 อัน
- **Panel เอา sub-nav ซ้าย (desktop) ออก** — เหลือ header + ค้นหา + เนื้อหาเต็มกว้าง; **มือถือคง dropdown**
- **CategoryPage**: เพิ่มหัวข้อหมวด (h2) เพื่อ orientation + fix React duplicate-key (หมวด system มี 2 กลุ่ม "ข้อมูล" ไม่ติดกัน)
- `resolveZoneForPath`: ทุก `/settings*` → settings zone (sidebar ค้าง active ถูก)
- FM/ACC mobile bottomNav contacts → `/settings/company` (เลิก stale `#contacts`)

### ผลลัพธ์
คลิกหมวดใน sidebar → `/settings/<หมวด>` → panel โชว์เนื้อหา (ไม่มี nav ซ้ำ); sidebar highlight หมวดที่อยู่ (รวม sub-route); ค้นหายังทำงาน (panel + CommandPalette)

> trade-off (เจ้าของรับทราบ): operational (ผู้ใช้/สาขา/โปรโมชัน/แบบสัญญา) เข้าผ่านหมวด→panel แทน sidebar quick-link

## เทส
- ✅ settings+config+components **253/253**, menu **39/39**, type-check 0, output pristine (ไม่มี dup-key warning)
- 4 tasks subagent-driven + review ทุก task; Final review (Opus) = **ship** (ไม่มี Critical/Important)
- 18 fail ในชุดเต็ม = ของเดิมบน main (`useContractCalculation`/`BcCalculator`) ไม่เกี่ยวกับ PR นี้

🤖 Generated with [Claude Code](https://claude.com/claude-code)