### PR TITLE
feat(contacts): สมุดผู้ติดต่อ เป็นเมนู+หน้าแยก (ออกจาก settings panel)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -479,8 +479,8 @@ function App() {
           <Route path="/chatbot-finance/learning" element={<ProtectedRoute roles={['OWNER', 'FINANCE_MANAGER']}><ChatbotFinanceLearningPage /></ProtectedRoute>} />
           <Route path="/customers" element={<CustomersPage />} />
           <Route path="/customers/:id" element={<CustomerDetailPage />} />
-          <Route path="/contacts" element={<ContactsPage />} />
-          <Route path="/contacts/:id" element={<ContactDetailPage />} />
+          <Route path="/contacts" element={<ProtectedRoute roles={['OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT']}><ContactsPage /></ProtectedRoute>} />
+          <Route path="/contacts/:id" element={<ProtectedRoute roles={['OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT']}><ContactDetailPage /></ProtectedRoute>} />
           <Route path="/customer-intake" element={<CustomerIntakePage />} />
           <Route path="/contracts" element={<ContractsPage />} />
           <Route

--- a/apps/web/src/components/CommandPalette.test.tsx
+++ b/apps/web/src/components/CommandPalette.test.tsx
@@ -171,4 +171,18 @@ describe('CommandPalette — settings registry integration', () => {
     // The registry-derived label "ผู้ใช้ & สิทธิ์ › ผู้ใช้ / พนักงาน" must NOT appear (deduped)
     expect(screen.queryByText('ผู้ใช้ & สิทธิ์ › ผู้ใช้ / พนักงาน')).not.toBeInTheDocument();
   });
+
+  it('shows "สมุดผู้ติดต่อ" → /contacts entry for OWNER', async () => {
+    await renderPaletteOpen(makeOwner());
+
+    const entry = screen.getByText('สมุดผู้ติดต่อ');
+    expect(entry).toBeInTheDocument();
+  });
+
+  it('shows "สมุดผู้ติดต่อ" → /contacts entry for FINANCE_MANAGER', async () => {
+    await renderPaletteOpen(makeFinanceManager());
+
+    const entry = screen.getByText('สมุดผู้ติดต่อ');
+    expect(entry).toBeInTheDocument();
+  });
 });

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -32,6 +32,7 @@ import {
   Mail,
   Smartphone,
   Clock,
+  BookUser,
 } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 import { useAuth } from '@/contexts/AuthContext';
@@ -54,6 +55,7 @@ const pages: NavEntry[] = [
   { label: 'POS ขายสินค้า', path: '/pos', icon: ShoppingCart, keywords: 'pos sale ขาย' },
   { label: 'ประวัติการขาย', path: '/sales', icon: Receipt, keywords: 'sales history' },
   { label: 'ลูกค้า', path: '/customers', icon: Users, keywords: 'customer ลูกค้า' },
+  { label: 'สมุดผู้ติดต่อ', path: '/contacts', icon: BookUser, keywords: 'contacts ผู้ติดต่อ ผู้ขาย supplier ไฟแนนซ์', roles: ['OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT'] },
   { label: 'สัญญาผ่อน', path: '/contracts', icon: FileCheck, keywords: 'contract สัญญา ผ่อน' },
   { label: 'ชำระเงิน', path: '/payments', icon: DollarSign, keywords: 'payment ชำระ จ่าย' },
   { label: 'ใบเสร็จรับเงิน', path: '/payments?tab=receipts', icon: Receipt, keywords: 'receipt ใบเสร็จ', roles: ['OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'ACCOUNTANT'] },

--- a/apps/web/src/config/__tests__/settings-access.test.ts
+++ b/apps/web/src/config/__tests__/settings-access.test.ts
@@ -8,12 +8,13 @@ describe('settings-access', () => {
     expect(visibleCategories('OWNER').map((c) => c.id)).toHaveLength(8);
   });
 
-  it('FINANCE_MANAGER เห็น subset ที่มี item เห็นได้ (เช่น company, accounting, finance, comms) ไม่เห็น access/ai', () => {
+  it('FINANCE_MANAGER เห็น subset ที่มี item เห็นได้ (accounting, finance, comms) ไม่เห็น company/access/ai', () => {
     const ids = visibleCategories('FINANCE_MANAGER').map((c) => c.id);
-    expect(ids).toContain('company');     // contacts
-    expect(ids).toContain('accounting');  // chart, peak-mapping
-    expect(ids).toContain('finance');     // payment-methods
-    expect(ids).not.toContain('access');  // OWNER-only items
+    expect(ids).not.toContain('company');  // contacts ย้ายออกแล้ว → company เป็น OWNER-only
+    expect(ids).toContain('accounting');   // chart, peak-mapping
+    expect(ids).toContain('finance');      // payment-methods
+    expect(ids).toContain('comms');        // sms
+    expect(ids).not.toContain('access');   // OWNER-only items
     expect(ids).not.toContain('ai');
   });
 
@@ -26,7 +27,7 @@ describe('settings-access', () => {
 
   it('firstVisibleCategoryId คืนหมวดแรกที่ role เห็น', () => {
     expect(firstVisibleCategoryId('OWNER')).toBe('company');
-    expect(firstVisibleCategoryId('FINANCE_MANAGER')).toBe('company');
+    expect(firstVisibleCategoryId('FINANCE_MANAGER')).toBe('accounting'); // company ไม่มี item ที่ FM เห็นแล้ว
   });
 
   it('searchSettings match label + keywords และกรอง role', () => {

--- a/apps/web/src/config/__tests__/settings-registry.test.ts
+++ b/apps/web/src/config/__tests__/settings-registry.test.ts
@@ -32,4 +32,10 @@ describe('settingsRegistry', () => {
       }
     }
   });
+
+  it('contacts ไม่อยู่ใน company category (ย้ายเป็น standalone แล้ว)', () => {
+    const company = settingsRegistry.find((c) => c.id === 'company')!;
+    const ids = company.items.map((i) => i.id);
+    expect(ids).not.toContain('contacts');
+  });
 });

--- a/apps/web/src/config/menu.test.ts
+++ b/apps/web/src/config/menu.test.ts
@@ -217,20 +217,20 @@ describe('Master data moved into settings zone (Option B, 2026-06-13) — now re
     expect(getZoneConfigForRole('ACCOUNTANT')?.showSettingsGear).toBe(true);
   });
 
-  it('FM/ACC settings zone includes /contacts (master-data) + /settings/company (registry)', () => {
+  it('FM/ACC settings zone includes /contacts (master-data) — company registry no longer visible', () => {
     const fmPaths = getSidebarForRole('FINANCE_MANAGER', 'settings').flatMap((s) =>
       s.items.map((i) => i.path),
     );
-    // P6: /contacts in master-data section; /settings/company still in registry section
+    // P6: /contacts in master-data section; /settings/company NOT in registry (contacts removed → company is OWNER-only)
     expect(fmPaths).toContain('/contacts');
-    expect(fmPaths).toContain('/settings/company');
+    expect(fmPaths).not.toContain('/settings/company');
     expect(fmPaths).not.toContain('/settings#contacts');  // old hash-link gone
 
     const accPaths = getSidebarForRole('ACCOUNTANT', 'settings').flatMap((s) =>
       s.items.map((i) => i.path),
     );
     expect(accPaths).toContain('/contacts');
-    expect(accPaths).toContain('/settings/company');
+    expect(accPaths).not.toContain('/settings/company');
     expect(accPaths).not.toContain('/settings#contacts');  // old hash-link gone
   });
 });
@@ -251,10 +251,10 @@ describe('P5 Task 1 — registry-driven settings-zone sidebar (updated for P6)',
     expect(masterSec.items.map((i) => i.path)).toContain('/contacts');
   });
 
-  it('FINANCE_MANAGER settings zone = master-data(/contacts) + visible categories (subset, no AI)', () => {
+  it('FINANCE_MANAGER settings zone = master-data(/contacts) + visible categories (subset, no AI, no company)', () => {
     const paths = getSidebarForRole('FINANCE_MANAGER', 'settings').flatMap((s) => s.items.map((i) => i.path));
     expect(paths).toContain('/contacts');             // master-data group
-    expect(paths).toContain('/settings/company');     // contacts (registry)
+    expect(paths).not.toContain('/settings/company'); // contacts removed → company is OWNER-only
     expect(paths).not.toContain('/settings/ai');      // OWNER-only
   });
 

--- a/apps/web/src/config/menu.test.ts
+++ b/apps/web/src/config/menu.test.ts
@@ -100,33 +100,39 @@ describe('getSidebarForRole — populated ZONE_CONFIG', () => {
     expect(keys).toContain('owner-fin-notifications');
   });
 
-  it('OWNER settings zone is now registry-driven (P5): one section keyed "settings"', () => {
+  it('OWNER settings zone is now registry-driven (P5) + master-data group (P6)', () => {
     const keys = getSidebarForRole('OWNER', 'settings').map((s) => s.key);
-    // P5: old static keys removed; replaced by single registry section
-    expect(keys).toEqual(['settings']);
+    // P6: master-data group prepended; registry "settings" section still present
+    expect(keys).toEqual(['master-data', 'settings']);
     expect(keys).not.toContain('owner-settings');
     expect(keys).not.toContain('owner-settings-extra');
     expect(keys).not.toContain('owner-fin-master');
   });
 
-  it('OWNER settings zone paths are all /settings/<catId> (P5 registry-driven)', () => {
+  it('OWNER settings zone paths: master-data /contacts + /settings/<catId> registry (P5+P6)', () => {
     const sections = getSidebarForRole('OWNER', 'settings');
-    const allPaths = sections.flatMap((s) => s.items.map((i) => i.path));
-    // All paths are /settings/<categoryId> — registry-driven
-    expect(allPaths.every((p) => p.startsWith('/settings/'))).toBe(true);
+    // master-data section has /contacts; settings section has /settings/<cat> paths
+    const masterSection = sections.find((s) => s.key === 'master-data');
+    const settingsSection = sections.find((s) => s.key === 'settings');
+    expect(masterSection).toBeDefined();
+    expect(settingsSection).toBeDefined();
+    expect(masterSection!.items.map((i) => i.path)).toEqual(['/contacts']);
+    const settingsPaths = settingsSection!.items.map((i) => i.path);
+    // All settings-section paths are /settings/<categoryId>
+    expect(settingsPaths.every((p) => p.startsWith('/settings/'))).toBe(true);
     // operational quick-links removed (now inside the panel)
-    expect(allPaths).not.toContain('/users');
-    expect(allPaths).not.toContain('/branches');
-    expect(allPaths).not.toContain('/settings');  // bare root not listed
+    expect(settingsPaths).not.toContain('/users');
+    expect(settingsPaths).not.toContain('/branches');
+    expect(settingsPaths).not.toContain('/settings');  // bare root not listed
     // all 8 registry categories visible to OWNER
-    expect(allPaths).toContain('/settings/company');
-    expect(allPaths).toContain('/settings/access');
-    expect(allPaths).toContain('/settings/accounting');
-    expect(allPaths).toContain('/settings/finance');
-    expect(allPaths).toContain('/settings/products');
-    expect(allPaths).toContain('/settings/comms');
-    expect(allPaths).toContain('/settings/ai');
-    expect(allPaths).toContain('/settings/system');
+    expect(settingsPaths).toContain('/settings/company');
+    expect(settingsPaths).toContain('/settings/access');
+    expect(settingsPaths).toContain('/settings/accounting');
+    expect(settingsPaths).toContain('/settings/finance');
+    expect(settingsPaths).toContain('/settings/products');
+    expect(settingsPaths).toContain('/settings/comms');
+    expect(settingsPaths).toContain('/settings/ai');
+    expect(settingsPaths).toContain('/settings/system');
   });
 
   it('FINANCE_MANAGER fin sections include payments (regression for fm-payments zone fix)', () => {
@@ -188,12 +194,12 @@ describe('VIEWER role (Owner Q4 2026-05-17)', () => {
   });
 });
 
-describe('Master data moved into settings zone (Option B, 2026-06-13) — now registry-driven (P5)', () => {
-  it('settings zone for OWNER/FM/ACC is registry-driven (single section keyed "settings")', () => {
-    // P5: old static "ข้อมูลหลัก" sections replaced by registry-driven section
-    expect(getSidebarForRole('OWNER', 'settings').map((s) => s.key)).toEqual(['settings']);
-    expect(getSidebarForRole('FINANCE_MANAGER', 'settings').map((s) => s.key)).toEqual(['settings']);
-    expect(getSidebarForRole('ACCOUNTANT', 'settings').map((s) => s.key)).toEqual(['settings']);
+describe('Master data moved into settings zone (Option B, 2026-06-13) — now registry-driven (P5) + own group (P6)', () => {
+  it('settings zone for OWNER/FM/ACC has master-data first, then settings section (P6)', () => {
+    // P6: master-data group prepended before the registry "settings" section
+    expect(getSidebarForRole('OWNER', 'settings').map((s) => s.key)).toEqual(['master-data', 'settings']);
+    expect(getSidebarForRole('FINANCE_MANAGER', 'settings').map((s) => s.key)).toEqual(['master-data', 'settings']);
+    expect(getSidebarForRole('ACCOUNTANT', 'settings').map((s) => s.key)).toEqual(['master-data', 'settings']);
   });
 
   it('ข้อมูลหลัก static sections no longer exist in any zone', () => {
@@ -211,36 +217,44 @@ describe('Master data moved into settings zone (Option B, 2026-06-13) — now re
     expect(getZoneConfigForRole('ACCOUNTANT')?.showSettingsGear).toBe(true);
   });
 
-  it('FM/ACC settings zone includes /settings/company (contacts reachable via registry)', () => {
+  it('FM/ACC settings zone includes /contacts (master-data) + /settings/company (registry)', () => {
     const fmPaths = getSidebarForRole('FINANCE_MANAGER', 'settings').flatMap((s) =>
       s.items.map((i) => i.path),
     );
-    // contacts is now under /settings/company (registry-driven)
+    // P6: /contacts in master-data section; /settings/company still in registry section
+    expect(fmPaths).toContain('/contacts');
     expect(fmPaths).toContain('/settings/company');
     expect(fmPaths).not.toContain('/settings#contacts');  // old hash-link gone
 
     const accPaths = getSidebarForRole('ACCOUNTANT', 'settings').flatMap((s) =>
       s.items.map((i) => i.path),
     );
+    expect(accPaths).toContain('/contacts');
     expect(accPaths).toContain('/settings/company');
     expect(accPaths).not.toContain('/settings#contacts');  // old hash-link gone
   });
 });
 
-describe('P5 Task 1 — registry-driven settings-zone sidebar', () => {
-  it('OWNER settings zone = registry categories (8), as links to /settings/<cat>', () => {
+describe('P5 Task 1 — registry-driven settings-zone sidebar (updated for P6)', () => {
+  it('OWNER settings zone = master-data group + registry categories (8) as /settings/<cat>', () => {
     const secs = getSidebarForRole('OWNER', 'settings');
-    const paths = secs.flatMap((s) => s.items.map((i) => i.path));
+    // P6: master-data is first, settings (registry) is second
+    const settingsSec = secs.find((s) => s.key === 'settings')!;
+    const paths = settingsSec.items.map((i) => i.path);
     expect(paths).toContain('/settings/company');
     expect(paths).toContain('/settings/system');
     expect(paths.every((p) => p.startsWith('/settings/'))).toBe(true);
     expect(paths).not.toContain('/users');      // operational no longer a sidebar quick-link
     expect(paths).not.toContain('/settings');   // bare panel root not listed; categories are
+    // master-data group has /contacts
+    const masterSec = secs.find((s) => s.key === 'master-data')!;
+    expect(masterSec.items.map((i) => i.path)).toContain('/contacts');
   });
 
-  it('FINANCE_MANAGER settings zone = its visible categories (subset, no AI)', () => {
+  it('FINANCE_MANAGER settings zone = master-data(/contacts) + visible categories (subset, no AI)', () => {
     const paths = getSidebarForRole('FINANCE_MANAGER', 'settings').flatMap((s) => s.items.map((i) => i.path));
-    expect(paths).toContain('/settings/company');     // contacts
+    expect(paths).toContain('/contacts');             // master-data group
+    expect(paths).toContain('/settings/company');     // contacts (registry)
     expect(paths).not.toContain('/settings/ai');      // OWNER-only
   });
 
@@ -259,16 +273,31 @@ describe('FM/ACC bottomNav contacts shortcut — stale hash fix (2026-06-24)', (
     }
   });
 
-  it('FM bottomNav contacts shortcut now points to /settings/company', () => {
+  it('FM bottomNav contacts shortcut now points to /contacts', () => {
     const bn = getZoneConfigForRole('FINANCE_MANAGER')?.bottomNav.settings ?? [];
     const paths = bn.map((i) => i.path);
-    expect(paths).toContain('/settings/company');
+    expect(paths).toContain('/contacts');
   });
 
-  it('ACC bottomNav contacts shortcut now points to /settings/company', () => {
+  it('ACC bottomNav contacts shortcut now points to /contacts', () => {
     const bn = getZoneConfigForRole('ACCOUNTANT')?.bottomNav.settings ?? [];
     const paths = bn.map((i) => i.path);
-    expect(paths).toContain('/settings/company');
+    expect(paths).toContain('/contacts');
+  });
+});
+
+describe('P6 Task 1 — สมุดผู้ติดต่อ as own gear-zone group', () => {
+  it('OWNER settings zone has ข้อมูลหลัก > สมุดผู้ติดต่อ → /contacts above the categories', () => {
+    const secs = getSidebarForRole('OWNER', 'settings');
+    expect(secs[0].key).toBe('master-data');
+    expect(secs[0].items.map((i) => i.path)).toEqual(['/contacts']);
+    expect(secs.some((s) => s.key === 'settings')).toBe(true); // categories still present
+  });
+  it('FM/ACC also get the contacts master-data group in settings zone', () => {
+    for (const r of ['FINANCE_MANAGER', 'ACCOUNTANT']) {
+      const paths = getSidebarForRole(r, 'settings').flatMap((s) => s.items.map((i) => i.path));
+      expect(paths).toContain('/contacts');
+    }
   });
 });
 
@@ -290,7 +319,8 @@ describe('resolveZoneForPath — hash-aware (regression: FM/ACC must not bounce 
     expect(resolveZoneForPath('SALES', '/settings')).toBeNull();
   });
 
-  it('a path not in any menu (e.g. standalone /contacts) returns null (pass-through)', () => {
-    expect(resolveZoneForPath('OWNER', '/contacts')).toBeNull();
+  it('/contacts resolves to settings zone for OWNER (now in master-data group, P6)', () => {
+    // P6: /contacts is in the master-data group inside the settings zone
+    expect(resolveZoneForPath('OWNER', '/contacts')).toBe('settings');
   });
 });

--- a/apps/web/src/config/menu.ts
+++ b/apps/web/src/config/menu.ts
@@ -878,7 +878,7 @@ const ZONE_CONFIG: Record<string, RoleZoneConfig> = {
       ],
       fin: FINANCE_MANAGER_CONFIG.bottomNav,
       settings: [
-        { label: 'ผู้ติดต่อ', path: '/settings/company', icon: BookUser },
+        { label: 'ผู้ติดต่อ', path: '/contacts', icon: BookUser },
         { label: 'เพิ่มเติม', path: '#more', icon: MoreHorizontal, action: 'sidebar' },
       ],
     },
@@ -903,7 +903,7 @@ const ZONE_CONFIG: Record<string, RoleZoneConfig> = {
       shop: [],
       fin: ACCOUNTANT_CONFIG.bottomNav,
       settings: [
-        { label: 'ผู้ติดต่อ', path: '/settings/company', icon: BookUser },
+        { label: 'ผู้ติดต่อ', path: '/contacts', icon: BookUser },
         { label: 'เพิ่มเติม', path: '#more', icon: MoreHorizontal, action: 'sidebar' },
       ],
     },
@@ -925,15 +925,21 @@ const ZONE_CONFIG: Record<string, RoleZoneConfig> = {
 function buildSettingsZoneSections(role: string): MenuSection[] {
   const cats = visibleCategories(role as SettingsRole);
   if (cats.length === 0) return [];
-  return [
-    {
-      key: 'settings',
-      label: 'ตั้งค่าระบบ',
-      icon: Settings,
-      zone: 'settings' as const,
-      items: cats.map((c) => ({ label: c.label, path: `/settings/${c.id}`, icon: c.icon })),
-    },
-  ];
+  const masterData: MenuSection = {
+    key: 'master-data',
+    label: 'ข้อมูลหลัก',
+    icon: BookUser,
+    zone: 'settings' as const,
+    items: [{ label: 'สมุดผู้ติดต่อ', path: '/contacts', icon: BookUser }],
+  };
+  const settings: MenuSection = {
+    key: 'settings',
+    label: 'ตั้งค่าระบบ',
+    icon: Settings,
+    zone: 'settings' as const,
+    items: cats.map((c) => ({ label: c.label, path: `/settings/${c.id}`, icon: c.icon })),
+  };
+  return [masterData, settings];
 }
 
 /**

--- a/apps/web/src/config/settings-registry.tsx
+++ b/apps/web/src/config/settings-registry.tsx
@@ -26,7 +26,6 @@ import PeakSyncPage from '@/pages/PeakSyncPage';
 import { ETaxConfigPage } from '@/pages/ETaxConfigPage';
 // inline components (อยู่ที่เดิม — แค่ import มา render)
 import { CompanyTab } from '@/pages/SettingsPage/tabs/CompanyTab';
-import { ContactsTab } from '@/pages/SettingsPage/tabs/ContactsTab';
 import { VatTab } from '@/pages/SettingsPage/tabs/VatTab';
 import { PeriodsTab } from '@/pages/SettingsPage/tabs/PeriodsTab';
 import { AttachmentTab } from '@/pages/SettingsPage/tabs/AttachmentTab';
@@ -67,7 +66,6 @@ export const settingsRegistry: SettingsCategory[] = [
     id: 'company', label: 'บริษัท & สาขา', icon: Building2, roles: ALL,
     items: [
       { id: 'company-info', label: 'ข้อมูลบริษัท', group: 'บริษัท', roles: ['OWNER'], kind: 'inline', component: CompanyTab, keywords: ['ที่อยู่', 'โลโก้', 'ผู้เซ็น', 'tax id'] },
-      { id: 'contacts', label: 'สมุดผู้ติดต่อ', group: 'บริษัท', roles: ALL, kind: 'inline', component: ContactsTab, keywords: ['ลูกค้า', 'ผู้ขาย', 'supplier'] },
       { id: 'entities', label: 'บริษัทในเครือ', group: 'บริษัท', roles: ['OWNER'], kind: 'route', component: CompanySettingsPage, path: '/settings/company/entities' },
       { id: 'branches', label: 'สาขา', group: 'สาขา', roles: ['OWNER'], kind: 'external', path: '/branches' },
     ],

--- a/apps/web/src/pages/settings/SettingsIndexRedirect.tsx
+++ b/apps/web/src/pages/settings/SettingsIndexRedirect.tsx
@@ -6,7 +6,6 @@ import type { SettingsRole } from '@/config/settings-registry';
 
 // hash tab เดิม (#vat ฯลฯ) → หมวดใหม่. item id ที่ตรงกับ hash จะถูกใช้ anchor ต่อ
 export const HASH_TO_CATEGORY: Record<string, string> = {
-  contacts: 'company',
   company: 'company',
   vat: 'accounting',
   periods: 'accounting',
@@ -25,6 +24,11 @@ export function SettingsIndexRedirect() {
 
   useEffect(() => {
     const hash = typeof window !== 'undefined' ? window.location.hash.slice(1) : '';
+    // #contacts is now a standalone page — redirect directly
+    if (hash === 'contacts') {
+      navigate('/contacts', { replace: true });
+      return;
+    }
     const mapped = HASH_TO_CATEGORY[hash];
     if (mapped) {
       // คง hash เป็น anchor ไปยัง section (item id ที่ตรงกับ hash ถ้ามี)

--- a/apps/web/src/pages/settings/__tests__/SettingsIndexRedirect.test.tsx
+++ b/apps/web/src/pages/settings/__tests__/SettingsIndexRedirect.test.tsx
@@ -4,7 +4,6 @@ import { HASH_TO_CATEGORY } from '../SettingsIndexRedirect';
 describe('HASH_TO_CATEGORY', () => {
   it('map hash tab เก่าครบทุกตัว → หมวดใหม่', () => {
     expect(HASH_TO_CATEGORY).toMatchObject({
-      contacts: 'company',
       company: 'company',
       vat: 'accounting',
       periods: 'accounting',
@@ -15,5 +14,9 @@ describe('HASH_TO_CATEGORY', () => {
       'offsite-backup': 'system',
       pdpa: 'system',
     });
+  });
+
+  it('#contacts is NOT in HASH_TO_CATEGORY (handled by dedicated redirect)', () => {
+    expect(HASH_TO_CATEGORY).not.toHaveProperty('contacts');
   });
 });

--- a/docs/superpowers/plans/2026-06-24-contacts-standalone-menu.md
+++ b/docs/superpowers/plans/2026-06-24-contacts-standalone-menu.md
@@ -1,0 +1,137 @@
+# Contacts — Standalone Menu + Page (P6) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** แยก "สมุดผู้ติดต่อ" ออกจาก settings panel (หมวด "บริษัท & สาขา") ให้เป็นเมนูของตัวเองในโซน "ตั้งค่ากลาง" (เหนือ 8 หมวด) ชี้ไปหน้า `/contacts` ที่มีอยู่แล้ว
+
+**Architecture:** หน้า `/contacts` (`ContactsPage` → `ContactsTab`) มีอยู่แล้ว (App.tsx). งานคือ: (1) gear-zone sidebar เพิ่มกลุ่ม "ข้อมูลหลัก" ที่มี item เดียว "สมุดผู้ติดต่อ → /contacts" ไว้บนสุด (เหนือ section "ตั้งค่าระบบ" ที่เป็น 8 หมวด); (2) เอา `contacts` ออกจาก registry หมวด company (เลิกซ้ำใน panel); (3) เก็บ CommandPalette + redirect + guard ให้ชี้ /contacts. user เลือก placement (ก) = gear zone.
+
+**Tech Stack:** React 18 + TS + Vite + react-router v7 + Tailwind + Vitest
+
+**Confirmed (user, 2026-06-24):** placement (ก) — gear-zone own group, above the 8 categories.
+
+## Global Constraints
+- registry = source of truth for the 8 categories; the "ข้อมูลหลัก" contacts group is a deliberate standalone sidebar group (contacts is master-data, not a settings category)
+- contacts roles = OWNER/FM/ACC (registry had `roles: ALL` = these 3 gear roles); all gear roles see the contacts group
+- `/contacts` page already exists — do NOT rebuild it; just link + guard
+- Don't break the 8-category settings sidebar (P5) or other zones
+- Commit per task; branch `feat/settings-contacts-standalone` (off main @ 6ee011ad)
+
+## File Structure
+- **Modify** `apps/web/src/config/menu.ts` — `buildSettingsZoneSections` returns `[ข้อมูลหลัก(contacts→/contacts), ตั้งค่าระบบ(categories)]`; FM/ACC bottomNav contacts → `/contacts`
+- **Modify** `apps/web/src/config/menu.test.ts`
+- **Modify** `apps/web/src/config/settings-registry.tsx` — remove `contacts` item from `company` category (+ drop now-unused ContactsTab import)
+- **Modify** `apps/web/src/config/__tests__/settings-registry.test.ts`, `apps/web/src/config/__tests__/settings-access.test.ts`
+- **Modify** `apps/web/src/components/CommandPalette.tsx` — add `สมุดผู้ติดต่อ → /contacts` page entry (+ test)
+- **Modify** `apps/web/src/pages/settings/SettingsIndexRedirect.tsx` — old `#contacts` → `/contacts` (+ test)
+- **Modify** `apps/web/src/App.tsx` — guard `/contacts` + `/contacts/:id` with roles OWNER/FM/ACC
+
+---
+
+## Task 1: Gear-zone "ข้อมูลหลัก" group (menu.ts)
+
+**Files:** `apps/web/src/config/menu.ts`, `apps/web/src/config/menu.test.ts`
+
+**Interfaces:** `buildSettingsZoneSections(role)` returns 2 sections for gear roles: `{key:'master-data', label:'ข้อมูลหลัก', icon: BookUser, zone:'settings', items:[{label:'สมุดผู้ติดต่อ', path:'/contacts', icon: BookUser}]}` THEN the existing `{key:'settings', label:'ตั้งค่าระบบ', ...categories}`.
+
+- [ ] **Step 1: test (RED)** — in menu.test.ts add:
+```ts
+it('OWNER settings zone has ข้อมูลหลัก > สมุดผู้ติดต่อ → /contacts above the categories', () => {
+  const secs = getSidebarForRole('OWNER', 'settings');
+  expect(secs[0].key).toBe('master-data');
+  expect(secs[0].items.map((i) => i.path)).toEqual(['/contacts']);
+  expect(secs.some((s) => s.key === 'settings')).toBe(true); // categories still present
+});
+it('FM/ACC also get the contacts master-data group in settings zone', () => {
+  for (const r of ['FINANCE_MANAGER', 'ACCOUNTANT']) {
+    const paths = getSidebarForRole(r, 'settings').flatMap((s) => s.items.map((i) => i.path));
+    expect(paths).toContain('/contacts');
+  }
+});
+```
+Run: `cd apps/web && npx vitest run src/config/menu.test.ts` → FAIL
+
+- [ ] **Step 2: implement** — in `menu.ts`, edit `buildSettingsZoneSections` (BookUser already imported):
+```ts
+function buildSettingsZoneSections(role: string): MenuSection[] {
+  const cats = visibleCategories(role as SettingsRole);
+  if (cats.length === 0) return [];
+  const masterData: MenuSection = {
+    key: 'master-data', label: 'ข้อมูลหลัก', icon: BookUser, zone: 'settings',
+    items: [{ label: 'สมุดผู้ติดต่อ', path: '/contacts', icon: BookUser }],
+  };
+  const settings: MenuSection = {
+    key: 'settings', label: 'ตั้งค่าระบบ', icon: Settings, zone: 'settings',
+    items: cats.map((c) => ({ label: c.label, path: `/settings/${c.id}`, icon: c.icon })),
+  };
+  return [masterData, settings];
+}
+```
+
+- [ ] **Step 3: FM/ACC bottomNav** — change FM + ACC `bottomNav.settings` contacts entry from `path: '/settings/company'` to `path: '/contacts'` (it was set to /settings/company in P5; now contacts has its own page). Keep label "ผู้ติดต่อ" + icon.
+
+- [ ] **Step 4: green + type-check** — `cd apps/web && npx vitest run src/config/menu.test.ts` PASS; `./tools/check-types.sh web` 0. Update any menu.test assertion that expected `secs[0].key === 'settings'` (now master-data is first).
+
+- [ ] **Step 5: commit** — `git add apps/web/src/config/menu.ts apps/web/src/config/menu.test.ts && git commit -m "feat(contacts): add สมุดผู้ติดต่อ as own gear-zone group → /contacts"`
+
+---
+
+## Task 2: Remove contacts from the registry company category
+
+**Files:** `apps/web/src/config/settings-registry.tsx`, `apps/web/src/config/__tests__/settings-registry.test.ts`, `apps/web/src/config/__tests__/settings-access.test.ts`
+
+**Interfaces:** `company` category no longer has a `contacts` item. Consequence: FM/ACC (who only saw `company` via contacts) no longer see the `company` category in the panel — that's intended (company-info/entities/branches are OWNER-only; contacts now standalone).
+
+- [ ] **Step 1: tests (RED)** — update/add:
+  - settings-registry.test.ts: if any test asserts a `contacts` item under company, change it to assert contacts is ABSENT from company items.
+  - settings-access.test.ts: the existing `'FINANCE_MANAGER ... company (contacts)'` expectation must change — FM no longer sees `company` category (company items are all OWNER-only now). Update to assert `visibleCategories('FINANCE_MANAGER')` does NOT include `company`, and still includes accounting/finance/comms. (Read the current assertions first; adjust to the new reality, don't gut.)
+  Run: `cd apps/web && npx vitest run src/config` → FAIL
+
+- [ ] **Step 2: implement** — in `settings-registry.tsx`, delete the `{ id: 'contacts', ... component: ContactsTab ... }` line from the `company` category items. Remove the now-unused `import { ContactsTab } from '@/pages/SettingsPage/tabs/ContactsTab';` (verify ContactsTab isn't referenced elsewhere in the registry — it isn't).
+
+- [ ] **Step 3: green + type-check** — `cd apps/web && npx vitest run src/config` PASS; `./tools/check-types.sh web` 0.
+
+- [ ] **Step 4: commit** — `git add apps/web/src/config/settings-registry.tsx apps/web/src/config/__tests__/ && git commit -m "feat(contacts): remove contacts from settings company category (now standalone)"`
+
+---
+
+## Task 3: CommandPalette entry + hash redirect + route guard
+
+**Files:** `apps/web/src/components/CommandPalette.tsx` (+ test), `apps/web/src/pages/settings/SettingsIndexRedirect.tsx` (+ test), `apps/web/src/App.tsx`
+
+- [ ] **Step 1: CommandPalette test (RED)** — assert "สมุดผู้ติดต่อ" appears as a palette entry with path `/contacts` (OWNER). Run → FAIL (the registry-derived contacts entry is gone now).
+
+- [ ] **Step 2: CommandPalette impl** — add to the base `pages` array (near the `ลูกค้า → /customers` entry, line ~56):
+```tsx
+{ label: 'สมุดผู้ติดต่อ', path: '/contacts', icon: BookUser, keywords: 'contacts ผู้ติดต่อ ผู้ขาย supplier ไฟแนนซ์', roles: ['OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT'] },
+```
+(import `BookUser` from lucide-react if not already imported in CommandPalette.tsx). Run palette test → PASS.
+
+- [ ] **Step 3: SettingsIndexRedirect test (RED)** — assert old `#contacts` now redirects to `/contacts` (not `/settings/company`). Run → FAIL.
+
+- [ ] **Step 4: SettingsIndexRedirect impl** — read `SettingsIndexRedirect.tsx`. Remove `contacts` from `HASH_TO_CATEGORY` and add a dedicated redirect: in the effect, if `hash === 'contacts'` → `navigate('/contacts', { replace: true })` before the category-mapping logic. (Or add a separate `HASH_TO_PATH: Record<string,string> = { contacts: '/contacts' }` checked first.) Keep the other hash mappings intact. Run test → PASS.
+
+- [ ] **Step 5: App.tsx guard** — wrap the existing `/contacts` and `/contacts/:id` routes (App.tsx ~482-483) with `<ProtectedRoute roles={['OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT']}>...</ProtectedRoute>` (they're currently bare). Match the ProtectedRoute usage pattern of adjacent routes.
+
+- [ ] **Step 6: green + type-check** — `cd apps/web && npx vitest run src/components src/pages/settings` PASS; `./tools/check-types.sh web` 0.
+
+- [ ] **Step 7: commit** — `git add apps/web/src/components/CommandPalette.tsx apps/web/src/pages/settings/SettingsIndexRedirect.tsx apps/web/src/App.tsx && git commit -m "feat(contacts): palette entry + #contacts→/contacts redirect + guard /contacts route"`
+
+---
+
+## Task 4: Verification
+- [ ] **Step 1:** `./tools/check-types.sh web` → 0
+- [ ] **Step 2:** `cd apps/web && npx vitest run src/pages/settings src/config src/components` → green
+- [ ] **Step 3:** grep no stale contacts-in-panel ref: `cd "/d/BESTCHOICE APP/BESTCHOICE" && grep -rn "settings/company#contacts\|id: 'contacts'" apps/web/src --include=*.ts --include=*.tsx | grep -v "\.test\."` → expect only acceptable residue (report)
+- [ ] **Step 4: smoke (if dev runs):** gear-zone sidebar shows "ข้อมูลหลัก > สมุดผู้ติดต่อ" on top, then 8/subset categories; click → `/contacts` page (not inside panel); `/settings/company` no longer lists contacts; old `/settings#contacts` → `/contacts`; CommandPalette "สมุดผู้ติดต่อ" → /contacts; SALES/BM can't reach /contacts (guard).
+
+---
+
+## Self-Review
+**Coverage:** standalone contacts group in gear zone → Task 1; removed from panel category → Task 2; palette + redirect + guard → Task 3.
+**Placeholder scan:** all steps have concrete code/targets. Test-update steps say "read current, adjust to new reality, don't gut".
+**Type consistency:** `buildSettingsZoneSections` returns `MenuSection[]`; master-data section shape matches; BookUser icon reused; contacts roles OWNER/FM/ACC consistent across menu/palette/guard.
+
+## Notes
+- After removing contacts, FM/ACC no longer see the `company` category in the settings panel (its remaining items are OWNER-only) — intended; contacts is reached via the new ข้อมูลหลัก group + /contacts page + palette.
+- `/contacts` page (ContactsPage→ContactsTab) unchanged.


### PR DESCRIPTION
## สรุป

ดึง **"สมุดผู้ติดต่อ"** ออกจากหมวด "บริษัท & สาขา" ในหน้า settings → ทำเป็น **เมนูของตัวเอง** ในโซน "ตั้งค่ากลาง" ชี้ไปหน้า **`/contacts`** ที่มีอยู่แล้ว (เจ้าของเลือก placement: gear-zone group เหนือ 8 หมวด)

> เดิม contacts ถูกโชว์ **2 ที่**: หน้า `/contacts` (มีอยู่แต่ไม่มีในเมนู) + เป็น inline tab ใน `/settings/company` → ซ้ำซ้อน. PR นี้รวมเหลือที่เดียว = หน้า /contacts

### เปลี่ยนอะไร
- **Sidebar (ตั้งค่ากลาง)**: เพิ่มกลุ่ม **"ข้อมูลหลัก → สมุดผู้ติดต่อ"** บนสุด (เหนือ 8 หมวด settings) ชี้ `/contacts`
- **Registry**: ลบ item `contacts` ออกจากหมวด company → FM/ACC เลยไม่เห็นหมวด company อีก (item ที่เหลือเป็น OWNER-only หมด) — ตั้งใจ; contacts เข้าผ่านกลุ่มใหม่ + /contacts แทน
- **CommandPalette**: เพิ่ม "สมุดผู้ติดต่อ → /contacts" (role-gated OWNER/FM/ACC)
- **Redirect**: bookmark เก่า `/settings#contacts` → `/contacts`
- **Security**: guard route `/contacts` + `/contacts/:id` (เดิม bare ไม่มี guard) → OWNER/FM/ACC
- FM/ACC mobile bottomNav contacts → `/contacts`

### หน้า /contacts ไม่แตะ
`ContactsPage` → `ContactsTab` คงเดิมทุกอย่าง

## เทส
- ✅ settings+config+components **259/259**, menu **41/41**, type-check 0, grep ไม่เหลือ contacts-in-panel
- 3 tasks subagent-driven + review ทุก task; Final review (Opus) = **ship** (ไม่มี Critical/Important)
- 18 fail ในชุดเต็ม = ของเดิมบน main (`useContractCalculation`/`BcCalculator`) ไม่เกี่ยวกับ PR นี้

🤖 Generated with [Claude Code](https://claude.com/claude-code)