### PR TITLE
chore(settings): refresh stale /settings#contacts comment examples (+ re-trigger deploy)

### DIFF
--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -147,7 +147,7 @@ function useZoneValidator() {
   return { role, zoneConfig, currentZone, setCurrentZone };
 }
 
-// path ที่มี hash (เช่น '/settings#contacts') ต้อง match ทั้ง pathname + hash
+// path ที่มี hash (เช่น '/settings/accounting#vat') ต้อง match ทั้ง pathname + hash
 function hashAwareActive(path: string, pathname: string, hash: string): boolean {
   if (path.includes('#')) return path === pathname + hash;
   return path === pathname || (path.length > 1 && pathname.startsWith(path + '/'));

--- a/apps/web/src/config/menu.ts
+++ b/apps/web/src/config/menu.ts
@@ -959,7 +959,7 @@ const ZONE_LOOKUP_ORDER: Zone[] = ['shop', 'fin', 'settings'];
 
 /**
  * Find which zone a path belongs to for a role. HASH-AWARE: a menu path like
- * '/settings#contacts' matches the route pathname '/settings' (react-router's
+ * '/settings/accounting#vat' matches on the route pathname (react-router's
  * pathname never includes the hash). Returns null if the path isn't in any of
  * the role's accessible zones (caller decides pass-through vs redirect).
  */


### PR DESCRIPTION
## สรุป

แก้ doc-comment 2 จุดที่ยังอ้างถึง `/settings#contacts` (path ที่เลิกใช้แล้ว — ตอนนี้ contacts = `/contacts` "รายชื่อผู้ติดต่อ" อยู่ใน submenu ตั้งค่าระบบ):
- `Sidebar.tsx:150` — เปลี่ยนตัวอย่างเป็น `/settings/accounting#vat`
- `menu.ts:962` — เปลี่ยนตัวอย่างใน JSDoc ของ `resolveZoneForPath`

comment-only — logic (`hashAwareActive`, `resolveZoneForPath`) ไม่เปลี่ยน

## หมายเหตุสำคัญ (CI)
PR #1294 (แยกหมวด "เชื่อมต่อ") merge เข้า main แล้ว (commit `3f8e13e7`) แต่ GitHub Actions **ไม่ได้สร้าง push-deploy run** ให้ commit นั้น (anomaly — merge ก่อนหน้า #1292/#1293 fire ปกติภายใน ~2 วิ; ยืนยันผ่าน API ว่ามีแต่ workflow_dispatch run ที่ skip). deploy job ทำงานเฉพาะ event `push` → workflow_dispatch ใช้ deploy ไม่ได้. การ merge PR นี้จะสร้าง push event ใหม่ → deploy ทั้ง `3f8e13e7` (integrations) + cleanup นี้ขึ้น prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)