### PR TITLE
refactor(menu): dedupe OWNER mobile settings bottom-bar (align with FM/ACC)

### DIFF
--- a/apps/web/src/config/menu.test.ts
+++ b/apps/web/src/config/menu.test.ts
@@ -285,6 +285,16 @@ describe('FM/ACC bottomNav contacts shortcut — stale hash fix (2026-06-24)', (
     const paths = bn.map((i) => i.path);
     expect(paths).toContain('/contacts');
   });
+
+  it('OWNER bottomNav settings zone dropped config dups (aligned with FM/ACC: contacts + เพิ่มเติม)', () => {
+    const paths = (getZoneConfigForRole('OWNER')?.bottomNav.settings ?? []).map((i) => i.path);
+    // dedupe 2026-06-24 — these all live in the settings submenu now
+    expect(paths).not.toContain('/users');
+    expect(paths).not.toContain('/branches');
+    expect(paths).not.toContain('/settings/company/entities');
+    expect(paths).not.toContain('/settings');
+    expect(paths).toContain('/contacts'); // non-dup standalone page kept as the quick shortcut
+  });
 });
 
 describe('contacts inside settings submenu — รายชื่อผู้ติดต่อ → /contacts (2026-06-24)', () => {

--- a/apps/web/src/config/menu.ts
+++ b/apps/web/src/config/menu.ts
@@ -29,7 +29,6 @@ import {
   Plug,
   Target,
   Settings,
-  UserCog,
   BadgePercent,
   Shield,
   ScrollText,
@@ -782,11 +781,11 @@ const ZONE_CONFIG: Record<string, RoleZoneConfig> = {
         { label: 'แชท', path: '/inbox', icon: MessageSquareMore, badgeKey: 'chat-unread' },
         { label: 'เพิ่มเติม', path: '#more', icon: MoreHorizontal, action: 'sidebar' },
       ],
+      // settings-zone mobile bar — aligned with FM/ACC (dedupe 2026-06-24): dropped the
+      // config shortcuts (users/entities/branches/ตั้งค่า) that duplicate the settings
+      // submenu. Full settings nav via เพิ่มเติม → drawer (รายชื่อผู้ติดต่อ + 9 หมวด).
       settings: [
-        { label: 'ผู้ใช้ / พนักงาน', path: '/users', icon: UserCog },
-        { label: 'บริษัท', path: '/settings/company/entities', icon: Building2 },
-        { label: 'สาขา', path: '/branches', icon: Building2 },
-        { label: 'ตั้งค่า', path: '/settings', icon: Settings },
+        { label: 'ผู้ติดต่อ', path: '/contacts', icon: BookUser },
         { label: 'เพิ่มเติม', path: '#more', icon: MoreHorizontal, action: 'sidebar' },
       ],
     },


### PR DESCRIPTION
## สรุป

แถบล่างมือถือของ OWNER (โซน settings) ยังมี config ซ้ำกับ settings submenu: **ผู้ใช้/พนักงาน, บริษัท, สาขา, ตั้งค่า**. FM/ACC ใช้ pattern สะอาดอยู่แล้ว (**ผู้ติดต่อ + เพิ่มเติม**) — PR นี้ทำ OWNER ให้ตรงกัน

### เปลี่ยน (OWNER `bottomNav.settings`)
- ลบ config dups: ผู้ใช้/พนักงาน (/users), บริษัท (/settings/company/entities), สาขา (/branches), ตั้งค่า (/settings)
- เหลือ: **ผู้ติดต่อ** (/contacts — หน้า standalone ไม่ซ้ำ) + **เพิ่มเติม** (เปิด drawer = รายชื่อผู้ติดต่อ + 9 หมวด)
- ลบ import `UserCog` ที่ไม่ใช้แล้ว + เพิ่ม regression test

> desktop ไม่เห็นแถบนี้ (mobile-only). ทุกอย่างยังเข้าได้ผ่าน เพิ่มเติม → drawer

## เทส
- ✅ config **55/55** (+1 OWNER guard), type-check 0
- sidebar shop/finance สะอาดอยู่แล้ว (รอบก่อน) — PR นี้ปิดงาน dedupe ส่วนสุดท้าย (mobile bar)

🤖 Generated with [Claude Code](https://claude.com/claude-code)