### PR TITLE
chore: pin Prisma VSCode ext to v6 + sync package-lock

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -54,5 +54,6 @@
 
   // ===== Misc =====
   "files.eol": "\n",
-  "editor.bracketPairColorization.enabled": true
+  "editor.bracketPairColorization.enabled": true,
+  "prisma.pinToPrisma6": true
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4073,7 +4073,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4090,7 +4089,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4107,7 +4105,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4124,7 +4121,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4141,7 +4137,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4158,7 +4153,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4175,7 +4169,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4192,7 +4185,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4209,7 +4201,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4226,7 +4217,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4243,7 +4233,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4260,7 +4249,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4277,7 +4265,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4294,7 +4281,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4311,7 +4297,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4328,7 +4313,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4345,7 +4329,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4362,7 +4345,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4379,7 +4361,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4396,7 +4377,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4413,7 +4393,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4430,7 +4409,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4447,7 +4425,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4464,7 +4441,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4481,7 +4457,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }


### PR DESCRIPTION
## สรุป

commit local changes ที่ค้างในเครื่อง (เจ้าของสั่ง "commit ทั้งหมด"):

- **`.vscode/settings.json`**: `prisma.pinToPrisma6 = true` — ปักหมุด Prisma VSCode extension ที่ v6 (ตรงกับ policy ที่เลื่อน Prisma 7 ออกไป ให้อยู่ 6.x ก่อน)
- **`package-lock.json`**: ลบ `"peer": true` churn บน esbuild platform deps (ไม่เปลี่ยน resolved version — เป็น metadata จาก npm version ต่างกัน)

> CustomerTagChips snapshot มีแต่ line-ending noise → ไม่มีอะไร commit. `~/` (โฟลเดอร์ขยะ) ไม่ได้ add เข้า repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)