### PR TITLE
feat(payments): redesign รับชำระค่างวด queue with period filter + 6 KPI cards

### DIFF
--- a/apps/api/src/modules/payments/payments.controller.spec.ts
+++ b/apps/api/src/modules/payments/payments.controller.spec.ts
@@ -223,7 +223,8 @@ describe('PaymentsController', () => {
   describe('pending payments branch filtering', () => {
     it('should force branchId for SALES user', () => {
       const user = { role: 'SALES', branchId: 'branch-1' };
-      controller.getPendingPayments(undefined, undefined, undefined, undefined, undefined, undefined, undefined, user);
+      // signature: (branchId, date, dueFrom, dueTo, status, search, dunningStage, page, limit, user)
+      controller.getPendingPayments(undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, user);
       expect(paymentsService.getPendingPayments).toHaveBeenCalledWith(
         expect.objectContaining({ branchId: 'branch-1' }),
       );
@@ -231,7 +232,7 @@ describe('PaymentsController', () => {
 
     it('should not force branchId for OWNER', () => {
       const user = { role: 'OWNER', branchId: 'branch-1' };
-      controller.getPendingPayments(undefined, undefined, undefined, undefined, undefined, undefined, undefined, user);
+      controller.getPendingPayments(undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, user);
       expect(paymentsService.getPendingPayments).toHaveBeenCalledWith(
         expect.objectContaining({ branchId: undefined }),
       );
@@ -239,7 +240,7 @@ describe('PaymentsController', () => {
 
     it('should allow OWNER to query specific branch', () => {
       const user = { role: 'OWNER', branchId: 'branch-1' };
-      controller.getPendingPayments('branch-2', undefined, undefined, undefined, undefined, undefined, undefined, user);
+      controller.getPendingPayments('branch-2', undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, user);
       expect(paymentsService.getPendingPayments).toHaveBeenCalledWith(
         expect.objectContaining({ branchId: 'branch-2' }),
       );

--- a/apps/api/src/modules/payments/payments.controller.ts
+++ b/apps/api/src/modules/payments/payments.controller.ts
@@ -54,6 +54,8 @@ export class PaymentsController {
   getPendingPayments(
     @Query('branchId') branchId?: string,
     @Query('date') date?: string,
+    @Query('dueFrom') dueFrom?: string,
+    @Query('dueTo') dueTo?: string,
     @Query('status') status?: string,
     @Query('search') search?: string,
     @Query('dunningStage') dunningStage?: string,
@@ -68,11 +70,31 @@ export class PaymentsController {
     return this.paymentsService.getPendingPayments({
       branchId: effectiveBranchId,
       date,
+      dueFrom,
+      dueTo,
       status,
       search,
       dunningStage,
       page: parsedPage && !isNaN(parsedPage) ? parsedPage : undefined,
       limit: parsedLimit && !isNaN(parsedLimit) ? parsedLimit : undefined,
+    });
+  }
+
+  // KPI summary for the payment-queue header — whole-system aggregate scoped
+  // by installment due-date window. Branch-forced for non-cross-branch roles.
+  @Get('pending-summary')
+  @Roles('OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'ACCOUNTANT', 'SALES')
+  getPendingSummary(
+    @Query('branchId') branchId?: string,
+    @Query('dueFrom') dueFrom?: string,
+    @Query('dueTo') dueTo?: string,
+    @CurrentUser() user?: { role: string; branchId: string | null },
+  ) {
+    const effectiveBranchId = this.getEffectiveBranchId(branchId, user);
+    return this.paymentsService.getPendingSummary({
+      branchId: effectiveBranchId,
+      dueFrom,
+      dueTo,
     });
   }
 

--- a/apps/api/src/modules/payments/payments.pending-summary.spec.ts
+++ b/apps/api/src/modules/payments/payments.pending-summary.spec.ts
@@ -1,0 +1,127 @@
+import { Prisma } from '@prisma/client';
+import { PaymentQueryService } from './services/payment-query.service';
+
+/**
+ * getPendingSummary powers the 6 KPI cards on the redesigned รับชำระค่างวด page.
+ * The figures feed straight into a collector's decisions + map to ledger codes,
+ * so the Decimal math (esp. outstandingPrincipal = Σ amountDue − Σ amountPaid)
+ * must be exact and never drift to IEEE-754 float.
+ */
+describe('PaymentQueryService — getPendingSummary', () => {
+  /**
+   * Build a service whose prisma.payment.aggregate routes by which _sum keys
+   * the method requested (pending vs waived vs collected bucket), and whose
+   * count answers the overdue-60 bucket. Captures the `where` of each call so
+   * tests can assert the due-date window was applied.
+   */
+  function makeService(buckets: {
+    pending?: { _count: number; _sum: { amountDue: unknown; amountPaid: unknown; lateFee: unknown } };
+    waived?: { _sum: { waivedAmount: unknown } };
+    collected?: { _count: number; _sum: { amountPaid: unknown } };
+    overdue60?: number;
+  }) {
+    const D = (v: string) => new Prisma.Decimal(v);
+    const calls: { pending?: any; waived?: any; collected?: any; overdue60?: any } = {};
+
+    const aggregate = jest.fn((args: any) => {
+      const sum = args._sum ?? {};
+      if (sum.amountDue) {
+        calls.pending = args.where;
+        return Promise.resolve(
+          buckets.pending ?? { _count: 0, _sum: { amountDue: D('0'), amountPaid: D('0'), lateFee: D('0') } },
+        );
+      }
+      if (sum.waivedAmount) {
+        calls.waived = args.where;
+        return Promise.resolve(buckets.waived ?? { _sum: { waivedAmount: D('0') } });
+      }
+      calls.collected = args.where;
+      return Promise.resolve(buckets.collected ?? { _count: 0, _sum: { amountPaid: D('0') } });
+    });
+
+    const count = jest.fn((args: any) => {
+      calls.overdue60 = args.where;
+      return Promise.resolve(buckets.overdue60 ?? 0);
+    });
+
+    const prisma = { payment: { aggregate, count } };
+    const service = new PaymentQueryService(prisma as any);
+    return { service, calls, aggregate, count };
+  }
+
+  it('computes all 6 KPI figures with Decimal-safe math (matches mockup)', async () => {
+    const D = (v: string) => new Prisma.Decimal(v);
+    const { service } = makeService({
+      pending: { _count: 50, _sum: { amountDue: D('60000.00'), amountPaid: D('3624.00'), lateFee: D('2150.00') } },
+      waived: { _sum: { waivedAmount: D('675.00') } },
+      overdue60: 3,
+      collected: { _count: 8, _sum: { amountPaid: D('12580.00') } },
+    });
+
+    const result = await service.getPendingSummary({});
+
+    expect(result).toEqual({
+      pendingCount: 50,
+      outstandingPrincipal: 56376, // 60000.00 − 3624.00, "เฉพาะค่างวด" (no late fee)
+      outstandingLateFee: 2150, // → Cr 42-1103
+      waivedLateFee: 675, // → Dr 52-1105 (อนุโลม)
+      overdue60Count: 3, // → trigger 21-2103 VAT
+      collectedAmount: 12580,
+      collectedCount: 8,
+    });
+  });
+
+  it('keeps satang precision (no float drift across the subtraction)', async () => {
+    const D = (v: string) => new Prisma.Decimal(v);
+    const { service } = makeService({
+      pending: { _count: 3, _sum: { amountDue: D('4547.49'), amountPaid: D('1515.83'), lateFee: D('99.17') } },
+    });
+
+    const result = await service.getPendingSummary({});
+    expect(result.outstandingPrincipal).toBe(3031.66); // 4547.49 − 1515.83
+    expect(result.outstandingLateFee).toBe(99.17);
+  });
+
+  it('never reports a negative outstanding (overpaid edge clamps to 0)', async () => {
+    const D = (v: string) => new Prisma.Decimal(v);
+    const { service } = makeService({
+      pending: { _count: 1, _sum: { amountDue: D('100.00'), amountPaid: D('150.00'), lateFee: D('0') } },
+    });
+
+    const result = await service.getPendingSummary({});
+    expect(result.outstandingPrincipal).toBe(0);
+  });
+
+  it('"ทั้งหมด" (no range) applies no dueDate filter to any bucket', async () => {
+    const { service, calls } = makeService({});
+    await service.getPendingSummary({});
+
+    expect(calls.pending.dueDate).toBeUndefined();
+    expect(calls.waived.dueDate).toBeUndefined();
+    expect(calls.collected.dueDate).toBeUndefined();
+    // overdue-60 always carries its cutoff, even with no period selected
+    expect(calls.overdue60.dueDate.lte).toBeInstanceOf(Date);
+  });
+
+  it('applies an inclusive due-date window when dueFrom/dueTo are given', async () => {
+    const { service, calls } = makeService({});
+    await service.getPendingSummary({ dueFrom: '2026-05-01', dueTo: '2026-05-31' });
+
+    expect(calls.pending.dueDate.gte).toEqual(new Date(2026, 4, 1));
+    // inclusive end → start of the next day (1 Jun)
+    expect(calls.pending.dueDate.lt).toEqual(new Date(2026, 5, 1));
+    // overdue-60 keeps the window's lower bound AND the 60-day cutoff
+    expect(calls.overdue60.dueDate.gte).toEqual(new Date(2026, 4, 1));
+    expect(calls.overdue60.dueDate.lte).toBeInstanceOf(Date);
+  });
+
+  it('scopes every bucket to APPROVED contracts of the requested branch', async () => {
+    const { service, calls } = makeService({});
+    await service.getPendingSummary({ branchId: 'branch-1' });
+
+    for (const where of [calls.pending, calls.waived, calls.collected, calls.overdue60]) {
+      expect(where.contract).toMatchObject({ workflowStatus: 'APPROVED', deletedAt: null, branchId: 'branch-1' });
+      expect(where.deletedAt).toBeNull();
+    }
+  });
+});

--- a/apps/api/src/modules/payments/payments.service.ts
+++ b/apps/api/src/modules/payments/payments.service.ts
@@ -249,6 +249,8 @@ export class PaymentsService {
   async getPendingPayments(filters: {
     branchId?: string;
     date?: string;
+    dueFrom?: string;
+    dueTo?: string;
     status?: string;
     search?: string;
     dunningStage?: string;
@@ -256,6 +258,11 @@ export class PaymentsService {
     limit?: number;
   }) {
     return this.services().query.getPendingPayments(filters);
+  }
+
+  // ─── Pending-queue KPI summary (whole-system aggregate) ─
+  async getPendingSummary(filters: { branchId?: string; dueFrom?: string; dueTo?: string }) {
+    return this.services().query.getPendingSummary(filters);
   }
 
   // ─── Daily summary ────────────────────────────────────

--- a/apps/api/src/modules/payments/services/payment-query.service.ts
+++ b/apps/api/src/modules/payments/services/payment-query.service.ts
@@ -1,8 +1,35 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
-import { Prisma } from '@prisma/client';
+import { Prisma, PaymentStatus } from '@prisma/client';
 import { PrismaService } from '../../../prisma/prisma.service';
 import { paginatedResponse } from '../../../common/helpers/pagination.helper';
 import { roundBaht } from '../../../utils/installment.util';
+
+/**
+ * Build a Prisma `dueDate` range filter from BKK-local YYYY-MM-DD bounds.
+ * `dueTo` is INCLUSIVE — we add one day and use `lt` so the whole end day is
+ * covered. Returns `null` when neither bound is supplied (= "ทั้งหมด", no
+ * filter). Bad/empty inputs are ignored gracefully.
+ */
+function buildDueDateRange(
+  dueFrom?: string,
+  dueTo?: string,
+): { gte?: Date; lt?: Date } | null {
+  const range: { gte?: Date; lt?: Date } = {};
+  if (dueFrom) {
+    const f = new Date(dueFrom);
+    if (!isNaN(f.getTime())) {
+      range.gte = new Date(f.getFullYear(), f.getMonth(), f.getDate());
+    }
+  }
+  if (dueTo) {
+    const t = new Date(dueTo);
+    if (!isNaN(t.getTime())) {
+      // inclusive end → start of the NEXT day
+      range.lt = new Date(t.getFullYear(), t.getMonth(), t.getDate() + 1);
+    }
+  }
+  return range.gte || range.lt ? range : null;
+}
 
 /**
  * Read-side queries + the tiny partial-QR writes (cancelActivePartialQr). No
@@ -39,6 +66,8 @@ export class PaymentQueryService {
   async getPendingPayments(filters: {
     branchId?: string;
     date?: string;
+    dueFrom?: string;
+    dueTo?: string;
     status?: string;
     search?: string;
     dunningStage?: string;
@@ -86,6 +115,12 @@ export class PaymentQueryService {
         gte: new Date(d.getFullYear(), d.getMonth(), d.getDate()),
         lt: new Date(d.getFullYear(), d.getMonth(), d.getDate() + 1),
       };
+    } else {
+      // Period filter (รับชำระค่างวด redesign): scope the queue by installment
+      // due-date window. `dueFrom`/`dueTo` are BKK local YYYY-MM-DD; `dueTo` is
+      // inclusive (we add a day and use `lt`). Either bound may be omitted.
+      const range = buildDueDateRange(filters.dueFrom, filters.dueTo);
+      if (range) where.dueDate = range;
     }
 
     const page = filters.page || 1;
@@ -115,6 +150,94 @@ export class PaymentQueryService {
     ]);
 
     return paginatedResponse(data, total, page, limit);
+  }
+
+  // ─── Pending-queue KPI summary (รับชำระค่างวด redesign) ─────────────────
+  // Whole-system aggregate (NOT page-limited) scoped by installment due-date
+  // window + branch. Powers the 6 KPI cards above the payment queue. Each
+  // figure maps to a real ledger code so collectors see the accounting impact:
+  //   outstandingPrincipal  ค่างวดที่ยังไม่เก็บ (amountDue − amountPaid)
+  //   outstandingLateFee     → Cr 42-1103 (ค่าปรับชำระล่าช้า) once collected
+  //   waivedLateFee          → Dr 52-1105 (ส่วนลด/อนุโลมค่าปรับ)
+  //   overdue60Count         → trigger 21-2103 (VAT บังคับ-ลูกหนี้ค้าง 60 วัน)
+  //   collected*             ยอด/รายการที่เก็บได้แล้วของงวดในช่วงนี้
+  async getPendingSummary(filters: {
+    branchId?: string;
+    dueFrom?: string;
+    dueTo?: string;
+  }) {
+    // Only count APPROVED contracts — mirrors getPendingPayments so the cards
+    // and the list never disagree.
+    const contractWhere: Record<string, unknown> = {
+      workflowStatus: 'APPROVED',
+      deletedAt: null,
+    };
+    if (filters.branchId) contractWhere.branchId = filters.branchId;
+
+    const range = buildDueDateRange(filters.dueFrom, filters.dueTo);
+    const dueDate = range ?? undefined;
+
+    const PENDING_STATUSES: PaymentStatus[] = [
+      PaymentStatus.PENDING,
+      PaymentStatus.OVERDUE,
+      PaymentStatus.PARTIALLY_PAID,
+    ];
+    const UNPAID_OVERDUE_STATUSES: PaymentStatus[] = [
+      PaymentStatus.OVERDUE,
+      PaymentStatus.PARTIALLY_PAID,
+    ];
+
+    // 60-day cutoff (date-only, server local = BKK in prod). A due date on or
+    // before this is "ค้าง ≥ 60 วัน". Combined with the period window's upper
+    // bound, so picking "เดือนนี้" correctly yields 0 (nothing due this month
+    // can be 60 days overdue yet).
+    const cutoff = new Date();
+    cutoff.setHours(0, 0, 0, 0);
+    cutoff.setDate(cutoff.getDate() - 60);
+    const overdueDueDate: Record<string, unknown> = { ...(dueDate ?? {}), lte: cutoff };
+
+    const [pending, waived, overdue60Count, collected] = await Promise.all([
+      // Pending bucket: count + outstanding principal + outstanding late fee
+      this.prisma.payment.aggregate({
+        where: { deletedAt: null, status: { in: PENDING_STATUSES }, contract: contractWhere, ...(dueDate ? { dueDate } : {}) },
+        _count: true,
+        _sum: { amountDue: true, amountPaid: true, lateFee: true },
+      }),
+      // Waived bucket: late fees written down (อนุโลม) — any status
+      this.prisma.payment.aggregate({
+        where: { deletedAt: null, lateFeeWaived: true, contract: contractWhere, ...(dueDate ? { dueDate } : {}) },
+        _sum: { waivedAmount: true },
+      }),
+      // Overdue ≥ 60 days bucket: still-unpaid installments past the cutoff
+      this.prisma.payment.count({
+        where: { deletedAt: null, status: { in: UNPAID_OVERDUE_STATUSES }, contract: contractWhere, dueDate: overdueDueDate },
+      }),
+      // Collected bucket: money actually received for installments due in range
+      this.prisma.payment.aggregate({
+        where: { deletedAt: null, amountPaid: { gt: 0 }, contract: contractWhere, ...(dueDate ? { dueDate } : {}) },
+        _count: true,
+        _sum: { amountPaid: true },
+      }),
+    ]);
+
+    const dec = (v: Prisma.Decimal | number | null | undefined) =>
+      new Prisma.Decimal(v ?? 0);
+    const outstandingPrincipal = dec(pending._sum?.amountDue)
+      .sub(dec(pending._sum?.amountPaid))
+      .toDecimalPlaces(2)
+      .toNumber();
+
+    return {
+      pendingCount: pending._count,
+      // เฉพาะค่างวด — amountDue excludes lateFee by schema, so this is the
+      // installment principal+interest+vat remaining, never the penalty.
+      outstandingPrincipal: Math.max(0, outstandingPrincipal),
+      outstandingLateFee: dec(pending._sum?.lateFee).toDecimalPlaces(2).toNumber(),
+      waivedLateFee: dec(waived._sum?.waivedAmount).toDecimalPlaces(2).toNumber(),
+      overdue60Count,
+      collectedAmount: dec(collected._sum?.amountPaid).toDecimalPlaces(2).toNumber(),
+      collectedCount: collected._count,
+    };
   }
 
   // ─── Daily summary ────────────────────────────────────

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -94,6 +94,9 @@ layer(base);
   --color-warning: hsl(var(--warning));
   --color-warning-foreground: hsl(var(--warning-foreground));
 
+  --color-orange: hsl(var(--orange));
+  --color-orange-foreground: hsl(var(--orange-foreground));
+
   --color-info-50: #f5f3ff;
   --color-info-100: #ede9fe;
   --color-info-500: #7239ea;
@@ -283,6 +286,8 @@ layer(base);
     --success-foreground: 0 0% 100%;
     --warning: 38 92% 50%;
     --warning-foreground: 0 0% 100%;
+    --orange: 25 95% 53%;
+    --orange-foreground: 0 0% 100%;
     --info: 199 89% 48%;
     --info-foreground: 0 0% 100%;
     /* Border — warm */
@@ -339,6 +344,8 @@ layer(base);
     --success-foreground: 0 0% 100%;
     --warning: 38 92% 45%;
     --warning-foreground: 0 0% 100%;
+    --orange: 25 90% 55%;
+    --orange-foreground: 0 0% 100%;
     --info: 199 89% 48%;
     --info-foreground: 0 0% 100%;
     --border: 230 4% 22%;

--- a/apps/web/src/pages/PaymentsPage/components/PaymentFilters.tsx
+++ b/apps/web/src/pages/PaymentsPage/components/PaymentFilters.tsx
@@ -1,5 +1,3 @@
-import { Card, CardContent } from '@/components/ui/card';
-
 interface PaymentFiltersProps {
   searchTerm: string;
   onSearchChange: (value: string) => void;
@@ -9,8 +7,6 @@ interface PaymentFiltersProps {
   onBranchFilterChange: (value: string) => void;
   isOwner: boolean;
   branches: { id: string; name: string }[];
-  pendingCount: number;
-  pendingTotalDue: number;
   onExport: () => void;
   hasPendingPayments: boolean;
 }
@@ -24,85 +20,53 @@ export default function PaymentFilters({
   onBranchFilterChange,
   isOwner,
   branches,
-  pendingCount,
-  pendingTotalDue,
   onExport,
   hasPendingPayments,
 }: PaymentFiltersProps) {
   return (
-    <>
-      {/* Summary Cards — Metronic KPI style */}
-      {hasPendingPayments && (
-        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-6">
-          <Card className="hover:shadow-md hover:-translate-y-0.5 transition-all duration-200 overflow-hidden">
-            <CardContent className="p-5 relative">
-              <div className="absolute inset-y-0 left-0 w-1 bg-primary rounded-l-xl" />
-              <div className="pl-2">
-                <div className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-2">รายการรอชำระ</div>
-                <div className="text-2xl font-bold text-foreground tabular-nums">{pendingCount}</div>
-              </div>
-            </CardContent>
-          </Card>
-          <Card className="hover:shadow-md hover:-translate-y-0.5 transition-all duration-200 overflow-hidden">
-            <CardContent className="p-5 relative">
-              <div className="absolute inset-y-0 left-0 w-1 bg-destructive rounded-l-xl" />
-              <div className="pl-2">
-                <div className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-2">ยอดรอชำระรวม</div>
-                <div className="text-2xl font-bold text-destructive tabular-nums">{pendingTotalDue.toLocaleString()} ฿</div>
-              </div>
-            </CardContent>
-          </Card>
-          <Card className="hover:shadow-md hover:-translate-y-0.5 transition-all duration-200 overflow-hidden border-dashed">
-            <CardContent className="p-5 flex items-center justify-center h-full">
-              <button
-                onClick={onExport}
-                className="inline-flex items-center gap-2 px-4 py-2 border border-input rounded-lg text-sm font-medium hover:bg-muted transition-colors text-muted-foreground hover:text-foreground"
-              >
-                <svg className="size-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><path strokeLinecap="round" strokeLinejoin="round" d="M12 10v6m0 0-3-3m3 3 3-3m2 8H7a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5.586a1 1 0 0 1 .707.293l5.414 5.414a1 1 0 0 1 .293.707V19a2 2 0 0 1-2 2z" /></svg>
-                ส่งออก Excel
-              </button>
-            </CardContent>
-          </Card>
+    <div className="bg-card rounded-xl border border-border/50 p-4 mb-5 shadow-sm">
+      <div className="flex flex-wrap gap-3 items-center">
+        <div className="relative flex-1 min-w-55">
+          <svg className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-muted-foreground pointer-events-none" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><circle cx="11" cy="11" r="8"/><path d="m21 21-4.35-4.35"/></svg>
+          <input
+            type="text"
+            value={searchTerm}
+            onChange={(e) => onSearchChange(e.target.value)}
+            placeholder="ค้นหาเลขสัญญา, ชื่อ, เบอร์โทร..."
+            className="w-full pl-9 pr-3 py-2 border border-input rounded-lg text-sm bg-background outline-hidden focus:ring-2 focus:ring-ring/30"
+          />
         </div>
-      )}
-
-      {/* Filter Bar */}
-      <div className="bg-card rounded-xl border border-border/50 p-4 mb-5 shadow-sm">
-        <div className="flex flex-wrap gap-3">
-          <div className="relative flex-1 min-w-[220px]">
-            <svg className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-muted-foreground pointer-events-none" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><circle cx="11" cy="11" r="8"/><path d="m21 21-4.35-4.35"/></svg>
-            <input
-              type="text"
-              value={searchTerm}
-              onChange={(e) => onSearchChange(e.target.value)}
-              placeholder="ค้นหาเลขสัญญา, ชื่อ, เบอร์โทร..."
-              className="w-full pl-9 pr-3 py-2 border border-input rounded-lg text-sm bg-background outline-hidden focus:ring-2 focus:ring-ring/30"
-            />
-          </div>
+        <select
+          value={statusFilter}
+          onChange={(e) => onStatusFilterChange(e.target.value)}
+          className="px-3 py-2 border border-input rounded-lg text-sm bg-background outline-hidden focus:ring-2 focus:ring-ring/30"
+        >
+          <option value="">ทุกสถานะ</option>
+          <option value="PENDING">รอชำระ</option>
+          <option value="OVERDUE">เกินกำหนด</option>
+          <option value="PARTIALLY_PAID">ชำระบางส่วน</option>
+        </select>
+        {isOwner && (
           <select
-            value={statusFilter}
-            onChange={(e) => onStatusFilterChange(e.target.value)}
+            value={branchFilter}
+            onChange={(e) => onBranchFilterChange(e.target.value)}
             className="px-3 py-2 border border-input rounded-lg text-sm bg-background outline-hidden focus:ring-2 focus:ring-ring/30"
           >
-            <option value="">ทุกสถานะ</option>
-            <option value="PENDING">รอชำระ</option>
-            <option value="OVERDUE">เกินกำหนด</option>
-            <option value="PARTIALLY_PAID">ชำระบางส่วน</option>
+            <option value="">ทุกสาขา</option>
+            {branches.map((b) => (
+              <option key={b.id} value={b.id}>{b.name}</option>
+            ))}
           </select>
-          {isOwner && (
-            <select
-              value={branchFilter}
-              onChange={(e) => onBranchFilterChange(e.target.value)}
-              className="px-3 py-2 border border-input rounded-lg text-sm bg-background outline-hidden focus:ring-2 focus:ring-ring/30"
-            >
-              <option value="">ทุกสาขา</option>
-              {branches.map((b) => (
-                <option key={b.id} value={b.id}>{b.name}</option>
-              ))}
-            </select>
-          )}
-        </div>
+        )}
+        <button
+          onClick={onExport}
+          disabled={!hasPendingPayments}
+          className="inline-flex items-center gap-2 px-4 py-2 border border-input rounded-lg text-sm font-medium hover:bg-muted transition-colors text-muted-foreground hover:text-foreground disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          <svg className="size-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><path strokeLinecap="round" strokeLinejoin="round" d="M12 10v6m0 0-3-3m3 3 3-3m2 8H7a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5.586a1 1 0 0 1 .707.293l5.414 5.414a1 1 0 0 1 .293.707V19a2 2 0 0 1-2 2z" /></svg>
+          ส่งออก Excel
+        </button>
       </div>
-    </>
+    </div>
   );
 }

--- a/apps/web/src/pages/PaymentsPage/components/PaymentKpiCards.tsx
+++ b/apps/web/src/pages/PaymentsPage/components/PaymentKpiCards.tsx
@@ -1,0 +1,95 @@
+import { Card, CardContent } from '@/components/ui/card';
+import type { PendingSummary } from '../types';
+
+interface PaymentKpiCardsProps {
+  summary: PendingSummary | undefined;
+  loading: boolean;
+  /** Title for the "collected" card, follows the selected period
+   *  (รับชำระเดือนนี้ / เดือนที่แล้ว / ทั้งหมด / ช่วงนี้). */
+  collectedLabel: string;
+}
+
+const ZERO: PendingSummary = {
+  pendingCount: 0,
+  outstandingPrincipal: 0,
+  outstandingLateFee: 0,
+  waivedLateFee: 0,
+  overdue60Count: 0,
+  collectedAmount: 0,
+  collectedCount: 0,
+};
+
+const baht = (n: number) => n.toLocaleString('th-TH');
+
+export default function PaymentKpiCards({ summary, loading, collectedLabel }: PaymentKpiCardsProps) {
+  const s = summary ?? ZERO;
+
+  // accent + value colours use design tokens only (no hardcoded hex). Mirrors
+  // the approved mockup: ค่าปรับล่าช้า=orange, อนุโลม/ค้าง60=warning(amber).
+  const cards = [
+    {
+      label: 'รายการรอชำระ',
+      value: s.pendingCount.toLocaleString('th-TH'),
+      foot: <>ทั้งระบบ</>,
+      accent: 'bg-success',
+      valueClass: 'text-foreground',
+    },
+    {
+      label: 'ยอดรอเก็บ',
+      value: `${baht(s.outstandingPrincipal)} ฿`,
+      foot: <>เฉพาะค่างวด</>,
+      accent: 'bg-destructive',
+      valueClass: 'text-destructive',
+    },
+    {
+      label: 'ค่าปรับล่าช้า (รอเก็บ)',
+      value: `${baht(s.outstandingLateFee)} ฿`,
+      foot: <>→ <code className="font-mono text-[11px]">Cr.42-1103</code></>,
+      accent: 'bg-orange',
+      valueClass: 'text-orange',
+    },
+    {
+      label: 'ค่าปรับที่ไม่เรียกเก็บ (อนุโลม)',
+      value: `${baht(s.waivedLateFee)} ฿`,
+      foot: <>→ <code className="font-mono text-[11px]">Dr.52-1105</code> ส่วนลด</>,
+      accent: 'bg-warning',
+      valueClass: 'text-warning',
+    },
+    {
+      label: 'ค้าง ≥ 60 วัน',
+      value: s.overdue60Count.toLocaleString('th-TH'),
+      foot: <>trigger <code className="font-mono text-[11px]">21-2103</code> VAT</>,
+      accent: 'bg-warning',
+      valueClass: 'text-warning',
+    },
+    {
+      label: collectedLabel,
+      value: `${baht(s.collectedAmount)} ฿`,
+      foot: <>{s.collectedCount.toLocaleString('th-TH')} รายการ</>,
+      accent: 'bg-info',
+      valueClass: 'text-foreground',
+    },
+  ];
+
+  return (
+    <div
+      className={`grid grid-cols-2 lg:grid-cols-3 gap-4 mb-5 ${loading && !summary ? 'animate-pulse' : ''}`}
+    >
+      {cards.map((c) => (
+        <Card
+          key={c.label}
+          className="hover:shadow-md hover:-translate-y-0.5 transition-all duration-200 overflow-hidden"
+        >
+          <CardContent className="p-5 relative">
+            <div className={`absolute inset-y-0 left-0 w-1 rounded-l-xl ${c.accent}`} />
+            <div className="pl-2">
+              <div className="text-xs font-medium text-muted-foreground mb-2 leading-snug">{c.label}</div>
+              <div className={`text-2xl font-bold tabular-nums leading-snug ${c.valueClass}`}>{c.value}</div>
+              <div className="text-[11px] text-muted-foreground mt-1.5 leading-snug">{c.foot}</div>
+            </div>
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/pages/PaymentsPage/components/PaymentPeriodBar.tsx
+++ b/apps/web/src/pages/PaymentsPage/components/PaymentPeriodBar.tsx
@@ -1,0 +1,43 @@
+import ThaiDateInput from '@/components/ui/ThaiDateInput';
+import { DateRangeChips } from '@/components/ui/DateRangeChips';
+
+interface PaymentPeriodBarProps {
+  startDate: string; // YYYY-MM-DD or ''
+  endDate: string; // YYYY-MM-DD or ''
+  onChange: (next: { startDate: string; endDate: string }) => void;
+}
+
+/**
+ * Period selector above the payment queue. Reuses the app-wide `DateRangeChips`
+ * (ทั้งหมด / เดือนนี้ / เดือนที่แล้ว / ช่วงวันที่...) so the formatted label +
+ * preset behaviour match the rest of the system. The custom from–to inputs are
+ * always rendered (พ.ศ. calendar via ThaiDateInput) so the "ช่วงวันที่..." chip
+ * can focus the start field — the chip queries `data-date-range-custom-start`.
+ */
+export default function PaymentPeriodBar({ startDate, endDate, onChange }: PaymentPeriodBarProps) {
+  return (
+    <div className="bg-card rounded-xl border border-border/50 p-4 mb-5 shadow-sm space-y-3">
+      <DateRangeChips startDate={startDate} endDate={endDate} onChange={onChange} />
+
+      <div className="flex flex-wrap items-center gap-2 border-t border-border/40 pt-3">
+        <span className="text-xs font-medium text-muted-foreground">กำหนดช่วงเอง :</span>
+        <ThaiDateInput
+          data-date-range-custom-start="true"
+          value={startDate}
+          max={endDate || undefined}
+          onChange={(e) => onChange({ startDate: e.target.value, endDate })}
+          className="px-3 py-2 border border-input rounded-lg text-sm bg-background outline-hidden focus:ring-2 focus:ring-ring/30"
+          placeholder="วันที่เริ่ม"
+        />
+        <span className="text-xs text-muted-foreground">ถึง</span>
+        <ThaiDateInput
+          value={endDate}
+          min={startDate || undefined}
+          onChange={(e) => onChange({ startDate, endDate: e.target.value })}
+          className="px-3 py-2 border border-input rounded-lg text-sm bg-background outline-hidden focus:ring-2 focus:ring-ring/30"
+          placeholder="วันที่สิ้นสุด"
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/pages/PaymentsPage/index.tsx
+++ b/apps/web/src/pages/PaymentsPage/index.tsx
@@ -18,10 +18,12 @@ import { Upload, Camera } from 'lucide-react';
 import PaymentFilters from './components/PaymentFilters';
 import PaymentTable from './components/PaymentTable';
 import PaymentSummary from './components/PaymentSummary';
+import PaymentPeriodBar from './components/PaymentPeriodBar';
+import PaymentKpiCards from './components/PaymentKpiCards';
 import { RecordPaymentModal, BatchPaymentModal } from './components/PaymentModals';
 import { RecordPaymentWizard } from './components/RecordPaymentWizard';
 import { ToleranceApprovalDialog } from '@/components/ToleranceApprovalDialog';
-import type { PendingPayment, DailySummary, OcrPaymentSlipResult } from './types';
+import type { PendingPayment, DailySummary, PendingSummary, OcrPaymentSlipResult } from './types';
 import { paymentStatusLabels, isSlipRequired } from './types';
 
 export default function PaymentsPage() {
@@ -46,6 +48,37 @@ export default function PaymentsPage() {
   const [searchTerm, setSearchTerm] = useState('');
   const debouncedSearch = useDebounce(searchTerm, 400);
   const [summaryDate, setSummaryDate] = useState(new Date().toISOString().split('T')[0]);
+
+  // Period filter for the pending queue (KPI cards + list) — scopes everything
+  // by installment dueDate. Default is "เดือนนี้" (matches DateRangeChips'
+  // thisMonth preset: [1st of month, today]) so that chip reads active on load.
+  // NOTE: a month default hides installments due in earlier months from the
+  // queue — switch to "ทั้งหมด" to chase back-dated overdue.
+  const [startDate, setStartDate] = useState(() => {
+    const now = new Date();
+    return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-01`;
+  });
+  const [endDate, setEndDate] = useState(() => {
+    const now = new Date();
+    return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
+  });
+  const dueFrom = startDate || undefined;
+  const dueTo = endDate || undefined;
+
+  // Title for the "collected" KPI card follows the chosen period.
+  const collectedLabel = useMemo(() => {
+    const toIso = (d: Date) =>
+      `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+    const today = new Date();
+    const thisFirst = toIso(new Date(today.getFullYear(), today.getMonth(), 1));
+    const thisToday = toIso(today);
+    const lastFirst = toIso(new Date(today.getFullYear(), today.getMonth() - 1, 1));
+    const lastEnd = toIso(new Date(today.getFullYear(), today.getMonth(), 0));
+    if (!startDate && !endDate) return 'รับชำระทั้งหมด';
+    if (startDate === thisFirst && endDate === thisToday) return 'รับชำระเดือนนี้';
+    if (startDate === lastFirst && endDate === lastEnd) return 'รับชำระเดือนที่แล้ว';
+    return 'รับชำระช่วงนี้';
+  }, [startDate, endDate]);
 
   // History sheet state
   const [historyContractId, setHistoryContractId] = useState<string | null>(null);
@@ -99,14 +132,31 @@ export default function PaymentsPage() {
     error: pendingErrorDetail,
     refetch: refetchPending,
   } = useQuery<PendingPayment[]>({
-    queryKey: ['pending-payments', statusFilter, debouncedSearch, branchFilter],
+    queryKey: ['pending-payments', statusFilter, debouncedSearch, branchFilter, dueFrom, dueTo],
     queryFn: async () => {
       const params = new URLSearchParams();
       if (statusFilter) params.set('status', statusFilter);
       if (debouncedSearch) params.set('search', debouncedSearch);
       if (branchFilter) params.set('branchId', branchFilter);
+      if (dueFrom) params.set('dueFrom', dueFrom);
+      if (dueTo) params.set('dueTo', dueTo);
       const { data } = await api.get(`/payments/pending?${params}`);
       return data.data;
+    },
+    enabled: tab === 'pending',
+  });
+
+  // Whole-system KPI summary (6 cards) — scoped by the same dueDate window +
+  // branch as the queue, but NOT page-limited.
+  const { data: pendingKpi, isLoading: loadingKpi } = useQuery<PendingSummary>({
+    queryKey: ['pending-summary', branchFilter, dueFrom, dueTo],
+    queryFn: async () => {
+      const params = new URLSearchParams();
+      if (branchFilter) params.set('branchId', branchFilter);
+      if (dueFrom) params.set('dueFrom', dueFrom);
+      if (dueTo) params.set('dueTo', dueTo);
+      const { data } = await api.get(`/payments/pending-summary?${params}`);
+      return data;
     },
     enabled: tab === 'pending',
   });
@@ -175,6 +225,10 @@ export default function PaymentsPage() {
       .toDecimalPlaces(2)
       .toNumber(),
   }), [pendingPayments]);
+
+  // Tab badge shows the whole-system pending count (from the aggregate KPI),
+  // falling back to the loaded page count until the summary resolves.
+  const tabBadgeCount = pendingKpi?.pendingCount ?? pendingSummary.count;
 
   // Excel export handler
   const handleExport = async () => {
@@ -450,9 +504,9 @@ export default function PaymentsPage() {
           className={`px-5 py-3 text-sm font-medium border-b-2 -mb-px transition-all ${tab === 'pending' ? 'border-primary text-primary' : 'border-transparent text-muted-foreground hover:text-foreground'}`}
         >
           รายการรอชำระ
-          {pendingSummary.count > 0 && (
+          {tabBadgeCount > 0 && (
             <span className={`ml-2 text-xs px-1.5 py-0.5 rounded-full ${tab === 'pending' ? 'bg-primary/10 text-primary' : 'bg-muted text-muted-foreground'}`}>
-              {pendingSummary.count}
+              {tabBadgeCount.toLocaleString('th-TH')}
             </span>
           )}
         </button>
@@ -481,6 +535,19 @@ export default function PaymentsPage() {
       {/* Pending Tab */}
       {tab === 'pending' && (
         <div>
+          {/* Period selector (scopes KPI cards + queue by installment dueDate) */}
+          <PaymentPeriodBar
+            startDate={startDate}
+            endDate={endDate}
+            onChange={({ startDate: sd, endDate: ed }) => {
+              setStartDate(sd);
+              setEndDate(ed);
+            }}
+          />
+
+          {/* 6 accounting-aware KPI cards (whole-system aggregate) */}
+          <PaymentKpiCards summary={pendingKpi} loading={loadingKpi} collectedLabel={collectedLabel} />
+
           <PaymentFilters
             searchTerm={searchTerm}
             onSearchChange={setSearchTerm}
@@ -490,8 +557,6 @@ export default function PaymentsPage() {
             onBranchFilterChange={setBranchFilter}
             isOwner={isOwner}
             branches={branches}
-            pendingCount={pendingSummary.count}
-            pendingTotalDue={pendingSummary.totalDue}
             onExport={handleExport}
             hasPendingPayments={pendingPayments.length > 0}
           />

--- a/apps/web/src/pages/PaymentsPage/types.ts
+++ b/apps/web/src/pages/PaymentsPage/types.ts
@@ -55,6 +55,25 @@ export interface DailySummary {
   data: DailySummaryPayment[];
 }
 
+/** KPI summary for the payment-queue header — whole-system aggregate from
+ *  GET /payments/pending-summary, scoped by the selected due-date window. */
+export interface PendingSummary {
+  /** จำนวนงวดที่ยังค้าง (PENDING/OVERDUE/PARTIALLY_PAID) */
+  pendingCount: number;
+  /** ยอดรอเก็บ "เฉพาะค่างวด" — Σ(amountDue − amountPaid), ไม่รวมค่าปรับ */
+  outstandingPrincipal: number;
+  /** ค่าปรับล่าช้าที่ยังรอเก็บ — Σ lateFee (→ Cr 42-1103 เมื่อเก็บได้) */
+  outstandingLateFee: number;
+  /** ค่าปรับที่อนุโลม (ยกเว้น) — Σ waivedAmount (→ Dr 52-1105 ส่วนลด) */
+  waivedLateFee: number;
+  /** จำนวนงวดค้าง ≥ 60 วัน (→ trigger 21-2103 VAT บังคับ) */
+  overdue60Count: number;
+  /** ยอดที่เก็บได้แล้วของงวดในช่วงนี้ — Σ amountPaid */
+  collectedAmount: number;
+  /** จำนวนรายการที่เก็บได้แล้ว */
+  collectedCount: number;
+}
+
 /**
  * @deprecated Use `getStatusBadgeProps(status, paymentStatusMap)` from `@/lib/status-badges` instead.
  * Kept for backwards-compat until all callers are migrated.


### PR DESCRIPTION
## สรุป
ออกแบบหน้า **รับชำระค่างวด** (`/payments` แท็บรายการรอชำระ) ใหม่ตาม mockup ที่เจ้าของอนุมัติ — แทนการ์ดเดิม 3 ใบด้วย **แถบเลือกช่วงเวลา + 6 KPI การ์ดที่ผูกรหัสบัญชีจริง** ขับเคลื่อนด้วย aggregate ทั้งระบบ (ไม่ผูก pagination)

## Backend
- **`GET /payments/pending-summary`** ใหม่ — aggregate ตาม `dueDate` window + สาขา, คืน 6 KPI (Decimal-safe):
  - `pendingCount` (ทั้งระบบ) · `outstandingPrincipal` เฉพาะค่างวด · `outstandingLateFee` → `Cr 42-1103`
  - `waivedLateFee` → `Dr 52-1105` · `overdue60Count` → trigger `21-2103` VAT · `collectedAmount/Count`
- ขยาย `GET /payments/pending` ให้รับ `dueFrom`/`dueTo` (คิว + การ์ดใช้ช่วงวันเดียวกัน)
- **6 specs ใหม่** — ตัวเลขตรง mockup, ความแม่นระดับสตางค์, กันค่าติดลบ, ช่วงวันที่ inclusive, scope สาขา

## Frontend
- `PaymentKpiCards` — 6 การ์ด, สีจาก design tokens ล้วน
- `PaymentPeriodBar` — **reuse `DateRangeChips`** ที่มีอยู่ (ทั้งหมด/เดือนนี้/เดือนที่แล้ว/ช่วงวันที่) + ช่อง from–to แบบ พ.ศ. (`ThaiDateInput`)
- ผูก period เข้าตารางคิว + badge แท็บ (เลขทั้งระบบ) · **default = เดือนนี้**
- เพิ่ม design token `--orange` (light+dark) แบบ additive สำหรับการ์ดค่าปรับล่าช้า

## หมายเหตุ
- Default "เดือนนี้" จะ **ซ่อนงวดค้างเดือนก่อน** จากคิว (มี comment เตือนในโค้ด) — กด "ทั้งหมด" เพื่อตามค้างเก่า
- กรองทุกอย่างด้วยมิติเดียว = `dueDate` ดังนั้นการ์ด "ค้าง ≥60 วัน" จะเป็น 0 เมื่อเลือกเดือนปัจจุบัน (ถูกต้องตามตรรกะ)

## Verify
- ✅ api + web `tsc` 0 errors · ✅ 154 payment specs pass (9 suites) · ✅ eslint clean
- ⚠️ ยังไม่ได้ตรวจด้วยตาบน dev server (ผ่าน types + tests + static mockup เท่านั้น)

🤖 Generated with [Claude Code](https://claude.com/claude-code)