### PR TITLE
fix(payments): KPI cards single row on desktop, reflow on tablet/mobile

### DIFF
--- a/apps/web/src/pages/PaymentsPage/components/PaymentKpiCards.tsx
+++ b/apps/web/src/pages/PaymentsPage/components/PaymentKpiCards.tsx
@@ -73,7 +73,7 @@ export default function PaymentKpiCards({ summary, loading, collectedLabel }: Pa
 
   return (
     <div
-      className={`grid grid-cols-2 lg:grid-cols-3 gap-4 mb-5 ${loading && !summary ? 'animate-pulse' : ''}`}
+      className={`grid grid-cols-2 md:grid-cols-3 xl:grid-cols-6 gap-4 mb-5 ${loading && !summary ? 'animate-pulse' : ''}`}
     >
       {cards.map((c) => (
         <Card


### PR DESCRIPTION
## สรุป
ปรับการ์ด KPI 6 ใบบนหน้า `/payments` ให้เรียง **แถวเดียวบนเดสก์ท็อป** ตามที่เจ้าของอนุมัติ พร้อม reflow บนจอเล็กให้เห็นครบทุกการ์ดไม่ต้องเลื่อน

| จอ | คอลัมน์ | แถว |
|---|---|---|
| มือถือ `<768px` | 2 | 3 |
| iPad `768–1279px` | 3 | 2 |
| เดสก์ท็อป `≥1280px` | **6** | **1** |

เปลี่ยน class กริดเดียว: `grid-cols-2 md:grid-cols-3 xl:grid-cols-6`

ใช้ `xl` (1280px) เป็นเส้นแบ่ง 6-คอลัมน์ ไม่ใช่ `lg` (1024px) เพื่อกัน iPad Pro แนวตั้งยัด 6 ใบจนเหลือ ~150px/ใบ

## Verify
- ✅ eslint clean (ไม่กระทบ type — แก้ className อย่างเดียว)
- ⚠️ ตามด้วย `--admin` merge ข้าม CI/E2E ตามที่เจ้าของสั่ง (ต่อจาก #1300)

🤖 Generated with [Claude Code](https://claude.com/claude-code)