### PR TITLE
Purchasing v2 — B0: backend additive foundation (ORDERED, grNumber, DefectReason, /order, /summary, retire receive())

### DIFF
--- a/apps/api/prisma/migrations/20260978000000_purchasing_v2_foundation/migration.sql
+++ b/apps/api/prisma/migrations/20260978000000_purchasing_v2_foundation/migration.sql
@@ -1,0 +1,30 @@
+-- AlterEnum: add ORDERED to POStatus
+ALTER TYPE "POStatus" ADD VALUE 'ORDERED';
+
+-- CreateEnum: DefectReason
+CREATE TYPE "DefectReason" AS ENUM ('SCREEN', 'BATTERY', 'IMEI_BLOCKED', 'BOX_MISSING', 'WRONG_MODEL', 'DOA', 'COSMETIC', 'OTHER');
+
+-- AlterTable: PurchaseOrder additive columns
+ALTER TABLE "purchase_orders" ADD COLUMN "ordered_at" TIMESTAMP(3);
+ALTER TABLE "purchase_orders" ADD COLUMN "is_direct_receive" BOOLEAN NOT NULL DEFAULT false;
+
+-- AlterTable: GoodsReceivingItem.defect_reason
+ALTER TABLE "goods_receiving_items" ADD COLUMN "defect_reason" "DefectReason";
+
+-- AlterTable: GoodsReceiving.gr_number — 2-step (add nullable, backfill, then NOT NULL + UNIQUE)
+ALTER TABLE "goods_receivings" ADD COLUMN "gr_number" TEXT;
+
+WITH seq AS (
+  SELECT id,
+         'GR-' || to_char("created_at", 'YYYY-MM') || '-' ||
+         lpad(
+           (row_number() OVER (PARTITION BY to_char("created_at", 'YYYY-MM')
+                               ORDER BY "created_at", id))::text,
+           3, '0'
+         ) AS gr
+  FROM "goods_receivings"
+)
+UPDATE "goods_receivings" g SET "gr_number" = seq.gr FROM seq WHERE g.id = seq.id;
+
+ALTER TABLE "goods_receivings" ALTER COLUMN "gr_number" SET NOT NULL;
+CREATE UNIQUE INDEX "goods_receivings_gr_number_key" ON "goods_receivings"("gr_number");

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -191,10 +191,22 @@ enum PaymentStatus {
 enum POStatus {
   DRAFT
   APPROVED
+  ORDERED
   PENDING
   PARTIALLY_RECEIVED
   FULLY_RECEIVED
   CANCELLED
+}
+
+enum DefectReason {
+  SCREEN
+  BATTERY
+  IMEI_BLOCKED
+  BOX_MISSING
+  WRONG_MODEL
+  DOA
+  COSMETIC
+  OTHER
 }
 
 enum POPaymentStatus {
@@ -1528,6 +1540,8 @@ model PurchaseOrder {
   expectedDate        DateTime?       @map("expected_date")
   dueDate             DateTime?       @map("due_date")
   status              POStatus        @default(DRAFT)
+  orderedAt       DateTime? @map("ordered_at")
+  isDirectReceive Boolean   @default(false) @map("is_direct_receive")
   totalAmount         Decimal         @map("total_amount") @db.Decimal(12, 2)
   discount            Decimal         @default(0) @db.Decimal(12, 2) // ส่วนลดก่อน VAT
   discountAfterVat    Decimal         @default(0) @map("discount_after_vat") @db.Decimal(12, 2)
@@ -1813,6 +1827,7 @@ model StockTransfer {
 
 model GoodsReceiving {
   id           String    @id @default(uuid())
+  grNumber     String    @unique @map("gr_number")
   poId         String    @map("po_id")
   receivedById String    @map("received_by_id")
   notes        String?
@@ -1837,6 +1852,7 @@ model GoodsReceivingItem {
   photos             String[]            @default([])
   status             ReceivingItemStatus
   rejectReason       String?             @map("reject_reason")
+  defectReason DefectReason? @map("defect_reason")
   batteryHealth      Int?                @map("battery_health")
   warrantyExpired    Boolean?            @map("warranty_expired")
   warrantyExpireDate DateTime?           @map("warranty_expire_date")

--- a/apps/api/prisma/seed.ts
+++ b/apps/api/prisma/seed.ts
@@ -534,12 +534,12 @@ async function main() {
   console.log('STEP 12: Creating GoodsReceivings...');
 
   const grData = [
-    { id: 'gr-001', poId: 'po-001', receivedById: 'user-001', notes: 'รับครบ 5 เครื่อง' },
-    { id: 'gr-002', poId: 'po-002', receivedById: 'user-002', notes: 'รับครบ 5 เครื่อง' },
-    { id: 'gr-003', poId: 'po-003', receivedById: 'user-001', notes: 'รับครบ 7 เครื่อง (มือสอง)' },
-    { id: 'gr-004', poId: 'po-004', receivedById: 'user-002' },
-    { id: 'gr-005', poId: 'po-005', receivedById: 'user-001', notes: 'iPad 4 เครื่อง' },
-    { id: 'gr-006', poId: 'po-006', receivedById: 'user-002', notes: 'อุปกรณ์เสริม Spigen' },
+    { id: 'gr-001', grNumber: 'GR-2026-01-001', poId: 'po-001', receivedById: 'user-001', notes: 'รับครบ 5 เครื่อง' },
+    { id: 'gr-002', grNumber: 'GR-2026-01-002', poId: 'po-002', receivedById: 'user-002', notes: 'รับครบ 5 เครื่อง' },
+    { id: 'gr-003', grNumber: 'GR-2026-01-003', poId: 'po-003', receivedById: 'user-001', notes: 'รับครบ 7 เครื่อง (มือสอง)' },
+    { id: 'gr-004', grNumber: 'GR-2026-01-004', poId: 'po-004', receivedById: 'user-002' },
+    { id: 'gr-005', grNumber: 'GR-2026-01-005', poId: 'po-005', receivedById: 'user-001', notes: 'iPad 4 เครื่อง' },
+    { id: 'gr-006', grNumber: 'GR-2026-01-006', poId: 'po-006', receivedById: 'user-002', notes: 'อุปกรณ์เสริม Spigen' },
   ];
 
   for (const gr of grData) {

--- a/apps/api/src/modules/purchase-orders/dto/create-po.dto.ts
+++ b/apps/api/src/modules/purchase-orders/dto/create-po.dto.ts
@@ -1,5 +1,6 @@
-import { IsString, IsNumber, IsOptional, IsDateString, IsArray, ValidateNested, IsIn, IsBoolean, ArrayMinSize, Min } from 'class-validator';
+import { IsString, IsNumber, IsOptional, IsDateString, IsArray, ValidateNested, IsIn, IsBoolean, ArrayMinSize, Min, IsEnum } from 'class-validator';
 import { Type } from 'class-transformer';
+import { DefectReason } from '@prisma/client';
 
 export class POItemDto {
   @IsString()
@@ -193,6 +194,10 @@ export class GoodsReceivingItemDto {
   @IsString()
   @IsOptional()
   rejectReason?: string;
+
+  @IsEnum(DefectReason)
+  @IsOptional()
+  defectReason?: DefectReason;
 
   @IsNumber()
   @IsOptional()

--- a/apps/api/src/modules/purchase-orders/dto/create-po.dto.ts
+++ b/apps/api/src/modules/purchase-orders/dto/create-po.dto.ts
@@ -121,21 +121,6 @@ export class UpdatePODto {
   status?: string;
 }
 
-export class ReceiveItemDto {
-  @IsString()
-  poItemId: string;
-
-  @IsNumber()
-  receivedQty: number;
-}
-
-export class ReceivePODto {
-  @IsArray()
-  @ValidateNested({ each: true })
-  @Type(() => ReceiveItemDto)
-  items: ReceiveItemDto[];
-}
-
 export class UpdatePaymentDto {
   @IsIn(['UNPAID', 'DEPOSIT_PAID', 'PARTIALLY_PAID', 'FULLY_PAID'])
   paymentStatus: string;

--- a/apps/api/src/modules/purchase-orders/dto/create-po.dto.ts
+++ b/apps/api/src/modules/purchase-orders/dto/create-po.dto.ts
@@ -100,6 +100,12 @@ export class RejectPODto {
   reason: string;
 }
 
+export class OrderPODto {
+  @IsDateString()
+  @IsOptional()
+  expectedDate?: string;
+}
+
 export class UpdatePODto {
   @IsDateString()
   @IsOptional()

--- a/apps/api/src/modules/purchase-orders/purchase-orders.controller.ts
+++ b/apps/api/src/modules/purchase-orders/purchase-orders.controller.ts
@@ -1,7 +1,7 @@
 import { Controller, Get, Post, Patch, Body, Param, Query, UseGuards } from '@nestjs/common';
 import { ApiTags, ApiBearerAuth } from '@nestjs/swagger';
 import { PurchaseOrdersService } from './purchase-orders.service';
-import { CreatePODto, UpdatePODto, ReceivePODto, GoodsReceivingDto, UpdatePaymentDto, RejectPODto, OrderPODto } from './dto/create-po.dto';
+import { CreatePODto, UpdatePODto, GoodsReceivingDto, UpdatePaymentDto, RejectPODto, OrderPODto } from './dto/create-po.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { RolesGuard } from '../auth/guards/roles.guard';
 import { BranchGuard } from '../auth/guards/branch.guard';
@@ -174,16 +174,6 @@ export class PurchaseOrdersController {
   @Roles('OWNER', 'BRANCH_MANAGER')
   updatePayment(@Param('id') id: string, @Body() dto: UpdatePaymentDto) {
     return this.purchaseOrdersService.updatePayment(id, dto);
-  }
-
-  @Post(':id/receive')
-  @Roles('OWNER', 'BRANCH_MANAGER')
-  receive(
-    @Param('id') id: string,
-    @Body() dto: ReceivePODto,
-    @CurrentUser() user: { id: string; branchId: string },
-  ) {
-    return this.purchaseOrdersService.receive(id, dto, user.id, user.branchId);
   }
 
   @Post(':id/goods-receiving')

--- a/apps/api/src/modules/purchase-orders/purchase-orders.controller.ts
+++ b/apps/api/src/modules/purchase-orders/purchase-orders.controller.ts
@@ -45,6 +45,12 @@ export class PurchaseOrdersController {
     );
   }
 
+  @Get('summary')
+  @Roles('OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'ACCOUNTANT')
+  getSummary() {
+    return this.purchaseOrdersService.getSummary();
+  }
+
   // === QC Confirmation (Step 4: สินค้าเข้าคลัง) ===
   // Static routes MUST be before :id parametric routes
 

--- a/apps/api/src/modules/purchase-orders/purchase-orders.controller.ts
+++ b/apps/api/src/modules/purchase-orders/purchase-orders.controller.ts
@@ -1,7 +1,7 @@
 import { Controller, Get, Post, Patch, Body, Param, Query, UseGuards } from '@nestjs/common';
 import { ApiTags, ApiBearerAuth } from '@nestjs/swagger';
 import { PurchaseOrdersService } from './purchase-orders.service';
-import { CreatePODto, UpdatePODto, ReceivePODto, GoodsReceivingDto, UpdatePaymentDto, RejectPODto } from './dto/create-po.dto';
+import { CreatePODto, UpdatePODto, ReceivePODto, GoodsReceivingDto, UpdatePaymentDto, RejectPODto, OrderPODto } from './dto/create-po.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { RolesGuard } from '../auth/guards/roles.guard';
 import { BranchGuard } from '../auth/guards/branch.guard';
@@ -136,6 +136,16 @@ export class PurchaseOrdersController {
     @CurrentUser() user: { id: string },
   ) {
     return this.purchaseOrdersService.approve(id, user.id);
+  }
+
+  @Post(':id/order')
+  @Roles('OWNER', 'BRANCH_MANAGER')
+  order(
+    @Param('id') id: string,
+    @Body() dto: OrderPODto,
+    @CurrentUser() user: { id: string },
+  ) {
+    return this.purchaseOrdersService.order(id, user.id, dto);
   }
 
   @Post(':id/reject')

--- a/apps/api/src/modules/purchase-orders/purchase-orders.defect.spec.ts
+++ b/apps/api/src/modules/purchase-orders/purchase-orders.defect.spec.ts
@@ -1,0 +1,36 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PurchaseOrdersService } from './purchase-orders.service';
+import { PrismaService } from '../../prisma/prisma.service';
+
+describe('goodsReceiving — persists structured defectReason on REJECT', () => {
+  it('writes defectReason onto the rejected GoodsReceivingItem', async () => {
+    const created: any[] = [];
+    const tx: any = {
+      purchaseOrder: {
+        findUnique: jest.fn().mockResolvedValue({
+          id: 'po-1', status: 'APPROVED', deletedAt: null, supplierId: 's1',
+          items: [{ id: 'poi-1', category: 'PHONE_NEW', brand: 'A', model: 'B' }],
+        }),
+        update: jest.fn().mockResolvedValue({}),
+      },
+      branch: { findFirst: jest.fn().mockResolvedValue({ id: 'wh', name: 'คลังกลาง' }) },
+      goodsReceiving: { create: jest.fn().mockResolvedValue({ id: 'gr1' }), count: jest.fn().mockResolvedValue(0) },
+      goodsReceivingItem: { create: jest.fn().mockImplementation(({ data }) => { created.push(data); return Promise.resolve({ id: 'gri1', ...data }); }) },
+      pOItem: { findMany: jest.fn().mockResolvedValue([]), update: jest.fn() },
+      product: { create: jest.fn(), findMany: jest.fn().mockResolvedValue([]) },
+      productPrice: { create: jest.fn() },
+    };
+    const prisma: any = { $transaction: jest.fn().mockImplementation((fn: any) => fn(tx)) };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [PurchaseOrdersService, { provide: PrismaService, useValue: prisma }],
+    }).compile();
+    const service = module.get<PurchaseOrdersService>(PurchaseOrdersService);
+
+    await service.goodsReceiving('po-1', {
+      items: [{ poItemId: 'poi-1', status: 'REJECT', rejectReason: 'จอแตก', defectReason: 'SCREEN' }],
+    } as never, 'user-1');
+
+    expect(created[0]).toEqual(expect.objectContaining({ status: 'REJECT', defectReason: 'SCREEN', rejectReason: 'จอแตก' }));
+  });
+});

--- a/apps/api/src/modules/purchase-orders/purchase-orders.grnumber-retry.spec.ts
+++ b/apps/api/src/modules/purchase-orders/purchase-orders.grnumber-retry.spec.ts
@@ -1,0 +1,28 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PurchaseOrdersService } from './purchase-orders.service';
+import { PrismaService } from '../../prisma/prisma.service';
+
+describe('goodsReceiving — retries on grNumber unique collision (P2002)', () => {
+  it('retries the transaction once on P2002 then succeeds', async () => {
+    let calls = 0;
+    const prisma: any = {
+      $transaction: jest.fn().mockImplementation(async (fn: any) => {
+        calls += 1;
+        if (calls === 1) {
+          const err: any = new Error('Unique constraint failed');
+          err.code = 'P2002';
+          throw err;
+        }
+        return { receivingId: 'r1', grNumber: 'GR-2026-06-002', status: 'FULLY_RECEIVED' };
+      }),
+    };
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [PurchaseOrdersService, { provide: PrismaService, useValue: prisma }],
+    }).compile();
+    const service = module.get<PurchaseOrdersService>(PurchaseOrdersService);
+
+    const result = await service.goodsReceiving('po-1', { items: [] } as never, 'user-1');
+    expect(calls).toBe(2);
+    expect(result.grNumber).toBe('GR-2026-06-002');
+  });
+});

--- a/apps/api/src/modules/purchase-orders/purchase-orders.order.spec.ts
+++ b/apps/api/src/modules/purchase-orders/purchase-orders.order.spec.ts
@@ -1,0 +1,55 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException } from '@nestjs/common';
+import { PurchaseOrdersService } from './purchase-orders.service';
+import { PrismaService } from '../../prisma/prisma.service';
+
+describe('PurchaseOrdersService.order — APPROVED → ORDERED', () => {
+  let service: PurchaseOrdersService;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+
+  const makePrisma = (status: string) => ({
+    purchaseOrder: {
+      findUnique: jest.fn().mockResolvedValue({
+        id: 'po-1', status, deletedAt: null, items: [], supplier: { id: 's1', name: 'S' },
+      }),
+      update: jest.fn().mockImplementation(({ data }) =>
+        Promise.resolve({ id: 'po-1', status: data.status, orderedAt: data.orderedAt })),
+    },
+  });
+
+  const build = async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [PurchaseOrdersService, { provide: PrismaService, useValue: prisma }],
+    }).compile();
+    return module.get<PurchaseOrdersService>(PurchaseOrdersService);
+  };
+
+  it('advances an APPROVED PO to ORDERED and stamps orderedAt', async () => {
+    prisma = makePrisma('APPROVED');
+    service = await build();
+    const result = await service.order('po-1', 'user-1', {});
+    expect(result.status).toBe('ORDERED');
+    expect(prisma.purchaseOrder.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'po-1' },
+        data: expect.objectContaining({ status: 'ORDERED', orderedAt: expect.any(Date) }),
+      }),
+    );
+  });
+
+  it('rejects ordering a PO that is not APPROVED', async () => {
+    prisma = makePrisma('DRAFT');
+    service = await build();
+    await expect(service.order('po-1', 'user-1', {})).rejects.toThrow(BadRequestException);
+  });
+
+  it('updates expectedDate when provided', async () => {
+    prisma = makePrisma('APPROVED');
+    service = await build();
+    await service.order('po-1', 'user-1', { expectedDate: '2026-07-15' });
+    expect(prisma.purchaseOrder.update).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ expectedDate: new Date('2026-07-15') }) }),
+    );
+  });
+});

--- a/apps/api/src/modules/purchase-orders/purchase-orders.service.spec.ts
+++ b/apps/api/src/modules/purchase-orders/purchase-orders.service.spec.ts
@@ -4,147 +4,81 @@ import { PurchaseOrdersService } from './purchase-orders.service';
 import { PrismaService } from '../../prisma/prisma.service';
 
 /**
- * T5-C16: PO goods-receive race condition.
- *
- * Scenario we're defending against:
- *  - PO has item with quantity=5, receivedQty=4.
- *  - Request A loads PO (in-memory receivedQty=4) then checks 4+2 > 5 -> throw.
- *  - But Request A's check runs against a STALE in-memory snapshot.
- *  - Before v4 fix: if Request B committed receivedQty:5 between A's read and
- *    A's update, A would still see 4 and incorrectly allow another unit,
- *    pushing receivedQty to 6 (over-receive).
- *
- * These tests assert that the new implementation re-reads POItem inside the
- * serializable transaction and uses the fresh receivedQty for the ceiling
- * check, so two sequential calls that would jointly exceed the ceiling fail
- * the second one correctly.
+ * T5-C16: PO goods-receive race condition — now defended on goodsReceiving()
+ * (the legacy receive() path was retired in Purchasing v2 B0). goodsReceiving()
+ * re-reads POItem rows via findMany inside a Serializable tx and rejects a
+ * second batch that would push receivedQty over quantity.
  */
-describe('PurchaseOrdersService — T5-C16 receive race condition', () => {
+describe('PurchaseOrdersService — T5-C16 goodsReceiving race condition', () => {
   let service: PurchaseOrdersService;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let prisma: any;
 
   beforeEach(async () => {
-    // Shared DB state the mock simulates
     const dbState = {
-      po: {
-        id: 'po-1',
-        poNumber: 'PO-2026-05-001',
-        supplierId: 'sup-1',
-        status: 'APPROVED' as string,
-        deletedAt: null,
-        items: [
-          {
-            id: 'poi-1',
-            brand: 'Apple',
-            model: 'iPhone 16',
-            quantity: 5,
-            receivedQty: 0,
-            category: 'PHONE_NEW',
-            accessoryType: null,
-            accessoryBrand: null,
-            color: null,
-            storage: null,
-            unitPrice: 30000,
-          },
-        ],
-      },
+      items: [{ id: 'poi-1', brand: 'Apple', model: 'iPhone 16', quantity: 5, receivedQty: 0, category: 'PHONE_NEW', accessoryType: null, accessoryBrand: null, color: null, storage: null, unitPrice: 30000 }],
     };
-
-    prisma = {
+    const tx = {
       purchaseOrder: {
-        findUnique: jest.fn().mockImplementation(() =>
-          Promise.resolve({
-            ...dbState.po,
-            supplier: { id: 'sup-1', name: 'Sup' },
-            items: dbState.po.items.map((i) => ({ ...i })),
-          }),
-        ),
+        findUnique: jest.fn().mockImplementation(() => Promise.resolve({ id: 'po-1', status: 'APPROVED', deletedAt: null, supplierId: 'sup-1', supplier: { id: 'sup-1', name: 'Sup' }, items: dbState.items.map((i) => ({ ...i })) })),
         update: jest.fn().mockResolvedValue({}),
       },
+      branch: { findFirst: jest.fn().mockResolvedValue({ id: 'wh', name: 'คลังกลาง' }) },
+      goodsReceiving: { create: jest.fn().mockResolvedValue({ id: 'gr1' }), count: jest.fn().mockResolvedValue(0) },
+      goodsReceivingItem: { create: jest.fn().mockResolvedValue({ id: 'gri1' }) },
+      product: {
+        create: jest.fn().mockImplementation(({ data }) => Promise.resolve({ id: `prod-${Math.random()}`, ...data })),
+        findMany: jest.fn().mockResolvedValue([]), // no existing IMEI conflicts
+      },
+      productPrice: { create: jest.fn() },
       pOItem: {
-        // T5-C16 fresh re-read inside serializable tx:
-        findUnique: jest.fn().mockImplementation(({ where: { id } }) => {
-          const item = dbState.po.items.find((i) => i.id === id);
-          return Promise.resolve(item ? { ...item } : null);
-        }),
-        findMany: jest.fn().mockImplementation(({ where: { id: { in: ids } } }) => {
-          return Promise.resolve(
-            dbState.po.items.filter((i) => ids.includes(i.id)).map((i) => ({ ...i })),
-          );
-        }),
+        findMany: jest.fn().mockImplementation(({ where: { id: { in: ids } } }) =>
+          Promise.resolve(dbState.items.filter((i) => ids.includes(i.id)).map((i) => ({ ...i })))),
         update: jest.fn().mockImplementation(({ where, data }) => {
-          const item = dbState.po.items.find((i) => i.id === where.id);
+          const item = dbState.items.find((i) => i.id === where.id);
           if (item) item.receivedQty = data.receivedQty;
           return Promise.resolve(item);
         }),
       },
-      product: {
-        create: jest.fn().mockImplementation(({ data }) =>
-          Promise.resolve({ id: `prod-${Math.random()}`, ...data }),
-        ),
-      },
-      $transaction: jest.fn().mockImplementation(async (fn) => {
-        // second arg (options) is ignored — we only care that the service
-        // calls $transaction with a callback. Serializability is enforced by
-        // Postgres at runtime; we verify the in-memory-state correctness here.
-        if (typeof fn === 'function') return fn(prisma);
-        return Promise.all(fn);
-      }),
     };
+    prisma = { $transaction: jest.fn().mockImplementation(async (fn: any) => (typeof fn === 'function' ? fn(tx) : Promise.all(fn))) };
 
     const module: TestingModule = await Test.createTestingModule({
-      providers: [
-        PurchaseOrdersService,
-        { provide: PrismaService, useValue: prisma },
-      ],
+      providers: [PurchaseOrdersService, { provide: PrismaService, useValue: prisma }],
     }).compile();
-
     service = module.get<PurchaseOrdersService>(PurchaseOrdersService);
   });
 
-  it('first receive within ceiling passes and advances receivedQty', async () => {
-    await service.receive(
-      'po-1',
-      { items: [{ poItemId: 'poi-1', receivedQty: 3 }] } as never,
-      'user-1',
-      'branch-1',
-    );
-    // fresh re-read was called inside the tx
-    expect(prisma.pOItem.findUnique).toHaveBeenCalledWith(
-      expect.objectContaining({ where: { id: 'poi-1' } }),
-    );
-    // receivedQty moved 0 -> 3
-    expect(prisma.pOItem.update).toHaveBeenCalledWith(
-      expect.objectContaining({ data: { receivedQty: 3 } }),
-    );
+  const passUnits = (n: number) => ({ items: Array.from({ length: n }, (_, i) => ({ poItemId: 'poi-1', status: 'PASS', imeiSerial: `IMEI-${Math.random()}-${i}` })) });
+
+  it('first batch within ceiling passes and advances receivedQty', async () => {
+    const result = await service.goodsReceiving('po-1', passUnits(3) as never, 'user-1');
+    expect(prisma.$transaction).toHaveBeenCalled();
+    expect(result.passed).toBe(3);          // 3 PASS units created
+    expect(result.status).toBe('PARTIALLY_RECEIVED'); // 3 of 5 ordered
   });
 
-  it('second receive that would exceed ordered qty is rejected based on fresh DB state', async () => {
-    // First call: receive 3 of 5 -> state.receivedQty becomes 3.
-    await service.receive(
-      'po-1',
-      { items: [{ poItemId: 'poi-1', receivedQty: 3 }] } as never,
-      'user-1',
-      'branch-1',
-    );
+  it('second batch that would exceed ordered qty is rejected on fresh DB state', async () => {
+    await service.goodsReceiving('po-1', passUnits(3) as never, 'user-1');
+    await expect(service.goodsReceiving('po-1', passUnits(3) as never, 'user-1')).rejects.toThrow(BadRequestException);
+  });
+});
 
-    // Second call: try to receive 3 more. 3+3=6 > 5 -> must throw.
-    // Critical: the PO.findUnique mock STILL returns items with the original
-    // receivedQty=0 cached in dbState.po.items references ... but we mutated
-    // dbState.po.items[].receivedQty via pOItem.update, so findUnique returns
-    // {receivedQty: 3}. The test below relies on the SERVICE using the FRESH
-    // re-read (pOItem.findUnique inside the tx) — which returns 3 — and
-    // correctly rejecting 3+3 > 5. If the service trusted only the initial
-    // po.items snapshot (which still shows 3 now), it would also pass, but
-    // what we're testing is that the fresh re-read IS happening.
-    await expect(
-      service.receive(
-        'po-1',
-        { items: [{ poItemId: 'poi-1', receivedQty: 3 }] } as never,
-        'user-1',
-        'branch-1',
-      ),
-    ).rejects.toThrow(BadRequestException);
+describe('goodsReceiving — IMEI duplicate guard', () => {
+  it('rejects an IMEI already present in the system', async () => {
+    const tx: any = {
+      purchaseOrder: { findUnique: jest.fn().mockResolvedValue({ id: 'po-1', status: 'APPROVED', deletedAt: null, supplierId: 's1', items: [{ id: 'poi-1', category: 'PHONE_NEW', quantity: 5, receivedQty: 0, brand: 'A', model: 'B' }] }), update: jest.fn() },
+      branch: { findFirst: jest.fn().mockResolvedValue({ id: 'wh', name: 'คลังกลาง' }) },
+      goodsReceiving: { create: jest.fn().mockResolvedValue({ id: 'gr1' }), count: jest.fn().mockResolvedValue(0) },
+      goodsReceivingItem: { create: jest.fn() },
+      pOItem: { findMany: jest.fn().mockResolvedValue([{ id: 'poi-1', quantity: 5, receivedQty: 0, brand: 'A', model: 'B' }]), update: jest.fn() },
+      product: { create: jest.fn(), findMany: jest.fn().mockResolvedValue([{ imeiSerial: 'DUP1', name: 'iPhone', deletedAt: null }]) },
+      productPrice: { create: jest.fn() },
+    };
+    const prisma: any = { $transaction: jest.fn().mockImplementation((fn: any) => fn(tx)) };
+    const module: TestingModule = await Test.createTestingModule({ providers: [PurchaseOrdersService, { provide: PrismaService, useValue: prisma }] }).compile();
+    const service = module.get<PurchaseOrdersService>(PurchaseOrdersService);
+
+    await expect(service.goodsReceiving('po-1', { items: [{ poItemId: 'poi-1', status: 'PASS', imeiSerial: 'DUP1' }] } as never, 'user-1')).rejects.toThrow(/IMEI ซ้ำ/);
   });
 });

--- a/apps/api/src/modules/purchase-orders/purchase-orders.service.ts
+++ b/apps/api/src/modules/purchase-orders/purchase-orders.service.ts
@@ -102,4 +102,8 @@ export class PurchaseOrdersService {
   getQCPending(filters: { branchId?: string; page?: number; limit?: number }) {
     return this.query.getQCPending(filters);
   }
+
+  getSummary() {
+    return this.query.getSummary();
+  }
 }

--- a/apps/api/src/modules/purchase-orders/purchase-orders.service.ts
+++ b/apps/api/src/modules/purchase-orders/purchase-orders.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../../prisma/prisma.service';
-import { CreatePODto, UpdatePODto, ReceivePODto, GoodsReceivingDto, UpdatePaymentDto } from './dto/create-po.dto';
+import { CreatePODto, UpdatePODto, ReceivePODto, GoodsReceivingDto, UpdatePaymentDto, OrderPODto } from './dto/create-po.dto';
 import { PoQueryService } from './services/po-query.service';
 import { PoLifecycleService } from './services/po-lifecycle.service';
 import { PoReceivingService } from './services/po-receiving.service';
@@ -44,6 +44,10 @@ export class PurchaseOrdersService {
 
   approve(id: string, userId: string) {
     return this.lifecycle.approve(id, userId);
+  }
+
+  order(id: string, userId: string, dto: OrderPODto) {
+    return this.lifecycle.order(id, userId, dto);
   }
 
   reject(id: string, userId: string, reason: string) {

--- a/apps/api/src/modules/purchase-orders/purchase-orders.service.ts
+++ b/apps/api/src/modules/purchase-orders/purchase-orders.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../../prisma/prisma.service';
-import { CreatePODto, UpdatePODto, ReceivePODto, GoodsReceivingDto, UpdatePaymentDto, OrderPODto } from './dto/create-po.dto';
+import { CreatePODto, UpdatePODto, GoodsReceivingDto, UpdatePaymentDto, OrderPODto } from './dto/create-po.dto';
 import { PoQueryService } from './services/po-query.service';
 import { PoLifecycleService } from './services/po-lifecycle.service';
 import { PoReceivingService } from './services/po-receiving.service';
@@ -12,7 +12,7 @@ import { PoReceivingService } from './services/po-receiving.service';
  * three plain sub-services and delegates:
  *  - PoQueryService     — reads, AP grouping, QC-pending, GR history/summary
  *  - PoLifecycleService — create (PO-number $tx), update/approve/reject/cancel/updatePayment
- *  - PoReceivingService — receive / goodsReceiving (Serializable $tx), confirmQC
+ *  - PoReceivingService — goodsReceiving (Serializable $tx), confirmQC
  */
 @Injectable()
 export class PurchaseOrdersService {
@@ -85,10 +85,6 @@ export class PurchaseOrdersService {
     endDate?: string;
   } = {}) {
     return this.query.getReceivingSummary(poId, filters);
-  }
-
-  receive(id: string, dto: ReceivePODto, userId: string, branchId: string) {
-    return this.receiving.receive(id, dto, userId, branchId);
   }
 
   goodsReceiving(id: string, dto: GoodsReceivingDto, userId: string) {

--- a/apps/api/src/modules/purchase-orders/purchase-orders.summary.spec.ts
+++ b/apps/api/src/modules/purchase-orders/purchase-orders.summary.spec.ts
@@ -1,0 +1,35 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PurchaseOrdersService } from './purchase-orders.service';
+import { PrismaService } from '../../prisma/prisma.service';
+
+describe('PurchaseOrdersService.getSummary', () => {
+  it('returns compute-on-read counts incl. overdue (ORDERED & expectedDate < now)', async () => {
+    const poCount = jest.fn().mockImplementation(({ where }) => {
+      if (where.status === 'DRAFT') return Promise.resolve(2);
+      if (where.status === 'APPROVED') return Promise.resolve(3);
+      if (where.status === 'ORDERED' && where.expectedDate) return Promise.resolve(1); // overdue
+      if (where.status === 'ORDERED') return Promise.resolve(5); // incoming
+      if (where.status === 'PARTIALLY_RECEIVED') return Promise.resolve(4);
+      if (where.paymentStatus) return Promise.resolve(7); // unpaid
+      return Promise.resolve(0);
+    });
+    const prisma: any = {
+      purchaseOrder: { count: poCount },
+      product: { count: jest.fn().mockResolvedValue(6) }, // waitingQc
+    };
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [PurchaseOrdersService, { provide: PrismaService, useValue: prisma }],
+    }).compile();
+    const service = module.get<PurchaseOrdersService>(PurchaseOrdersService);
+
+    const s = await service.getSummary();
+    expect(s).toEqual({
+      pendingApproval: 2, toOrder: 3, incoming: 5, overdue: 1,
+      receiving: 4, waitingQc: 6, unpaid: 7,
+    });
+    // overdue query must filter ORDERED + expectedDate < now
+    expect(poCount).toHaveBeenCalledWith(
+      expect.objectContaining({ where: expect.objectContaining({ status: 'ORDERED', expectedDate: { lt: expect.any(Date) } }) }),
+    );
+  });
+});

--- a/apps/api/src/modules/purchase-orders/services/po-lifecycle.service.ts
+++ b/apps/api/src/modules/purchase-orders/services/po-lifecycle.service.ts
@@ -1,7 +1,7 @@
 import { NotFoundException, BadRequestException } from '@nestjs/common';
 import { Prisma, POPaymentStatus } from '@prisma/client';
 import { PrismaService } from '../../../prisma/prisma.service';
-import { CreatePODto, UpdatePODto, UpdatePaymentDto } from '../dto/create-po.dto';
+import { CreatePODto, UpdatePODto, UpdatePaymentDto, OrderPODto } from '../dto/create-po.dto';
 import { generatePONumber } from '../../../utils/sequence.util';
 import { d, dAdd, dSub, dSum } from '../../../utils/decimal.util';
 import { loadVatRateDecimal } from '../../../utils/vat-rate.util';
@@ -160,6 +160,25 @@ export class PoLifecycleService {
     return this.prisma.purchaseOrder.update({
       where: { id },
       data: { status: 'APPROVED', approvedById: userId },
+      include: {
+        supplier: { select: { id: true, name: true } },
+        items: true,
+      },
+    });
+  }
+
+  async order(id: string, userId: string, dto: OrderPODto) {
+    const po = await this.query.findOne(id);
+    if (po.status !== 'APPROVED') {
+      throw new BadRequestException('สั่งซื้อได้เฉพาะ PO ที่อนุมัติแล้ว (APPROVED) เท่านั้น');
+    }
+    return this.prisma.purchaseOrder.update({
+      where: { id },
+      data: {
+        status: 'ORDERED',
+        orderedAt: new Date(),
+        ...(dto.expectedDate ? { expectedDate: new Date(dto.expectedDate) } : {}),
+      },
       include: {
         supplier: { select: { id: true, name: true } },
         items: true,

--- a/apps/api/src/modules/purchase-orders/services/po-product-naming.util.ts
+++ b/apps/api/src/modules/purchase-orders/services/po-product-naming.util.ts
@@ -3,10 +3,9 @@ import { ProductCategory } from '@prisma/client';
 /**
  * Builds the display name for a product created from a PO item.
  *
- * Extracted VERBATIM from the (previously duplicated) name-building block in
- * PoReceivingService.receive() and PoReceivingService.goodsReceiving(). Pure
- * helper — no prisma, no side effects. The two original blocks were identical
- * apart from inline comments, so sharing this preserves behavior byte-for-byte.
+ * Extracted VERBATIM from the name-building block in
+ * PoReceivingService.goodsReceiving(). Pure helper — no prisma, no side effects.
+ * (Originally shared with the legacy receive() path, retired in Purchasing v2 B0.)
  */
 export function buildProductName(
   poItem: {

--- a/apps/api/src/modules/purchase-orders/services/po-query.service.ts
+++ b/apps/api/src/modules/purchase-orders/services/po-query.service.ts
@@ -293,6 +293,21 @@ export class PoQueryService {
     };
   }
 
+  async getSummary() {
+    const now = new Date();
+    const base = { deletedAt: null };
+    const [pendingApproval, toOrder, incoming, overdue, receiving, waitingQc, unpaid] = await Promise.all([
+      this.prisma.purchaseOrder.count({ where: { ...base, status: 'DRAFT' } }),
+      this.prisma.purchaseOrder.count({ where: { ...base, status: 'APPROVED' } }),
+      this.prisma.purchaseOrder.count({ where: { ...base, status: 'ORDERED' } }),
+      this.prisma.purchaseOrder.count({ where: { ...base, status: 'ORDERED', expectedDate: { lt: now } } }),
+      this.prisma.purchaseOrder.count({ where: { ...base, status: 'PARTIALLY_RECEIVED' } }),
+      this.prisma.product.count({ where: { deletedAt: null, status: { in: ['QC_PENDING', 'PHOTO_PENDING'] } } }),
+      this.prisma.purchaseOrder.count({ where: { ...base, status: { notIn: ['CANCELLED', 'DRAFT'] }, paymentStatus: { not: 'FULLY_PAID' } } }),
+    ]);
+    return { pendingApproval, toOrder, incoming, overdue, receiving, waitingQc, unpaid };
+  }
+
   /**
    * Get products pending QC (QC_PENDING status)
    */

--- a/apps/api/src/modules/purchase-orders/services/po-receiving.service.ts
+++ b/apps/api/src/modules/purchase-orders/services/po-receiving.service.ts
@@ -3,6 +3,7 @@ import { Prisma, ProductCategory } from '@prisma/client';
 import { PrismaService } from '../../../prisma/prisma.service';
 import { ReceivePODto, GoodsReceivingDto } from '../dto/create-po.dto';
 import { buildProductName } from './po-product-naming.util';
+import { generateGRNumber } from '../../../utils/sequence.util';
 
 /**
  * Inventory-mutating goods-receiving flows. Owns the 3 write transactions:
@@ -156,9 +157,11 @@ export class PoReceivingService {
           throw new BadRequestException('ไม่พบคลังกลาง กรุณาตั้งค่าสาขาคลังกลางก่อน');
         }
 
-        // Create goods receiving record
+        // Generate GR number inside the serializable tx; @unique is the backstop.
+        const grNumber = await generateGRNumber(tx);
         const receiving = await tx.goodsReceiving.create({
           data: {
+            grNumber,
             poId: id,
             receivedById: userId,
             notes: dto.notes,
@@ -340,6 +343,7 @@ export class PoReceivingService {
 
         return {
           receivingId: receiving.id,
+          grNumber,
           poId: id,
           status: newStatus,
           passed: passedProducts.length,

--- a/apps/api/src/modules/purchase-orders/services/po-receiving.service.ts
+++ b/apps/api/src/modules/purchase-orders/services/po-receiving.service.ts
@@ -130,230 +130,239 @@ export class PoReceivingService {
    * POItem rows by id inside the tx so no cached copy is trusted.
    */
   async goodsReceiving(id: string, dto: GoodsReceivingDto, userId: string) {
-    return this.prisma.$transaction(
-      async (tx) => {
-        const po = await tx.purchaseOrder.findUnique({
-          where: { id },
-          include: { items: true, supplier: true },
-        });
+    const MAX_ATTEMPTS = 3;
+    for (let attempt = 1; ; attempt++) {
+      try {
+        return await this.prisma.$transaction(
+          async (tx) => {
+            const po = await tx.purchaseOrder.findUnique({
+              where: { id },
+              include: { items: true, supplier: true },
+            });
 
-        if (!po || po.deletedAt) throw new NotFoundException('ไม่พบใบสั่งซื้อ');
-        if (!['APPROVED', 'PARTIALLY_RECEIVED'].includes(po.status)) {
-          throw new BadRequestException('PO นี้ไม่อยู่ในสถานะที่สามารถรับสินค้าได้ (ต้อง APPROVED หรือ PARTIALLY_RECEIVED)');
-        }
+            if (!po || po.deletedAt) throw new NotFoundException('ไม่พบใบสั่งซื้อ');
+            if (!['APPROVED', 'PARTIALLY_RECEIVED'].includes(po.status)) {
+              throw new BadRequestException('PO นี้ไม่อยู่ในสถานะที่สามารถรับสินค้าได้ (ต้อง APPROVED หรือ PARTIALLY_RECEIVED)');
+            }
 
-        // Find main warehouse branch
-        let mainWarehouse = await tx.branch.findFirst({
-          where: { isMainWarehouse: true, isActive: true, deletedAt: null },
-        });
-        if (!mainWarehouse) {
-          // Fallback: use first active branch
-          mainWarehouse = await tx.branch.findFirst({
-            where: { isActive: true, deletedAt: null },
-            orderBy: { createdAt: 'asc' },
-          });
-        }
-        if (!mainWarehouse) {
-          throw new BadRequestException('ไม่พบคลังกลาง กรุณาตั้งค่าสาขาคลังกลางก่อน');
-        }
+            // Find main warehouse branch
+            let mainWarehouse = await tx.branch.findFirst({
+              where: { isMainWarehouse: true, isActive: true, deletedAt: null },
+            });
+            if (!mainWarehouse) {
+              // Fallback: use first active branch
+              mainWarehouse = await tx.branch.findFirst({
+                where: { isActive: true, deletedAt: null },
+                orderBy: { createdAt: 'asc' },
+              });
+            }
+            if (!mainWarehouse) {
+              throw new BadRequestException('ไม่พบคลังกลาง กรุณาตั้งค่าสาขาคลังกลางก่อน');
+            }
 
-        // Generate GR number inside the serializable tx; @unique is the backstop.
-        const grNumber = await generateGRNumber(tx);
-        const receiving = await tx.goodsReceiving.create({
-          data: {
-            grNumber,
-            poId: id,
-            receivedById: userId,
-            notes: dto.notes,
-          },
-        });
-
-        const passedProducts: Awaited<ReturnType<typeof tx.product.update>>[] = [];
-        const rejectedItems: Awaited<ReturnType<typeof tx.goodsReceivingItem.create>>[] = [];
-
-        // Group items by poItemId to count per PO item
-        const countByPoItem: Record<string, number> = {};
-        for (const item of dto.items) {
-          if (item.status === 'PASS') {
-            countByPoItem[item.poItemId] = (countByPoItem[item.poItemId] || 0) + 1;
-          }
-        }
-
-        // T5-C16: Re-read POItem rows inside the serializable tx to get the
-        // authoritative receivedQty at this instant. Any parallel GR batch
-        // that committed before us will be visible here; any that commits
-        // after us will be serialized and retry. `countByPoItem` inside this
-        // batch is already aggregated to avoid double-counting when the same
-        // poItemId appears twice in dto.items.
-        const freshPoItems = await tx.pOItem.findMany({
-          where: { id: { in: Object.keys(countByPoItem) } },
-          select: { id: true, quantity: true, receivedQty: true, brand: true, model: true },
-        });
-        const freshByPoItem = new Map(freshPoItems.map((p) => [p.id, p]));
-
-        // Validate quantities using fresh DB rows (not cached po.items)
-        for (const [poItemId, passCount] of Object.entries(countByPoItem)) {
-          const fresh = freshByPoItem.get(poItemId);
-          if (!fresh) throw new NotFoundException(`ไม่พบรายการ PO: ${poItemId}`);
-
-          const totalReceived = fresh.receivedQty + passCount;
-          if (totalReceived > fresh.quantity) {
-            throw new BadRequestException(
-              `จำนวนรับเกิน: ${fresh.brand ?? ''} ${fresh.model ?? ''} (สั่ง ${fresh.quantity}, รับแล้ว ${fresh.receivedQty}, กำลังรับ ${passCount})`,
-            );
-          }
-        }
-
-        // Validate duplicate IMEI/Serial in this batch
-        const imeiList = dto.items
-          .filter((i) => i.status === 'PASS' && i.imeiSerial)
-          .map((i) => i.imeiSerial!);
-        const uniqueImeis = new Set(imeiList);
-        if (uniqueImeis.size !== imeiList.length) {
-          throw new BadRequestException('พบ IMEI ซ้ำกันในรายการที่กำลังรับเข้า');
-        }
-
-        // Validate IMEI not already exists in system (include soft-deleted due to DB unique constraint)
-        if (imeiList.length > 0) {
-          const existingProducts = await tx.product.findMany({
-            where: { imeiSerial: { in: imeiList } },
-            select: { imeiSerial: true, name: true, deletedAt: true },
-          });
-          if (existingProducts.length > 0) {
-            const dupes = existingProducts.map((p) => {
-              const suffix = p.deletedAt ? ' [ตัดจำหน่ายแล้ว]' : '';
-              return `${p.imeiSerial} (${p.name}${suffix})`;
-            }).join(', ');
-            throw new BadRequestException(`IMEI ซ้ำกับสินค้าที่มีในระบบแล้ว: ${dupes}`);
-          }
-        }
-
-        // Process each item
-        for (const item of dto.items) {
-          const poItem = po.items.find((i) => i.id === item.poItemId);
-          if (!poItem) throw new NotFoundException(`ไม่พบรายการ PO: ${item.poItemId}`);
-
-          if (item.status === 'PASS') {
-            // Build product name from PO item details
-            const productCategory = (poItem.category as ProductCategory) || 'PHONE_NEW';
-            const productName = buildProductName(poItem, productCategory);
-
-            // Create product for passed items
-            // PHONE_USED → PHOTO_PENDING (ต้องถ่ายรูป 6 มุมก่อนเข้าคลัง)
-            // PHONE_NEW / ACCESSORY → IN_STOCK (เข้าคลังได้เลย)
-            const initialStatus = productCategory === 'PHONE_USED' ? 'PHOTO_PENDING' : 'IN_STOCK';
-            const product = await tx.product.create({
+            // Generate GR number inside the serializable tx; @unique is the backstop.
+            const grNumber = await generateGRNumber(tx);
+            const receiving = await tx.goodsReceiving.create({
               data: {
-                name: productName,
-                brand: poItem.brand || '',
-                model: poItem.model || '',
-                color: poItem.color || null,
-                storage: poItem.storage || null,
-                category: productCategory,
-                costPrice: Number(poItem.unitPrice),
-                supplierId: po.supplierId,
-                poId: po.id,
-                branchId: mainWarehouse!.id,
-                status: initialStatus,
-                imeiSerial: item.imeiSerial || null,
-                serialNumber: item.serialNumber || null,
-                photos: item.photos || [],
-                batteryHealth: item.batteryHealth ?? null,
-                warrantyExpired: item.warrantyExpired ?? null,
-                warrantyExpireDate: item.warrantyExpireDate ? new Date(item.warrantyExpireDate) : null,
-                hasBox: item.hasBox ?? null,
-                checklistResults: item.checklistResults ? (item.checklistResults as unknown as Prisma.InputJsonValue) : undefined,
-                accessoryType: poItem.accessoryType || null,
-                accessoryBrand: poItem.accessoryBrand || null,
+                grNumber,
+                poId: id,
+                receivedById: userId,
+                notes: dto.notes,
               },
             });
 
-            // Create selling price if provided
-            if (item.sellingPrice && item.sellingPrice > 0) {
-              await tx.productPrice.create({
-                data: {
-                  productId: product.id,
-                  label: 'ราคาขาย',
-                  amount: item.sellingPrice,
-                  isDefault: true,
-                },
+            const passedProducts: Awaited<ReturnType<typeof tx.product.update>>[] = [];
+            const rejectedItems: Awaited<ReturnType<typeof tx.goodsReceivingItem.create>>[] = [];
+
+            // Group items by poItemId to count per PO item
+            const countByPoItem: Record<string, number> = {};
+            for (const item of dto.items) {
+              if (item.status === 'PASS') {
+                countByPoItem[item.poItemId] = (countByPoItem[item.poItemId] || 0) + 1;
+              }
+            }
+
+            // T5-C16: Re-read POItem rows inside the serializable tx to get the
+            // authoritative receivedQty at this instant. Any parallel GR batch
+            // that committed before us will be visible here; any that commits
+            // after us will be serialized and retry. `countByPoItem` inside this
+            // batch is already aggregated to avoid double-counting when the same
+            // poItemId appears twice in dto.items.
+            const freshPoItems = await tx.pOItem.findMany({
+              where: { id: { in: Object.keys(countByPoItem) } },
+              select: { id: true, quantity: true, receivedQty: true, brand: true, model: true },
+            });
+            const freshByPoItem = new Map(freshPoItems.map((p) => [p.id, p]));
+
+            // Validate quantities using fresh DB rows (not cached po.items)
+            for (const [poItemId, passCount] of Object.entries(countByPoItem)) {
+              const fresh = freshByPoItem.get(poItemId);
+              if (!fresh) throw new NotFoundException(`ไม่พบรายการ PO: ${poItemId}`);
+
+              const totalReceived = fresh.receivedQty + passCount;
+              if (totalReceived > fresh.quantity) {
+                throw new BadRequestException(
+                  `จำนวนรับเกิน: ${fresh.brand ?? ''} ${fresh.model ?? ''} (สั่ง ${fresh.quantity}, รับแล้ว ${fresh.receivedQty}, กำลังรับ ${passCount})`,
+                );
+              }
+            }
+
+            // Validate duplicate IMEI/Serial in this batch
+            const imeiList = dto.items
+              .filter((i) => i.status === 'PASS' && i.imeiSerial)
+              .map((i) => i.imeiSerial!);
+            const uniqueImeis = new Set(imeiList);
+            if (uniqueImeis.size !== imeiList.length) {
+              throw new BadRequestException('พบ IMEI ซ้ำกันในรายการที่กำลังรับเข้า');
+            }
+
+            // Validate IMEI not already exists in system (include soft-deleted due to DB unique constraint)
+            if (imeiList.length > 0) {
+              const existingProducts = await tx.product.findMany({
+                where: { imeiSerial: { in: imeiList } },
+                select: { imeiSerial: true, name: true, deletedAt: true },
+              });
+              if (existingProducts.length > 0) {
+                const dupes = existingProducts.map((p) => {
+                  const suffix = p.deletedAt ? ' [ตัดจำหน่ายแล้ว]' : '';
+                  return `${p.imeiSerial} (${p.name}${suffix})`;
+                }).join(', ');
+                throw new BadRequestException(`IMEI ซ้ำกับสินค้าที่มีในระบบแล้ว: ${dupes}`);
+              }
+            }
+
+            // Process each item
+            for (const item of dto.items) {
+              const poItem = po.items.find((i) => i.id === item.poItemId);
+              if (!poItem) throw new NotFoundException(`ไม่พบรายการ PO: ${item.poItemId}`);
+
+              if (item.status === 'PASS') {
+                // Build product name from PO item details
+                const productCategory = (poItem.category as ProductCategory) || 'PHONE_NEW';
+                const productName = buildProductName(poItem, productCategory);
+
+                // Create product for passed items
+                // PHONE_USED → PHOTO_PENDING (ต้องถ่ายรูป 6 มุมก่อนเข้าคลัง)
+                // PHONE_NEW / ACCESSORY → IN_STOCK (เข้าคลังได้เลย)
+                const initialStatus = productCategory === 'PHONE_USED' ? 'PHOTO_PENDING' : 'IN_STOCK';
+                const product = await tx.product.create({
+                  data: {
+                    name: productName,
+                    brand: poItem.brand || '',
+                    model: poItem.model || '',
+                    color: poItem.color || null,
+                    storage: poItem.storage || null,
+                    category: productCategory,
+                    costPrice: Number(poItem.unitPrice),
+                    supplierId: po.supplierId,
+                    poId: po.id,
+                    branchId: mainWarehouse!.id,
+                    status: initialStatus,
+                    imeiSerial: item.imeiSerial || null,
+                    serialNumber: item.serialNumber || null,
+                    photos: item.photos || [],
+                    batteryHealth: item.batteryHealth ?? null,
+                    warrantyExpired: item.warrantyExpired ?? null,
+                    warrantyExpireDate: item.warrantyExpireDate ? new Date(item.warrantyExpireDate) : null,
+                    hasBox: item.hasBox ?? null,
+                    checklistResults: item.checklistResults ? (item.checklistResults as unknown as Prisma.InputJsonValue) : undefined,
+                    accessoryType: poItem.accessoryType || null,
+                    accessoryBrand: poItem.accessoryBrand || null,
+                  },
+                });
+
+                // Create selling price if provided
+                if (item.sellingPrice && item.sellingPrice > 0) {
+                  await tx.productPrice.create({
+                    data: {
+                      productId: product.id,
+                      label: 'ราคาขาย',
+                      amount: item.sellingPrice,
+                      isDefault: true,
+                    },
+                  });
+                }
+
+                // Create receiving item linked to product
+                await tx.goodsReceivingItem.create({
+                  data: {
+                    receivingId: receiving.id,
+                    poItemId: item.poItemId,
+                    imeiSerial: item.imeiSerial,
+                    serialNumber: item.serialNumber,
+                    photos: item.photos || [],
+                    status: 'PASS',
+                    productId: product.id,
+                    batteryHealth: item.batteryHealth ?? null,
+                    warrantyExpired: item.warrantyExpired ?? null,
+                    warrantyExpireDate: item.warrantyExpireDate ? new Date(item.warrantyExpireDate) : null,
+                    hasBox: item.hasBox ?? null,
+                    checklistResults: item.checklistResults ? (item.checklistResults as unknown as Prisma.InputJsonValue) : undefined,
+                  },
+                });
+
+                passedProducts.push(product);
+              } else {
+                // Create receiving item for rejected items (no product created)
+                const rejectedItem = await tx.goodsReceivingItem.create({
+                  data: {
+                    receivingId: receiving.id,
+                    poItemId: item.poItemId,
+                    imeiSerial: item.imeiSerial,
+                    serialNumber: item.serialNumber,
+                    photos: item.photos || [],
+                    status: 'REJECT',
+                    rejectReason: item.rejectReason,
+                  },
+                });
+
+                rejectedItems.push(rejectedItem);
+              }
+            }
+
+            // T5-C16: Update PO item received quantities using fresh values
+            // (not cached po.items which could be stale against a parallel tx).
+            for (const [poItemId, passCount] of Object.entries(countByPoItem)) {
+              const fresh = freshByPoItem.get(poItemId)!;
+              await tx.pOItem.update({
+                where: { id: poItemId },
+                data: { receivedQty: fresh.receivedQty + passCount },
               });
             }
 
-            // Create receiving item linked to product
-            await tx.goodsReceivingItem.create({
-              data: {
-                receivingId: receiving.id,
-                poItemId: item.poItemId,
-                imeiSerial: item.imeiSerial,
-                serialNumber: item.serialNumber,
-                photos: item.photos || [],
-                status: 'PASS',
-                productId: product.id,
-                batteryHealth: item.batteryHealth ?? null,
-                warrantyExpired: item.warrantyExpired ?? null,
-                warrantyExpireDate: item.warrantyExpireDate ? new Date(item.warrantyExpireDate) : null,
-                hasBox: item.hasBox ?? null,
-                checklistResults: item.checklistResults ? (item.checklistResults as unknown as Prisma.InputJsonValue) : undefined,
-              },
+            // Check if all items fully received
+            const updatedPO = await tx.purchaseOrder.findUnique({
+              where: { id },
+              include: { items: true },
             });
 
-            passedProducts.push(product);
-          } else {
-            // Create receiving item for rejected items (no product created)
-            const rejectedItem = await tx.goodsReceivingItem.create({
-              data: {
-                receivingId: receiving.id,
-                poItemId: item.poItemId,
-                imeiSerial: item.imeiSerial,
-                serialNumber: item.serialNumber,
-                photos: item.photos || [],
-                status: 'REJECT',
-                rejectReason: item.rejectReason,
-              },
+            const allReceived = updatedPO!.items.every((item) => item.receivedQty >= item.quantity);
+            const newStatus = allReceived ? 'FULLY_RECEIVED' : 'PARTIALLY_RECEIVED';
+
+            await tx.purchaseOrder.update({
+              where: { id },
+              data: { status: newStatus },
             });
 
-            rejectedItems.push(rejectedItem);
-          }
-        }
-
-        // T5-C16: Update PO item received quantities using fresh values
-        // (not cached po.items which could be stale against a parallel tx).
-        for (const [poItemId, passCount] of Object.entries(countByPoItem)) {
-          const fresh = freshByPoItem.get(poItemId)!;
-          await tx.pOItem.update({
-            where: { id: poItemId },
-            data: { receivedQty: fresh.receivedQty + passCount },
-          });
-        }
-
-        // Check if all items fully received
-        const updatedPO = await tx.purchaseOrder.findUnique({
-          where: { id },
-          include: { items: true },
-        });
-
-        const allReceived = updatedPO!.items.every((item) => item.receivedQty >= item.quantity);
-        const newStatus = allReceived ? 'FULLY_RECEIVED' : 'PARTIALLY_RECEIVED';
-
-        await tx.purchaseOrder.update({
-          where: { id },
-          data: { status: newStatus },
-        });
-
-        return {
-          receivingId: receiving.id,
-          grNumber,
-          poId: id,
-          status: newStatus,
-          passed: passedProducts.length,
-          rejected: rejectedItems.length,
-          products: passedProducts,
-          mainWarehouse: mainWarehouse!.name,
-        };
-      },
-      { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
-    );
+            return {
+              receivingId: receiving.id,
+              grNumber,
+              poId: id,
+              status: newStatus,
+              passed: passedProducts.length,
+              rejected: rejectedItems.length,
+              products: passedProducts,
+              mainWarehouse: mainWarehouse!.name,
+            };
+          },
+          { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
+        );
+      } catch (e) {
+        const code = (e as { code?: string })?.code;
+        if ((code === 'P2002' || code === 'P2034') && attempt < MAX_ATTEMPTS) continue;
+        throw e;
+      }
+    }
   }
 
   /**

--- a/apps/api/src/modules/purchase-orders/services/po-receiving.service.ts
+++ b/apps/api/src/modules/purchase-orders/services/po-receiving.service.ts
@@ -313,6 +313,7 @@ export class PoReceivingService {
                     photos: item.photos || [],
                     status: 'REJECT',
                     rejectReason: item.rejectReason,
+                    defectReason: item.defectReason ?? null,
                   },
                 });
 

--- a/apps/api/src/modules/purchase-orders/services/po-receiving.service.ts
+++ b/apps/api/src/modules/purchase-orders/services/po-receiving.service.ts
@@ -1,13 +1,12 @@
 import { NotFoundException, BadRequestException } from '@nestjs/common';
 import { Prisma, ProductCategory } from '@prisma/client';
 import { PrismaService } from '../../../prisma/prisma.service';
-import { ReceivePODto, GoodsReceivingDto } from '../dto/create-po.dto';
+import { GoodsReceivingDto } from '../dto/create-po.dto';
 import { buildProductName } from './po-product-naming.util';
 import { generateGRNumber } from '../../../utils/sequence.util';
 
 /**
- * Inventory-mutating goods-receiving flows. Owns the 3 write transactions:
- *  - receive()        — Serializable $transaction (legacy receive)
+ * Inventory-mutating goods-receiving flows. Owns the 2 write transactions:
  *  - goodsReceiving() — Serializable $transaction (per-unit IMEI/photo flow)
  *  - confirmQC()      — $transaction (QC_PENDING → IN_STOCK / PHOTO_PENDING)
  *
@@ -21,105 +20,6 @@ import { generateGRNumber } from '../../../utils/sequence.util';
  */
 export class PoReceivingService {
   constructor(private prisma: PrismaService) {}
-
-  /**
-   * Legacy receive - kept for backward compatibility
-   *
-   * T5-C16: wrapped in Serializable transaction + per-item re-read so two
-   * concurrent GR requests cannot both pass the `totalReceived > quantity`
-   * check against stale in-memory receivedQty. The inner re-read (inside
-   * the same serializable tx) guarantees one of the two concurrent writers
-   * will see the other's update and either retry or fail the invariant.
-   */
-  async receive(id: string, dto: ReceivePODto, userId: string, branchId: string) {
-    return this.prisma.$transaction(
-      async (tx) => {
-        const po = await tx.purchaseOrder.findUnique({
-          where: { id },
-          include: { items: true, supplier: true },
-        });
-
-        if (!po || po.deletedAt) throw new NotFoundException('ไม่พบใบสั่งซื้อ');
-        if (!['APPROVED', 'PARTIALLY_RECEIVED'].includes(po.status)) {
-          throw new BadRequestException('PO นี้ไม่อยู่ในสถานะที่สามารถรับสินค้าได้');
-        }
-
-        const receivedProducts: Awaited<ReturnType<typeof tx.product.create>>[] = [];
-
-        for (const receiveItem of dto.items) {
-          const poItem = po.items.find((i) => i.id === receiveItem.poItemId);
-          if (!poItem) {
-            throw new NotFoundException(`ไม่พบรายการ PO: ${receiveItem.poItemId}`);
-          }
-
-          // T5-C16: Re-read inside the serializable tx instead of trusting
-          // the cached poItem.receivedQty. This closes the race where two
-          // GR requests both read 0 and both pass the ceiling check.
-          const fresh = await tx.pOItem.findUnique({
-            where: { id: receiveItem.poItemId },
-            select: { receivedQty: true, quantity: true },
-          });
-          const currentReceived = fresh?.receivedQty ?? poItem.receivedQty;
-          const orderedQty = fresh?.quantity ?? poItem.quantity;
-          const totalReceived = currentReceived + receiveItem.receivedQty;
-          if (totalReceived > orderedQty) {
-            throw new BadRequestException(
-              `จำนวนรับเกิน: ${poItem.brand} ${poItem.model} (สั่ง ${orderedQty}, รับแล้ว ${currentReceived}, กำลังรับ ${receiveItem.receivedQty})`,
-            );
-          }
-
-          await tx.pOItem.update({
-            where: { id: receiveItem.poItemId },
-            data: { receivedQty: totalReceived },
-          });
-
-          for (let i = 0; i < receiveItem.receivedQty; i++) {
-            const productCategory = (poItem.category as ProductCategory) || 'PHONE_NEW';
-            const productName = buildProductName(poItem, productCategory);
-            const product = await tx.product.create({
-              data: {
-                name: productName,
-                brand: poItem.brand || '',
-                model: poItem.model || '',
-                color: poItem.color || null,
-                storage: poItem.storage || null,
-                category: productCategory,
-                costPrice: Number(poItem.unitPrice),
-                supplierId: po.supplierId,
-                poId: po.id,
-                branchId,
-                status: 'PO_RECEIVED',
-                accessoryType: poItem.accessoryType || null,
-                accessoryBrand: poItem.accessoryBrand || null,
-              },
-            });
-            receivedProducts.push(product);
-          }
-        }
-
-        const updatedPO = await tx.purchaseOrder.findUnique({
-          where: { id },
-          include: { items: true },
-        });
-
-        const allReceived = updatedPO!.items.every((item) => item.receivedQty >= item.quantity);
-        const newStatus = allReceived ? 'FULLY_RECEIVED' : 'PARTIALLY_RECEIVED';
-
-        await tx.purchaseOrder.update({
-          where: { id },
-          data: { status: newStatus },
-        });
-
-        return {
-          poId: id,
-          status: newStatus,
-          receivedProducts: receivedProducts.length,
-          products: receivedProducts,
-        };
-      },
-      { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
-    );
-  }
 
   /**
    * New goods receiving flow with IMEI/Serial/photos/pass-reject per unit

--- a/apps/api/src/utils/sequence.gr.spec.ts
+++ b/apps/api/src/utils/sequence.gr.spec.ts
@@ -1,0 +1,23 @@
+import { generateGRNumber } from './sequence.util';
+
+describe('generateGRNumber', () => {
+  it('formats GR-YYYY-MM-NNN using the monthly count + 1', async () => {
+    const tx = { goodsReceiving: { count: jest.fn().mockResolvedValue(4) } };
+    const now = new Date();
+    const yyyy = now.getFullYear();
+    const mm = String(now.getMonth() + 1).padStart(2, '0');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const gr = await generateGRNumber(tx as any);
+    expect(gr).toBe(`GR-${yyyy}-${mm}-005`);
+    expect(tx.goodsReceiving.count).toHaveBeenCalledWith(
+      expect.objectContaining({ where: expect.objectContaining({ createdAt: expect.any(Object) }) }),
+    );
+  });
+
+  it('starts at 001 when there are no receivings this month', async () => {
+    const tx = { goodsReceiving: { count: jest.fn().mockResolvedValue(0) } };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const gr = await generateGRNumber(tx as any);
+    expect(gr.endsWith('-001')).toBe(true);
+  });
+});

--- a/apps/api/src/utils/sequence.util.ts
+++ b/apps/api/src/utils/sequence.util.ts
@@ -7,6 +7,7 @@ type PrismaTx = {
   contract: { findFirst: (...args: unknown[]) => Promise<{ contractNumber: string } | null> };
   sale: { findFirst: (...args: unknown[]) => Promise<{ saleNumber: string } | null> };
   purchaseOrder: { count: (...args: unknown[]) => Promise<number> };
+  goodsReceiving: { count: (...args: unknown[]) => Promise<number> };
   quote?: { findFirst: (...args: unknown[]) => Promise<{ quoteNumber: string } | null> };
   booking?: { findFirst: (...args: unknown[]) => Promise<{ bookingNumber: string } | null> };
 };
@@ -136,4 +137,22 @@ export async function generatePONumber(tx: PrismaTx): Promise<string> {
     where: { createdAt: { gte: monthStart, lt: monthEnd } },
   });
   return `PO-${year}-${month}-${String(monthCount + 1).padStart(3, '0')}`;
+}
+
+/**
+ * Generate next GR (Goods Receipt) number (GR-2026-03-001, GR-2026-03-002, ...).
+ * Operational running number — mirrors generatePONumber (count-based monthly sequence).
+ * MUST be called inside the receive Serializable $transaction; @unique is the backstop
+ * and a P2002 retry (in po-receiving.service) covers count-based collisions.
+ */
+export async function generateGRNumber(tx: PrismaTx): Promise<string> {
+  const today = new Date();
+  const year = today.getFullYear();
+  const month = String(today.getMonth() + 1).padStart(2, '0');
+  const monthStart = new Date(year, today.getMonth(), 1);
+  const monthEnd = new Date(year, today.getMonth() + 1, 1);
+  const monthCount = await tx.goodsReceiving.count({
+    where: { createdAt: { gte: monthStart, lt: monthEnd } },
+  });
+  return `GR-${year}-${month}-${String(monthCount + 1).padStart(3, '0')}`;
 }

--- a/docs/superpowers/plans/2026-06-29-purchasing-b0-backend-foundation.md
+++ b/docs/superpowers/plans/2026-06-29-purchasing-b0-backend-foundation.md
@@ -1,0 +1,889 @@
+# Purchasing v2 — Batch 0: Backend Additive Foundation — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Lay the purely-additive backend foundation for the Purchasing & Receiving UX overhaul — a new `ORDERED` PO state + "สั่งซื้อ" action, a numbered Goods Receipt (`grNumber`), a structured `DefectReason`, a compute-on-read purchasing summary, and the retirement of the dead legacy `receive()` path — without touching accounting/finance.
+
+**Architecture:** Extend the existing, already-isolated `purchase-orders` module additively. New schema columns/enums + two new endpoints (`POST /:id/order`, `GET /summary`) + a GR-number generator wired into the existing Serializable `goodsReceiving()` transaction. No data-model rewrite, no nullable-FK churn (direct-receive arrives in B3 as auto-PO), no cross-module imports.
+
+**Tech Stack:** NestJS + Prisma + PostgreSQL (`apps/api`), jest unit tests, `class-validator` DTOs.
+
+**Spec:** `docs/superpowers/specs/2026-06-29-purchasing-receiving-ux-v2-design.md`
+
+## Global Constraints
+
+- **Red line — no accounting/finance:** receiving stays **JE-free**; introduce **no** import of any accounting/finance/journal/expense/tax module into `purchase-orders`; do not touch `trade-in` or `Product.ownedByCompanyId`. (Verified: module is `imports: []`, Prisma-only.)
+- **Additive only:** no rewrite of existing models; `GoodsReceiving.poId` and `GoodsReceivingItem.poItemId` **stay `NOT NULL`**.
+- **Migration timestamp = `20260978000000`** (verified 2026-06-29: the highest existing migration is `20260977000000_add_payment_drafts`, so `20260977000000` is taken — use `20260978000000`). Production uses `prisma migrate deploy` only.
+- **Money = `Decimal` (`@db.Decimal(12,2)`)**, never Float/Int.
+- **Soft delete:** every read filters `deletedAt: null`; never hard-delete.
+- **Validation messages in Thai** (`class-validator`).
+- **Tests:** jest; DB-backed specs run `--runInBand` (parallel-DB is flaky per memory). These B0 specs are mock-based (no DB) so they run in the normal suite.
+- **Type gate:** `./tools/check-types.sh all` must report 0 errors before each commit.
+
+---
+
+### Task 1: Schema migration — `ORDERED`, `orderedAt`, `isDirectReceive`, `grNumber`, `DefectReason`
+
+**Files:**
+- Modify: `apps/api/prisma/schema.prisma` (enum `POStatus` ~line 191; model `PurchaseOrder` ~line 1523; model `GoodsReceiving` lines 1814-1829; model `GoodsReceivingItem` lines 1831-1857)
+- Create: `apps/api/prisma/migrations/20260978000000_purchasing_v2_foundation/migration.sql`
+
+**Interfaces:**
+- Produces: `POStatus.ORDERED`; `PurchaseOrder.orderedAt: DateTime?`, `PurchaseOrder.isDirectReceive: Boolean (default false)`; `GoodsReceiving.grNumber: String @unique`; `GoodsReceivingItem.defectReason: DefectReason?`; new `enum DefectReason`.
+
+- [ ] **Step 1: Edit the schema — `POStatus` enum**
+
+In `apps/api/prisma/schema.prisma`, add `ORDERED` to `enum POStatus` (place it after `APPROVED`):
+
+```prisma
+enum POStatus {
+  DRAFT
+  APPROVED
+  ORDERED
+  PENDING
+  PARTIALLY_RECEIVED
+  FULLY_RECEIVED
+  CANCELLED
+}
+```
+
+- [ ] **Step 2: Edit the schema — new `DefectReason` enum**
+
+Add a new enum near the other purchasing enums (e.g. just below `POStatus`):
+
+```prisma
+enum DefectReason {
+  SCREEN
+  BATTERY
+  IMEI_BLOCKED
+  BOX_MISSING
+  WRONG_MODEL
+  DOA
+  COSMETIC
+  OTHER
+}
+```
+
+- [ ] **Step 3: Edit the schema — `PurchaseOrder` fields**
+
+In `model PurchaseOrder`, add two columns alongside the existing scalar fields (next to `status`):
+
+```prisma
+  orderedAt       DateTime? @map("ordered_at")
+  isDirectReceive Boolean   @default(false) @map("is_direct_receive")
+```
+
+- [ ] **Step 4: Edit the schema — `GoodsReceiving.grNumber` + `GoodsReceivingItem.defectReason`**
+
+In `model GoodsReceiving` add (after `id`):
+
+```prisma
+  grNumber     String    @unique @map("gr_number")
+```
+
+In `model GoodsReceivingItem` add (after `rejectReason`):
+
+```prisma
+  defectReason DefectReason? @map("defect_reason")
+```
+
+(Do **not** add a separate `@@index([grNumber])` — `@unique` already creates the index.)
+
+- [ ] **Step 5: Generate the migration SQL (create-only) so it can be hand-edited for the grNumber backfill**
+
+Run: `cd apps/api && npx prisma migrate dev --name purchasing_v2_foundation --create-only`
+Expected: a new folder `prisma/migrations/<timestamp>_purchasing_v2_foundation/migration.sql` is created. Rename the folder so its timestamp is `20260978000000`.
+
+- [ ] **Step 6: Replace the auto-generated `grNumber` step with a safe 2-step backfill**
+
+A `NOT NULL UNIQUE` column cannot be added directly to a populated table. Edit `migration.sql` so the `goods_receivings.gr_number` section reads exactly (keep the auto-generated `ALTER TYPE`/`ADD COLUMN` lines for the other fields):
+
+```sql
+-- PurchaseOrder additive columns
+ALTER TABLE "purchase_orders" ADD COLUMN "ordered_at" TIMESTAMP(3);
+ALTER TABLE "purchase_orders" ADD COLUMN "is_direct_receive" BOOLEAN NOT NULL DEFAULT false;
+
+-- POStatus + DefectReason enums (auto-generated ALTER TYPE / CREATE TYPE lines kept as generated)
+
+-- GoodsReceivingItem.defect_reason
+ALTER TABLE "goods_receiving_items" ADD COLUMN "defect_reason" "DefectReason";
+
+-- GoodsReceiving.gr_number — 2-step: add nullable, backfill, then NOT NULL + UNIQUE
+ALTER TABLE "goods_receivings" ADD COLUMN "gr_number" TEXT;
+
+WITH seq AS (
+  SELECT id,
+         'GR-' || to_char("created_at", 'YYYY-MM') || '-' ||
+         lpad(
+           (row_number() OVER (PARTITION BY to_char("created_at", 'YYYY-MM')
+                               ORDER BY "created_at", id))::text,
+           3, '0'
+         ) AS gr
+  FROM "goods_receivings"
+)
+UPDATE "goods_receivings" g SET "gr_number" = seq.gr FROM seq WHERE g.id = seq.id;
+
+ALTER TABLE "goods_receivings" ALTER COLUMN "gr_number" SET NOT NULL;
+CREATE UNIQUE INDEX "goods_receivings_gr_number_key" ON "goods_receivings"("gr_number");
+```
+
+- [ ] **Step 7: Apply the migration + regenerate the client**
+
+Run: `cd apps/api && npx prisma migrate dev`
+Expected: migration applies cleanly; `Prisma Client` regenerates with the new fields/enums.
+
+- [ ] **Step 8: Type-check**
+
+Run: `./tools/check-types.sh all`
+Expected: 0 errors.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add apps/api/prisma/schema.prisma apps/api/prisma/migrations/20260978000000_purchasing_v2_foundation
+git commit -m "feat(purchasing): additive schema — ORDERED, orderedAt, isDirectReceive, grNumber, DefectReason"
+```
+
+---
+
+### Task 2: "สั่งซื้อ" action — `POST /purchase-orders/:id/order`
+
+**Files:**
+- Modify: `apps/api/src/modules/purchase-orders/dto/create-po.dto.ts` (add `OrderPODto`)
+- Modify: `apps/api/src/modules/purchase-orders/services/po-lifecycle.service.ts` (add `order()`)
+- Modify: `apps/api/src/modules/purchase-orders/purchase-orders.service.ts` (facade delegate)
+- Modify: `apps/api/src/modules/purchase-orders/purchase-orders.controller.ts` (new route)
+- Create: `apps/api/src/modules/purchase-orders/purchase-orders.order.spec.ts`
+
+**Interfaces:**
+- Consumes: `PoQueryService.findOne(id)` (existing — reads via `prisma.purchaseOrder.findUnique`, throws `NotFoundException` if missing/deleted).
+- Produces: `PurchaseOrdersService.order(id: string, userId: string, dto: OrderPODto): Promise<PurchaseOrder>` — `APPROVED → ORDERED`, sets `orderedAt = now`, optionally updates `expectedDate`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/api/src/modules/purchase-orders/purchase-orders.order.spec.ts`:
+
+```typescript
+import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException } from '@nestjs/common';
+import { PurchaseOrdersService } from './purchase-orders.service';
+import { PrismaService } from '../../prisma/prisma.service';
+
+describe('PurchaseOrdersService.order — APPROVED → ORDERED', () => {
+  let service: PurchaseOrdersService;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+
+  const makePrisma = (status: string) => ({
+    purchaseOrder: {
+      findUnique: jest.fn().mockResolvedValue({
+        id: 'po-1', status, deletedAt: null, items: [], supplier: { id: 's1', name: 'S' },
+      }),
+      update: jest.fn().mockImplementation(({ data }) =>
+        Promise.resolve({ id: 'po-1', status: data.status, orderedAt: data.orderedAt })),
+    },
+  });
+
+  const build = async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [PurchaseOrdersService, { provide: PrismaService, useValue: prisma }],
+    }).compile();
+    return module.get<PurchaseOrdersService>(PurchaseOrdersService);
+  };
+
+  it('advances an APPROVED PO to ORDERED and stamps orderedAt', async () => {
+    prisma = makePrisma('APPROVED');
+    service = await build();
+    const result = await service.order('po-1', 'user-1', {});
+    expect(result.status).toBe('ORDERED');
+    expect(prisma.purchaseOrder.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'po-1' },
+        data: expect.objectContaining({ status: 'ORDERED', orderedAt: expect.any(Date) }),
+      }),
+    );
+  });
+
+  it('rejects ordering a PO that is not APPROVED', async () => {
+    prisma = makePrisma('DRAFT');
+    service = await build();
+    await expect(service.order('po-1', 'user-1', {})).rejects.toThrow(BadRequestException);
+  });
+
+  it('updates expectedDate when provided', async () => {
+    prisma = makePrisma('APPROVED');
+    service = await build();
+    await service.order('po-1', 'user-1', { expectedDate: '2026-07-15' });
+    expect(prisma.purchaseOrder.update).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ expectedDate: new Date('2026-07-15') }) }),
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/api && npx jest purchase-orders.order.spec.ts`
+Expected: FAIL — `service.order is not a function`.
+
+- [ ] **Step 3: Add `OrderPODto`**
+
+In `dto/create-po.dto.ts`, add:
+
+```typescript
+export class OrderPODto {
+  @IsDateString()
+  @IsOptional()
+  expectedDate?: string;
+}
+```
+
+- [ ] **Step 4: Add `order()` to `PoLifecycleService`**
+
+In `po-lifecycle.service.ts`, add this method (after `approve()`), and import `OrderPODto`:
+
+```typescript
+  async order(id: string, userId: string, dto: { expectedDate?: string }) {
+    const po = await this.query.findOne(id);
+    if (po.status !== 'APPROVED') {
+      throw new BadRequestException('สั่งซื้อได้เฉพาะ PO ที่อนุมัติแล้ว (APPROVED) เท่านั้น');
+    }
+    return this.prisma.purchaseOrder.update({
+      where: { id },
+      data: {
+        status: 'ORDERED',
+        orderedAt: new Date(),
+        ...(dto.expectedDate ? { expectedDate: new Date(dto.expectedDate) } : {}),
+      },
+      include: {
+        supplier: { select: { id: true, name: true } },
+        items: true,
+      },
+    });
+  }
+```
+
+Update the import line at the top of the file:
+
+```typescript
+import { CreatePODto, UpdatePODto, UpdatePaymentDto, OrderPODto } from '../dto/create-po.dto';
+```
+
+(`OrderPODto` is referenced by the facade/controller; importing here keeps the type available if you choose to type the param as `OrderPODto`.)
+
+- [ ] **Step 5: Add the facade delegate**
+
+In `purchase-orders.service.ts`, add (after `approve()`), and add `OrderPODto` to the dto import:
+
+```typescript
+  order(id: string, userId: string, dto: OrderPODto) {
+    return this.lifecycle.order(id, userId, dto);
+  }
+```
+
+Import update at top:
+
+```typescript
+import { CreatePODto, UpdatePODto, ReceivePODto, GoodsReceivingDto, UpdatePaymentDto, OrderPODto } from './dto/create-po.dto';
+```
+
+- [ ] **Step 6: Add the controller route**
+
+In `purchase-orders.controller.ts`, add `OrderPODto` to the dto import and add the route (after `approve`):
+
+```typescript
+  @Post(':id/order')
+  @Roles('OWNER', 'BRANCH_MANAGER')
+  order(
+    @Param('id') id: string,
+    @Body() dto: OrderPODto,
+    @CurrentUser() user: { id: string },
+  ) {
+    return this.purchaseOrdersService.order(id, user.id, dto);
+  }
+```
+
+- [ ] **Step 7: Run test to verify it passes**
+
+Run: `cd apps/api && npx jest purchase-orders.order.spec.ts`
+Expected: PASS (3 tests).
+
+- [ ] **Step 8: Type-check + commit**
+
+```bash
+./tools/check-types.sh all
+git add apps/api/src/modules/purchase-orders
+git commit -m "feat(purchasing): add POST /:id/order (APPROVED -> ORDERED) with orderedAt"
+```
+
+---
+
+### Task 3: `grNumber` generator + wire into `goodsReceiving()` with retry
+
+**Files:**
+- Modify: `apps/api/src/utils/sequence.util.ts` (add `generateGRNumber`)
+- Modify: `apps/api/src/modules/purchase-orders/services/po-receiving.service.ts` (`goodsReceiving()` — set `grNumber`, wrap in retry, return it)
+- Create: `apps/api/src/utils/sequence.gr.spec.ts`
+
+**Interfaces:**
+- Consumes: `PrismaTx` (existing type used by `generatePONumber`).
+- Produces: `generateGRNumber(tx: PrismaTx): Promise<string>` → `GR-YYYY-MM-NNN`; `goodsReceiving()` result now includes `grNumber: string`.
+
+- [ ] **Step 1: Write the failing test for the generator**
+
+Create `apps/api/src/utils/sequence.gr.spec.ts`:
+
+```typescript
+import { generateGRNumber } from './sequence.util';
+
+describe('generateGRNumber', () => {
+  it('formats GR-YYYY-MM-NNN using the monthly count + 1', async () => {
+    const tx = { goodsReceiving: { count: jest.fn().mockResolvedValue(4) } };
+    const now = new Date();
+    const yyyy = now.getFullYear();
+    const mm = String(now.getMonth() + 1).padStart(2, '0');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const gr = await generateGRNumber(tx as any);
+    expect(gr).toBe(`GR-${yyyy}-${mm}-005`);
+    expect(tx.goodsReceiving.count).toHaveBeenCalledWith(
+      expect.objectContaining({ where: expect.objectContaining({ createdAt: expect.any(Object) }) }),
+    );
+  });
+
+  it('starts at 001 when there are no receivings this month', async () => {
+    const tx = { goodsReceiving: { count: jest.fn().mockResolvedValue(0) } };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const gr = await generateGRNumber(tx as any);
+    expect(gr.endsWith('-001')).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/api && npx jest sequence.gr.spec.ts`
+Expected: FAIL — `generateGRNumber is not a function`.
+
+- [ ] **Step 3: Implement `generateGRNumber`**
+
+In `apps/api/src/utils/sequence.util.ts`, add below `generatePONumber` (mirroring it exactly, counting `goodsReceiving`):
+
+```typescript
+export async function generateGRNumber(tx: PrismaTx): Promise<string> {
+  const today = new Date();
+  const year = today.getFullYear();
+  const month = String(today.getMonth() + 1).padStart(2, '0');
+  const monthStart = new Date(year, today.getMonth(), 1);
+  const monthEnd = new Date(year, today.getMonth() + 1, 1);
+  const monthCount = await tx.goodsReceiving.count({
+    where: { createdAt: { gte: monthStart, lt: monthEnd } },
+  });
+  return `GR-${year}-${month}-${String(monthCount + 1).padStart(3, '0')}`;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/api && npx jest sequence.gr.spec.ts`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Wire `grNumber` into `goodsReceiving()`**
+
+In `po-receiving.service.ts`: import the generator, set `grNumber` on the GR create, and return it.
+
+Add to the import at the top:
+
+```typescript
+import { generateGRNumber } from '../../../utils/sequence.util';
+```
+
+Change the GR-create block (currently lines ~160-166) to:
+
+```typescript
+        // Generate GR number inside the serializable tx; @unique is the backstop.
+        const grNumber = await generateGRNumber(tx);
+        const receiving = await tx.goodsReceiving.create({
+          data: {
+            grNumber,
+            poId: id,
+            receivedById: userId,
+            notes: dto.notes,
+          },
+        });
+```
+
+Add `grNumber` to the return object (currently lines ~341-349):
+
+```typescript
+        return {
+          receivingId: receiving.id,
+          grNumber,
+          poId: id,
+          status: newStatus,
+          passed: passedProducts.length,
+          rejected: rejectedItems.length,
+          products: passedProducts,
+          mainWarehouse: mainWarehouse!.name,
+        };
+```
+
+- [ ] **Step 6: Add a retry wrapper around the transaction (count-based numbering is not collision-proof on its own)**
+
+Wrap the existing `return this.prisma.$transaction(...)` in `goodsReceiving()` with a bounded retry on unique-collision (P2002) / serialization-failure (P2034). Replace `return this.prisma.$transaction(` with a loop:
+
+```typescript
+  async goodsReceiving(id: string, dto: GoodsReceivingDto, userId: string) {
+    const MAX_ATTEMPTS = 3;
+    for (let attempt = 1; ; attempt++) {
+      try {
+        return await this.prisma.$transaction(
+          async (tx) => {
+            // ... existing body unchanged ...
+          },
+          { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
+        );
+      } catch (e) {
+        const code = (e as { code?: string })?.code;
+        if ((code === 'P2002' || code === 'P2034') && attempt < MAX_ATTEMPTS) continue;
+        throw e;
+      }
+    }
+  }
+```
+
+(The existing transaction body — branch lookup, GR create, item loop, ceiling check, status recompute — is unchanged; it just now lives inside the `try`.)
+
+- [ ] **Step 7: Write a focused test for the retry wrapper**
+
+Create `apps/api/src/modules/purchase-orders/purchase-orders.grnumber-retry.spec.ts`:
+
+```typescript
+import { Test, TestingModule } from '@nestjs/testing';
+import { PurchaseOrdersService } from './purchase-orders.service';
+import { PrismaService } from '../../prisma/prisma.service';
+
+describe('goodsReceiving — retries on grNumber unique collision (P2002)', () => {
+  it('retries the transaction once on P2002 then succeeds', async () => {
+    let calls = 0;
+    const prisma: any = {
+      $transaction: jest.fn().mockImplementation(async (fn: any) => {
+        calls += 1;
+        if (calls === 1) {
+          const err: any = new Error('Unique constraint failed');
+          err.code = 'P2002';
+          throw err;
+        }
+        return { receivingId: 'r1', grNumber: 'GR-2026-06-002', status: 'FULLY_RECEIVED' };
+      }),
+    };
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [PurchaseOrdersService, { provide: PrismaService, useValue: prisma }],
+    }).compile();
+    const service = module.get<PurchaseOrdersService>(PurchaseOrdersService);
+
+    const result = await service.goodsReceiving('po-1', { items: [] } as never, 'user-1');
+    expect(calls).toBe(2);
+    expect(result.grNumber).toBe('GR-2026-06-002');
+  });
+});
+```
+
+- [ ] **Step 8: Run tests to verify they pass**
+
+Run: `cd apps/api && npx jest sequence.gr.spec.ts purchase-orders.grnumber-retry.spec.ts`
+Expected: PASS.
+
+- [ ] **Step 9: Type-check + commit**
+
+```bash
+./tools/check-types.sh all
+git add apps/api/src/utils apps/api/src/modules/purchase-orders
+git commit -m "feat(purchasing): numbered Goods Receipt (grNumber) with collision retry"
+```
+
+---
+
+### Task 4: Persist structured `defectReason` on rejected receiving items
+
+**Files:**
+- Modify: `apps/api/src/modules/purchase-orders/dto/create-po.dto.ts` (`GoodsReceivingItemDto.defectReason`)
+- Modify: `apps/api/src/modules/purchase-orders/services/po-receiving.service.ts` (REJECT branch persists `defectReason`)
+- Create: `apps/api/src/modules/purchase-orders/purchase-orders.defect.spec.ts`
+
+**Interfaces:**
+- Produces: `GoodsReceivingItemDto.defectReason?: DefectReason`; rejected `GoodsReceivingItem` rows store `defectReason`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/api/src/modules/purchase-orders/purchase-orders.defect.spec.ts`:
+
+```typescript
+import { Test, TestingModule } from '@nestjs/testing';
+import { PurchaseOrdersService } from './purchase-orders.service';
+import { PrismaService } from '../../prisma/prisma.service';
+
+describe('goodsReceiving — persists structured defectReason on REJECT', () => {
+  it('writes defectReason onto the rejected GoodsReceivingItem', async () => {
+    const created: any[] = [];
+    const tx: any = {
+      purchaseOrder: {
+        findUnique: jest.fn().mockResolvedValue({
+          id: 'po-1', status: 'APPROVED', deletedAt: null, supplierId: 's1',
+          items: [{ id: 'poi-1', category: 'PHONE_NEW', brand: 'A', model: 'B' }],
+        }),
+        update: jest.fn().mockResolvedValue({}),
+      },
+      branch: { findFirst: jest.fn().mockResolvedValue({ id: 'wh', name: 'คลังกลาง' }) },
+      goodsReceiving: { create: jest.fn().mockResolvedValue({ id: 'gr1' }), count: jest.fn().mockResolvedValue(0) },
+      goodsReceivingItem: { create: jest.fn().mockImplementation(({ data }) => { created.push(data); return Promise.resolve({ id: 'gri1', ...data }); }) },
+      pOItem: { findMany: jest.fn().mockResolvedValue([]), update: jest.fn() },
+      product: { create: jest.fn(), findMany: jest.fn().mockResolvedValue([]) },
+      productPrice: { create: jest.fn() },
+    };
+    const prisma: any = { $transaction: jest.fn().mockImplementation((fn: any) => fn(tx)) };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [PurchaseOrdersService, { provide: PrismaService, useValue: prisma }],
+    }).compile();
+    const service = module.get<PurchaseOrdersService>(PurchaseOrdersService);
+
+    await service.goodsReceiving('po-1', {
+      items: [{ poItemId: 'poi-1', status: 'REJECT', rejectReason: 'จอแตก', defectReason: 'SCREEN' }],
+    } as never, 'user-1');
+
+    expect(created[0]).toEqual(expect.objectContaining({ status: 'REJECT', defectReason: 'SCREEN', rejectReason: 'จอแตก' }));
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/api && npx jest purchase-orders.defect.spec.ts`
+Expected: FAIL — created item has no `defectReason`.
+
+- [ ] **Step 3: Add the DTO field**
+
+In `dto/create-po.dto.ts`, import the enum and add the field to `GoodsReceivingItemDto`:
+
+```typescript
+import { DefectReason } from '@prisma/client';
+```
+```typescript
+  @IsEnum(DefectReason)
+  @IsOptional()
+  defectReason?: DefectReason;
+```
+Add `IsEnum` to the `class-validator` import list at the top of the file.
+
+- [ ] **Step 4: Persist it in the REJECT branch**
+
+In `po-receiving.service.ts`, in the `else` (REJECT) branch where the rejected `goodsReceivingItem` is created (currently ~lines 301-311), add `defectReason`:
+
+```typescript
+            const rejectedItem = await tx.goodsReceivingItem.create({
+              data: {
+                receivingId: receiving.id,
+                poItemId: item.poItemId,
+                imeiSerial: item.imeiSerial,
+                serialNumber: item.serialNumber,
+                photos: item.photos || [],
+                status: 'REJECT',
+                rejectReason: item.rejectReason,
+                defectReason: item.defectReason ?? null,
+              },
+            });
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd apps/api && npx jest purchase-orders.defect.spec.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Type-check + commit**
+
+```bash
+./tools/check-types.sh all
+git add apps/api/src/modules/purchase-orders
+git commit -m "feat(purchasing): structured DefectReason on rejected receiving items"
+```
+
+---
+
+### Task 5: `GET /purchase-orders/summary` — compute-on-read counts
+
+**Files:**
+- Modify: `apps/api/src/modules/purchase-orders/services/po-query.service.ts` (add `getSummary()`)
+- Modify: `apps/api/src/modules/purchase-orders/purchase-orders.service.ts` (facade)
+- Modify: `apps/api/src/modules/purchase-orders/purchase-orders.controller.ts` (static route, **before** `:id`)
+- Create: `apps/api/src/modules/purchase-orders/purchase-orders.summary.spec.ts`
+
+**Interfaces:**
+- Produces: `PurchaseOrdersService.getSummary(): Promise<{ pendingApproval: number; toOrder: number; incoming: number; overdue: number; receiving: number; waitingQc: number; unpaid: number }>`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/api/src/modules/purchase-orders/purchase-orders.summary.spec.ts`:
+
+```typescript
+import { Test, TestingModule } from '@nestjs/testing';
+import { PurchaseOrdersService } from './purchase-orders.service';
+import { PrismaService } from '../../prisma/prisma.service';
+
+describe('PurchaseOrdersService.getSummary', () => {
+  it('returns compute-on-read counts incl. overdue (ORDERED & expectedDate < now)', async () => {
+    const poCount = jest.fn().mockImplementation(({ where }) => {
+      if (where.status === 'DRAFT') return Promise.resolve(2);
+      if (where.status === 'APPROVED') return Promise.resolve(3);
+      if (where.status === 'ORDERED' && where.expectedDate) return Promise.resolve(1); // overdue
+      if (where.status === 'ORDERED') return Promise.resolve(5); // incoming
+      if (where.status === 'PARTIALLY_RECEIVED') return Promise.resolve(4);
+      if (where.paymentStatus) return Promise.resolve(7); // unpaid
+      return Promise.resolve(0);
+    });
+    const prisma: any = {
+      purchaseOrder: { count: poCount },
+      product: { count: jest.fn().mockResolvedValue(6) }, // waitingQc
+    };
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [PurchaseOrdersService, { provide: PrismaService, useValue: prisma }],
+    }).compile();
+    const service = module.get<PurchaseOrdersService>(PurchaseOrdersService);
+
+    const s = await service.getSummary();
+    expect(s).toEqual({
+      pendingApproval: 2, toOrder: 3, incoming: 5, overdue: 1,
+      receiving: 4, waitingQc: 6, unpaid: 7,
+    });
+    // overdue query must filter ORDERED + expectedDate < now
+    expect(poCount).toHaveBeenCalledWith(
+      expect.objectContaining({ where: expect.objectContaining({ status: 'ORDERED', expectedDate: { lt: expect.any(Date) } }) }),
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/api && npx jest purchase-orders.summary.spec.ts`
+Expected: FAIL — `service.getSummary is not a function`.
+
+- [ ] **Step 3: Implement `getSummary()` in `PoQueryService`**
+
+Add to `po-query.service.ts`:
+
+```typescript
+  async getSummary() {
+    const now = new Date();
+    const base = { deletedAt: null };
+    const [pendingApproval, toOrder, incoming, overdue, receiving, waitingQc, unpaid] = await Promise.all([
+      this.prisma.purchaseOrder.count({ where: { ...base, status: 'DRAFT' } }),
+      this.prisma.purchaseOrder.count({ where: { ...base, status: 'APPROVED' } }),
+      this.prisma.purchaseOrder.count({ where: { ...base, status: 'ORDERED' } }),
+      this.prisma.purchaseOrder.count({ where: { ...base, status: 'ORDERED', expectedDate: { lt: now } } }),
+      this.prisma.purchaseOrder.count({ where: { ...base, status: 'PARTIALLY_RECEIVED' } }),
+      this.prisma.product.count({ where: { deletedAt: null, status: { in: ['QC_PENDING', 'PHOTO_PENDING'] } } }),
+      this.prisma.purchaseOrder.count({ where: { ...base, status: { notIn: ['CANCELLED', 'DRAFT'] }, paymentStatus: { not: 'FULLY_PAID' } } }),
+    ]);
+    return { pendingApproval, toOrder, incoming, overdue, receiving, waitingQc, unpaid };
+  }
+```
+
+- [ ] **Step 4: Add the facade delegate**
+
+In `purchase-orders.service.ts`:
+
+```typescript
+  getSummary() {
+    return this.query.getSummary();
+  }
+```
+
+- [ ] **Step 5: Add the controller route (static, before `:id`)**
+
+In `purchase-orders.controller.ts`, add **above** the `@Get(':id')` route (place it next to `accounts-payable`):
+
+```typescript
+  @Get('summary')
+  @Roles('OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'ACCOUNTANT')
+  getSummary() {
+    return this.purchaseOrdersService.getSummary();
+  }
+```
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run: `cd apps/api && npx jest purchase-orders.summary.spec.ts`
+Expected: PASS.
+
+- [ ] **Step 7: Type-check + commit**
+
+```bash
+./tools/check-types.sh all
+git add apps/api/src/modules/purchase-orders
+git commit -m "feat(purchasing): GET /purchase-orders/summary compute-on-read counts"
+```
+
+---
+
+### Task 6: Retire the dead legacy `receive()` + migrate its race tests onto `goodsReceiving()`
+
+**Files:**
+- Modify: `apps/api/src/modules/purchase-orders/purchase-orders.controller.ts` (delete `POST :id/receive`)
+- Modify: `apps/api/src/modules/purchase-orders/purchase-orders.service.ts` (delete facade `receive`)
+- Modify: `apps/api/src/modules/purchase-orders/services/po-receiving.service.ts` (delete `receive()`)
+- Modify: `apps/api/src/modules/purchase-orders/dto/create-po.dto.ts` (delete `ReceivePODto` + `ReceiveItemDto`)
+- Rewrite: `apps/api/src/modules/purchase-orders/purchase-orders.service.spec.ts` (race tests now drive `goodsReceiving()`; add an IMEI-dup regression test)
+
+**Interfaces:**
+- Removes: `POST /purchase-orders/:id/receive`, `PurchaseOrdersService.receive`, `PoReceivingService.receive`, `ReceivePODto`, `ReceiveItemDto`.
+- Verified safe to remove: zero UI callers (frontend posts only to `/goods-receiving`), zero internal callers, only the 3 race unit tests reference it.
+
+- [ ] **Step 1: Rewrite the race spec to target `goodsReceiving()`**
+
+Replace the body of `purchase-orders.service.spec.ts` with a `goodsReceiving`-driven version. The fresh re-read in `goodsReceiving()` uses `pOItem.findMany` (not `findUnique`), so assert on that:
+
+```typescript
+import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException } from '@nestjs/common';
+import { PurchaseOrdersService } from './purchase-orders.service';
+import { PrismaService } from '../../prisma/prisma.service';
+
+/**
+ * T5-C16: PO goods-receive race condition — now defended on goodsReceiving()
+ * (the legacy receive() path was retired in Purchasing v2 B0). goodsReceiving()
+ * re-reads POItem rows via findMany inside a Serializable tx and rejects a
+ * second batch that would push receivedQty over quantity.
+ */
+describe('PurchaseOrdersService — T5-C16 goodsReceiving race condition', () => {
+  let service: PurchaseOrdersService;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+
+  beforeEach(async () => {
+    const dbState = {
+      items: [{ id: 'poi-1', brand: 'Apple', model: 'iPhone 16', quantity: 5, receivedQty: 0, category: 'PHONE_NEW', accessoryType: null, accessoryBrand: null, color: null, storage: null, unitPrice: 30000 }],
+    };
+    const tx = {
+      purchaseOrder: {
+        findUnique: jest.fn().mockImplementation(() => Promise.resolve({ id: 'po-1', status: 'APPROVED', deletedAt: null, supplierId: 'sup-1', supplier: { id: 'sup-1', name: 'Sup' }, items: dbState.items.map((i) => ({ ...i })) })),
+        update: jest.fn().mockResolvedValue({}),
+      },
+      branch: { findFirst: jest.fn().mockResolvedValue({ id: 'wh', name: 'คลังกลาง' }) },
+      goodsReceiving: { create: jest.fn().mockResolvedValue({ id: 'gr1' }), count: jest.fn().mockResolvedValue(0) },
+      goodsReceivingItem: { create: jest.fn().mockResolvedValue({ id: 'gri1' }) },
+      product: {
+        create: jest.fn().mockImplementation(({ data }) => Promise.resolve({ id: `prod-${Math.random()}`, ...data })),
+        findMany: jest.fn().mockResolvedValue([]), // no existing IMEI conflicts
+      },
+      productPrice: { create: jest.fn() },
+      pOItem: {
+        findMany: jest.fn().mockImplementation(({ where: { id: { in: ids } } }) =>
+          Promise.resolve(dbState.items.filter((i) => ids.includes(i.id)).map((i) => ({ ...i })))),
+        update: jest.fn().mockImplementation(({ where, data }) => {
+          const item = dbState.items.find((i) => i.id === where.id);
+          if (item) item.receivedQty = data.receivedQty;
+          return Promise.resolve(item);
+        }),
+      },
+    };
+    prisma = { $transaction: jest.fn().mockImplementation(async (fn: any) => (typeof fn === 'function' ? fn(tx) : Promise.all(fn))) };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [PurchaseOrdersService, { provide: PrismaService, useValue: prisma }],
+    }).compile();
+    service = module.get<PurchaseOrdersService>(PurchaseOrdersService);
+  });
+
+  const passUnits = (n: number) => ({ items: Array.from({ length: n }, (_, i) => ({ poItemId: 'poi-1', status: 'PASS', imeiSerial: `IMEI-${Math.random()}-${i}` })) });
+
+  it('first batch within ceiling passes and advances receivedQty', async () => {
+    await service.goodsReceiving('po-1', passUnits(3) as never, 'user-1');
+    expect(prisma.$transaction).toHaveBeenCalled();
+    // PO item advanced 0 -> 3 via fresh re-read
+    // (assert on the tx mock's pOItem.update through the closure)
+  });
+
+  it('second batch that would exceed ordered qty is rejected on fresh DB state', async () => {
+    await service.goodsReceiving('po-1', passUnits(3) as never, 'user-1');
+    await expect(service.goodsReceiving('po-1', passUnits(3) as never, 'user-1')).rejects.toThrow(BadRequestException);
+  });
+});
+```
+
+- [ ] **Step 2: Add an IMEI-duplicate regression test (coverage preserved after retiring `receive()`)**
+
+Append to the same spec file a second `describe` proving the existing IMEI guard in `goodsReceiving()` rejects a system-duplicate IMEI:
+
+```typescript
+describe('goodsReceiving — IMEI duplicate guard', () => {
+  it('rejects an IMEI already present in the system', async () => {
+    const tx: any = {
+      purchaseOrder: { findUnique: jest.fn().mockResolvedValue({ id: 'po-1', status: 'APPROVED', deletedAt: null, supplierId: 's1', items: [{ id: 'poi-1', category: 'PHONE_NEW', quantity: 5, receivedQty: 0, brand: 'A', model: 'B' }] }), update: jest.fn() },
+      branch: { findFirst: jest.fn().mockResolvedValue({ id: 'wh', name: 'คลังกลาง' }) },
+      goodsReceiving: { create: jest.fn().mockResolvedValue({ id: 'gr1' }), count: jest.fn().mockResolvedValue(0) },
+      goodsReceivingItem: { create: jest.fn() },
+      pOItem: { findMany: jest.fn().mockResolvedValue([{ id: 'poi-1', quantity: 5, receivedQty: 0, brand: 'A', model: 'B' }]), update: jest.fn() },
+      product: { create: jest.fn(), findMany: jest.fn().mockResolvedValue([{ imeiSerial: 'DUP1', name: 'iPhone', deletedAt: null }]) },
+      productPrice: { create: jest.fn() },
+    };
+    const prisma: any = { $transaction: jest.fn().mockImplementation((fn: any) => fn(tx)) };
+    const module: TestingModule = await Test.createTestingModule({ providers: [PurchaseOrdersService, { provide: PrismaService, useValue: prisma }] }).compile();
+    const service = module.get<PurchaseOrdersService>(PurchaseOrdersService);
+
+    await expect(service.goodsReceiving('po-1', { items: [{ poItemId: 'poi-1', status: 'PASS', imeiSerial: 'DUP1' }] } as never, 'user-1')).rejects.toThrow(/IMEI ซ้ำ/);
+  });
+});
+```
+
+- [ ] **Step 3: Run the rewritten spec to verify it passes against the CURRENT code (before deletion)**
+
+Run: `cd apps/api && npx jest purchase-orders.service.spec.ts`
+Expected: PASS (race + IMEI guard) — proves the migrated tests are green on the surviving `goodsReceiving()` path before we delete `receive()`.
+
+- [ ] **Step 4: Delete `receive()` from the receiving service**
+
+In `po-receiving.service.ts`, delete the entire `receive()` method (lines ~24-121, including its JSDoc). Remove `ReceivePODto` from the import on line 4 → `import { GoodsReceivingDto } from '../dto/create-po.dto';`.
+
+- [ ] **Step 5: Delete the facade method**
+
+In `purchase-orders.service.ts`, delete the `receive(...)` method (lines ~86-88) and remove `ReceivePODto` from the dto import.
+
+- [ ] **Step 6: Delete the controller route**
+
+In `purchase-orders.controller.ts`, delete the `@Post(':id/receive')` block (lines ~163-171) and remove `ReceivePODto` from the dto import on line 4.
+
+- [ ] **Step 7: Delete the DTOs**
+
+In `dto/create-po.dto.ts`, delete `ReceiveItemDto` (lines ~117-123) and `ReceivePODto` (lines ~125-130).
+
+- [ ] **Step 8: Run the full purchase-orders suite + type-check**
+
+Run: `cd apps/api && npx jest --runInBand src/modules/purchase-orders && ./tools/check-types.sh all`
+Expected: all purchase-orders specs PASS; 0 type errors (no lingering `ReceivePODto`/`receive` references).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add apps/api/src/modules/purchase-orders
+git commit -m "refactor(purchasing): retire dead legacy receive(); migrate race+IMEI tests to goodsReceiving()"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage (B0 items):**
+- ORDERED + orderedAt → Task 1 (schema) + Task 2 (action). ✅
+- isDirectReceive column (used by B3) → Task 1. ✅
+- grNumber (2-step migration + generator + Serializable + retry backstop) → Task 1 + Task 3. ✅
+- DefectReason enum + persistence → Task 1 + Task 4. ✅
+- GET /summary (compute-on-read, overdue derived) → Task 5. ✅
+- Retire legacy receive() + migrate 3 race tests → Task 6. ✅
+- IMEI dup guard: **already implemented** in `goodsReceiving()` (po-receiving.service.ts:204-226) — B0 adds a regression test only (Task 6, Step 2), no new guard code. ✅ (documented deviation from the spec's "add guard" wording, which assumed it was missing.)
+
+**Placeholder scan:** none — every code/test step contains full content.
+
+**Type consistency:** `order(id, userId, dto)` signature consistent across lifecycle/facade/controller; `generateGRNumber(tx)` matches `generatePONumber(tx)`; `getSummary()` return keys identical in service, test, and (future) frontend consumer; `defectReason` typed as `DefectReason` from `@prisma/client` in DTO and persisted with the same name.
+
+**Cross-batch note:** `isDirectReceive` and the GR-number return field are consumed by later batches (B1 detail/print, B3 direct-receive, B5 dashboard); their shapes are fixed here.

--- a/docs/superpowers/plans/2026-06-29-purchasing-b1-list-detail.md
+++ b/docs/superpowers/plans/2026-06-29-purchasing-b1-list-detail.md
@@ -1,0 +1,1280 @@
+# Purchasing v2 — Batch 1: PO List + Detail Redesign + Printable Goods Receipt — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the PO list scannable and the PO detail informative on top of the (already-shipped) B0 backend — add an `ORDERED` status everywhere it shows, a partial-receive **progress bar**, a payment **chip**, a computed **overdue badge**, debounced PO#/supplier **search**, clearer **empty states**; wire a **"สั่งซื้อ"** action to `POST /purchase-orders/:id/order`; rebuild the PO detail with a **status timeline**, per-item received/QC progress, and a **GR history** list (grNumber + receiver + time); and add a **printable ใบรับของ (Goods Receipt)** per receiving record reusing the existing `PaymentVoucherPage` print pattern.
+
+**Architecture:** Pure frontend batch over `apps/web/src/pages/PurchaseOrdersPage/**` plus one new lazy-loaded print page + route in `App.tsx`. All data comes from already-existing endpoints (`GET /purchase-orders`, `GET /purchase-orders/:id`, `GET /purchase-orders/:id/goods-receivings/:receivingId`) and the B0 endpoint `POST /purchase-orders/:id/order`. No backend changes, no schema changes — B0 already added `ORDERED`, `orderedAt`, `grNumber`, `DefectReason`.
+
+**Tech Stack:** React 18 + TypeScript + Vite + Tailwind + shadcn/ui + Radix + lucide-react (`apps/web`); `@tanstack/react-query` + `@/lib/api`; vitest + React Testing Library for logic-bearing units; Playwright for e2e (not added in this batch — manual mobile pass instead).
+
+**Spec:** `docs/superpowers/specs/2026-06-29-purchasing-receiving-ux-v2-design.md`
+
+## Global Constraints
+
+- **⛔ BLOCKING PREREQUISITE — B0 must be merged + deployed first.** This batch assumes the B0 backend foundation (`docs/superpowers/plans/2026-06-29-purchasing-b0-backend-foundation.md`) is already in `main`. **Verified 2026-06-29: B0 is NOT yet implemented in this repo** — `schema.prisma` has no `ORDERED` enum value / `orderedAt` / `grNumber` / `DefectReason` / `isDirectReceive`; the controller has no `POST /purchase-orders/:id/order` (the legacy `POST /:id/receive` still exists, i.e. the B0 "retire legacy receive" step also hasn't run). **Do NOT start B1 until B0 is shipped.** Before Task 1, confirm all of these resolve non-empty: `grep -n "ORDERED\|orderedAt\|grNumber" apps/api/prisma/schema.prisma` and `grep -n "':id/order'\|/order" apps/api/src/modules/purchase-orders/purchase-orders.controller.ts`. (Heads-up for the B0 executor, not B1: B0's plan says "next migration ≥ `20260977000000`", but `20260977000000_add_payment_drafts` already exists — B0 must bump to `20260978000000+`. This does not affect B1.)
+- **RED LINE — no accounting/finance:** introduce **NO** import of any accounting/finance/journal/expense/tax module into purchase-orders; do **not** touch `trade-in` or `Product.ownedByCompanyId`; receiving stays **JE-free**. This batch is frontend-only and reads existing PO endpoints — it cannot post a JE; keep it that way (no new API calls to expense/journal/accounting routes).
+- **Additive only:** extend the existing PO page components and types; do not delete the existing `PODetailModal` data flow contract (`selectedPO`/`poDetail` props from `usePurchaseOrdersData`). The new print page is additive.
+- **Frontend rules (`.claude/rules/frontend.md`):**
+  - Data fetching via `@tanstack/react-query` **only**; API calls via `api.get/api.post` from `@/lib/api` **only** — no raw `fetch`/`axios`.
+  - UI: **shadcn/ui + Radix + lucide-react** only. Reuse `Badge` (`@/components/ui/badge`), `Card`/`CardContent` (`@/components/ui/card`), `Button` (`@/components/ui/button`), `DataTable` (`@/components/ui/DataTable`).
+  - **DESIGN TOKENS ONLY** — no hardcoded gray/hex, no `text-gray-*`/`bg-gray-*`, **no `bg-white` except print/receipt context**. Use `bg-background`/`bg-card`/`bg-muted`, `text-foreground`/`text-muted-foreground`, `border-border`, `bg-success`/`bg-warning`/`bg-destructive`/`bg-primary` + token tints (`bg-success/10`, etc.). The print page (`GoodsReceiptPrintPage`) MAY use `bg-white` (it mirrors `PaymentVoucherPage`).
+  - **Thai UI text uses `leading-snug`** (never `leading-none`).
+  - Routes are **lazy-loaded** via `React.lazy()` in `App.tsx`.
+  - Notifications via **`sonner`** `toast.success/error` only — never `alert()`/`confirm()`.
+  - Search inputs use **`useDebounce`** (`@/hooks/useDebounce`).
+- **Money = Decimal:** money fields arrive as decimal strings; render with `Number(x).toLocaleString()` or `formatNumber`/`formatNumberDecimal` from `@/utils/formatters` (existing pattern in these files). Never do float math that could drift a satang in display — progress fractions are unit counts (ints), which is fine.
+- **Type gate:** `./tools/check-types.sh all` must report **0 errors** before each commit.
+- **Tests:** vitest where it adds genuine value (pure compute helpers: overdue/progress/timeline). For visual components, end with concrete MANUAL verification (desktop + mobile viewport). No fake/trivial tests.
+
+---
+
+### Task 1: Add `ORDERED` to constants + status-badge map + the "สั่งซื้อ" mutation
+
+**Files:**
+- Modify: `apps/web/src/pages/PurchaseOrdersPage/constants.ts` (lines 3-19: `statusLabels` + `statusColors`)
+- Modify: `apps/web/src/lib/status-badges.ts` (`poStatusMap`, lines 149-156)
+- Modify: `apps/web/src/pages/PurchaseOrdersPage/hooks/usePurchaseOrdersData.ts` (add `orderMutation` after `approveMutation` ~line 99-106; export it in the return object ~line 366)
+
+**Interfaces:**
+- Consumes: `POST /purchase-orders/:id/order` (B0 endpoint — `APPROVED → ORDERED`, optional body `{ expectedDate?: string }`; returns the updated PO).
+- Produces: `statusLabels.ORDERED = 'สั่งซื้อแล้ว'`, `statusColors.ORDERED`, `poStatusMap.ORDERED`, and `orderMutation: UseMutationResult<unknown, unknown, string, unknown>` (mutate(poId)).
+
+- [ ] **Step 1: Add the `ORDERED` label + color to `constants.ts`**
+
+In `apps/web/src/pages/PurchaseOrdersPage/constants.ts`, add `ORDERED` to both maps (place after `APPROVED`). Note: `statusLabels` is the one that matters — it's read by the Excel export (`index.tsx:85`); `statusColors` is currently **dead code** (defined but imported nowhere — the actual badge colours come from `poStatusMap` in Step 2), so its `ORDERED` entry is added only for consistency and has no visual effect.
+
+```typescript
+export const statusLabels: Record<string, string> = {
+  PENDING: 'รอดำเนินการ',
+  DRAFT: 'รออนุมัติ',
+  APPROVED: 'อนุมัติแล้ว',
+  ORDERED: 'สั่งซื้อแล้ว',
+  PARTIALLY_RECEIVED: 'รับบางส่วน',
+  FULLY_RECEIVED: 'รับครบแล้ว',
+  CANCELLED: 'ยกเลิก',
+};
+
+export const statusColors: Record<string, string> = {
+  PENDING: 'bg-muted text-foreground',
+  DRAFT: 'bg-warning/10 text-warning dark:bg-warning/15',
+  APPROVED: 'bg-primary-100 text-primary-700',
+  ORDERED: 'bg-info/10 text-info dark:bg-info/15',
+  PARTIALLY_RECEIVED: 'bg-warning/10 text-warning dark:bg-warning/15',
+  FULLY_RECEIVED: 'bg-success/10 text-success dark:bg-success/15',
+  CANCELLED: 'bg-destructive/10 text-destructive dark:bg-destructive/15',
+};
+```
+
+- [ ] **Step 2: Add `ORDERED` to the central `poStatusMap`**
+
+In `apps/web/src/lib/status-badges.ts`, add an `ORDERED` entry to `poStatusMap` (after `APPROVED`, line 152). Use the `info` variant so it visually reads as "in flight" distinct from `primary` (APPROVED) and `warning` (partial):
+
+```typescript
+export const poStatusMap: Record<string, StatusConfig> = {
+  PENDING: { variant: 'secondary', label: 'รอดำเนินการ' },
+  DRAFT: { variant: 'warning', appearance: 'light', label: 'รออนุมัติ' },
+  APPROVED: { variant: 'primary', appearance: 'light', label: 'อนุมัติแล้ว' },
+  ORDERED: { variant: 'info', appearance: 'light', label: 'สั่งซื้อแล้ว' },
+  PARTIALLY_RECEIVED: { variant: 'warning', appearance: 'light', label: 'รับบางส่วน' },
+  FULLY_RECEIVED: { variant: 'success', appearance: 'light', label: 'รับครบแล้ว' },
+  CANCELLED: { variant: 'destructive', appearance: 'light', label: 'ยกเลิก' },
+};
+```
+
+(`info` is a valid `badgeVariants` variant — verified in `apps/web/src/components/ui/badge.tsx` compound-variant list at lines 75-76, `variant: 'info', appearance: 'light'`.)
+
+- [ ] **Step 3: Add `orderMutation` to `usePurchaseOrdersData`**
+
+In `apps/web/src/pages/PurchaseOrdersPage/hooks/usePurchaseOrdersData.ts`, add a new mutation immediately after `approveMutation` (which ends at line 106). It mirrors `approveMutation` exactly but hits the B0 order endpoint:
+
+```typescript
+  const orderMutation = useMutation({
+    mutationFn: async (id: string) => api.post(`/purchase-orders/${id}/order`),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['purchase-orders'] });
+      toast.success('สั่งซื้อ PO สำเร็จ (สถานะ: สั่งซื้อแล้ว)');
+    },
+    onError: (err: unknown) => toast.error(getErrorMessage(err)),
+  });
+```
+
+- [ ] **Step 4: Export `orderMutation` from the hook**
+
+In the same file, add `orderMutation,` to the returned `// Mutations` block (next to `approveMutation,` at line 367):
+
+```typescript
+    // Mutations
+    qcConfirmMutation,
+    createMutation,
+    approveMutation,
+    orderMutation,
+    rejectPOMutation,
+    cancelMutation,
+    goodsReceivingMutation,
+    paymentMutation,
+```
+
+- [ ] **Step 5: Type-check**
+
+Run: `./tools/check-types.sh all`
+Expected: 0 errors. (`api`, `useMutation`, `getErrorMessage`, `queryClient`, `toast` are all already imported in this file — lines 2-4.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/pages/PurchaseOrdersPage/constants.ts apps/web/src/lib/status-badges.ts apps/web/src/pages/PurchaseOrdersPage/hooks/usePurchaseOrdersData.ts
+git commit -m "feat(purchasing-web): ORDERED label/badge + สั่งซื้อ mutation (POST :id/order)"
+```
+
+---
+
+### Task 2: List compute helpers (progress + overdue) with vitest coverage
+
+**Files:**
+- Create: `apps/web/src/pages/PurchaseOrdersPage/po-list.util.ts`
+- Create: `apps/web/src/pages/PurchaseOrdersPage/po-list.util.test.ts`
+
+**Interfaces:**
+- Produces:
+  - `receiveProgress(po: { items: { quantity: number; receivedQty: number }[] }): { received: number; ordered: number; pct: number }` — `pct` is 0-100, `0` when `ordered === 0`.
+  - `isOverdue(po: { status: string; expectedDate: string | null }, now?: Date): boolean` — `true` **only** when `status === 'ORDERED' && expectedDate != null && new Date(expectedDate) < now`. (Matches spec decision 4: overdue = `status = ORDERED AND expectedDate < now`.)
+
+These are pure, reused by `POListTab` (Task 3) and the timeline (Task 4), and are exactly the kind of logic worth a real test (the spec calls out the overdue rule precisely).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/web/src/pages/PurchaseOrdersPage/po-list.util.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { receiveProgress, isOverdue } from './po-list.util';
+
+describe('receiveProgress', () => {
+  it('sums received/ordered across items and computes pct', () => {
+    const po = { items: [{ quantity: 7, receivedQty: 3 }, { quantity: 3, receivedQty: 0 }] };
+    expect(receiveProgress(po)).toEqual({ received: 3, ordered: 10, pct: 30 });
+  });
+
+  it('caps pct at 100 when over-received (defensive)', () => {
+    const po = { items: [{ quantity: 2, receivedQty: 5 }] };
+    expect(receiveProgress(po).pct).toBe(100);
+  });
+
+  it('returns pct 0 (not NaN) for an empty PO', () => {
+    expect(receiveProgress({ items: [] })).toEqual({ received: 0, ordered: 0, pct: 0 });
+  });
+});
+
+describe('isOverdue', () => {
+  const now = new Date('2026-06-29T00:00:00Z');
+
+  it('is true for an ORDERED PO past its expectedDate', () => {
+    expect(isOverdue({ status: 'ORDERED', expectedDate: '2026-06-20' }, now)).toBe(true);
+  });
+
+  it('is false for an ORDERED PO not yet due', () => {
+    expect(isOverdue({ status: 'ORDERED', expectedDate: '2026-07-10' }, now)).toBe(false);
+  });
+
+  it('is false when not ORDERED even if past due (e.g. APPROVED / PARTIALLY_RECEIVED)', () => {
+    expect(isOverdue({ status: 'APPROVED', expectedDate: '2026-06-20' }, now)).toBe(false);
+    expect(isOverdue({ status: 'PARTIALLY_RECEIVED', expectedDate: '2026-06-20' }, now)).toBe(false);
+  });
+
+  it('is false when expectedDate is null', () => {
+    expect(isOverdue({ status: 'ORDERED', expectedDate: null }, now)).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/web && npx vitest run src/pages/PurchaseOrdersPage/po-list.util.test.ts`
+Expected: FAIL — module `./po-list.util` not found.
+
+- [ ] **Step 3: Implement the helpers**
+
+Create `apps/web/src/pages/PurchaseOrdersPage/po-list.util.ts`:
+
+```typescript
+/**
+ * Pure compute helpers for the PO list/detail. Kept out of the components so
+ * the overdue rule (spec decision 4: status=ORDERED AND expectedDate < now)
+ * and the partial-receive progress math are unit-tested in one place.
+ */
+
+export function receiveProgress(po: {
+  items: { quantity: number; receivedQty: number }[];
+}): { received: number; ordered: number; pct: number } {
+  const ordered = po.items.reduce((s, i) => s + i.quantity, 0);
+  const received = po.items.reduce((s, i) => s + i.receivedQty, 0);
+  const pct = ordered > 0 ? Math.min(Math.round((received / ordered) * 100), 100) : 0;
+  return { received, ordered, pct };
+}
+
+export function isOverdue(
+  po: { status: string; expectedDate: string | null },
+  now: Date = new Date(),
+): boolean {
+  if (po.status !== 'ORDERED' || !po.expectedDate) return false;
+  return new Date(po.expectedDate) < now;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/web && npx vitest run src/pages/PurchaseOrdersPage/po-list.util.test.ts`
+Expected: PASS (7 assertions across 2 describes).
+
+- [ ] **Step 5: Type-check + commit**
+
+```bash
+./tools/check-types.sh all
+git add apps/web/src/pages/PurchaseOrdersPage/po-list.util.ts apps/web/src/pages/PurchaseOrdersPage/po-list.util.test.ts
+git commit -m "feat(purchasing-web): receiveProgress + isOverdue list helpers (tested)"
+```
+
+---
+
+### Task 3: `POListTab` redesign — status pills (incl. ORDERED), progress bar, payment chip, overdue badge, search, สั่งซื้อ action, empty states
+
+**Files:**
+- Modify: `apps/web/src/pages/PurchaseOrdersPage/components/POListTab.tsx` (imports lines 1-18; props interface lines 22-35; status `<select>` lines 329-340; filter-chip status map lines 371-384; `received` column lines 222-244; `status` column lines 187-199; `actions` column lines 245-313; search input lines 322-328; `DataTable` empty props lines 405-408)
+- Modify: `apps/web/src/pages/PurchaseOrdersPage/index.tsx` (pass `orderMutation` into `<POListTab>` — props block lines 141-154)
+
+**Interfaces:**
+- Consumes: `data.orderMutation` (Task 1); `receiveProgress`, `isOverdue` (Task 2); `useDebounce` (`@/hooks/useDebounce`).
+- Produces: redesigned list with new `POListTabProps.orderMutation`.
+
+- [ ] **Step 1: Add `orderMutation` to `POListTabProps` + import the helpers + `useDebounce` + icons**
+
+In `POListTab.tsx`, update the imports. The current first lines are:
+
+```typescript
+import { useMemo, useState } from 'react';
+import { UseMutationResult } from '@tanstack/react-query';
+import DataTable, { Column } from '@/components/ui/DataTable';
+import { formatDateShort } from '@/utils/formatters';
+import { PurchaseOrder } from '../types';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent } from '@/components/ui/card';
+import { getStatusBadgeProps, poStatusMap, poPaymentStatusMap } from '@/lib/status-badges';
+import { PackageCheck, Check, X, Ban, FileText, Search } from 'lucide-react';
+```
+
+Change to (add `useDebounce`, the two helpers, and the `ShoppingCart` + `AlertTriangle` icons):
+
+```typescript
+import { useMemo, useState } from 'react';
+import { UseMutationResult } from '@tanstack/react-query';
+import DataTable, { Column } from '@/components/ui/DataTable';
+import { formatDateShort } from '@/utils/formatters';
+import { useDebounce } from '@/hooks/useDebounce';
+import { PurchaseOrder } from '../types';
+import { receiveProgress, isOverdue } from '../po-list.util';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent } from '@/components/ui/card';
+import { getStatusBadgeProps, poStatusMap, poPaymentStatusMap } from '@/lib/status-badges';
+import { PackageCheck, Check, X, Ban, FileText, Search, ShoppingCart, AlertTriangle } from 'lucide-react';
+```
+
+Then add `orderMutation` to `POListTabProps` (after `approveMutation` at line 30):
+
+```typescript
+  approveMutation: UseMutationResult<unknown, unknown, string, unknown>;
+  orderMutation: UseMutationResult<unknown, unknown, string, unknown>;
+  rejectPOMutation: UseMutationResult<unknown, unknown, { id: string; reason: string }, unknown>;
+```
+
+And add `orderMutation` to the destructured params of `POListTab(...)` (after `approveMutation` at line 74):
+
+```typescript
+  approveMutation,
+  orderMutation,
+  rejectPOMutation,
+```
+
+- [ ] **Step 2: Debounce the search so filtering is not per-keystroke**
+
+The current `filteredPos` keys off raw `search` (line 89-107). Add a debounced value and use it in the memo. Right after the `const [search, setSearch] = useState('');` line (line 80), add:
+
+```typescript
+  const debouncedSearch = useDebounce(search, 250);
+```
+
+Then change the `filteredPos` memo's first line from `const q = search.trim().toLowerCase();` to use the debounced value, and update its dependency array:
+
+```typescript
+  const filteredPos = useMemo(() => {
+    const q = debouncedSearch.trim().toLowerCase();
+    const range = periodRange(periodFilter);
+    return pos.filter((po) => {
+      if (supplierFilter && po.supplier.id !== supplierFilter) return false;
+      if (range) {
+        const d = new Date(po.orderDate);
+        if (d < range.start || d >= range.end) return false;
+      }
+      if (q) {
+        const hay = [po.poNumber, po.supplier.name, po.supplier.contactName]
+          .filter(Boolean)
+          .join(' ')
+          .toLowerCase();
+        if (!hay.includes(q)) return false;
+      }
+      return true;
+    });
+  }, [pos, debouncedSearch, supplierFilter, periodFilter]);
+```
+
+(`hasFilter` at line 316 still keys off the immediate `search` so the chip row appears instantly — leave it as `Boolean(search || statusFilter || supplierFilter || periodFilter)`.)
+
+- [ ] **Step 3: Add `ORDERED` to the status `<select>` and the active-chip label map**
+
+In the status filter `<select>` (lines 334-339), add the `ORDERED` option after `APPROVED`:
+
+```tsx
+          <option value="">ทุกสถานะ</option>
+          <option value="DRAFT">รออนุมัติ</option>
+          <option value="APPROVED">อนุมัติแล้ว</option>
+          <option value="ORDERED">สั่งซื้อแล้ว</option>
+          <option value="PARTIALLY_RECEIVED">รับบางส่วน</option>
+          <option value="FULLY_RECEIVED">รับครบแล้ว</option>
+          <option value="CANCELLED">ยกเลิก</option>
+```
+
+And in the active-filter chip label map (lines 374-380) add the `ORDERED` key:
+
+```tsx
+              label={`สถานะ: ${
+                {
+                  DRAFT: 'รออนุมัติ',
+                  APPROVED: 'อนุมัติแล้ว',
+                  ORDERED: 'สั่งซื้อแล้ว',
+                  PARTIALLY_RECEIVED: 'รับบางส่วน',
+                  FULLY_RECEIVED: 'รับครบแล้ว',
+                  CANCELLED: 'ยกเลิก',
+                }[statusFilter] || statusFilter
+              }`}
+```
+
+- [ ] **Step 4: Make the status column a pill that also shows the OVERDUE badge**
+
+Replace the existing `status` column render (lines 187-199) with one that appends a red "เลยกำหนด" badge when `isOverdue(po)` is true (the status pill itself stays the centralized `poStatusMap` badge, which now includes `ORDERED` from Task 1):
+
+```tsx
+    {
+      key: 'status',
+      label: 'สถานะ',
+      sortable: true,
+      render: (po) => {
+        const cfg = getStatusBadgeProps(po.status, poStatusMap);
+        return (
+          <div className="flex flex-col items-start gap-1">
+            <Badge variant={cfg.variant} appearance={cfg.appearance}>
+              {cfg.label}
+            </Badge>
+            {isOverdue(po) && (
+              <Badge variant="destructive" appearance="light" className="gap-1">
+                <AlertTriangle className="size-3" />
+                เลยกำหนด
+              </Badge>
+            )}
+          </div>
+        );
+      },
+    },
+```
+
+(`Badge` accepts `className` — it's a `cva` component; existing call sites pass only variant/appearance, but className is supported via `cn(...)` inside `badge.tsx`.)
+
+- [ ] **Step 5: Rewrite the `received` (progress) column to use `receiveProgress`**
+
+Replace the existing `received` column (lines 222-244) so the count + bar come from the shared helper and the label reads "รับแล้ว N/M" with token colors:
+
+```tsx
+    {
+      key: 'received',
+      label: 'รับสินค้า',
+      render: (po) => {
+        const { received, ordered, pct } = receiveProgress(po);
+        const done = ordered > 0 && received >= ordered;
+        return (
+          <div className="flex items-center gap-2 min-w-[120px]">
+            <span className="text-sm whitespace-nowrap tabular-nums">
+              <span className="text-muted-foreground">รับแล้ว </span>
+              <span className={done ? 'text-success font-semibold' : 'font-medium'}>{received}</span>
+              <span className="text-muted-foreground">/{ordered}</span>
+            </span>
+            {ordered > 0 && (
+              <div className="flex-1 bg-secondary rounded-full h-1.5 min-w-[40px]">
+                <div
+                  className={`h-1.5 rounded-full ${done ? 'bg-success' : 'bg-primary'}`}
+                  style={{ width: `${pct}%` }}
+                />
+              </div>
+            )}
+          </div>
+        );
+      },
+    },
+```
+
+- [ ] **Step 6: Add a "สั่งซื้อ" action button for APPROVED POs + show receive for ORDERED too**
+
+In the `actions` column (lines 245-313), two edits:
+
+(a) The receive button currently shows for `['APPROVED', 'PARTIALLY_RECEIVED']` (line 259). Add `'ORDERED'` so an ordered PO can be received directly (back-compat: receive is allowed from ORDERED **or** APPROVED per spec state machine):
+
+```tsx
+          {['APPROVED', 'ORDERED', 'PARTIALLY_RECEIVED'].includes(po.status) && (
+            <button
+              onClick={() => openReceiveModal(po)}
+              className="p-1.5 rounded-md text-primary hover:bg-primary/10 transition-colors"
+              title="รับสินค้า"
+              aria-label={`รับสินค้า ${po.poNumber}`}
+            >
+              <PackageCheck className="size-4" />
+            </button>
+          )}
+```
+
+(b) Add a new "สั่งซื้อ" button that shows only for `APPROVED` POs, immediately **before** the receive button block:
+
+```tsx
+          {po.status === 'APPROVED' && (
+            <button
+              onClick={() => {
+                setConfirmDialog({
+                  open: true,
+                  message: `ยืนยันสั่งซื้อ PO ${po.poNumber}? (สถานะจะเปลี่ยนเป็น "สั่งซื้อแล้ว")`,
+                  action: () => orderMutation.mutate(po.id),
+                });
+              }}
+              disabled={orderMutation.isPending}
+              className="p-1.5 rounded-md text-info hover:bg-info/10 transition-colors disabled:opacity-50"
+              title="สั่งซื้อ"
+              aria-label={`สั่งซื้อ ${po.poNumber}`}
+            >
+              <ShoppingCart className="size-4" />
+            </button>
+          )}
+```
+
+- [ ] **Step 7: Add the payment chip column made always-clickable + clearer empty states**
+
+The payment column (lines 200-221) is already a clickable chip via `poPaymentStatusMap` — **no change needed**; it already satisfies the spec's "payment CHIP". (Note in Self-Review.)
+
+For empty states, the `DataTable` already takes `emptyMessage`/`emptyIcon`/`emptyDescription` (lines 405-408). Improve the no-filter empty message to be actionable (the filter case is already good). Change lines 406-408 to:
+
+```tsx
+            emptyMessage={hasFilter ? 'ไม่พบใบสั่งซื้อที่ตรงกับตัวกรอง' : 'ยังไม่มีใบสั่งซื้อ'}
+            emptyIcon={hasFilter ? Search : ShoppingCart}
+            emptyDescription={
+              hasFilter
+                ? 'ลองล้างตัวกรองหรือเปลี่ยนคำค้นหา'
+                : 'กด "+ สร้าง PO" ที่มุมขวาบนเพื่อเริ่มสั่งซื้อสินค้าจากผู้จัดจำหน่าย'
+            }
+```
+
+- [ ] **Step 8: Pass `orderMutation` from `index.tsx`**
+
+In `apps/web/src/pages/PurchaseOrdersPage/index.tsx`, the `<POListTab ... />` props block is at lines 141-154. Add `orderMutation` after `approveMutation`:
+
+```tsx
+        <POListTab
+          statusFilter={data.statusFilter}
+          setStatusFilter={data.setStatusFilter}
+          pos={data.pos}
+          isLoading={data.isLoading}
+          openDetailModal={data.openDetailModal}
+          openReceiveModal={data.openReceiveModal}
+          openPaymentModal={data.openPaymentModal}
+          approveMutation={data.approveMutation}
+          orderMutation={data.orderMutation}
+          rejectPOMutation={data.rejectPOMutation}
+          cancelMutation={data.cancelMutation}
+          setConfirmDialog={data.setConfirmDialog}
+          suppliers={data.suppliers}
+        />
+```
+
+- [ ] **Step 9: Type-check**
+
+Run: `./tools/check-types.sh all`
+Expected: 0 errors.
+
+- [ ] **Step 10: Run the existing web unit tests to confirm no regression**
+
+Run: `cd apps/web && npx vitest run src/pages/PurchaseOrdersPage`
+Expected: PASS (the Task 2 util test; this task added no new test file).
+
+- [ ] **Step 11: MANUAL verification (desktop + mobile)**
+
+Start dev: `cd apps/web && npm run dev` (login as `admin@bestchoice.com` / `admin1234`), go to `/purchase-orders`.
+- **Desktop:** confirm the list shows: status pill with the new "สั่งซื้อแล้ว" (info/blue) for any ORDERED PO; a red "เลยกำหนด" badge under status when an ORDERED PO's expectedDate is in the past; a "รับแล้ว N/M" + progress bar in the รับสินค้า column; the payment chip is still clickable (opens payment modal). On an **APPROVED** PO confirm a cart (สั่งซื้อ) icon appears → click it → confirm dialog → on confirm the row flips to "สั่งซื้อแล้ว" and a green toast shows. Type a PO# in search → list filters after ~250ms.
+- **Mobile (DevTools responsive, ~390px width):** the filter row wraps (`flex-wrap` already present); the progress bar shrinks but the count stays readable; action icons remain tappable. Verify the empty state (filter to a status with 0 rows) shows the Search icon + "ลองล้างตัวกรอง…" copy.
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add apps/web/src/pages/PurchaseOrdersPage/components/POListTab.tsx apps/web/src/pages/PurchaseOrdersPage/index.tsx
+git commit -m "feat(purchasing-web): PO list — ORDERED pill, overdue badge, progress bar, สั่งซื้อ action, debounced search, empty states"
+```
+
+---
+
+### Task 4: PO detail redesign — status timeline + per-item received/QC progress + GR history (grNumber + receiver + time + print link)
+
+**Files:**
+- Modify: `apps/web/src/pages/PurchaseOrdersPage/types.ts` (add `grNumber` to `GoodsReceivingRecord`, lines 25-31; add `orderedAt` to `PurchaseOrder` after `expectedDate`; add an optional `receivingItems?` array to `POItem` for the QC tally — Step 7. Do NOT add `poItemId` to `GoodsReceivingItem`.)
+- Modify: `apps/web/src/pages/PurchaseOrdersPage/components/PODetailModal.tsx` (add a timeline block after the general-info card ~line 96; enrich the รายการสินค้า table received/คงเหลือ cells which already exist lines 255-264 — add a per-item QC mini-summary computed from `selectedPO.items[].receivingItems[].product.status`; enrich the GR-history block lines 290-350 to show `grNumber` + a print link; widen the sticky-footer receive gate to include `ORDERED` — Step 9)
+- Create: `apps/web/src/pages/PurchaseOrdersPage/po-detail.util.ts`
+- Create: `apps/web/src/pages/PurchaseOrdersPage/po-detail.util.test.ts`
+
+**Interfaces:**
+- Consumes: `selectedPO: PurchaseOrder`, `poDetail: PODetail | null` (existing props); `receiveProgress`/`isOverdue` (Task 2); `useNavigate` from `react-router` (for the print link).
+- Produces:
+  - `GoodsReceivingRecord.grNumber: string` (type addition — backend already returns it after B0).
+  - `timelineSteps(po: { status: string; orderedAt?: string | null; ... }): { key: string; label: string; state: 'done' | 'current' | 'upcoming' | 'cancelled' }[]` in `po-detail.util.ts`.
+
+- [ ] **Step 1: Add `grNumber` to the `GoodsReceivingRecord` type + `orderedAt`/`expectedDate` already present**
+
+In `apps/web/src/pages/PurchaseOrdersPage/types.ts`, the `GoodsReceivingRecord` interface (lines 25-31) lacks `grNumber`. Add it (backend `findOne` includes it post-B0 via the `goodsReceivings` include):
+
+```typescript
+export interface GoodsReceivingRecord {
+  id: string;
+  grNumber: string;
+  createdAt: string;
+  notes: string | null;
+  receivedBy: { id: string; name: string };
+  items: GoodsReceivingItem[];
+}
+```
+
+Also add `orderedAt` to `PurchaseOrder` (additive — the backend returns it post-B0; the `isOverdue` helper keys off `expectedDate`+`status`, and `timelineSteps` keys off `status`, so `orderedAt` is not strictly consumed by B1 logic, but typing it keeps the shape honest and lets the detail surface "สั่งเมื่อ" later). Insert it between the existing `expectedDate` (line 37) and `dueDate` (line 38) — do NOT re-declare `dueDate`, it already exists:
+
+```typescript
+  expectedDate: string | null;
+  orderedAt: string | null;
+  dueDate: string | null;
+```
+
+- [ ] **Step 2: Write the failing test for `timelineSteps`**
+
+Create `apps/web/src/pages/PurchaseOrdersPage/po-detail.util.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { timelineSteps } from './po-detail.util';
+
+const stateOf = (steps: ReturnType<typeof timelineSteps>, key: string) =>
+  steps.find((s) => s.key === key)?.state;
+
+describe('timelineSteps', () => {
+  it('has 5 steps in order: draft → approved → ordered → received → completed', () => {
+    const steps = timelineSteps({ status: 'DRAFT' });
+    expect(steps.map((s) => s.key)).toEqual(['draft', 'approved', 'ordered', 'received', 'completed']);
+  });
+
+  it('DRAFT: draft is current, rest upcoming', () => {
+    const s = timelineSteps({ status: 'DRAFT' });
+    expect(stateOf(s, 'draft')).toBe('current');
+    expect(stateOf(s, 'approved')).toBe('upcoming');
+  });
+
+  it('ORDERED: draft+approved+ordered done, ordered is current, received upcoming', () => {
+    const s = timelineSteps({ status: 'ORDERED' });
+    expect(stateOf(s, 'draft')).toBe('done');
+    expect(stateOf(s, 'approved')).toBe('done');
+    expect(stateOf(s, 'ordered')).toBe('current');
+    expect(stateOf(s, 'received')).toBe('upcoming');
+  });
+
+  it('PARTIALLY_RECEIVED: received is current, prior all done', () => {
+    const s = timelineSteps({ status: 'PARTIALLY_RECEIVED' });
+    expect(stateOf(s, 'ordered')).toBe('done');
+    expect(stateOf(s, 'received')).toBe('current');
+    expect(stateOf(s, 'completed')).toBe('upcoming');
+  });
+
+  it('FULLY_RECEIVED: every step done, completed current', () => {
+    const s = timelineSteps({ status: 'FULLY_RECEIVED' });
+    expect(stateOf(s, 'received')).toBe('done');
+    expect(stateOf(s, 'completed')).toBe('current');
+  });
+
+  it('CANCELLED: all steps marked cancelled', () => {
+    const s = timelineSteps({ status: 'CANCELLED' });
+    expect(s.every((st) => st.state === 'cancelled')).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `cd apps/web && npx vitest run src/pages/PurchaseOrdersPage/po-detail.util.test.ts`
+Expected: FAIL — module `./po-detail.util` not found.
+
+- [ ] **Step 4: Implement `timelineSteps`**
+
+Create `apps/web/src/pages/PurchaseOrdersPage/po-detail.util.ts`:
+
+```typescript
+/**
+ * PO status timeline (spec: Draft → อนุมัติ → สั่งแล้ว → รับ → ครบ).
+ * Maps the PO status to a per-step state so the detail view can render a
+ * progress timeline. PARTIALLY_RECEIVED and APPROVED back-compat both handled.
+ */
+
+export type TimelineState = 'done' | 'current' | 'upcoming' | 'cancelled';
+
+export interface TimelineStep {
+  key: 'draft' | 'approved' | 'ordered' | 'received' | 'completed';
+  label: string;
+  state: TimelineState;
+}
+
+const ORDER: TimelineStep['key'][] = ['draft', 'approved', 'ordered', 'received', 'completed'];
+const LABELS: Record<TimelineStep['key'], string> = {
+  draft: 'รออนุมัติ',
+  approved: 'อนุมัติ',
+  ordered: 'สั่งแล้ว',
+  received: 'รับเข้า',
+  completed: 'รับครบ',
+};
+
+// Which step index is "current" for each status.
+const CURRENT_INDEX: Record<string, number> = {
+  DRAFT: 0,
+  APPROVED: 1,
+  ORDERED: 2,
+  PARTIALLY_RECEIVED: 3,
+  FULLY_RECEIVED: 4,
+};
+
+export function timelineSteps(po: { status: string }): TimelineStep[] {
+  if (po.status === 'CANCELLED') {
+    return ORDER.map((key) => ({ key, label: LABELS[key], state: 'cancelled' as TimelineState }));
+  }
+  const current = CURRENT_INDEX[po.status] ?? 0;
+  return ORDER.map((key, idx) => {
+    let state: TimelineState;
+    if (idx < current) state = 'done';
+    else if (idx === current) state = 'current';
+    else state = 'upcoming';
+    return { key, label: LABELS[key], state };
+  });
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd apps/web && npx vitest run src/pages/PurchaseOrdersPage/po-detail.util.test.ts`
+Expected: PASS (6 tests).
+
+- [ ] **Step 6: Render the timeline in `PODetailModal` (after the general-info card)**
+
+In `PODetailModal.tsx`, add the imports at the top. Current first lines:
+
+```typescript
+import { formatDateShort, formatDateMedium, formatDateTime } from '@/utils/formatters';
+import { PurchaseOrder, PODetail, POItem } from '../types';
+import { Badge } from '@/components/ui/badge';
+import { getStatusBadgeProps, poStatusMap, poPaymentStatusMap } from '@/lib/status-badges';
+```
+
+Change to:
+
+```typescript
+import { useNavigate } from 'react-router';
+import { formatDateShort, formatDateMedium, formatDateTime } from '@/utils/formatters';
+import { PurchaseOrder, PODetail, POItem } from '../types';
+import { timelineSteps } from '../po-detail.util';
+import { Badge } from '@/components/ui/badge';
+import { getStatusBadgeProps, poStatusMap, poPaymentStatusMap } from '@/lib/status-badges';
+import { Check, Circle, Printer } from 'lucide-react';
+```
+
+Inside the component body, add `const navigate = useNavigate();` right after the `getItemDesc` definition (before `if (!isOpen) return null;` at line 36).
+
+Then insert a **timeline card** immediately after the closing `</div>` of the "ข้อมูลทั่วไป" card (line 96, just before the "การจ่ายเงิน" card at line 98):
+
+```tsx
+              {/* สถานะการดำเนินการ (timeline) */}
+              {selectedPO.status !== 'CANCELLED' && (
+                <div className="rounded-xl border border-border/50 bg-card p-5 shadow-sm">
+                  <h3 className="text-sm font-semibold text-foreground mb-4 leading-snug">สถานะการดำเนินการ</h3>
+                  <ol className="flex items-center justify-between gap-1">
+                    {timelineSteps(selectedPO).map((step, idx, arr) => {
+                      const done = step.state === 'done';
+                      const current = step.state === 'current';
+                      return (
+                        <li key={step.key} className="flex-1 flex flex-col items-center text-center relative">
+                          {idx < arr.length - 1 && (
+                            <span
+                              className={`absolute top-3 left-1/2 w-full h-0.5 ${done ? 'bg-success' : 'bg-border'}`}
+                              aria-hidden
+                            />
+                          )}
+                          <span
+                            className={`relative z-10 flex items-center justify-center size-6 rounded-full border-2 ${
+                              done
+                                ? 'bg-success border-success text-success-foreground'
+                                : current
+                                  ? 'bg-primary border-primary text-primary-foreground'
+                                  : 'bg-background border-border text-muted-foreground'
+                            }`}
+                          >
+                            {done ? <Check className="size-3.5" /> : <Circle className="size-2 fill-current" />}
+                          </span>
+                          <span
+                            className={`mt-1.5 text-[11px] leading-snug ${
+                              current ? 'text-primary font-semibold' : done ? 'text-foreground' : 'text-muted-foreground'
+                            }`}
+                          >
+                            {step.label}
+                          </span>
+                        </li>
+                      );
+                    })}
+                  </ol>
+                </div>
+              )}
+```
+
+(`success-foreground`/`primary-foreground` are existing tokens used elsewhere; `Circle className="fill-current"` gives a filled dot.)
+
+- [ ] **Step 7: Add a per-item QC mini-summary to the รายการสินค้า table**
+
+The product table already renders `รับแล้ว`/`คงเหลือ` per item (lines 255-264). Add a per-item QC indicator column derived from each PO item's received products' status.
+
+> **DATA-SOURCE CORRECTION (verified against `po-query.service.ts:47-78`):** `findOne` returns `goodsReceivings.items` with a plain `items: true` — those raw rows carry **no `product` relation**, so reading `gr.items[].product.status` from `poDetail.goodsReceivings` would be `undefined` at runtime and the QC column would always render "-". The QC product status **is** available, but on a different include: `findOne` selects PO `items` with `items.include.receivingItems.include.product` (`{ id, name, imeiSerial, serialNumber, status, branchId }`). So compute the QC tally **per PO item** from `selectedPO.items[].receivingItems[].product.status` — data that is actually present. This keeps B1 frontend-only (no backend include change needed).
+
+First, expose `receivingItems` on the frontend `POItem` type so the compute is typed. In `apps/web/src/pages/PurchaseOrdersPage/types.ts`, add a `receivingItems?` field to `POItem` (optional because the list endpoint `findAll` returns `items: true` WITHOUT `receivingItems` — only the detail `findOne` populates it):
+
+```typescript
+export interface POItem {
+  id: string;
+  brand: string;
+  model: string;
+  color: string | null;
+  storage: string | null;
+  category: string | null;
+  quantity: number;
+  unitPrice: string;
+  receivedQty: number;
+  accessoryType: string | null;
+  accessoryBrand: string | null;
+  receivingItems?: {
+    id: string;
+    status: 'PASS' | 'REJECT';
+    product: { id: string; status: string } | null;
+  }[];
+}
+```
+
+(Do **not** add `poItemId` to `GoodsReceivingItem` — the QC compute no longer needs it. The existing `GoodsReceivingItem.product` field stays as-is for the GR-history block, which today never reads `product` anyway because `findOne`'s `goodsReceivings.items: true` omits it.)
+
+Then add this helper inside the component (after `navigate`), keyed by PO item id:
+
+```tsx
+  // Per-PO-item QC tally from each item's receiving products (findOne includes
+  // items.receivingItems.product.status — see po-query.service.ts:55-62).
+  const qcByItem = new Map<string, { qcPending: number; inStock: number }>();
+  for (const item of selectedPO.items) {
+    const acc = { qcPending: 0, inStock: 0 };
+    for (const ri of item.receivingItems ?? []) {
+      if (ri.status !== 'PASS' || !ri.product) continue;
+      if (ri.product.status === 'QC_PENDING' || ri.product.status === 'PHOTO_PENDING') acc.qcPending += 1;
+      else if (ri.product.status === 'IN_STOCK') acc.inStock += 1;
+    }
+    if (acc.qcPending > 0 || acc.inStock > 0) qcByItem.set(item.id, acc);
+  }
+```
+
+Add a "QC" header to the table `<thead>` (after the `คงเหลือ` header at line 238):
+
+```tsx
+                      <th className="px-3 py-2.5 text-right font-semibold">คงเหลือ</th>
+                      <th className="px-3 py-2.5 text-right font-semibold">QC</th>
+                      <th className="px-3 py-2.5 text-right font-semibold">รวม</th>
+```
+
+And add the matching cell in each row, after the `คงเหลือ` `<td>` (which ends at line 264):
+
+```tsx
+                        <td className="px-3 py-2.5 text-right">
+                          {(() => {
+                            const qc = qcByItem.get(item.id);
+                            if (!qc || (qc.qcPending === 0 && qc.inStock === 0)) return <span className="text-muted-foreground">-</span>;
+                            return (
+                              <div className="flex flex-col items-end gap-0.5">
+                                {qc.qcPending > 0 && (
+                                  <Badge variant="warning" appearance="light" className="text-[10px]">รอ QC {qc.qcPending}</Badge>
+                                )}
+                                {qc.inStock > 0 && (
+                                  <Badge variant="success" appearance="light" className="text-[10px]">เข้าสต็อก {qc.inStock}</Badge>
+                                )}
+                              </div>
+                            );
+                          })()}
+                        </td>
+```
+
+- [ ] **Step 8: Enrich the GR-history block with grNumber + print link**
+
+The GR-history block (lines 290-350) currently shows `gr.receivedBy.name` + `formatDateTime(gr.createdAt)` + PASS/REJECT counts. Update the header row of each GR card (lines 308-325) to show the `grNumber` prominently and a print button that routes to the print page (Task 5). Replace the `<div className="flex items-center justify-between mb-2">...</div>` block (lines 308-325) with:
+
+```tsx
+                          <div className="flex items-center justify-between mb-2 gap-2">
+                            <div className="text-sm min-w-0">
+                              <span className="font-mono font-semibold text-primary">{gr.grNumber}</span>
+                              <div className="text-xs text-muted-foreground leading-snug">
+                                โดย {gr.receivedBy.name} · {formatDateTime(gr.createdAt)}
+                              </div>
+                            </div>
+                            <div className="flex items-center gap-2 shrink-0">
+                              <span className="px-2 py-0.5 rounded-full text-xs font-medium bg-success/10 text-success dark:bg-success/15">
+                                ผ่าน {passCount}
+                              </span>
+                              {rejectCount > 0 && (
+                                <span className="px-2 py-0.5 rounded-full text-xs font-medium bg-destructive/10 text-destructive dark:bg-destructive/15">
+                                  ไม่ผ่าน {rejectCount}
+                                </span>
+                              )}
+                              <button
+                                type="button"
+                                onClick={() => navigate(`/purchase-orders/${selectedPO.id}/goods-receivings/${gr.id}/print`)}
+                                className="inline-flex items-center gap-1 px-2 py-1 rounded-md text-xs text-primary hover:bg-primary/10 transition-colors"
+                                title="พิมพ์ใบรับของ"
+                                aria-label={`พิมพ์ใบรับของ ${gr.grNumber}`}
+                              >
+                                <Printer className="size-3.5" />
+                                พิมพ์
+                              </button>
+                            </div>
+                          </div>
+```
+
+- [ ] **Step 9: Allow receive from an ORDERED PO in the detail modal footer (parity with the list)**
+
+The sticky-footer "รับสินค้า" button currently gates on `['APPROVED', 'PARTIALLY_RECEIVED'].includes(selectedPO.status)` (PODetailModal line 354). Task 3 Step 6(a) already added `'ORDERED'` to the **list's** receive gate; mirror that here so an ORDERED PO can also be received from the detail. Change the footer condition:
+
+```tsx
+            {/* Sticky Footer */}
+            {['APPROVED', 'ORDERED', 'PARTIALLY_RECEIVED'].includes(selectedPO.status) && (
+```
+
+(Both gates must match the B0 receive state machine — receive allowed from `ORDERED` or `APPROVED`, back-compat.)
+
+- [ ] **Step 10: Type-check**
+
+Run: `./tools/check-types.sh all`
+Expected: 0 errors. (`useNavigate` is from `react-router` — same import path used across the repo, e.g. `PaymentVoucherPage.tsx:14`.)
+
+- [ ] **Step 11: Run the PO unit tests**
+
+Run: `cd apps/web && npx vitest run src/pages/PurchaseOrdersPage`
+Expected: PASS (Task 2 + Task 4 util tests).
+
+- [ ] **Step 12: MANUAL verification (desktop + mobile)**
+
+On `/purchase-orders`, open a PO that has at least one goods-receiving (or receive one first):
+- **Desktop:** the detail modal shows a 5-node timeline (รออนุมัติ → อนุมัติ → สั่งแล้ว → รับเข้า → รับครบ) with done steps green-checked, the current step blue-bold, future steps muted; a cancelled PO hides the timeline. The product table shows a QC column with "รอ QC N"/"เข้าสต็อก N" badges. The GR-history shows `GR-YYYY-MM-NNN` in mono primary, "โดย <name> · <time>", PASS/REJECT chips, and a "พิมพ์" button.
+- **Mobile (~390px):** the timeline labels stay on one line (`text-[11px]`); the product table scrolls horizontally inside the card; the GR card header wraps without overflow (chips + print button on the right). Click "พิมพ์" → routes to the print page (Task 5 verifies the page itself).
+
+- [ ] **Step 13: Commit**
+
+```bash
+git add apps/web/src/pages/PurchaseOrdersPage/types.ts apps/web/src/pages/PurchaseOrdersPage/components/PODetailModal.tsx apps/web/src/pages/PurchaseOrdersPage/po-detail.util.ts apps/web/src/pages/PurchaseOrdersPage/po-detail.util.test.ts
+git commit -m "feat(purchasing-web): PO detail — status timeline, per-item QC progress, GR history with grNumber + print link"
+```
+
+---
+
+### Task 5: Printable ใบรับของ (Goods Receipt) page + lazy route
+
+**Files:**
+- Create: `apps/web/src/pages/PurchaseOrdersPage/GoodsReceiptPrintPage.tsx`
+- Modify: `apps/web/src/App.tsx` (lazy import alongside the other PO/print pages — `PurchaseOrdersPage` is declared at line 94, `PaymentVoucherPage` at line 128; new `<Route>` next to the `/purchase-orders` route block at lines 337-344)
+
+**Interfaces:**
+- Consumes: `GET /purchase-orders/:id/goods-receivings/:receivingId` → `getGoodsReceivingById` (verified backend shape in `po-query.service.ts:224-240`): returns `{ id, grNumber, createdAt, notes, po: { id, poNumber, supplierId, supplier: { id, name } }, receivedBy: { id, name }, items: [{ id, status, imeiSerial, serialNumber, rejectReason, defectReason, poItem: { brand, model, color, storage, category, accessoryType, accessoryBrand, quantity, receivedQty }, product: {...} }] }`. (`grNumber` + `defectReason` exist post-B0.)
+- Consumes: `useCompanyDisplayName`, `useCompanyAddress`, `useCompanyTaxId`, `useCompanyLogoUrl` (`@/hooks/useCompanyInfo`); `QueryBoundary` (default export of `@/components/QueryBoundary`); `formatDateTime` (`@/utils/formatters`); `api` (default export of `@/lib/api`). (Note: the page uses `formatDateTime` for timestamps — it does NOT import `formatThaiDateLong`; only list what the Step-1 code actually imports to avoid an unused-import error.)
+- Produces: route `/purchase-orders/:id/goods-receivings/:receivingId/print`.
+
+> Reuse note: this page mirrors `apps/web/src/pages/PaymentVoucherPage.tsx` exactly — the same screen-only `.no-print` toolbar (กลับ + พิมพ์), the same co-located `<style>` `@page A4 / @media print` block, the same `voucher-sheet` article with `bg-white ... print:border-0 print:p-0 print:shadow-none`, and the same `useCompanyInfo` header. `bg-white` is allowed here (print/receipt context). It is the lightest doc (no JE, no WHT, no signatures grid required by spec — spec asks only for grNumber, supplier, items, receiver, time).
+
+- [ ] **Step 1: Create the print page**
+
+Create `apps/web/src/pages/PurchaseOrdersPage/GoodsReceiptPrintPage.tsx`:
+
+```tsx
+// Purchasing v2 B1 — Printable ใบรับของ (Goods Receipt) per GoodsReceiving record.
+//
+// Route: /purchase-orders/:id/goods-receivings/:receivingId/print
+//
+// Mirrors PaymentVoucherPage's print pattern: screen-only toolbar (.no-print),
+// an A4 voucher-sheet, co-located @media print CSS, window.print() for PDF.
+// Receiving posts NO journal entry — this is an operational receipt, not an
+// accounting document (spec red line: purchasing stays JE-free).
+
+import { useEffect } from 'react';
+import { useParams, useNavigate } from 'react-router';
+import { useQuery } from '@tanstack/react-query';
+import { ArrowLeft, Printer } from 'lucide-react';
+import api from '@/lib/api';
+import QueryBoundary from '@/components/QueryBoundary';
+import { formatDateTime } from '@/utils/formatters';
+import {
+  useCompanyDisplayName,
+  useCompanyAddress,
+  useCompanyTaxId,
+  useCompanyLogoUrl,
+} from '@/hooks/useCompanyInfo';
+
+interface GRItem {
+  id: string;
+  status: 'PASS' | 'REJECT';
+  imeiSerial: string | null;
+  serialNumber: string | null;
+  rejectReason: string | null;
+  defectReason: string | null;
+  poItem: {
+    brand: string;
+    model: string;
+    color: string | null;
+    storage: string | null;
+    category: string | null;
+    accessoryType: string | null;
+    accessoryBrand: string | null;
+  } | null;
+}
+
+interface GRDoc {
+  id: string;
+  grNumber: string;
+  createdAt: string;
+  notes: string | null;
+  po: { id: string; poNumber: string; supplier: { id: string; name: string } };
+  receivedBy: { id: string; name: string };
+  items: GRItem[];
+}
+
+const DEFECT_LABELS: Record<string, string> = {
+  SCREEN: 'จอภาพ',
+  BATTERY: 'แบตเตอรี่',
+  IMEI_BLOCKED: 'IMEI ถูกบล็อก',
+  BOX_MISSING: 'กล่อง/อุปกรณ์ไม่ครบ',
+  WRONG_MODEL: 'ผิดรุ่น',
+  DOA: 'เสียตั้งแต่แกะ (DOA)',
+  COSMETIC: 'ตำหนิภายนอก',
+  OTHER: 'อื่นๆ',
+};
+
+function itemDesc(it: GRItem): string {
+  const p = it.poItem;
+  if (!p) return '-';
+  if (p.category === 'ACCESSORY') {
+    const isCharger = p.accessoryType === 'ชุดชาร์จ';
+    const parts = [p.accessoryType, p.accessoryBrand, p.model ? (isCharger ? p.model : `สำหรับ ${p.model}`) : '']
+      .filter(Boolean);
+    return parts.join(' / ') || '-';
+  }
+  return [p.brand, p.model, p.color, p.storage].filter(Boolean).join(' ') || '-';
+}
+
+export default function GoodsReceiptPrintPage() {
+  const { id, receivingId } = useParams<{ id: string; receivingId: string }>();
+  const navigate = useNavigate();
+
+  const grQuery = useQuery<GRDoc>({
+    queryKey: ['gr-print', id, receivingId],
+    queryFn: async () => {
+      const { data } = await api.get(`/purchase-orders/${id}/goods-receivings/${receivingId}`);
+      return data;
+    },
+    enabled: !!id && !!receivingId,
+  });
+
+  useEffect(() => {
+    document.title = grQuery.data ? `ใบรับของ ${grQuery.data.grNumber}` : 'ใบรับของ';
+  }, [grQuery.data]);
+
+  return (
+    <div className="bg-muted/30 min-h-screen">
+      <div className="no-print bg-card border-b border-border sticky top-0 z-10">
+        <div className="max-w-[210mm] mx-auto px-6 py-3 flex items-center justify-between">
+          <button
+            type="button"
+            onClick={() => navigate(-1)}
+            className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground"
+          >
+            <ArrowLeft size={14} />
+            กลับ
+          </button>
+          <button
+            type="button"
+            onClick={() => window.print()}
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-semibold rounded-md bg-primary text-primary-foreground hover:bg-primary/90"
+          >
+            <Printer size={14} />
+            พิมพ์ / Save PDF
+          </button>
+        </div>
+      </div>
+
+      <QueryBoundary
+        isLoading={grQuery.isLoading}
+        isError={grQuery.isError}
+        error={grQuery.error}
+        onRetry={grQuery.refetch}
+      >
+        {grQuery.data && <GoodsReceiptSheet doc={grQuery.data} />}
+      </QueryBoundary>
+
+      <style>{`
+        @page { size: A4; margin: 14mm 12mm; }
+        @media print {
+          .no-print { display: none !important; }
+          .voucher-sheet { box-shadow: none !important; }
+          body { background: white !important; }
+        }
+      `}</style>
+    </div>
+  );
+}
+
+function GoodsReceiptSheet({ doc }: { doc: GRDoc }) {
+  const companyName = useCompanyDisplayName();
+  const companyAddress = useCompanyAddress();
+  const companyTaxId = useCompanyTaxId();
+  const companyLogoUrl = useCompanyLogoUrl();
+  const passCount = doc.items.filter((i) => i.status === 'PASS').length;
+  const rejectCount = doc.items.filter((i) => i.status === 'REJECT').length;
+
+  return (
+    <div className="max-w-[210mm] mx-auto py-6 px-6 print:px-0 print:py-0">
+      <article
+        className="voucher-sheet bg-white border border-border rounded-md p-8 shadow-sm print:border-0 print:p-0 print:shadow-none"
+        style={{ minHeight: '270mm' }}
+      >
+        <header className="text-center border-b-2 border-foreground pb-3">
+          {companyLogoUrl && (
+            <img src={companyLogoUrl} alt={companyName} className="mx-auto mb-2 h-12 w-auto object-contain" />
+          )}
+          <h1 className="text-xl font-bold leading-snug">{companyName}</h1>
+          <p className="text-sm text-muted-foreground mt-1 leading-snug">
+            {companyAddress}{companyTaxId && ` · เลขผู้เสียภาษี ${companyTaxId}`}
+          </p>
+          <h2 className="text-2xl font-bold tracking-wider mt-4 leading-snug">ใบรับของ</h2>
+          <p className="text-xs text-muted-foreground">Goods Receipt</p>
+        </header>
+
+        <section className="grid grid-cols-2 gap-x-8 gap-y-2 mt-5 text-sm">
+          <Meta label="เลขที่ใบรับของ" value={doc.grNumber} mono />
+          <Meta label="วันที่รับ" value={formatDateTime(doc.createdAt)} />
+          <Meta label="อ้างอิงใบสั่งซื้อ" value={doc.po.poNumber} mono />
+          <Meta label="ผู้จัดจำหน่าย" value={doc.po.supplier.name} />
+          <Meta label="ผู้รับของ" value={doc.receivedBy.name} />
+          <Meta label="สรุป" value={`รับเข้า ${doc.items.length} · ผ่าน ${passCount} · ไม่ผ่าน ${rejectCount}`} />
+        </section>
+
+        <table className="w-full mt-6 text-xs border border-border">
+          <thead className="bg-muted/40">
+            <tr>
+              <th className="border border-border p-2 text-left w-10">#</th>
+              <th className="border border-border p-2 text-left">รายการ</th>
+              <th className="border border-border p-2 text-left">IMEI / Serial</th>
+              <th className="border border-border p-2 text-center w-20">ผล</th>
+              <th className="border border-border p-2 text-left">หมายเหตุ</th>
+            </tr>
+          </thead>
+          <tbody>
+            {doc.items.length === 0 ? (
+              <tr>
+                <td colSpan={5} className="border border-border p-3 text-center text-muted-foreground">
+                  ไม่มีรายการ
+                </td>
+              </tr>
+            ) : (
+              doc.items.map((it, idx) => (
+                <tr key={it.id}>
+                  <td className="border border-border p-2 tabular-nums">{idx + 1}</td>
+                  <td className="border border-border p-2 leading-snug">{itemDesc(it)}</td>
+                  <td className="border border-border p-2 font-mono">
+                    {it.imeiSerial || it.serialNumber || '—'}
+                  </td>
+                  <td className="border border-border p-2 text-center">
+                    {it.status === 'PASS' ? 'ผ่าน' : 'ไม่ผ่าน'}
+                  </td>
+                  <td className="border border-border p-2 leading-snug">
+                    {it.status === 'REJECT'
+                      ? [it.defectReason ? DEFECT_LABELS[it.defectReason] ?? it.defectReason : null, it.rejectReason]
+                          .filter(Boolean)
+                          .join(' · ') || '—'
+                      : '—'}
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+
+        {doc.notes && (
+          <section className="mt-6">
+            <p className="text-xs text-muted-foreground mb-1">หมายเหตุ</p>
+            <p className="text-sm leading-snug">{doc.notes}</p>
+          </section>
+        )}
+
+        <section className="grid grid-cols-2 gap-6 mt-12">
+          <Sig label="ผู้รับของ" />
+          <Sig label="ผู้ตรวจสอบ" />
+        </section>
+
+        <footer className="mt-8 pt-3 border-t border-border text-[10px] text-muted-foreground flex justify-between">
+          <span>ออกเอกสารจากระบบ BESTCHOICE — เอกสารรับของภายใน ไม่ใช่ใบกำกับภาษี</span>
+          <span>ใบรับของ v1.0</span>
+        </footer>
+      </article>
+    </div>
+  );
+}
+
+function Meta({ label, value, mono = false }: { label: string; value: string; mono?: boolean }) {
+  return (
+    <div>
+      <p className="text-xs text-muted-foreground leading-snug">{label}</p>
+      <p className={(mono ? 'font-mono ' : '') + 'text-sm leading-snug'}>{value}</p>
+    </div>
+  );
+}
+
+function Sig({ label }: { label: string }) {
+  return (
+    <div className="text-center">
+      <div className="h-16 mb-2 border-b border-foreground" />
+      <p className="text-xs text-muted-foreground leading-snug">({label})</p>
+      <p className="text-[10px] text-muted-foreground mt-1">วันที่ ___ / ___ / ______</p>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Register the lazy import in `App.tsx`**
+
+In `apps/web/src/App.tsx`, add a lazy import next to the other PO/print page imports (the `PurchaseOrdersPage` import is the one referenced by the `/purchase-orders` route; `PaymentVoucherPage` is at line 128). Add:
+
+```typescript
+const GoodsReceiptPrintPage = lazy(() => import('@/pages/PurchaseOrdersPage/GoodsReceiptPrintPage'));
+```
+
+(Place it adjacent to wherever `PurchaseOrdersPage` is declared — grep `const PurchaseOrdersPage = lazy(` to find the line, then add the new line directly under it.)
+
+- [ ] **Step 3: Register the route in `App.tsx`**
+
+Add a `<Route>` directly after the `/purchase-orders` route block (the comment `{/* จัดซื้อ (Purchasing) */}` is at line 337, the route element spans lines 338-344), inside the same `MainLayout`/`ProtectedRoute` tree. Use the same roles as the `/purchase-orders` route (`OWNER`, `BRANCH_MANAGER`) — note the backend `getGoodsReceivingById` allows OWNER/BM/FM/ACCOUNTANT, but the page lives under the purchasing zone so we mirror the list route's roles:
+
+```tsx
+          {/* จัดซื้อ (Purchasing) */}
+          <Route
+            path="/purchase-orders"
+            element={
+              <ProtectedRoute roles={['OWNER', 'BRANCH_MANAGER']}>
+                <PurchaseOrdersPage />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/purchase-orders/:id/goods-receivings/:receivingId/print"
+            element={
+              <ProtectedRoute roles={['OWNER', 'BRANCH_MANAGER']}>
+                <GoodsReceiptPrintPage />
+              </ProtectedRoute>
+            }
+          />
+```
+
+- [ ] **Step 4: Type-check**
+
+Run: `./tools/check-types.sh all`
+Expected: 0 errors.
+
+- [ ] **Step 5: MANUAL verification (desktop print + mobile)**
+
+From a PO detail with a goods-receiving, click "พิมพ์" on a GR card (Task 4) → lands on `/purchase-orders/<id>/goods-receivings/<grId>/print`.
+- **Desktop:** the page shows the company header (name/address/tax id), title "ใบรับของ / Goods Receipt", a meta grid (เลขที่ใบรับของ = `GR-YYYY-MM-NNN`, วันที่รับ, อ้างอิงใบสั่งซื้อ = PO#, ผู้จัดจำหน่าย, ผู้รับของ, สรุป), an items table (#, รายการ, IMEI/Serial, ผล, หมายเหตุ with Thai defect labels on rejects), notes if present, 2 signature slots, footer. Click "พิมพ์ / Save PDF" → browser print dialog opens at A4; the screen toolbar is hidden in the preview (`.no-print`), the sheet has no border/shadow on paper.
+- **Mobile (~390px):** the toolbar + sheet scale down; the items table scrolls horizontally; the print button still works.
+- **Tab title:** browser tab shows `ใบรับของ GR-YYYY-MM-NNN`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/pages/PurchaseOrdersPage/GoodsReceiptPrintPage.tsx apps/web/src/App.tsx
+git commit -m "feat(purchasing-web): printable ใบรับของ (Goods Receipt) page + lazy route"
+```
+
+---
+
+### Task 6: Batch verification (full type + web test run) and ship gate
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Full web unit-test run (no regressions)**
+
+Run: `cd apps/web && npx vitest run`
+Expected: all existing web tests + the 2 new util test files (`po-list.util.test.ts`, `po-detail.util.test.ts`) PASS.
+
+- [ ] **Step 2: Full type gate**
+
+Run: `./tools/check-types.sh all`
+Expected: 0 errors across api + web.
+
+- [ ] **Step 3: Confirm no accounting/finance import crept in (red-line check)**
+
+Run: `grep -rnE "from '@/.*(accounting|journal|expense|finance|tax)" apps/web/src/pages/PurchaseOrdersPage`
+Expected: **no matches** (the only `@/hooks/useCompanyInfo` import in `GoodsReceiptPrintPage` is company display data, not an accounting module). If any match appears, remove it.
+
+- [ ] **Step 4: Commit (if any cleanup) / otherwise proceed to code-review + /pre-deploy**
+
+Per the spec's per-batch cadence: run the `code-reviewer` agent → fix Critical/Warning → `/pre-deploy` → branch → main → deploy → owner review. No code change in this step unless review surfaces one.
+
+---
+
+## Self-Review
+
+**Spec coverage (B1 items — from spec §"B1 — PO list + detail redesign"):**
+
+| Spec bullet (B1) | Task |
+|---|---|
+| Status **pills** incl. new **ORDERED** state | Task 1 (label + `poStatusMap.ORDERED`) + Task 3 Step 4 (pill render) |
+| Partial-receive **progress bar** ("รับแล้ว 3/10" from items receivedQty/quantity) | Task 2 (`receiveProgress`) + Task 3 Step 5 |
+| Payment **chip** | Task 3 Step 7 — **already present** in current code (clickable `poPaymentStatusMap` chip, POListTab lines 200-221); verified, no change needed |
+| **OVERDUE badge** (computed: status ORDERED && expectedDate < now) | Task 2 (`isOverdue`) + Task 3 Step 4 |
+| PO#/supplier **SEARCH** (useDebounce) | Task 3 Step 1-2 (added `useDebounce` over existing search) |
+| Clearer **empty states** | Task 3 Step 7 (no-data actionable message + icon) |
+| **"สั่งซื้อ" action** wired to `POST /:id/order` (APPROVED → ORDERED) via new mutation in `usePurchaseOrdersData` | Task 1 Step 3-4 (`orderMutation`) + Task 3 Step 6 (button) |
+| Add the **ORDERED label to constants** | Task 1 Step 1 (`statusLabels`/`statusColors`) |
+| PO detail **status TIMELINE** (Draft → อนุมัติ → สั่งแล้ว → รับ → ครบ) | Task 4 (`timelineSteps`) + Task 4 Step 6 (render) |
+| Per-item **received/QC progress** | Task 4 Step 7 (QC column; received/คงเหลือ already in table) |
+| **GR HISTORY** list (each GR shows grNumber + receiver + time) | Task 4 Step 1 (type `grNumber`) + Step 8 (render grNumber + receiver + time) |
+| **Printable ใบรับของ** per GR (grNumber, supplier, items, receiver, time) — reuse repo print pattern | Task 5 (mirrors `PaymentVoucherPage`) |
+
+**Placeholder scan:** none. Every code/JSX/test step shows full content; every run command has an expected result; every MANUAL step lists what to click + what to see on desktop AND mobile.
+
+**Type/prop-name consistency across tasks:**
+- `orderMutation` typed identically as `UseMutationResult<unknown, unknown, string, unknown>` in `POListTabProps` (Task 3) and produced as such by `usePurchaseOrdersData` (Task 1), matching the sibling `approveMutation`/`cancelMutation` shape already in the file.
+- `receiveProgress`/`isOverdue` signatures (Task 2) match every call site (Task 3 list, Task 4 detail). `receiveProgress` accepts a structural `{ items: {quantity; receivedQty}[] }` so both `PurchaseOrder` and `PODetail` satisfy it.
+- `timelineSteps(po: { status: string })` (Task 4) is called with `selectedPO` (has `status: string`) — structurally compatible.
+- `GoodsReceivingRecord.grNumber` (Task 4 Step 1) is added to `types.ts` to match the backend `findOne` include shape (`po-query.service.ts:66-72`: `goodsReceivings` includes `receivedBy` + `items: true`; the GR row scalar `grNumber` exists post-B0). The per-item QC tally (Task 4 Step 7) does **not** read `goodsReceivings.items[].product` (that include is absent in `findOne` — `items: true` carries no `product`); instead it reads `selectedPO.items[].receivingItems[].product.status`, which `findOne` **does** include (`po-query.service.ts:55-62`), via the new optional `POItem.receivingItems?` type field.
+- The print page's `GRDoc`/`GRItem` interfaces (Task 5) match the **distinct** `getGoodsReceivingById` shape (`po-query.service.ts:224-240`: `po.poNumber` + `po.supplier`, `poItem.{brand,model,color,storage,category,accessoryType,accessoryBrand}`, `defectReason`) — these are local to the print page, not the shared `PODetail` type, so no cross-file conflict.
+
+**Deviations found vs spec wording:**
+1. **Payment chip already exists** — the spec lists it as a B1 deliverable, but `POListTab` already renders a clickable payment chip via `poPaymentStatusMap` (lines 200-221). No new work; documented above. This mirrors B0's "IMEI guard already implemented" deviation style.
+2. **Received/คงเหลือ columns already exist** in both the list (`received` column) and the detail product table — B1 adds the **progress-bar styling refactor** (shared helper) on the list and a **new QC** column on the detail, rather than building received-tracking from scratch.
+3. **GR history block already exists** in `PODetailModal` (lines 290-350) showing receiver + time + PASS/REJECT counts — B1 adds `grNumber` (the one missing field) + the print link, rather than building the block from zero.
+4. **Print page roles:** backend `getGoodsReceivingById` permits OWNER/BM/FM/ACCOUNTANT, but the new print route uses `['OWNER','BRANCH_MANAGER']` to mirror the `/purchase-orders` list route (purchasing zone). FM/ACCOUNTANT do not have a list entry to reach it from, so this is consistent; widen later if a finance entry point is added.
+5. **No new backend work** — B0 already shipped `ORDERED`/`orderedAt`/`grNumber`/`DefectReason` and the `POST /:id/order` + GR endpoints, so B1 is purely frontend (spec's B1 is a frontend batch). The plan adds **zero** API/schema changes, honoring the red line by construction.

--- a/docs/superpowers/plans/2026-06-29-purchasing-b2-create-wizard.md
+++ b/docs/superpowers/plans/2026-06-29-purchasing-b2-create-wizard.md
@@ -1,0 +1,1352 @@
+# Purchasing v2 — Batch 2: สร้าง PO 4-Step Wizard (desktop) with transparent VAT — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rebuild the one-long-modal "สร้างใบสั่งซื้อ" into a guided **4-step wizard** — (1) เลือกผู้ขาย (+inline create, show credit terms → due-date preview), (2) เพิ่มรายการ (product picker + running subtotal), (3) ส่วนลด/VAT with a **transparent breakdown that mirrors the backend math exactly**, (4) ทบทวน+บันทึก — plus **auto-save draft to localStorage** (recover on reopen). The existing `POST /purchase-orders` contract (`CreatePODto`) is **unchanged**; this is a pure front-of-glass rebuild.
+
+**Architecture:** Refactor `apps/web/src/pages/PurchaseOrdersPage`. The data/mutation layer (`usePurchaseOrdersData`) and the create payload builder (`usePOForm.handleCreate`) are **kept intact**. New work: a `useCreatePoWizard` hook (step state + can-advance gate + due-date preview + localStorage draft, modeled on `ContractCreatePage`'s `useDraftStorage` + auto-save), a small pure `poTotals.ts` calculator (the single source of truth for the breakdown, mirroring `po-lifecycle.service.ts.create()`), and a rebuilt `CreatePOModal` that renders 4 step panels + a stepper (reusing `ContractCreatePage`'s `StepIndicator` pattern). The VAT/net math already in `usePOForm` (`Math.round(subtotalAfterDiscount * 0.07 * 100) / 100`) is extracted into `poTotals.ts` so the wizard and the payload builder compute from one place.
+
+**Tech Stack:** React 18 + TypeScript + Vite + Tailwind + shadcn/ui + Radix + lucide (`apps/web`); `@tanstack/react-query` + `@/lib/api`; vitest + RTL for unit tests; manual desktop verification for UI.
+
+**Spec:** `docs/superpowers/specs/2026-06-29-purchasing-receiving-ux-v2-design.md`
+
+## Global Constraints
+
+- **RED LINE — no accounting/finance:** introduce **NO** import of any accounting/finance/journal/expense/tax module into `purchase-orders` (frontend or backend). This batch is **frontend-only** under `apps/web/src/pages/PurchaseOrdersPage/**` — it touches **zero** backend code, **zero** schema, **zero** money-posting paths. Do not touch `trade-in` or `Product.ownedByCompanyId`; receiving stays JE-free.
+- **Additive only:** the `POST /purchase-orders` contract (`CreatePODto` — see `apps/api/src/modules/purchase-orders/dto/create-po.dto.ts:42`) is **unchanged**. The wizard MUST POST the exact same payload `usePOForm.handleCreate` posts today (`usePOForm.ts:94-119`). No new request fields.
+- **Frontend rules (`.claude/rules/frontend.md`):**
+  - Data: `useQuery`/`useMutation` from `@tanstack/react-query` + `api` from `@/lib/api` only — **no** raw `fetch`/`axios`. (This batch reuses the existing `createMutation`/`suppliers` query; no new network calls.)
+  - UI: shadcn/ui + Radix + Tailwind + `lucide-react` only. No other component libs.
+  - **Design tokens only** — no hardcoded gray/hex; no `text-gray-*`/`bg-gray-*`; **no `bg-white`** (except print/receipt — not applicable here). Use `bg-background`/`bg-card`/`bg-muted`, `text-foreground`/`text-muted-foreground`, `border-border`, `hover:bg-accent`, `text-primary`/`text-destructive`/`text-success`/`text-warning`.
+  - **Thai UI text uses `leading-snug`** (never `leading-none`).
+  - Routes lazy-loaded (PurchaseOrdersPage already is — no change needed).
+  - `toast.*` from `sonner` for notifications; no `alert()`/`confirm()`.
+  - `useDebounce` for any search input (the supplier picker `ContactCombobox` already debounces internally — reuse it, do not add another).
+- **Money = Decimal precision parity:** the frontend can only use JS `number`, so the breakdown calculator MUST reproduce the backend's exact rounding: VAT = `subtotalAfterDiscount × vatRate` rounded **HALF_UP to 2 dp**, applied **only if `supplier.hasVat`**; net = `subtotalAfterDiscount + vatAmount − discountAfterVat`. This is what `po-lifecycle.service.ts:53-66` does with `Prisma.Decimal` + `ROUND_HALF_UP`, and what `usePOForm.ts:122-132` already does with `Math.round(x*100)/100` (which equals HALF_UP for the satang place). Keep `0.07` as the client-side rate to match `usePOForm` today (documented deviation — see Self-Review).
+- **Reuse, don't reinvent:** `StepIndicator` pattern from `ContractCreatePage/components/StepIndicator.tsx`; the draft pattern from `hooks/useDraftStorage.ts` + the auto-save/recover wiring in `ContractCreatePage/hooks/useContractCreateData.ts:62-94`; `ContactCombobox` for supplier pick + inline create; `ThaiDateInput`; `formatNumberDecimal`/`formatDateShort` from `@/utils/formatters`; product catalog helpers `brands`/`getModels`/`getModelInfo` from `@/data/productCatalog`.
+- **Type gate:** `./tools/check-types.sh all` must report **0 errors** before each commit.
+
+---
+
+### Task 1: Extract the breakdown calculator `poTotals.ts` (single source of truth, mirrors backend)
+
+Today the VAT/discount/net math lives inline in `usePOForm.ts:122-132`. Extract it into a pure, unit-tested function so the wizard's transparent breakdown (Step 3 + Step 4 review) and the payload-builder compute from **one** place that provably mirrors `po-lifecycle.service.ts.create()`.
+
+**Files:**
+- Create: `apps/web/src/pages/PurchaseOrdersPage/poTotals.ts`
+- Create (test): `apps/web/src/pages/PurchaseOrdersPage/poTotals.test.ts`
+- Modify: `apps/web/src/pages/PurchaseOrdersPage/hooks/usePOForm.ts` (lines 122-132 → call the new helper)
+
+**Interfaces:**
+- Produces:
+  ```ts
+  export interface PoTotalsInput {
+    items: { quantity: string; unitPrice: string }[];
+    discount: string;        // ส่วนลดก่อน VAT (raw form string)
+    discountAfterVat: string; // ส่วนลดหลัง VAT (raw form string)
+    supplierHasVat: boolean;
+  }
+  export interface PoTotals {
+    subtotal: number;
+    discountNum: number;            // clamped to subtotal
+    subtotalAfterDiscount: number;
+    vatAmount: number;              // HALF_UP 2dp, 0 if !hasVat
+    totalWithVat: number;
+    discountAfterVatNum: number;    // clamped to totalWithVat, 0 if !hasVat
+    netAmount: number;
+  }
+  export const VAT_RATE = 0.07;
+  export function computePoTotals(input: PoTotalsInput): PoTotals;
+  ```
+- Consumed by: `usePOForm` (Task 1), the wizard breakdown (Task 4), the review step (Task 5).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/web/src/pages/PurchaseOrdersPage/poTotals.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { computePoTotals } from './poTotals';
+
+describe('computePoTotals — mirrors po-lifecycle.service.create()', () => {
+  it('no-VAT supplier: net = subtotal - discount, no VAT line', () => {
+    const t = computePoTotals({
+      items: [{ quantity: '2', unitPrice: '1000' }, { quantity: '1', unitPrice: '500' }],
+      discount: '300',
+      discountAfterVat: '999', // must be ignored when !hasVat
+      supplierHasVat: false,
+    });
+    expect(t.subtotal).toBe(2500);
+    expect(t.discountNum).toBe(300);
+    expect(t.subtotalAfterDiscount).toBe(2200);
+    expect(t.vatAmount).toBe(0);
+    expect(t.totalWithVat).toBe(2200);
+    expect(t.discountAfterVatNum).toBe(0);
+    expect(t.netAmount).toBe(2200);
+  });
+
+  it('VAT supplier: VAT = subtotalAfterDiscount * 0.07 ROUND_HALF_UP (half-satang rounds up)', () => {
+    // 1050 * 0.07 = 73.5 -> HALF_UP -> 73.5 (exact); use a value that lands on a half-satang
+    // 107.35 * 0.07 = 7.5145 -> 7.51 ; choose 100.50 -> 7.035 -> 7.04 (HALF_UP at 3rd dp 5)
+    const t = computePoTotals({
+      items: [{ quantity: '1', unitPrice: '100.50' }],
+      discount: '0',
+      discountAfterVat: '0',
+      supplierHasVat: true,
+    });
+    expect(t.subtotalAfterDiscount).toBe(100.5);
+    expect(t.vatAmount).toBe(7.04); // 7.035 rounds HALF_UP to 7.04
+    expect(t.totalWithVat).toBe(107.54);
+    expect(t.netAmount).toBe(107.54);
+  });
+
+  it('VAT supplier with both discounts: net = (sub-disc) + vat - discAfterVat', () => {
+    const t = computePoTotals({
+      items: [{ quantity: '10', unitPrice: '1000' }], // 10000
+      discount: '1000',                                // -> 9000
+      discountAfterVat: '500',
+      supplierHasVat: true,
+    });
+    expect(t.subtotalAfterDiscount).toBe(9000);
+    expect(t.vatAmount).toBe(630);        // 9000 * 0.07
+    expect(t.totalWithVat).toBe(9630);
+    expect(t.discountAfterVatNum).toBe(500);
+    expect(t.netAmount).toBe(9130);
+  });
+
+  it('clamps discount to subtotal and discountAfterVat to totalWithVat', () => {
+    const t = computePoTotals({
+      items: [{ quantity: '1', unitPrice: '100' }],
+      discount: '999',          // clamps to 100
+      discountAfterVat: '999',  // clamps to totalWithVat
+      supplierHasVat: true,
+    });
+    expect(t.discountNum).toBe(100);
+    expect(t.subtotalAfterDiscount).toBe(0);
+    expect(t.vatAmount).toBe(0);
+    expect(t.totalWithVat).toBe(0);
+    expect(t.discountAfterVatNum).toBe(0);
+    expect(t.netAmount).toBe(0);
+  });
+
+  it('treats empty/NaN quantity & price as 0', () => {
+    const t = computePoTotals({
+      items: [{ quantity: '', unitPrice: '' }, { quantity: '2', unitPrice: '50' }],
+      discount: '',
+      discountAfterVat: '',
+      supplierHasVat: false,
+    });
+    expect(t.subtotal).toBe(100);
+    expect(t.netAmount).toBe(100);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/web && npx vitest run src/pages/PurchaseOrdersPage/poTotals.test.ts`
+Expected: FAIL — `Failed to resolve import './poTotals'`.
+
+- [ ] **Step 3: Implement `poTotals.ts` (lifted verbatim from `usePOForm.ts:122-132`)**
+
+Create `apps/web/src/pages/PurchaseOrdersPage/poTotals.ts`:
+
+```ts
+// Single source of truth for the PO money breakdown shown in the create wizard.
+// Mirrors apps/api/src/modules/purchase-orders/services/po-lifecycle.service.ts
+// create() EXACTLY: subtotal -> minus discount -> VAT = subtotalAfterDiscount *
+// vatRate ROUND_HALF_UP (only when supplier.hasVat) -> minus discountAfterVat = net.
+// Backend uses Prisma.Decimal + ROUND_HALF_UP; on the client Math.round(x*100)/100
+// is HALF_UP at the satang place, matching usePOForm's prior inline math.
+
+export const VAT_RATE = 0.07;
+
+export interface PoTotalsInput {
+  items: { quantity: string; unitPrice: string }[];
+  discount: string;
+  discountAfterVat: string;
+  supplierHasVat: boolean;
+}
+
+export interface PoTotals {
+  subtotal: number;
+  discountNum: number;
+  subtotalAfterDiscount: number;
+  vatAmount: number;
+  totalWithVat: number;
+  discountAfterVatNum: number;
+  netAmount: number;
+}
+
+const round2 = (n: number) => Math.round(n * 100) / 100;
+
+export function computePoTotals({
+  items,
+  discount,
+  discountAfterVat,
+  supplierHasVat,
+}: PoTotalsInput): PoTotals {
+  const subtotal = items.reduce(
+    (sum, i) => sum + Number(i.quantity || 0) * Number(i.unitPrice || 0),
+    0,
+  );
+  const discountNum = Math.min(Number(discount) || 0, subtotal);
+  const subtotalAfterDiscount = subtotal - discountNum;
+  const vatAmount = supplierHasVat ? round2(subtotalAfterDiscount * VAT_RATE) : 0;
+  const totalWithVat = subtotalAfterDiscount + vatAmount;
+  const discountAfterVatNum = supplierHasVat
+    ? Math.min(Number(discountAfterVat) || 0, totalWithVat)
+    : 0;
+  const netAmount = totalWithVat - discountAfterVatNum;
+  return {
+    subtotal,
+    discountNum,
+    subtotalAfterDiscount,
+    vatAmount,
+    totalWithVat,
+    discountAfterVatNum,
+    netAmount,
+  };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/web && npx vitest run src/pages/PurchaseOrdersPage/poTotals.test.ts`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Make `usePOForm` consume the helper (no behavior change)**
+
+In `apps/web/src/pages/PurchaseOrdersPage/hooks/usePOForm.ts`, add the import (after line 4 `import { emptyItem } ...`):
+
+```ts
+import { computePoTotals } from '../poTotals';
+```
+
+Replace the inline math block (current lines 122-132):
+
+```ts
+  const subtotal = items.reduce((sum, i) => sum + Number(i.quantity || 0) * Number(i.unitPrice || 0), 0);
+  const selectedSupplier = suppliers.find((s) => s.id === form.supplierId);
+  const supplierHasVat = selectedSupplier?.hasVat ?? false;
+  const discountNum = Math.min(Number(form.discount) || 0, subtotal);
+  const subtotalAfterDiscount = subtotal - discountNum;
+  const vatAmount = supplierHasVat ? Math.round(subtotalAfterDiscount * 0.07 * 100) / 100 : 0;
+  const totalWithVat = subtotalAfterDiscount + vatAmount;
+  const discountAfterVatNum = supplierHasVat
+    ? Math.min(Number(form.discountAfterVat) || 0, totalWithVat)
+    : 0;
+  const netAmount = totalWithVat - discountAfterVatNum;
+```
+
+with:
+
+```ts
+  const selectedSupplier = suppliers.find((s) => s.id === form.supplierId);
+  const supplierHasVat = selectedSupplier?.hasVat ?? false;
+  const {
+    subtotal,
+    discountNum,
+    subtotalAfterDiscount,
+    vatAmount,
+    totalWithVat,
+    discountAfterVatNum,
+    netAmount,
+  } = computePoTotals({
+    items,
+    discount: form.discount,
+    discountAfterVat: form.discountAfterVat,
+    supplierHasVat,
+  });
+```
+
+(The returned object at `usePOForm.ts:134-158` already destructures these same names — leave it unchanged. `handleCreate`'s payload at lines 94-119 is also unchanged.)
+
+- [ ] **Step 6: Type-check**
+
+Run: `./tools/check-types.sh all`
+Expected: 0 errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/web/src/pages/PurchaseOrdersPage/poTotals.ts apps/web/src/pages/PurchaseOrdersPage/poTotals.test.ts apps/web/src/pages/PurchaseOrdersPage/hooks/usePOForm.ts
+git commit -m "refactor(purchasing): extract computePoTotals breakdown calculator (mirrors backend VAT/net)"
+```
+
+---
+
+### Task 2: Wizard state hook `useCreatePoWizard` — step gate + due-date preview + auto-save draft
+
+Add a focused hook that owns the wizard's step index, the per-step can-advance gate, the credit-term-driven due-date preview, and the localStorage draft (save/load/clear), modeled on `ContractCreatePage/hooks/useContractCreateData.ts:62-94` + `hooks/useDraftStorage.ts`. It is **layered on top of** `usePOForm` (consumes its `form`/`items`/`selectedSupplier`/`netAmount`/`resetForm`) — it does not duplicate the create logic.
+
+**Files:**
+- Create: `apps/web/src/pages/PurchaseOrdersPage/hooks/useCreatePoWizard.ts`
+- Create (test): `apps/web/src/pages/PurchaseOrdersPage/hooks/useCreatePoWizard.test.ts`
+
+**Interfaces:**
+- Consumes (from `usePOForm` return + props):
+  ```ts
+  interface UseCreatePoWizardOptions {
+    isOpen: boolean;
+    form: { supplierId: string; orderDate: string; expectedDate: string; discount: string; discountAfterVat: string; notes: string; paymentStatus: string; paymentMethod: string; paidAmount: string; paymentNotes: string };
+    setForm: React.Dispatch<React.SetStateAction<UseCreatePoWizardOptions['form']>>;
+    items: ItemForm[];
+    setItems: React.Dispatch<React.SetStateAction<ItemForm[]>>;
+    selectedSupplier: { id: string; name: string; hasVat: boolean; paymentMethods: { paymentMethod: string; creditTermDays?: number; isDefault: boolean }[] } | undefined;
+  }
+  ```
+- Produces:
+  ```ts
+  interface CreatePoWizardApi {
+    step: number;                 // 0..3
+    goToStep: (s: number) => void;
+    next: () => void;
+    back: () => void;
+    canNext: boolean;             // gate for current step
+    dueDatePreview: Date | null;  // orderDate + selected/default creditTermDays
+    creditTermDays: number | null;
+    draftRecovered: boolean;
+    clearDraft: () => void;
+  }
+  export const WIZARD_STEPS: string[]; // ['เลือกผู้ขาย','เพิ่มรายการ','ส่วนลด/VAT','ทบทวน+บันทึก']
+  export function useCreatePoWizard(opts: UseCreatePoWizardOptions): CreatePoWizardApi;
+  ```
+- Uses a **new** draft key `bestchoice-po-draft` (do NOT reuse the contract key `bestchoice-contract-draft`).
+
+- [ ] **Step 1: Write the failing test (pure due-date + step-gate logic via a thin wrapper)**
+
+The due-date + step-gate logic is the load-bearing part; test it directly with `@testing-library/react`'s `renderHook`. Create `apps/web/src/pages/PurchaseOrdersPage/hooks/useCreatePoWizard.test.ts`:
+
+```ts
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useCreatePoWizard } from './useCreatePoWizard';
+import type { ItemForm } from '../types';
+
+const baseItem: ItemForm = { brand: 'Apple', category: 'PHONE_NEW', model: 'iPhone 16', color: '', storage: '', quantity: '2', unitPrice: '30000', accessoryType: '', accessoryBrand: '' };
+
+function makeOpts(overrides: Partial<Parameters<typeof useCreatePoWizard>[0]> = {}) {
+  const form = {
+    supplierId: 's1', orderDate: '2026-07-01', expectedDate: '', discount: '', discountAfterVat: '',
+    notes: '', paymentStatus: 'UNPAID', paymentMethod: '', paidAmount: '', paymentNotes: '',
+  };
+  return {
+    isOpen: true,
+    form,
+    setForm: vi.fn(),
+    items: [baseItem],
+    setItems: vi.fn(),
+    selectedSupplier: { id: 's1', name: 'ผู้ขาย ก', hasVat: true, paymentMethods: [{ paymentMethod: 'CREDIT', creditTermDays: 30, isDefault: true }] },
+    ...overrides,
+  } as Parameters<typeof useCreatePoWizard>[0];
+}
+
+describe('useCreatePoWizard', () => {
+  beforeEach(() => localStorage.clear());
+
+  it('step 0 (supplier) gate: requires a supplierId', () => {
+    const { result, rerender } = renderHook((p) => useCreatePoWizard(p), { initialProps: makeOpts({ selectedSupplier: undefined, form: { ...makeOpts().form, supplierId: '' } }) });
+    expect(result.current.step).toBe(0);
+    expect(result.current.canNext).toBe(false);
+    rerender(makeOpts()); // now supplier selected
+    expect(result.current.canNext).toBe(true);
+  });
+
+  it('step 1 (items) gate: every item needs category, quantity>0, unitPrice>0', () => {
+    const { result, rerender } = renderHook((p) => useCreatePoWizard(p), { initialProps: makeOpts() });
+    act(() => result.current.next()); // -> step 1
+    expect(result.current.step).toBe(1);
+    expect(result.current.canNext).toBe(true);
+    rerender(makeOpts({ items: [{ ...baseItem, unitPrice: '' }] }));
+    expect(result.current.canNext).toBe(false);
+  });
+
+  it('computes dueDatePreview = orderDate + default creditTermDays', () => {
+    const { result } = renderHook((p) => useCreatePoWizard(p), { initialProps: makeOpts() });
+    expect(result.current.creditTermDays).toBe(30);
+    // 2026-07-01 + 30 days = 2026-07-31
+    expect(result.current.dueDatePreview?.toISOString().slice(0, 10)).toBe('2026-07-31');
+  });
+
+  it('dueDatePreview follows the selected paymentMethod credit term', () => {
+    const opts = makeOpts({
+      form: { ...makeOpts().form, paymentMethod: 'CASH' },
+      selectedSupplier: { id: 's1', name: 'ก', hasVat: true, paymentMethods: [
+        { paymentMethod: 'CASH', creditTermDays: 0, isDefault: false },
+        { paymentMethod: 'CREDIT', creditTermDays: 45, isDefault: true },
+      ] },
+    });
+    const { result } = renderHook((p) => useCreatePoWizard(p), { initialProps: opts });
+    expect(result.current.creditTermDays).toBe(0); // CASH selected -> no credit term
+    expect(result.current.dueDatePreview).toBeNull();
+  });
+
+  it('saves a draft to localStorage and recovers it on a fresh mount', () => {
+    const setForm = vi.fn();
+    const setItems = vi.fn();
+    const { unmount } = renderHook((p) => useCreatePoWizard(p), { initialProps: makeOpts() });
+    // force an immediate save (the hook saves on form/items/step change, debounced via effect)
+    expect(localStorage.getItem('bestchoice-po-draft')).not.toBeNull();
+    unmount();
+    const { result } = renderHook((p) => useCreatePoWizard(p), { initialProps: makeOpts({ setForm, setItems }) });
+    expect(result.current.draftRecovered).toBe(true);
+    expect(setForm).toHaveBeenCalled();
+    expect(setItems).toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/web && npx vitest run src/pages/PurchaseOrdersPage/hooks/useCreatePoWizard.test.ts`
+Expected: FAIL — cannot resolve `./useCreatePoWizard`.
+
+- [ ] **Step 3: Implement the hook**
+
+Create `apps/web/src/pages/PurchaseOrdersPage/hooks/useCreatePoWizard.ts`:
+
+```ts
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { toast } from 'sonner';
+import { formatDateShort } from '@/utils/formatters';
+import type { ItemForm } from '../types';
+
+export const WIZARD_STEPS = ['เลือกผู้ขาย', 'เพิ่มรายการ', 'ส่วนลด/VAT', 'ทบทวน+บันทึก'];
+const LAST_STEP = WIZARD_STEPS.length - 1;
+
+const DRAFT_KEY = 'bestchoice-po-draft';
+const DRAFT_TTL_MS = 24 * 60 * 60 * 1000; // 24h, matches the contract-draft TTL
+
+type WizardForm = {
+  supplierId: string; orderDate: string; expectedDate: string; discount: string;
+  discountAfterVat: string; notes: string; paymentStatus: string; paymentMethod: string;
+  paidAmount: string; paymentNotes: string;
+};
+
+interface PoDraft {
+  step: number;
+  form: WizardForm;
+  items: ItemForm[];
+  savedAt: string;
+}
+
+export interface UseCreatePoWizardOptions {
+  isOpen: boolean;
+  form: WizardForm;
+  setForm: React.Dispatch<React.SetStateAction<WizardForm>>;
+  items: ItemForm[];
+  setItems: React.Dispatch<React.SetStateAction<ItemForm[]>>;
+  selectedSupplier:
+    | { id: string; name: string; hasVat: boolean; paymentMethods: { paymentMethod: string; creditTermDays?: number; isDefault: boolean }[] }
+    | undefined;
+}
+
+export interface CreatePoWizardApi {
+  step: number;
+  goToStep: (s: number) => void;
+  next: () => void;
+  back: () => void;
+  canNext: boolean;
+  dueDatePreview: Date | null;
+  creditTermDays: number | null;
+  draftRecovered: boolean;
+  clearDraft: () => void;
+}
+
+export function useCreatePoWizard(opts: UseCreatePoWizardOptions): CreatePoWizardApi {
+  const { isOpen, form, setForm, items, setItems, selectedSupplier } = opts;
+  const [step, setStep] = useState(0);
+  const [draftRecovered, setDraftRecovered] = useState(false);
+  const recoveredRef = useRef(false);
+
+  const clearDraft = useCallback(() => {
+    localStorage.removeItem(DRAFT_KEY);
+  }, []);
+
+  // Restore draft once per open
+  useEffect(() => {
+    if (!isOpen || recoveredRef.current) return;
+    recoveredRef.current = true;
+    const raw = localStorage.getItem(DRAFT_KEY);
+    if (!raw) return;
+    try {
+      const draft = JSON.parse(raw) as PoDraft;
+      if (new Date().getTime() - new Date(draft.savedAt).getTime() > DRAFT_TTL_MS) {
+        localStorage.removeItem(DRAFT_KEY);
+        return;
+      }
+      setForm(draft.form);
+      setItems(draft.items);
+      setStep(draft.step);
+      setDraftRecovered(true);
+      toast('พบใบสั่งซื้อร่างที่บันทึกไว้ — กู้คืนแล้ว', {
+        description: `บันทึกเมื่อ ${new Date(draft.savedAt).toLocaleString('th-TH')}`,
+        duration: 5000,
+      });
+    } catch {
+      localStorage.removeItem(DRAFT_KEY);
+    }
+  }, [isOpen, setForm, setItems]);
+
+  // Reset recovery latch when the modal closes so reopening recovers again
+  useEffect(() => {
+    if (!isOpen) {
+      recoveredRef.current = false;
+      setDraftRecovered(false);
+      setStep(0);
+    }
+  }, [isOpen]);
+
+  // Auto-save: persist on every form/items/step change while open (only if there is content)
+  useEffect(() => {
+    if (!isOpen) return;
+    const hasContent = !!form.supplierId || items.some((i) => i.category || i.unitPrice);
+    if (!hasContent) return;
+    const draft: PoDraft = { step, form, items, savedAt: new Date().toISOString() };
+    localStorage.setItem(DRAFT_KEY, JSON.stringify(draft));
+  }, [isOpen, step, form, items]);
+
+  // Credit-term-driven due-date preview (mirrors po-lifecycle.service.create():69-77)
+  const selectedPm = form.paymentMethod
+    ? selectedSupplier?.paymentMethods.find((pm) => pm.paymentMethod === form.paymentMethod)
+    : selectedSupplier?.paymentMethods.find((pm) => pm.isDefault) ?? selectedSupplier?.paymentMethods[0];
+  const creditTermDays = selectedPm?.creditTermDays ?? null;
+  let dueDatePreview: Date | null = null;
+  if (creditTermDays && form.orderDate) {
+    const dd = new Date(form.orderDate);
+    if (!Number.isNaN(dd.getTime())) {
+      dd.setDate(dd.getDate() + creditTermDays);
+      dueDatePreview = dd;
+    }
+  }
+
+  // Per-step advance gate
+  const itemsValid = items.length > 0 && items.every(
+    (i) => i.category && Number(i.quantity) > 0 && Number(i.unitPrice) > 0,
+  );
+  const canNext =
+    step === 0 ? !!form.supplierId :
+    step === 1 ? itemsValid :
+    true; // steps 2 & 3 are always advanceable (3 = submit handled by the form)
+
+  const goToStep = useCallback((s: number) => {
+    if (s >= 0 && s <= LAST_STEP) setStep(s);
+  }, []);
+  const next = useCallback(() => setStep((s) => Math.min(s + 1, LAST_STEP)), []);
+  const back = useCallback(() => setStep((s) => Math.max(s - 1, 0)), []);
+
+  // formatDateShort referenced so callers may render the preview consistently;
+  // exported preview is a Date so the panel can choose its own formatting.
+  void formatDateShort;
+
+  return { step, goToStep, next, back, canNext, dueDatePreview, creditTermDays, draftRecovered, clearDraft };
+}
+```
+
+> Note: the `void formatDateShort;` line keeps the import available for the panel components without an unused-import error here; remove it if you prefer to import `formatDateShort` only in Task 3's panel. Either is fine — the panels (Task 3/5) will format `dueDatePreview` with `formatDateShort`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/web && npx vitest run src/pages/PurchaseOrdersPage/hooks/useCreatePoWizard.test.ts`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Type-check + commit**
+
+```bash
+./tools/check-types.sh all
+git add apps/web/src/pages/PurchaseOrdersPage/hooks/useCreatePoWizard.ts apps/web/src/pages/PurchaseOrdersPage/hooks/useCreatePoWizard.test.ts
+git commit -m "feat(purchasing): useCreatePoWizard — step gate, due-date preview, localStorage draft"
+```
+
+---
+
+### Task 3: Step panels 1 & 2 — Supplier (with due-date preview) + Items (with running subtotal)
+
+Split the modal body into per-step panel components so the wizard renders one panel at a time. This task builds the **Supplier** panel (step 0) and the **Items** panel (step 1). Both lift their JSX from the existing `CreatePOModal.tsx` Section 1 (lines 106-169) and Section 2 (lines 171-451) so visuals/validation stay identical; the only additions are the **due-date preview** (step 0) and the **running subtotal footer** (step 1).
+
+**Files:**
+- Create: `apps/web/src/pages/PurchaseOrdersPage/components/wizard/StepSupplier.tsx`
+- Create: `apps/web/src/pages/PurchaseOrdersPage/components/wizard/StepItems.tsx`
+
+**Interfaces:**
+- `StepSupplier` props:
+  ```ts
+  interface StepSupplierProps {
+    form: CreatePOModalProps['form'];
+    setForm: CreatePOModalProps['setForm'];
+    suppliersLoading: boolean;
+    suppliersError: boolean;
+    selectedSupplier: CreatePOModalProps['selectedSupplier'];
+    onSupplierSelect: CreatePOModalProps['onSupplierSelect'];
+    supplierHasVat: boolean;
+    creditTermDays: number | null;
+    dueDatePreview: Date | null;
+    inputClass: string;
+  }
+  ```
+- `StepItems` props:
+  ```ts
+  interface StepItemsProps {
+    items: ItemForm[];
+    setItems: React.Dispatch<React.SetStateAction<ItemForm[]>>;
+    addItem: () => void;
+    removeItem: (idx: number) => void;
+    updateItem: (idx: number, field: string, value: string) => void;
+    toggleModel: (idx: number, modelName: string) => void;
+    subtotal: number;
+    selectClass: string;
+    inputClass: string;
+  }
+  ```
+  (`CreatePOModalProps` is the existing exported interface in `CreatePOModal.tsx:9`; reuse its member types via `CreatePOModalProps['form']` etc. — do not redeclare them.)
+
+- [ ] **Step 1: Create `StepSupplier.tsx`**
+
+Lift Section 1 JSX from `CreatePOModal.tsx:106-169` verbatim (the supplier card: `ContactCombobox` + VAT badge + payment-method badge + orderDate/expectedDate `ThaiDateInput`s), then append a due-date preview block. Create the file:
+
+```tsx
+import ThaiDateInput from '@/components/ui/ThaiDateInput';
+import { ContactCombobox } from '@/components/contacts/ContactCombobox';
+import { formatDateShort } from '@/utils/formatters';
+import type { CreatePOModalProps } from '../CreatePOModal';
+
+interface StepSupplierProps {
+  form: CreatePOModalProps['form'];
+  setForm: CreatePOModalProps['setForm'];
+  suppliersLoading: boolean;
+  suppliersError: boolean;
+  selectedSupplier: CreatePOModalProps['selectedSupplier'];
+  onSupplierSelect: CreatePOModalProps['onSupplierSelect'];
+  supplierHasVat: boolean;
+  creditTermDays: number | null;
+  dueDatePreview: Date | null;
+  inputClass: string;
+}
+
+export function StepSupplier({
+  form, setForm, suppliersLoading, suppliersError, selectedSupplier,
+  onSupplierSelect, supplierHasVat, creditTermDays, dueDatePreview, inputClass,
+}: StepSupplierProps) {
+  return (
+    <div className="rounded-xl border border-border/50 bg-card p-5 shadow-sm">
+      <div className="flex items-center gap-2.5 mb-4">
+        <div className="flex items-center justify-center size-8 rounded-lg bg-success/10 text-success">
+          <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M22 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>
+        </div>
+        <div>
+          <h3 className="text-sm font-semibold text-foreground leading-snug">ข้อมูลผู้จัดจำหน่าย</h3>
+          <p className="text-xs text-muted-foreground leading-snug">เลือกผู้จัดจำหน่ายและวันที่สั่งซื้อ</p>
+        </div>
+      </div>
+
+      <div className="space-y-3">
+        <div>
+          <label className="block text-2xs font-medium text-muted-foreground uppercase tracking-wider mb-2">ผู้จัดจำหน่าย <span className="text-destructive">*</span></label>
+          <ContactCombobox
+            roleNeeded="SUPPLIER"
+            value={selectedSupplier?.name ?? (suppliersLoading ? 'กำลังโหลด...' : '')}
+            onSelect={onSupplierSelect}
+            invalid={!form.supplierId && suppliersError}
+            placeholder="เลือก/ค้นหาผู้จัดจำหน่าย"
+          />
+          <input type="hidden" value={form.supplierId} />
+          {selectedSupplier && (
+            <div className="mt-1 flex gap-2 flex-wrap">
+              <span className={`px-2 py-0.5 rounded-full text-xs font-medium leading-snug ${supplierHasVat ? 'bg-primary/10 text-primary dark:bg-primary/15' : 'bg-muted text-muted-foreground'}`}>
+                {supplierHasVat ? 'ผู้จัดจำหน่ายมี VAT - จะคำนวณ VAT 7% อัตโนมัติ' : 'ผู้จัดจำหน่ายไม่มี VAT'}
+              </span>
+              {selectedSupplier.paymentMethods?.length > 0 && (
+                <span className="px-2 py-0.5 rounded-full text-xs font-medium leading-snug bg-primary/10 text-primary">
+                  ชำระ: {selectedSupplier.paymentMethods.map((pm) => {
+                    const labels: Record<string, string> = { CASH: 'เงินสด', BANK_TRANSFER: 'โอนธนาคาร', CHECK: 'เช็ค', CREDIT: 'เครดิต' };
+                    return labels[pm.paymentMethod] || pm.paymentMethod;
+                  }).join(', ')}
+                </span>
+              )}
+            </div>
+          )}
+        </div>
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <label className="block text-2xs font-medium text-muted-foreground uppercase tracking-wider mb-2">วันที่สั่ง <span className="text-destructive">*</span></label>
+            <ThaiDateInput value={form.orderDate} onChange={(e) => setForm({ ...form, orderDate: e.target.value })} className={inputClass} required />
+          </div>
+          <div>
+            <label className="block text-2xs font-medium text-muted-foreground uppercase tracking-wider mb-2">วันที่คาดรับสินค้า</label>
+            <ThaiDateInput value={form.expectedDate} onChange={(e) => setForm({ ...form, expectedDate: e.target.value })} className={inputClass} />
+          </div>
+        </div>
+
+        {/* Due-date preview (credit-term driven) */}
+        {selectedSupplier && (
+          <div className="rounded-lg bg-muted/50 px-3 py-2 text-sm leading-snug">
+            {creditTermDays && dueDatePreview ? (
+              <span className="text-foreground">
+                เครดิต <span className="font-semibold">{creditTermDays}</span> วัน → ครบกำหนดชำระ{' '}
+                <span className="font-semibold text-primary">{formatDateShort(dueDatePreview)}</span>
+              </span>
+            ) : (
+              <span className="text-muted-foreground">ไม่มีเครดิต (ชำระทันที) — ไม่มีวันครบกำหนด</span>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Create `StepItems.tsx`**
+
+Lift Section 2 JSX from `CreatePOModal.tsx:171-451` verbatim (the items card: header with "+ เพิ่มรายการ", the `items.map(...)` block with all the category/brand/model/accessory/color/storage/quantity/unitPrice fields). Add a running-subtotal footer at the bottom. Because the inner per-item JSX is large and already correct, copy it exactly; only the wrapper header text and the appended footer differ. Create the file:
+
+```tsx
+import { brands, getModels, getModelInfo } from '@/data/productCatalog';
+import { accessoryTypes, chargerConnectorTypes } from '../../constants';
+import { formatNumberDecimal } from '@/utils/formatters';
+import type { ItemForm } from '../../types';
+
+interface StepItemsProps {
+  items: ItemForm[];
+  setItems: React.Dispatch<React.SetStateAction<ItemForm[]>>;
+  addItem: () => void;
+  removeItem: (idx: number) => void;
+  updateItem: (idx: number, field: string, value: string) => void;
+  toggleModel: (idx: number, modelName: string) => void;
+  subtotal: number;
+  selectClass: string;
+  inputClass: string;
+}
+
+export function StepItems({
+  items, setItems, addItem, removeItem, updateItem, toggleModel, subtotal, selectClass, inputClass,
+}: StepItemsProps) {
+  return (
+    <div className="rounded-xl border border-border/50 bg-card p-5 shadow-sm">
+      <div className="flex items-center gap-2.5 mb-4">
+        <div className="flex items-center justify-center size-8 rounded-lg bg-primary/10 text-primary">
+          <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="m7.5 4.27 9 5.15"/><path d="M21 8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16Z"/><path d="m3.3 7 8.7 5 8.7-5"/><path d="M12 22V12"/></svg>
+        </div>
+        <div className="flex-1">
+          <h3 className="text-sm font-semibold text-foreground leading-snug">รายการสินค้า</h3>
+          <p className="text-xs text-muted-foreground leading-snug">เพิ่มสินค้าที่ต้องการสั่งซื้อ</p>
+        </div>
+        <button type="button" onClick={addItem} className="text-sm text-primary hover:text-primary/90 font-medium">
+          + เพิ่มรายการ
+        </button>
+      </div>
+
+      <div className="space-y-4">
+        {/* PASTE the items.map(...) block VERBATIM from CreatePOModal.tsx lines 187-449.
+            It already uses brands/getModels/getModelInfo/accessoryTypes/chargerConnectorTypes,
+            selectClass/inputClass, updateItem/removeItem/toggleModel/setItems — all now provided
+            as props/imports above. Do not change its logic; copy it exactly. */}
+      </div>
+
+      {/* Running subtotal footer (new) */}
+      <div className="mt-4 flex items-center justify-between rounded-lg bg-muted/50 px-3 py-2.5">
+        <span className="text-sm text-muted-foreground leading-snug">
+          รวม {items.length} รายการ · {items.reduce((n, i) => n + (Number(i.quantity) || 0), 0)} ชิ้น
+        </span>
+        <span className="text-base font-semibold text-foreground tabular-nums font-mono">
+          {formatNumberDecimal(subtotal, 2)} บาท
+        </span>
+      </div>
+    </div>
+  );
+}
+```
+
+> Implementation note: when you paste the `items.map(...)` block, keep every line from `CreatePOModal.tsx:187` (`{items.map((item, idx) => {`) through `:449` (`})}`) unchanged. The only allowed edit is adding `leading-snug` to any Thai-text `<h3>/<p>/<label>/<span>` that lacks it (per the frontend rule). All referenced identifiers (`item`, `isAccessory`, `isCharger`, `availableModels`, `modelInfo`, `availableColors`, `availableStorage`, `selectedModels`, `accessoryAutoName`) are defined inside that block — copy them as-is.
+
+- [ ] **Step 3: Type-check**
+
+These panels aren't wired yet (Task 6 wires them), but they must compile. Run: `./tools/check-types.sh all`
+Expected: 0 errors. (If `CreatePOModalProps` is not yet exported, it already is — `CreatePOModal.tsx:9` declares `export interface CreatePOModalProps`.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/src/pages/PurchaseOrdersPage/components/wizard/StepSupplier.tsx apps/web/src/pages/PurchaseOrdersPage/components/wizard/StepItems.tsx
+git commit -m "feat(purchasing): wizard StepSupplier (due-date preview) + StepItems (running subtotal)"
+```
+
+---
+
+### Task 4: Step panel 3 — transparent ส่วนลด/VAT breakdown (`StepDiscountVat`)
+
+Build the discount/VAT step as a **transparent, line-by-line breakdown** that shows exactly how net is derived, computed from `computePoTotals` (Task 1) so the numbers provably match the backend. Lift the summary JSX from `CreatePOModal.tsx` Section 3 (lines 453-533) and make every intermediate line explicit (subtotal → discount → subtotalAfterDiscount → VAT 7% → totalWithVat → discountAfterVat → net), with a one-line "วิธีคำนวณ" explainer.
+
+**Files:**
+- Create: `apps/web/src/pages/PurchaseOrdersPage/components/wizard/StepDiscountVat.tsx`
+
+**Interfaces:**
+- Props:
+  ```ts
+  interface StepDiscountVatProps {
+    form: CreatePOModalProps['form'];
+    setForm: CreatePOModalProps['setForm'];
+    supplierHasVat: boolean;
+    totals: PoTotals; // from computePoTotals (Task 1)
+  }
+  ```
+
+- [ ] **Step 1: Create `StepDiscountVat.tsx`**
+
+```tsx
+import { formatNumberDecimal } from '@/utils/formatters';
+import type { CreatePOModalProps } from '../CreatePOModal';
+import type { PoTotals } from '../../poTotals';
+
+interface StepDiscountVatProps {
+  form: CreatePOModalProps['form'];
+  setForm: CreatePOModalProps['setForm'];
+  supplierHasVat: boolean;
+  totals: PoTotals;
+}
+
+const baht = (n: number) => `${formatNumberDecimal(n, 2)} บาท`;
+const discountInput =
+  'w-36 px-2 py-1 border border-input rounded text-sm text-right tabular-nums font-mono focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:ring-offset-[3px] focus-visible:ring-offset-background outline-hidden';
+
+export function StepDiscountVat({ form, setForm, supplierHasVat, totals }: StepDiscountVatProps) {
+  const { subtotal, discountNum, subtotalAfterDiscount, vatAmount, totalWithVat, discountAfterVatNum, netAmount } = totals;
+  return (
+    <div className="rounded-xl border border-border/50 bg-card p-5 shadow-sm">
+      <div className="flex items-center gap-2.5 mb-4">
+        <div className="flex items-center justify-center size-8 rounded-lg bg-primary/10 text-primary">
+          <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M12 2v20M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"/></svg>
+        </div>
+        <div>
+          <h3 className="text-sm font-semibold text-foreground leading-snug">ส่วนลด และ VAT</h3>
+          <p className="text-xs text-muted-foreground leading-snug">
+            {supplierHasVat ? 'คำนวณ VAT 7% หลังหักส่วนลด แล้วจึงหักส่วนลดหลัง VAT' : 'ผู้จัดจำหน่ายไม่มี VAT'}
+          </p>
+        </div>
+      </div>
+
+      <div className="bg-muted/50 rounded-lg p-4 space-y-2 text-sm">
+        {/* 1. subtotal */}
+        <div className="flex justify-between">
+          <span className="text-muted-foreground leading-snug">มูลค่าสินค้า{supplierHasVat ? ' (ก่อน VAT)' : ''}</span>
+          <span className="font-medium tabular-nums font-mono">{baht(subtotal)}</span>
+        </div>
+
+        {/* 2. discount before VAT (editable) */}
+        <div className="flex justify-between items-center">
+          <span className="text-muted-foreground leading-snug">หัก ส่วนลด{supplierHasVat ? ' (ก่อน VAT)' : ''}</span>
+          <input
+            type="number" min="0" placeholder="0" value={form.discount}
+            onChange={(e) => setForm({ ...form, discount: e.target.value })}
+            className={discountInput}
+          />
+        </div>
+
+        {/* 3. subtotalAfterDiscount */}
+        <div className="flex justify-between border-t border-border/60 pt-2">
+          <span className="text-muted-foreground leading-snug">= มูลค่าหลังหักส่วนลด</span>
+          <span className="tabular-nums font-mono">{baht(subtotalAfterDiscount)}</span>
+        </div>
+
+        {supplierHasVat && (
+          <>
+            {/* 4. VAT */}
+            <div className="flex justify-between">
+              <span className="text-muted-foreground leading-snug">+ VAT 7% (ปัดเศษขึ้นครึ่งสตางค์)</span>
+              <span className="tabular-nums font-mono">{baht(vatAmount)}</span>
+            </div>
+            {/* 5. totalWithVat */}
+            <div className="flex justify-between border-t border-border/60 pt-2">
+              <span className="text-muted-foreground leading-snug">= มูลค่ารวม VAT</span>
+              <span className="tabular-nums font-mono">{baht(totalWithVat)}</span>
+            </div>
+            {/* 6. discount after VAT (editable) */}
+            <div className="flex justify-between items-center">
+              <span className="text-muted-foreground leading-snug">หัก ส่วนลด (หลัง VAT)</span>
+              <input
+                type="number" min="0" placeholder="0" value={form.discountAfterVat}
+                onChange={(e) => setForm({ ...form, discountAfterVat: e.target.value })}
+                className={discountInput}
+              />
+            </div>
+          </>
+        )}
+
+        {/* 7. net */}
+        <div className="flex justify-between border-t-2 border-border pt-2.5 mt-1 font-semibold text-base">
+          <span className="leading-snug">ยอดสุทธิ</span>
+          <span className="text-primary tabular-nums font-mono">{baht(netAmount)}</span>
+        </div>
+
+        {/* explainer */}
+        <p className="text-2xs text-muted-foreground leading-snug pt-1">
+          {supplierHasVat
+            ? `วิธีคิด: (${formatNumberDecimal(subtotal, 2)} − ${formatNumberDecimal(discountNum, 2)}) × 1.07 − ${formatNumberDecimal(discountAfterVatNum, 2)} = ${formatNumberDecimal(netAmount, 2)} บาท`
+            : `วิธีคิด: ${formatNumberDecimal(subtotal, 2)} − ${formatNumberDecimal(discountNum, 2)} = ${formatNumberDecimal(netAmount, 2)} บาท`}
+        </p>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Type-check**
+
+Run: `./tools/check-types.sh all`
+Expected: 0 errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/src/pages/PurchaseOrdersPage/components/wizard/StepDiscountVat.tsx
+git commit -m "feat(purchasing): wizard StepDiscountVat — transparent VAT/discount/net breakdown"
+```
+
+---
+
+### Task 5: Step panel 4 — review + payment/attachments/notes (`StepReview`)
+
+The final step shows a read-only summary of supplier + items + the breakdown, then keeps the **payment / attachments / notes** controls (lifted from `CreatePOModal.tsx` Section 4 lines 535-627, Section 5 lines 629-707, and the Notes block lines 709-726) so nothing the owner uses today is lost. The "สร้าง PO" submit button lives in the wizard footer (Task 6), not here.
+
+**Files:**
+- Create: `apps/web/src/pages/PurchaseOrdersPage/components/wizard/StepReview.tsx`
+
+**Interfaces:**
+- Props:
+  ```ts
+  interface StepReviewProps {
+    form: CreatePOModalProps['form'];
+    setForm: CreatePOModalProps['setForm'];
+    items: ItemForm[];
+    selectedSupplier: CreatePOModalProps['selectedSupplier'];
+    supplierHasVat: boolean;
+    totals: PoTotals;
+    dueDatePreview: Date | null;
+    attachmentUrl: string;
+    setAttachmentUrl: (v: string) => void;
+    formAttachments: string[];
+    setFormAttachments: React.Dispatch<React.SetStateAction<string[]>>;
+    selectClass: string;
+    inputClass: string;
+  }
+  ```
+
+- [ ] **Step 1: Create `StepReview.tsx`**
+
+Build the read-only summary card first, then paste the existing Payment (Section 4), Attachments (Section 5), and Notes blocks verbatim from `CreatePOModal.tsx:535-726` (they reference `form`/`setForm`/`selectedSupplier`/`netAmount`/`attachmentUrl`/`setAttachmentUrl`/`formAttachments`/`setFormAttachments`/`selectClass`/`inputClass` — all provided as props; use `totals.netAmount` wherever the original used `netAmount`). Create the file:
+
+```tsx
+import { formatNumberDecimal, formatDateShort } from '@/utils/formatters';
+import type { CreatePOModalProps } from '../CreatePOModal';
+import type { ItemForm } from '../../types';
+import type { PoTotals } from '../../poTotals';
+
+interface StepReviewProps {
+  form: CreatePOModalProps['form'];
+  setForm: CreatePOModalProps['setForm'];
+  items: ItemForm[];
+  selectedSupplier: CreatePOModalProps['selectedSupplier'];
+  supplierHasVat: boolean;
+  totals: PoTotals;
+  dueDatePreview: Date | null;
+  attachmentUrl: string;
+  setAttachmentUrl: (v: string) => void;
+  formAttachments: string[];
+  setFormAttachments: React.Dispatch<React.SetStateAction<string[]>>;
+  selectClass: string;
+  inputClass: string;
+}
+
+const baht = (n: number) => `${formatNumberDecimal(n, 2)} บาท`;
+
+function itemLabel(i: ItemForm): string {
+  if (i.category === 'ACCESSORY') {
+    const isCharger = i.accessoryType === 'ชุดชาร์จ';
+    return isCharger
+      ? [i.accessoryType, i.accessoryBrand, i.model].filter(Boolean).join(' ')
+      : [i.accessoryType, i.accessoryBrand, i.model ? `สำหรับ ${i.model}` : ''].filter(Boolean).join(' ');
+  }
+  return [i.brand, i.model, i.color, i.storage].filter(Boolean).join(' ');
+}
+
+export function StepReview({
+  form, setForm, items, selectedSupplier, supplierHasVat, totals, dueDatePreview,
+  attachmentUrl, setAttachmentUrl, formAttachments, setFormAttachments, selectClass, inputClass,
+}: StepReviewProps) {
+  const netAmount = totals.netAmount;
+  return (
+    <div className="space-y-5">
+      {/* Read-only summary */}
+      <div className="rounded-xl border border-border/50 bg-card p-5 shadow-sm space-y-3">
+        <h3 className="text-sm font-semibold text-foreground leading-snug">ทบทวนใบสั่งซื้อ</h3>
+        <div className="grid grid-cols-2 gap-3 text-sm">
+          <div>
+            <div className="text-2xs text-muted-foreground uppercase tracking-wider leading-snug">ผู้จัดจำหน่าย</div>
+            <div className="text-foreground leading-snug">{selectedSupplier?.name ?? '-'}</div>
+          </div>
+          <div>
+            <div className="text-2xs text-muted-foreground uppercase tracking-wider leading-snug">วันที่สั่ง</div>
+            <div className="text-foreground leading-snug">{form.orderDate ? formatDateShort(form.orderDate) : '-'}</div>
+          </div>
+          {dueDatePreview && (
+            <div>
+              <div className="text-2xs text-muted-foreground uppercase tracking-wider leading-snug">ครบกำหนดชำระ</div>
+              <div className="text-foreground leading-snug">{formatDateShort(dueDatePreview)}</div>
+            </div>
+          )}
+        </div>
+        <div className="border-t border-border/60 pt-3 space-y-1.5">
+          {items.map((i, idx) => (
+            <div key={idx} className="flex justify-between text-sm">
+              <span className="text-muted-foreground leading-snug">{itemLabel(i)} × {i.quantity || 0}</span>
+              <span className="tabular-nums font-mono">{baht((Number(i.quantity) || 0) * (Number(i.unitPrice) || 0))}</span>
+            </div>
+          ))}
+        </div>
+        <div className="border-t border-border/60 pt-3 space-y-1 text-sm">
+          <div className="flex justify-between"><span className="text-muted-foreground leading-snug">มูลค่าสินค้า</span><span className="tabular-nums font-mono">{baht(totals.subtotal)}</span></div>
+          {totals.discountNum > 0 && <div className="flex justify-between"><span className="text-muted-foreground leading-snug">ส่วนลด</span><span className="tabular-nums font-mono">−{baht(totals.discountNum)}</span></div>}
+          {supplierHasVat && <div className="flex justify-between"><span className="text-muted-foreground leading-snug">VAT 7%</span><span className="tabular-nums font-mono">{baht(totals.vatAmount)}</span></div>}
+          {totals.discountAfterVatNum > 0 && <div className="flex justify-between"><span className="text-muted-foreground leading-snug">ส่วนลด (หลัง VAT)</span><span className="tabular-nums font-mono">−{baht(totals.discountAfterVatNum)}</span></div>}
+          <div className="flex justify-between border-t border-border pt-1.5 font-semibold text-base"><span className="leading-snug">ยอดสุทธิ</span><span className="text-primary tabular-nums font-mono">{baht(netAmount)}</span></div>
+        </div>
+      </div>
+
+      {/* PASTE Section 4 (Payment) from CreatePOModal.tsx lines 535-627 VERBATIM here,
+          replacing every `netAmount` reference with `netAmount` (already aliased to totals.netAmount above).
+          Add leading-snug to any Thai <label>/<h3>/<p> missing it. */}
+
+      {/* PASTE Section 5 (Attachments) from CreatePOModal.tsx lines 629-707 VERBATIM here
+          (it is gated by `form.paymentStatus !== 'UNPAID'`). */}
+
+      {/* PASTE the Notes block from CreatePOModal.tsx lines 709-726 VERBATIM here. */}
+    </div>
+  );
+}
+```
+
+> Implementation note: the three pasted sections already use `selectClass`/`inputClass` (declared in `CreatePOModal.tsx:85-86`) and the props above. The Payment section's status `onChange` (lines 552-559) computes `Math.round(netAmount * 100) / 100` — that `netAmount` now resolves to the local `const netAmount = totals.netAmount`, so the behavior is identical. Do not alter the file/reader logic.
+
+- [ ] **Step 2: Type-check**
+
+Run: `./tools/check-types.sh all`
+Expected: 0 errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/src/pages/PurchaseOrdersPage/components/wizard/StepReview.tsx
+git commit -m "feat(purchasing): wizard StepReview — read-only summary + payment/attachments/notes"
+```
+
+---
+
+### Task 6: Rebuild `CreatePOModal` as the 4-step wizard shell + wire the new hook
+
+Replace the modal body (the 5 stacked sections) with: a header, a `StepIndicator`-style stepper, a single active step panel, and a footer whose buttons are step-aware (กลับ / ถัดไป on steps 0-2; ยกเลิก / สร้าง PO on step 3). Keep `CreatePOModalProps` shape **identical** so `index.tsx` (lines 166-196) needs only the two new props for the wizard hook output (added in Step 4 here). The submit still calls the unchanged `handleCreate`.
+
+**Files:**
+- Modify: `apps/web/src/pages/PurchaseOrdersPage/components/CreatePOModal.tsx` (replace body lines 88-746; keep the `CreatePOModalProps` interface and the `selectClass`/`inputClass` consts)
+- Modify: `apps/web/src/pages/PurchaseOrdersPage/index.tsx` (instantiate `useCreatePoWizard`, pass its output to `CreatePOModal`, clear draft on success)
+
+**Interfaces:**
+- `CreatePOModalProps` gains (added to the existing interface at `CreatePOModal.tsx:9-50`):
+  ```ts
+    wizard: import('../hooks/useCreatePoWizard').CreatePoWizardApi;
+    totals: import('../poTotals').PoTotals;
+  ```
+  (All other members stay exactly as today, so the panels can receive them.)
+
+- [ ] **Step 1: Add `expectedDate` to the form member type + the two new props to `CreatePOModalProps`**
+
+First, **fix a pre-existing type gap**: the `form` member of `CreatePOModalProps` (lines 12-23) is missing `expectedDate`, even though the actual `usePOForm` state has it (`usePOForm.ts:16,30`) and the original JSX reads `form.expectedDate` (`CreatePOModal.tsx:162`). It compiled before only because `setForm`/the spread tolerated the extra field; but `StepSupplier`/`StepReview` access `form.expectedDate` through the indexed type `CreatePOModalProps['form']`, and `useCreatePoWizard`'s `WizardForm` requires it — so without this fix Tasks 3/5/6 emit TS2339 / "missing property expectedDate". In `CreatePOModal.tsx`, add `expectedDate: string;` to the `form` object type (after `orderDate: string;` at line 14):
+
+```ts
+    orderDate: string;
+    expectedDate: string;
+```
+
+Then, inside `export interface CreatePOModalProps { ... }`, add the two wizard props (after `setFormAttachments` at line 49):
+
+```ts
+  wizard: import('../hooks/useCreatePoWizard').CreatePoWizardApi;
+  totals: import('../poTotals').PoTotals;
+```
+
+- [ ] **Step 2: Replace the imports + the component body**
+
+Replace the top imports (lines 1-7) with:
+
+```tsx
+import { UseMutationResult } from '@tanstack/react-query';
+import { Check, Users, Package, Calculator, FileText } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { ItemForm } from '../types';
+import type { ContactPickResult } from '@/components/contacts/ContactCombobox';
+import { WIZARD_STEPS } from '../hooks/useCreatePoWizard';
+import { StepSupplier } from './wizard/StepSupplier';
+import { StepItems } from './wizard/StepItems';
+import { StepDiscountVat } from './wizard/StepDiscountVat';
+import { StepReview } from './wizard/StepReview';
+```
+
+(`brands/getModels/getModelInfo`, `accessoryTypes/chargerConnectorTypes`, `ThaiDateInput`, `ContactCombobox` are no longer used directly in this file — they moved into the panels. Keep `ContactPickResult` for the prop type. The `ItemForm` import stays.)
+
+Then replace the function body (from `export function CreatePOModal({` at line 52 through the final `}` at line 747) with the wizard shell. Destructure the props (including the two new ones), keep `if (!isOpen) return null;` and the `selectClass`/`inputClass` consts, then render:
+
+```tsx
+export function CreatePOModal({
+  isOpen, onClose, form, setForm, items, setItems, addItem, removeItem, updateItem, toggleModel,
+  suppliersLoading, suppliersError, selectedSupplier, onSupplierSelect, supplierHasVat,
+  subtotal, createMutation, handleCreate,
+  attachmentUrl, setAttachmentUrl, formAttachments, setFormAttachments,
+  wizard, totals,
+}: CreatePOModalProps) {
+  if (!isOpen) return null;
+
+  const selectClass = 'w-full px-3 py-2 border border-input rounded-lg text-sm focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:ring-offset-[3px] focus-visible:ring-offset-background outline-hidden';
+  const inputClass = selectClass;
+
+  const stepIcons = [Users, Package, Calculator, FileText];
+  const { step, goToStep, next, back, canNext } = wizard;
+  const isLast = step === WIZARD_STEPS.length - 1;
+
+  return (
+    <div className="fixed inset-0 z-50 bg-black/50 backdrop-blur-xs flex items-start justify-center pt-8 pb-8" role="dialog" aria-modal="true" aria-label="สร้างใบสั่งซื้อ">
+      <div className="w-full max-w-3xl bg-background rounded-xl shadow-2xl overflow-hidden flex flex-col max-h-[calc(100vh-4rem)]">
+
+        {/* Header */}
+        <div className="sticky top-0 z-10 bg-background/95 backdrop-blur-xs border-b px-6 py-4 flex items-center justify-between shrink-0">
+          <button type="button" onClick={onClose} className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors">
+            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="m15 18-6-6 6-6"/></svg>
+            ปิด
+          </button>
+          <h2 className="text-lg font-semibold text-foreground leading-snug">สร้างใบสั่งซื้อ</h2>
+          <div className="w-16" />
+        </div>
+
+        {/* Stepper */}
+        <div className="px-6 pt-4 shrink-0">
+          <div className="flex items-center">
+            {WIZARD_STEPS.map((label, i) => {
+              const completed = i < step;
+              const current = i === step;
+              const clickable = i < step; // only go back to completed steps via the indicator
+              const Icon = stepIcons[i] || Package;
+              return (
+                <div key={label} className="flex items-center flex-1 last:flex-none">
+                  <button
+                    type="button"
+                    disabled={!clickable}
+                    onClick={() => clickable && goToStep(i)}
+                    className={cn('flex items-center gap-2 group', clickable ? 'cursor-pointer' : 'cursor-default')}
+                  >
+                    <div className={cn(
+                      'size-8 rounded-lg flex items-center justify-center shrink-0 transition-all',
+                      completed && 'bg-primary text-primary-foreground',
+                      current && 'bg-primary text-primary-foreground ring-4 ring-primary/20',
+                      !completed && !current && 'bg-muted text-muted-foreground',
+                    )}>
+                      {completed ? <Check className="size-4" strokeWidth={2.5} /> : <Icon className="size-4" />}
+                    </div>
+                    <div className={cn('text-sm font-medium leading-snug hidden sm:block', current ? 'text-foreground' : 'text-muted-foreground')}>
+                      {label}
+                    </div>
+                  </button>
+                  {i < WIZARD_STEPS.length - 1 && (
+                    <div className="flex-1 mx-3 h-0.5 rounded-full bg-muted overflow-hidden">
+                      <div className={cn('h-full rounded-full transition-all', i < step ? 'bg-primary w-full' : 'w-0')} />
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* Active step panel */}
+        <form onSubmit={handleCreate} className="flex-1 overflow-y-auto">
+          <div className="p-6">
+            {step === 0 && (
+              <StepSupplier
+                form={form} setForm={setForm}
+                suppliersLoading={suppliersLoading} suppliersError={suppliersError}
+                selectedSupplier={selectedSupplier} onSupplierSelect={onSupplierSelect}
+                supplierHasVat={supplierHasVat}
+                creditTermDays={wizard.creditTermDays} dueDatePreview={wizard.dueDatePreview}
+                inputClass={inputClass}
+              />
+            )}
+            {step === 1 && (
+              <StepItems
+                items={items} setItems={setItems} addItem={addItem} removeItem={removeItem}
+                updateItem={updateItem} toggleModel={toggleModel} subtotal={subtotal}
+                selectClass={selectClass} inputClass={inputClass}
+              />
+            )}
+            {step === 2 && (
+              <StepDiscountVat form={form} setForm={setForm} supplierHasVat={supplierHasVat} totals={totals} />
+            )}
+            {step === 3 && (
+              <StepReview
+                form={form} setForm={setForm} items={items} selectedSupplier={selectedSupplier}
+                supplierHasVat={supplierHasVat} totals={totals} dueDatePreview={wizard.dueDatePreview}
+                attachmentUrl={attachmentUrl} setAttachmentUrl={setAttachmentUrl}
+                formAttachments={formAttachments} setFormAttachments={setFormAttachments}
+                selectClass={selectClass} inputClass={inputClass}
+              />
+            )}
+          </div>
+
+          {/* Footer */}
+          <div className="sticky bottom-0 bg-background/95 backdrop-blur-xs border-t px-6 py-4 flex justify-between gap-3 shrink-0">
+            <button
+              type="button"
+              onClick={() => (step === 0 ? onClose() : back())}
+              className="px-6 py-2.5 text-sm border border-input rounded-lg hover:bg-muted transition-colors"
+            >
+              {step === 0 ? 'ยกเลิก' : 'ย้อนกลับ'}
+            </button>
+            {isLast ? (
+              <button
+                type="submit"
+                disabled={createMutation.isPending}
+                className="px-6 py-2.5 text-sm bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 disabled:opacity-50 font-semibold transition-colors shadow-sm"
+              >
+                {createMutation.isPending ? 'กำลังสร้าง...' : 'สร้าง PO'}
+              </button>
+            ) : (
+              <button
+                type="button"
+                onClick={() => canNext && next()}
+                disabled={!canNext}
+                className="px-6 py-2.5 text-sm bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 disabled:opacity-50 font-semibold transition-colors shadow-sm"
+              >
+                ถัดไป
+              </button>
+            )}
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+```
+
+> Important: the `<form onSubmit={handleCreate}>` wraps all panels, but only the step-3 button is `type="submit"`. The step-0..2 "ถัดไป" buttons are `type="button"` so pressing them never submits. This preserves the existing `handleCreate` validation/early-returns (`usePOForm.ts:83-93`) as a final guard even though the wizard gate already blocks empty supplier/items.
+
+- [ ] **Step 3: Remove now-unused destructured props (avoid TS6133 unused-var errors)**
+
+The new body no longer references `discountNum`, `subtotalAfterDiscount`, `vatAmount`, `totalWithVat`, `discountAfterVatNum`, `netAmount` directly (they're inside `totals`/the panels). They remain in `CreatePOModalProps` (passed from `index.tsx`) but are not destructured in the function signature above — that's fine, unused props on the interface don't error. **Do not** destructure them. (If `check-types` flags any genuinely-unused import you left behind, delete it.)
+
+- [ ] **Step 4: Wire the wizard hook + clear-draft-on-success in `index.tsx`**
+
+In `apps/web/src/pages/PurchaseOrdersPage/index.tsx`:
+
+(a) Add the import near the others (after line 10):
+
+```tsx
+import { useCreatePoWizard } from './hooks/useCreatePoWizard';
+import { computePoTotals } from './poTotals';
+```
+
+(b) Instantiate the wizard after `poForm` (after line 36 `resetFormRef.current = poForm.resetForm;`):
+
+```tsx
+  const wizard = useCreatePoWizard({
+    isOpen: data.isCreateModalOpen,
+    form: poForm.form,
+    setForm: poForm.setForm,
+    items: poForm.items,
+    setItems: poForm.setItems,
+    selectedSupplier: poForm.selectedSupplier,
+  });
+
+  const totals = computePoTotals({
+    items: poForm.items,
+    discount: poForm.form.discount,
+    discountAfterVat: poForm.form.discountAfterVat,
+    supplierHasVat: poForm.supplierHasVat,
+  });
+```
+
+(c) Clear the draft when a PO is successfully created. The success path already resets the form via `onCreateSuccess` → `resetFormRef.current()` (`index.tsx:24-26`). Extend it to also clear the draft. Replace the `onCreateSuccess` callback (lines 24-26):
+
+```tsx
+  const wizardClearRef = useRef<() => void>(() => {});
+  const onCreateSuccess = useCallback(() => {
+    resetFormRef.current();
+    wizardClearRef.current();
+  }, []);
+```
+
+and after the `wizard` is created, sync the ref:
+
+```tsx
+  wizardClearRef.current = wizard.clearDraft;
+```
+
+(`useRef` is already imported at `index.tsx:1`.)
+
+(d) Pass the two new props to `<CreatePOModal>` (inside the JSX at lines 166-196, add before `/>`):
+
+```tsx
+        wizard={wizard}
+        totals={totals}
+```
+
+- [ ] **Step 5: Type-check**
+
+Run: `./tools/check-types.sh all`
+Expected: 0 errors.
+
+- [ ] **Step 6: Run the full PurchaseOrdersPage vitest suite (regression on the calculator + hook)**
+
+Run: `cd apps/web && npx vitest run src/pages/PurchaseOrdersPage`
+Expected: PASS (poTotals.test.ts 5 + useCreatePoWizard.test.ts 5).
+
+- [ ] **Step 7: Manual verification — desktop**
+
+Run the app (`cd apps/web && npm run dev`), log in as `admin@bestchoice.com / admin1234`, go to `/purchase-orders` → "+ สร้าง PO". Verify on a **desktop viewport (≥1024px)**:
+1. Step 1 "เลือกผู้ขาย": stepper shows 4 steps with step 1 active. "ถัดไป" is **disabled** until a supplier is picked. Pick a VAT supplier with a credit term → the due-date preview line shows "เครดิต N วัน → ครบกำหนดชำระ DD/MM/YYYY". Pick a no-credit/CASH method → shows "ไม่มีเครดิต (ชำระทันที)".
+2. Inline-create: type a new supplier name → "+ สร้างผู้ติดต่อใหม่" appears → create → it is selected and "ถัดไป" enables.
+3. Step 2 "เพิ่มรายการ": add 2 items; the footer shows "รวม N รายการ · M ชิ้น" and the running subtotal updates live. "ถัดไป" is **disabled** if any item lacks category/quantity/price.
+4. Step 3 "ส่วนลด/VAT": the breakdown shows every line (มูลค่าสินค้า → ส่วนลด → หลังหักส่วนลด → VAT 7% → รวม VAT → ส่วนลดหลัง VAT → ยอดสุทธิ) and a "วิธีคิด:" explainer. Type a discount → all downstream lines + net recompute. Confirm the **net here equals** the net you see after saving (see step 7 below). For a **no-VAT** supplier the VAT lines are hidden.
+5. Step 4 "ทบทวน+บันทึก": read-only summary lists each item + the totals matching step 3. Payment/attachments/notes controls work as before. Click "สร้าง PO" → toast "สร้างใบสั่งซื้อสำเร็จ (สถานะ: รออนุมัติ)" and the modal closes.
+6. Re-open "+ สร้าง PO" after filling a couple of steps and closing **without** saving → toast "พบใบสั่งซื้อร่างที่บันทึกไว้ — กู้คืนแล้ว" and the fields/step are restored. After a successful save, re-opening does **not** recover (draft cleared).
+7. Cross-check the math: create a VAT PO, then open it in PODetailModal/list and confirm the saved `netAmount` equals the wizard's step-3 net (proves `computePoTotals` mirrors `po-lifecycle.service.create()`).
+
+- [ ] **Step 8: Manual verification — mobile viewport**
+
+In dev tools, switch to a narrow viewport (e.g. 390px). Re-open the wizard. Verify: the stepper collapses to icons-only (step labels are `hidden sm:block`), the active panel scrolls, and the footer "ย้อนกลับ / ถัดไป" buttons remain reachable at the bottom. (Full mobile-first receive rebuild is B3 — for B2 the create wizard only needs to be usable, not redesigned, on small screens.)
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add apps/web/src/pages/PurchaseOrdersPage/components/CreatePOModal.tsx apps/web/src/pages/PurchaseOrdersPage/index.tsx
+git commit -m "feat(purchasing): CreatePOModal 4-step wizard shell + wire useCreatePoWizard/computePoTotals"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage (B2 items from spec §"Batches" B2 + the IA table "สร้าง PO" row):**
+- **4-step wizard** ((1) เลือกผู้ขาย → (2) เพิ่มรายการ → (3) ส่วนลด/VAT → (4) ทบทวน+บันทึก) → Task 2 (step state/gate) + Task 3 (StepSupplier/StepItems) + Task 4 (StepDiscountVat) + Task 5 (StepReview) + Task 6 (shell + stepper + footer). ✅
+- **supplier inline-create** → Task 3 StepSupplier reuses `ContactCombobox roleNeeded="SUPPLIER"` (which already has the "+ สร้างผู้ติดต่อใหม่" → `CreateContactModal` path) + the existing `onSupplierSelect` invalidate/refetch wiring in `index.tsx:42-58`. ✅
+- **show credit terms → due-date PREVIEW** → Task 2 `dueDatePreview`/`creditTermDays` (mirrors `po-lifecycle.service.create():69-77`) rendered in Task 3 StepSupplier + echoed in Task 5 StepReview. ✅
+- **product picker + running subtotal** → Task 3 StepItems (lifted item editor + new subtotal footer). ✅
+- **transparent VAT/discount breakdown mirroring backend `ROUND_HALF_UP`/net math** → Task 1 `computePoTotals` (unit-tested against the exact `subtotal → −discount → VAT HALF_UP if hasVat → −discountAfterVat = net` sequence) + Task 4 StepDiscountVat line-by-line display + explainer. ✅
+- **AUTO-SAVE DRAFT to localStorage, reusing ContractCreate pattern** → Task 2 `useCreatePoWizard` (save-on-change + 24h-TTL recover + toast, modeled on `useDraftStorage.ts` + `useContractCreateData.ts:62-94`) with a distinct key `bestchoice-po-draft`; cleared on successful create (Task 6 Step 4c). ✅
+- **keep `POST /purchase-orders` (CreatePODto) unchanged** → no backend files touched; `usePOForm.handleCreate` (the payload builder at `usePOForm.ts:94-119`) is untouched; Task 1 only refactors the *display* math behind the same return names. ✅
+
+**Placeholder scan:** No "TBD/TODO/implement later". Two steps say "PASTE … VERBATIM" (Task 3 Step 2 items block, Task 5 Step 1 payment/attachments/notes blocks) — these cite the **exact source line ranges** (`CreatePOModal.tsx:187-449`, `535-627`, `629-707`, `709-726`) of real, already-correct JSX to copy unchanged, with the only permitted edit (add `leading-snug`) spelled out. That is a deliberate lift-don't-rewrite instruction, not a placeholder.
+
+**Type/prop-name consistency:** `PoTotals`/`computePoTotals`/`VAT_RATE` (Task 1) are imported by name in Tasks 4, 5, 6. `CreatePoWizardApi`/`WIZARD_STEPS`/`useCreatePoWizard` (Task 2) used in Task 6. Panels reuse the **existing** exported `CreatePOModalProps` member types via indexed access (`CreatePOModalProps['form']` etc.) so they can't drift from the modal. `selectClass`/`inputClass` strings are defined once in `CreatePOModal.tsx` and passed down. `dueDatePreview: Date | null` consistent across hook → StepSupplier → StepReview. Payment status `onChange` keeps its `netAmount` reference, now aliased to `totals.netAmount` in StepReview.
+
+**Deviations found vs spec wording:**
+1. **VAT rate source.** The spec says "mirror the backend math EXACTLY". The backend resolves the rate via `loadVatRateDecimal(prisma)` (SystemConfig `VAT_RATE`, default 0.07; `po-lifecycle.service.ts:62`), but the existing frontend (`usePOForm.ts:127`) already hardcodes `0.07`. To stay a pure front-of-glass rebuild with **no new network call** and to match the number the form computes today, `computePoTotals` keeps `VAT_RATE = 0.07` (Task 1). If the owner ever changes `VAT_RATE` in settings, both the old modal and this wizard would be off by the same amount — pre-existing, not introduced here. The authoritative net is still the backend's (saved on the PO); the wizard preview just matches today's client behavior. Documented as `VAT_RATE` constant so a future task can wire it to settings.
+2. **"ROUND_HALF_UP" on the client.** The backend uses `Prisma.Decimal.ROUND_HALF_UP`; the client uses `Math.round(x*100)/100`, which is HALF_UP at the satang place for non-negative money (all PO amounts are ≥0, enforced by `@Min(0)` DTOs). Equivalent for this domain; the unit test in Task 1 pins a half-satang case (`100.50 × 0.07 = 7.035 → 7.04`).
+3. **Header "กลับ" → "ปิด".** The original modal's top-left button said "กลับ" but always closed the modal; in the wizard, back-navigation is the footer "ย้อนกลับ", so the header button is relabeled "ปิด" to avoid confusion. Cosmetic.
+4. **No B1 dependency.** B1 (list/detail redesign) is not yet implemented (only B0 plan exists); this batch is independent of it and of the B0 `ORDERED`/`grNumber` schema work — it touches none of those. New PO still saves as `DRAFT` exactly as today.

--- a/docs/superpowers/plans/2026-06-29-purchasing-b3-receive-mobile-direct.md
+++ b/docs/superpowers/plans/2026-06-29-purchasing-b3-receive-mobile-direct.md
@@ -1,0 +1,1575 @@
+# Purchasing v2 — Batch 3: Mobile-first Receiving + Supplier-Direct Receive (auto-PO) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make รับเข้าหน้างาน (goods receiving) a fast, mobile-first flow on a real phone — per-unit IMEI with live duplicate feedback, camera photo capture, used-phone checklist, PASS/REJECT with a structured `DefectReason`, and partial-receive progress — and add **supplier-direct receive ("รับเข้าตรง")** for urgent buys with no pre-made PO. Direct-receive is implemented as an **auto-PO**: one Serializable backend transaction creates a real `PurchaseOrder` (`isDirectReceive=true`, `unitPrice=costPrice`, supplier required), advances it `APPROVED → ORDERED` bypassing the OWNER approval gate (audited), then runs the **existing** `goodsReceiving()` so GR history / AP / progress / timeline all work with zero null-guards. **No JE. No accounting touch.**
+
+**Architecture:** Additive backend method + endpoint on the already-isolated `purchase-orders` module (`imports: []`, Prisma-only). New `DirectReceiveDto` + `PoReceivingService.directReceive()` (wraps `PoLifecycleService` create-shape logic + `goodsReceiving()` in ONE `$transaction`) + facade delegate + controller route. Frontend: rebuild `GoodsReceivingModal.tsx` into a mobile-first flow rendered in `Drawer` (bottom-sheet) on mobile via `useIsMobile`, keeping the existing desktop modal layout; add a "รับเข้าตรง (supplier)" entry that opens the same per-unit flow seeded from an ad-hoc supplier + line form and calls the new endpoint.
+
+**Tech Stack:** NestJS + Prisma + PostgreSQL (`apps/api`), jest mock-based unit tests. React 18 + TypeScript + Vite + Tailwind + shadcn/ui + Radix + lucide + react-query + `@/lib/api` (`apps/web`), vitest + RTL for logic, Playwright/manual for UI.
+
+**Spec:** `docs/superpowers/specs/2026-06-29-purchasing-receiving-ux-v2-design.md`
+
+## Global Constraints
+
+- **RED LINE — no accounting/finance:** introduce **NO** import of any accounting/finance/journal/expense/tax module into `purchase-orders`; do **not** touch `trade-in` or `Product.ownedByCompanyId`; **receiving stays JE-free**. Direct-receive posts **zero** `JournalEntry`/`GeneralLedger`/`ExpenseDocument` rows. Verified: the module declares **no `imports` array at all** (only `controllers`/`providers`/`exports`) and injects only `PrismaService` via the facade — architecturally sealed; do **not** add an `imports` entry in this batch ([purchase-orders.module.ts](../../../apps/api/src/modules/purchase-orders/purchase-orders.module.ts)). `auditLog` is a delegate on `PrismaService`, so writing the approval-bypass `AuditLog` needs **no** new import (mirror the `this.prisma.auditLog.create({ data: { userId, action, entity, entityId, oldValue?, newValue } })` shape in [trade-in-lifecycle.service.ts](../../../apps/api/src/modules/trade-in/services/trade-in-lifecycle.service.ts) — `TRADE_IN_APPRAISAL_FORCE_OVERRIDE`).
+- **`costPrice` is mandatory + validated on direct-receive.** COGS reads `Product.costPrice` at sale time; direct-receive sets `POItem.unitPrice = costPrice`, and `goodsReceiving()` already copies `unitPrice → Product.costPrice` ([po-receiving.service.ts:250](../../../apps/api/src/modules/purchase-orders/services/po-receiving.service.ts)). Reject `costPrice <= 0` / missing.
+- **Additive only:** reuse the existing `PurchaseOrder`/`POItem`/`GoodsReceiving` write paths. `GoodsReceiving.poId` and `GoodsReceivingItem.poItemId` stay `NOT NULL` (auto-PO guarantees a real `poId`). No new migration in this batch (B0 already shipped `ORDERED`, `orderedAt`, `isDirectReceive`, `grNumber`, `DefectReason`).
+- **Frontend rules** (`.claude/rules/frontend.md`): react-query + `@/lib/api` only (no raw `fetch`/`axios`); shadcn/ui + Radix + lucide only; **DESIGN TOKENS ONLY** — no hardcoded gray/hex, no `bg-white` (except print/receipt); Thai UI text uses `leading-snug`; lazy-loaded routes; `sonner` toasts; `useDebounce` for search. **Money = `Decimal`** on backend, never Float/Int.
+- **Validation messages in Thai** (`class-validator`). Backend specs are mock-based jest (no DB → run in the normal suite, not `--runInBand`).
+- **Type gate:** `./tools/check-types.sh all` must report **0 errors** before each commit.
+- **Reuse, don't reinvent** (all verified to exist): `Drawer`/`DrawerContent`/`DrawerHeader`/`DrawerTitle`/`DrawerFooter` ([components/ui/drawer.tsx](../../../apps/web/src/components/ui/drawer.tsx)); `useIsMobile` ([hooks/useIsMobile.ts](../../../apps/web/src/hooks/useIsMobile.ts)); base64 file→`photos[]` pattern from `PaymentModal.tsx:283-294`; `checklistCategories`/`defaultChecklist` ([constants.ts:48-64](../../../apps/web/src/pages/PurchaseOrdersPage/constants.ts)); `getErrorMessage` + `api` ([lib/api.ts]); `ThaiDateInput`.
+
+---
+
+### Task 1: `DirectReceiveDto` + supplier-direct receive backend (auto-PO in ONE `$transaction`)
+
+**Files:**
+- Modify: `apps/api/src/modules/purchase-orders/dto/create-po.dto.ts` (add `DirectReceiveItemDto` + `DirectReceiveDto`; add `defectReason` to `GoodsReceivingItemDto`)
+- Modify: `apps/api/src/modules/purchase-orders/services/po-receiving.service.ts` (add `directReceive()`; persist `defectReason` in the REJECT branch)
+- Modify: `apps/api/src/modules/purchase-orders/purchase-orders.service.ts` (facade delegate `directReceive`)
+- Modify: `apps/api/src/modules/purchase-orders/purchase-orders.controller.ts` (new route `POST /direct-receive`, static — before `:id`)
+- Create: `apps/api/src/modules/purchase-orders/purchase-orders.direct-receive.spec.ts`
+
+**Interfaces:**
+- Consumes: `PrismaService` (incl. `prisma.$transaction`, `tx.purchaseOrder.create`, `tx.purchaseOrder.update`, `tx.auditLog.create`, `tx.supplier.findUnique`); `generatePONumber(tx)` ([sequence.util.ts:129](../../../apps/api/src/utils/sequence.util.ts)); `generateGRNumber(tx)` (B0); `buildProductName` ([po-product-naming.util.ts]).
+- Produces:
+  - `DirectReceiveItemDto` = `POItemDto` fields (`brand/model/color/storage/category/accessoryType/accessoryBrand`, `quantity`, **`unitPrice` renamed semantics: this is `costPrice`**) + per-unit receiving fields (`imeiSerial`, `serialNumber`, `photos`, `status`, `rejectReason`, `defectReason`, `batteryHealth`, `warrantyExpired`, `warrantyExpireDate`, `hasBox`, `checklistResults`, `sellingPrice`). One DTO item = one physical unit (qty fixed at 1 per item; the frontend expands a line into N units).
+  - `DirectReceiveDto = { supplierId: string; orderDate: string; notes?: string; items: DirectReceiveItemDto[] }`.
+  - `PurchaseOrdersService.directReceive(dto: DirectReceiveDto, userId: string): Promise<{ poId; poNumber; receivingId; grNumber; status; passed; rejected; products; mainWarehouse }>`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/api/src/modules/purchase-orders/purchase-orders.direct-receive.spec.ts`:
+
+```typescript
+import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { PurchaseOrdersService } from './purchase-orders.service';
+import { PrismaService } from '../../prisma/prisma.service';
+
+/**
+ * B3 supplier-direct receive = auto-PO. ONE $transaction:
+ *  create PO (isDirectReceive, unitPrice=costPrice) -> set APPROVED/ORDERED
+ *  (approval-bypass + AuditLog) -> run goodsReceiving() to make GR + products.
+ * No JE; poId never null.
+ */
+describe('PurchaseOrdersService.directReceive — auto-PO supplier receive', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const makeTx = () => {
+    const created: Record<string, unknown[]> = {
+      po: [], poUpdate: [], audit: [], gr: [], gri: [], product: [], price: [], poItemUpdate: [],
+    };
+    const poItems = [{ id: 'poi-1', category: 'PHONE_NEW', brand: 'Apple', model: 'iPhone 16',
+      color: null, storage: '256GB', accessoryType: null, accessoryBrand: null,
+      quantity: 1, receivedQty: 0, unitPrice: 30000 }];
+    const tx: any = {
+      purchaseOrder: {
+        count: jest.fn().mockResolvedValue(2),
+        create: jest.fn().mockImplementation(({ data }) => {
+          created.po.push(data);
+          return Promise.resolve({ id: 'po-new', poNumber: 'PO-2099-01-003', supplierId: data.supplierId,
+            status: data.status, isDirectReceive: data.isDirectReceive, deletedAt: null,
+            supplier: { id: data.supplierId, name: 'ACME' },
+            items: poItems });
+        }),
+        findUnique: jest.fn().mockImplementation(() => Promise.resolve({ id: 'po-new', status: 'ORDERED',
+          deletedAt: null, supplierId: 'sup-1', supplier: { id: 'sup-1', name: 'ACME' },
+          items: poItems.map((i) => ({ ...i })) })),
+        update: jest.fn().mockImplementation(({ data }) => { created.poUpdate.push(data); return Promise.resolve({ id: 'po-new', status: data.status }); }),
+      },
+      auditLog: { create: jest.fn().mockImplementation(({ data }) => { created.audit.push(data); return Promise.resolve({}); }) },
+      supplier: { findUnique: jest.fn().mockResolvedValue({ id: 'sup-1', deletedAt: null }) },
+      branch: { findFirst: jest.fn().mockResolvedValue({ id: 'wh', name: 'คลังกลาง' }) },
+      goodsReceiving: { create: jest.fn().mockResolvedValue({ id: 'gr1' }), count: jest.fn().mockResolvedValue(0) },
+      goodsReceivingItem: { create: jest.fn().mockImplementation(({ data }) => { created.gri.push(data); return Promise.resolve({ id: 'gri1', ...data }); }) },
+      pOItem: {
+        findMany: jest.fn().mockImplementation(({ where: { id: { in: ids } } }) =>
+          Promise.resolve(poItems.filter((i) => ids.includes(i.id)).map((i) => ({ ...i })))),
+        update: jest.fn().mockImplementation(({ data }) => { created.poItemUpdate.push(data); return Promise.resolve({}); }),
+      },
+      product: {
+        create: jest.fn().mockImplementation(({ data }) => { created.product.push(data); return Promise.resolve({ id: 'prod-1', ...data }); }),
+        findMany: jest.fn().mockResolvedValue([]),
+      },
+      productPrice: { create: jest.fn().mockImplementation(({ data }) => { created.price.push(data); return Promise.resolve({}); }) },
+    };
+    return { tx, created };
+  };
+
+  const build = async (prisma: any) => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [PurchaseOrdersService, { provide: PrismaService, useValue: prisma }],
+    }).compile();
+    return module.get<PurchaseOrdersService>(PurchaseOrdersService);
+  };
+
+  const baseDto = () => ({
+    supplierId: 'sup-1',
+    orderDate: '2099-01-15',
+    items: [{
+      category: 'PHONE_NEW', brand: 'Apple', model: 'iPhone 16', storage: '256GB',
+      quantity: 1, unitPrice: 30000, status: 'PASS', imeiSerial: 'IMEI-1', serialNumber: 'SN-1', sellingPrice: 39900,
+    }],
+  });
+
+  it('creates an isDirectReceive PO at ORDERED, writes an approval-bypass AuditLog, and runs goodsReceiving', async () => {
+    const { tx, created } = makeTx();
+    const prisma: any = { $transaction: jest.fn().mockImplementation((fn: any) => fn(tx)) };
+    const service = await build(prisma);
+
+    const result = await service.directReceive(baseDto() as never, 'user-1');
+
+    // PO created with the auto-PO flags + cost as unitPrice
+    expect(created.po[0]).toEqual(expect.objectContaining({ supplierId: 'sup-1', isDirectReceive: true, status: 'APPROVED' }));
+    expect((created.po[0] as any).items.create[0]).toEqual(expect.objectContaining({ unitPrice: 30000, quantity: 1 }));
+    // advanced APPROVED -> ORDERED
+    expect(created.poUpdate.some((u: any) => u.status === 'ORDERED' && u.orderedAt instanceof Date)).toBe(true);
+    // approval-bypass audit row
+    expect(created.audit[0]).toEqual(expect.objectContaining({ userId: 'user-1', action: 'PO_DIRECT_RECEIVE_APPROVAL_BYPASS', entity: 'purchase_order', entityId: 'po-new' }));
+    // product created with costPrice from unitPrice
+    expect(created.product[0]).toEqual(expect.objectContaining({ costPrice: 30000, imeiSerial: 'IMEI-1' }));
+    // GR result surfaced
+    expect(result).toEqual(expect.objectContaining({ poId: 'po-new', poNumber: 'PO-2099-01-003', receivingId: 'gr1', passed: 1, rejected: 0 }));
+  });
+
+  it('rejects a missing/zero costPrice (COGS would silently break)', async () => {
+    const { tx } = makeTx();
+    const prisma: any = { $transaction: jest.fn().mockImplementation((fn: any) => fn(tx)) };
+    const service = await build(prisma);
+    const dto = baseDto();
+    dto.items[0].unitPrice = 0;
+    await expect(service.directReceive(dto as never, 'user-1')).rejects.toThrow(BadRequestException);
+  });
+
+  it('rejects when the supplier does not exist', async () => {
+    const { tx } = makeTx();
+    tx.supplier.findUnique = jest.fn().mockResolvedValue(null);
+    const prisma: any = { $transaction: jest.fn().mockImplementation((fn: any) => fn(tx)) };
+    const service = await build(prisma);
+    await expect(service.directReceive(baseDto() as never, 'user-1')).rejects.toThrow(NotFoundException);
+  });
+
+  it('persists structured defectReason on a REJECT unit', async () => {
+    const { tx, created } = makeTx();
+    const prisma: any = { $transaction: jest.fn().mockImplementation((fn: any) => fn(tx)) };
+    const service = await build(prisma);
+    const dto = baseDto();
+    dto.items[0] = { ...dto.items[0], status: 'REJECT', rejectReason: 'จอแตก', defectReason: 'SCREEN' } as never;
+    await service.directReceive(dto as never, 'user-1');
+    expect(created.gri[0]).toEqual(expect.objectContaining({ status: 'REJECT', defectReason: 'SCREEN', rejectReason: 'จอแตก' }));
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/api && npx jest purchase-orders.direct-receive.spec.ts`
+Expected: FAIL — `service.directReceive is not a function`.
+
+- [ ] **Step 3: Add `defectReason` to `GoodsReceivingItemDto` + the new direct-receive DTOs**
+
+In `dto/create-po.dto.ts`, update the top import to include `IsEnum` and import `DefectReason`:
+
+```typescript
+import { IsString, IsNumber, IsOptional, IsDateString, IsArray, ValidateNested, IsIn, IsBoolean, IsEnum, ArrayMinSize, Min } from 'class-validator';
+import { Type } from 'class-transformer';
+import { DefectReason } from '@prisma/client';
+```
+
+Add `defectReason` to `GoodsReceivingItemDto` (just after `rejectReason`, ~line 189) so the existing `/goods-receiving` flow can also send it (frontend Task 3 uses it):
+
+```typescript
+  @IsEnum(DefectReason)
+  @IsOptional()
+  defectReason?: DefectReason;
+```
+
+> NOTE: if B0 already added this field to `GoodsReceivingItemDto`, skip it (the Self-Review documents this). `IsEnum`/`DefectReason` imports are still required for `DirectReceiveItemDto` below.
+
+Append the two new DTO classes at the end of the file:
+
+```typescript
+export class DirectReceiveItemDto {
+  // Product spec (mirrors POItemDto)
+  @IsString() @IsOptional() brand?: string;
+  @IsString() @IsOptional() model?: string;
+  @IsString() @IsOptional() color?: string;
+  @IsString() @IsOptional() storage?: string;
+  @IsString() @IsOptional() category?: string;
+  @IsString() @IsOptional() accessoryType?: string;
+  @IsString() @IsOptional() accessoryBrand?: string;
+
+  // One DTO item = one physical unit.
+  @IsNumber() @Min(1) quantity: number;
+
+  // costPrice (booked as POItem.unitPrice; copied into Product.costPrice by goodsReceiving). MANDATORY for COGS.
+  @IsNumber() @Min(0.01, { message: 'กรุณาระบุราคาทุน (costPrice) มากกว่า 0' }) unitPrice: number;
+
+  // Per-unit receiving fields (mirror GoodsReceivingItemDto)
+  @IsString() @IsOptional() imeiSerial?: string;
+  @IsString() @IsOptional() serialNumber?: string;
+  @IsArray() @IsOptional() photos?: string[];
+  @IsIn(['PASS', 'REJECT']) status: 'PASS' | 'REJECT';
+  @IsString() @IsOptional() rejectReason?: string;
+  @IsEnum(DefectReason) @IsOptional() defectReason?: DefectReason;
+  @IsNumber() @IsOptional() batteryHealth?: number;
+  @IsBoolean() @IsOptional() warrantyExpired?: boolean;
+  @IsString() @IsOptional() warrantyExpireDate?: string;
+  @IsBoolean() @IsOptional() hasBox?: boolean;
+  @IsArray() @IsOptional() @ValidateNested({ each: true }) @Type(() => ChecklistResultDto)
+  checklistResults?: ChecklistResultDto[];
+  @IsNumber() @IsOptional() @Min(0) sellingPrice?: number;
+}
+
+export class DirectReceiveDto {
+  @IsString() supplierId: string;
+
+  @IsDateString() orderDate: string;
+
+  @IsString() @IsOptional() notes?: string;
+
+  @IsArray() @ArrayMinSize(1) @ValidateNested({ each: true }) @Type(() => DirectReceiveItemDto)
+  items: DirectReceiveItemDto[];
+}
+```
+
+- [ ] **Step 4: Persist `defectReason` in the existing REJECT branch (shared by both flows)**
+
+In `po-receiving.service.ts`, the REJECT branch (currently lines 301-311) does not store `defectReason`. Add it:
+
+```typescript
+          } else {
+            // Create receiving item for rejected items (no product created)
+            const rejectedItem = await tx.goodsReceivingItem.create({
+              data: {
+                receivingId: receiving.id,
+                poItemId: item.poItemId,
+                imeiSerial: item.imeiSerial,
+                serialNumber: item.serialNumber,
+                photos: item.photos || [],
+                status: 'REJECT',
+                rejectReason: item.rejectReason,
+                defectReason: item.defectReason ?? null,
+              },
+            });
+
+            rejectedItems.push(rejectedItem);
+          }
+```
+
+> NOTE: if B0 already added `defectReason` here, skip — the Self-Review documents this.
+
+- [ ] **Step 5: Implement `directReceive()` in `PoReceivingService`**
+
+In `po-receiving.service.ts`, update the import on line 4 and add the imports for the number generators + `DirectReceiveDto`:
+
+```typescript
+import { GoodsReceivingDto, DirectReceiveDto } from '../dto/create-po.dto';
+import { generatePONumber } from '../../../utils/sequence.util';
+```
+
+> NOTE: B0 retired the legacy `receive()` and removed `ReceivePODto` from this import; this batch's import line keeps `GoodsReceivingDto` and adds `DirectReceiveDto`. `generatePONumber` is the existing PO-number generator. `Prisma`/`ProductCategory`/`buildProductName` are already imported at the top (lines 2,5).
+
+Add the method as a new public method (place it after `goodsReceiving()`, before `confirmQC()`):
+
+```typescript
+  /**
+   * B3 — Supplier-direct receive ("รับเข้าตรง") = auto-PO.
+   *
+   * Urgent buys from a vendor with no pre-made PO. Instead of threading a
+   * nullable poId through the PO-centric read paths, we auto-create a REAL PO
+   * (supplier + line items, unitPrice = costPrice) and advance it
+   * APPROVED -> ORDERED in ONE Serializable $transaction, bypassing the OWNER
+   * approval gate (audited), then run the existing goodsReceiving() flow.
+   * Net: GoodsReceiving.poId is never null; GR history / AP / progress / the
+   * T5-C16 ceiling check all work unchanged. JE-FREE — no accounting touch.
+   */
+  async directReceive(dto: DirectReceiveDto, userId: string) {
+    // Up-front guard: every line must carry a positive costPrice (COGS reads it).
+    const badCost = dto.items.find((i) => !(Number(i.unitPrice) > 0));
+    if (badCost) {
+      throw new BadRequestException('กรุณาระบุราคาทุน (costPrice) มากกว่า 0 ให้ครบทุกรายการ');
+    }
+
+    const MAX_ATTEMPTS = 3;
+    for (let attempt = 1; ; attempt++) {
+      try {
+        return await this.prisma.$transaction(
+          async (tx) => {
+            // 1) Validate supplier
+            const supplier = await tx.supplier.findUnique({ where: { id: dto.supplierId } });
+            if (!supplier || supplier.deletedAt) throw new NotFoundException('ไม่พบ Supplier');
+
+            // 2) Create the auto-PO (unitPrice = costPrice). Starts APPROVED so the
+            //    OWNER approval gate is structurally bypassed (audited at step 4).
+            const poNumber = await generatePONumber(tx);
+            const totalAmount = dto.items.reduce((s, i) => s + Number(i.unitPrice) * i.quantity, 0);
+            const po = await tx.purchaseOrder.create({
+              data: {
+                poNumber,
+                supplierId: dto.supplierId,
+                orderDate: new Date(dto.orderDate),
+                totalAmount,
+                netAmount: totalAmount, // direct receive: no VAT/discount math (purchasing stays off the accounting surface)
+                notes: dto.notes ?? null,
+                createdById: userId,
+                approvedById: userId,
+                status: 'APPROVED',
+                isDirectReceive: true,
+                paymentStatus: 'UNPAID',
+                items: {
+                  create: dto.items.map((i) => ({
+                    brand: i.brand || null,
+                    model: i.model || null,
+                    color: i.color || null,
+                    storage: i.storage || null,
+                    category: i.category || null,
+                    accessoryType: i.accessoryType || null,
+                    accessoryBrand: i.accessoryBrand || null,
+                    quantity: i.quantity,
+                    unitPrice: i.unitPrice,
+                  })),
+                },
+              },
+              include: { items: true, supplier: { select: { id: true, name: true } } },
+            });
+
+            // 3) Advance APPROVED -> ORDERED (mirrors PoLifecycleService.order from B0)
+            await tx.purchaseOrder.update({
+              where: { id: po.id },
+              data: { status: 'ORDERED', orderedAt: new Date() },
+            });
+
+            // 4) Audit the approval-bypass (no cross-module import — auditLog is on PrismaService)
+            await tx.auditLog.create({
+              data: {
+                userId,
+                action: 'PO_DIRECT_RECEIVE_APPROVAL_BYPASS',
+                entity: 'purchase_order',
+                entityId: po.id,
+                newValue: {
+                  poNumber: po.poNumber,
+                  supplierId: dto.supplierId,
+                  isDirectReceive: true,
+                  reason: 'รับเข้าตรงจาก supplier (ไม่มี PO ล่วงหน้า) — ข้ามขั้นอนุมัติ',
+                  itemCount: dto.items.length,
+                },
+              },
+            });
+
+            // 5) Map each DTO line onto the freshly-created POItem id, then run the
+            //    SAME per-unit receiving pipeline (in this tx) the standard flow uses.
+            const grItems = dto.items.map((line, idx) => ({
+              poItemId: po.items[idx].id,
+              imeiSerial: line.imeiSerial,
+              serialNumber: line.serialNumber,
+              photos: line.photos,
+              status: line.status,
+              rejectReason: line.rejectReason,
+              defectReason: line.defectReason,
+              batteryHealth: line.batteryHealth,
+              warrantyExpired: line.warrantyExpired,
+              warrantyExpireDate: line.warrantyExpireDate,
+              hasBox: line.hasBox,
+              checklistResults: line.checklistResults,
+              sellingPrice: line.sellingPrice,
+            }));
+
+            const gr = await this.runReceiveInTx(tx, po.id, { items: grItems, notes: dto.notes }, userId);
+
+            return { poId: po.id, poNumber: po.poNumber, ...gr };
+          },
+          { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
+        );
+      } catch (e) {
+        const code = (e as { code?: string })?.code;
+        if ((code === 'P2002' || code === 'P2034') && attempt < MAX_ATTEMPTS) continue;
+        throw e;
+      }
+    }
+  }
+```
+
+> The above calls `this.runReceiveInTx(tx, ...)` — the receiving pipeline extracted from `goodsReceiving()` so both the standalone endpoint and direct-receive share **one** code path (DRY). Step 6 extracts it.
+
+- [ ] **Step 6: Extract the receiving pipeline into a private `runReceiveInTx(tx, ...)` and call it from `goodsReceiving()`**
+
+The body of `goodsReceiving()`'s `$transaction` callback (currently lines 134-349 — branch lookup, GR create, ceiling check, IMEI guard, per-unit loop, POItem updates, status recompute) becomes a private method taking the `tx` client. This keeps the existing flow byte-identical while letting `directReceive()` reuse it. Replace the whole `goodsReceiving()` method (lines 131-353) with:
+
+```typescript
+  async goodsReceiving(id: string, dto: GoodsReceivingDto, userId: string) {
+    return this.prisma.$transaction(
+      async (tx) => this.runReceiveInTx(tx, id, dto, userId),
+      { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
+    );
+  }
+
+  /**
+   * Shared per-unit receiving pipeline. Runs INSIDE a caller-provided
+   * Serializable tx (standard goodsReceiving OR direct-receive auto-PO).
+   * Closure-bound tx — never crosses a service boundary. T5-C16 ceiling
+   * re-read + IMEI dup guard + product create + POItem.update + status
+   * recompute all live here, unchanged.
+   */
+  private async runReceiveInTx(
+    tx: Prisma.TransactionClient,
+    id: string,
+    dto: GoodsReceivingDto,
+    userId: string,
+  ) {
+    const po = await tx.purchaseOrder.findUnique({
+      where: { id },
+      include: { items: true, supplier: true },
+    });
+
+    if (!po || po.deletedAt) throw new NotFoundException('ไม่พบใบสั่งซื้อ');
+    if (!['APPROVED', 'ORDERED', 'PARTIALLY_RECEIVED'].includes(po.status)) {
+      throw new BadRequestException('PO นี้ไม่อยู่ในสถานะที่สามารถรับสินค้าได้ (ต้อง APPROVED, ORDERED หรือ PARTIALLY_RECEIVED)');
+    }
+
+    // ... (the remaining existing body from current lines 144-349 verbatim:
+    //      main-warehouse lookup, gr create with grNumber, countByPoItem,
+    //      fresh re-read + ceiling check, IMEI batch+system dup guards,
+    //      per-unit PASS product+price+GRI create / REJECT GRI create,
+    //      POItem.update loop, status recompute + update, return object) ...
+  }
+```
+
+> IMPORTANT for the implementer: paste the **entire** current `$transaction` callback body (lines 144-349, starting at `// Find main warehouse branch` through the `return { receivingId, ... }`) into `runReceiveInTx` after the status check above, with three edits:
+> 1. The status check already added `'ORDERED'` (direct-receive PO is `ORDERED` when received; the standard flow's `APPROVED`/`PARTIALLY_RECEIVED` still pass). This is additive — no existing case regresses.
+> 2. Keep the B0 `grNumber` line (`const grNumber = await generateGRNumber(tx);` then `grNumber` in the GR `create`) — `generateGRNumber` is already imported (B0). If for any reason B0's import is absent, add `import { generateGRNumber } from '../../../utils/sequence.util';`.
+> 3. The REJECT branch already has the `defectReason` line from Step 4.
+> No logic changes — only the `tx` is now a parameter instead of closure-captured from `goodsReceiving()`. The type is `Prisma.TransactionClient` (already importable from the `Prisma` namespace imported on line 2).
+
+- [ ] **Step 7: Add the facade delegate**
+
+In `purchase-orders.service.ts`, add `DirectReceiveDto` to the dto import on line 3 and add the delegate (after `goodsReceiving`):
+
+```typescript
+import { CreatePODto, UpdatePODto, GoodsReceivingDto, DirectReceiveDto, UpdatePaymentDto } from './dto/create-po.dto';
+```
+```typescript
+  directReceive(dto: DirectReceiveDto, userId: string) {
+    return this.receiving.directReceive(dto, userId);
+  }
+```
+
+> NOTE: B0 removed `ReceivePODto` + the `receive()` delegate. If `ReceivePODto` is still present in the import (B0 not yet merged in this tree), the implementer must reconcile — but per the plan instructions B0 is assumed shipped.
+
+- [ ] **Step 8: Add the controller route (static, before `:id`)**
+
+In `purchase-orders.controller.ts`, add `DirectReceiveDto` to the dto import (line 4) and add the route **above** the `@Get(':id')` block (next to `qc-confirm`, in the "Static routes MUST be before :id" zone):
+
+```typescript
+  @Post('direct-receive')
+  @Roles('OWNER', 'BRANCH_MANAGER')
+  directReceive(
+    @Body() dto: DirectReceiveDto,
+    @CurrentUser() user: { id: string },
+  ) {
+    return this.purchaseOrdersService.directReceive(dto, user.id);
+  }
+```
+
+- [ ] **Step 9: Run tests to verify they pass**
+
+Run: `cd apps/api && npx jest purchase-orders.direct-receive.spec.ts`
+Expected: PASS (4 tests).
+
+- [ ] **Step 10: Run the surviving receive specs to prove the `runReceiveInTx` extraction didn't regress**
+
+Run: `cd apps/api && npx jest --runInBand src/modules/purchase-orders`
+Expected: all purchase-orders specs PASS (the B0 race + IMEI-dup specs that drive `goodsReceiving()` still green because the body is unchanged — only relocated).
+
+- [ ] **Step 11: Type-check + commit**
+
+```bash
+./tools/check-types.sh all
+git add apps/api/src/modules/purchase-orders
+git commit -m "feat(purchasing): supplier-direct receive as auto-PO (POST /direct-receive, approval-bypass audited, JE-free)"
+```
+
+---
+
+### Task 2: Frontend data layer — `directReceiveMutation` + direct-receive form state
+
+**Files:**
+- Modify: `apps/web/src/pages/PurchaseOrdersPage/types.ts` (add `DefectReasonValue`, `DirectReceiveLineForm`; extend `ReceivingUnitForm` with `defectReason`)
+- Modify: `apps/web/src/pages/PurchaseOrdersPage/constants.ts` (add `defectReasonOptions`)
+- Modify: `apps/web/src/pages/PurchaseOrdersPage/hooks/usePurchaseOrdersData.ts` (add `directReceiveMutation`, `isDirectReceiveOpen` state + `openDirectReceive`/`closeDirectReceive`, send `defectReason` in the existing GR mutation)
+- Create: `apps/web/src/pages/PurchaseOrdersPage/hooks/usePurchaseOrdersData.test.tsx` (vitest — payload-shape logic only)
+
+**Interfaces:**
+- Produces:
+  - `type DefectReasonValue = 'SCREEN' | 'BATTERY' | 'IMEI_BLOCKED' | 'BOX_MISSING' | 'WRONG_MODEL' | 'DOA' | 'COSMETIC' | 'OTHER'` (matches the B0 Prisma `DefectReason` enum values).
+  - `defectReasonOptions: { value: DefectReasonValue; label: string }[]`.
+  - `directReceiveMutation: UseMutationResult<{ data: { poNumber: string; passed: number; rejected: number; mainWarehouse: string } }, unknown, DirectReceivePayload, unknown>`.
+  - `DirectReceivePayload = { supplierId: string; orderDate: string; notes?: string; items: ReceivingUnitForm[]; lineCost: Record<string, string> }` where `lineCost[poItemId-ish]` carries the per-line costPrice. (We thread costPrice per *unit* by storing it on each `ReceivingUnitForm` — see Step 1.)
+- Consumes: `api.post('/purchase-orders/direct-receive', ...)`, `getErrorMessage`, `toast`.
+
+- [ ] **Step 1: Extend `ReceivingUnitForm` with `defectReason` + `costPrice`; add `DefectReasonValue` + `DirectReceiveLineForm`**
+
+In `types.ts`, change `ReceivingUnitForm` (currently lines 75-89) to add the two fields and add the new types at the bottom of the file:
+
+```typescript
+export type DefectReasonValue =
+  | 'SCREEN' | 'BATTERY' | 'IMEI_BLOCKED' | 'BOX_MISSING'
+  | 'WRONG_MODEL' | 'DOA' | 'COSMETIC' | 'OTHER';
+
+export interface ReceivingUnitForm {
+  poItemId: string;
+  label: string;
+  category: string;
+  imeiSerial: string;
+  serialNumber: string;
+  status: 'PASS' | 'REJECT';
+  rejectReason: string;
+  defectReason: DefectReasonValue | '';
+  batteryHealth: string;
+  warrantyExpired: boolean;
+  warrantyExpireDate: string;
+  hasBox: boolean;
+  checklist: { item: string; category: string; passed: boolean; note: string }[];
+  sellingPrice: string;
+  photos: string[];
+  costPrice: string; // direct-receive only (empty for PO-based receive)
+  // Direct-receive-only product attrs (PO-based seeds leave these undefined —
+  // the PO unit derives its name from the PO line; direct-receive seeds set them).
+  // Required by buildDirectReceiveItem (Task 2 Step 6) + lineToUnits (Task 4 Step 2).
+  brand?: string;
+  model?: string;
+  color?: string;
+  storage?: string;
+  accessoryType?: string;
+  accessoryBrand?: string;
+}
+
+// One ad-hoc supplier-direct line (expands into `quantity` ReceivingUnitForm units)
+export interface DirectReceiveLineForm {
+  category: string;
+  brand: string;
+  model: string;
+  color: string;
+  storage: string;
+  accessoryType: string;
+  accessoryBrand: string;
+  quantity: string;
+  costPrice: string;
+}
+```
+
+> `photos: string[]` was implicitly handled before (the old form never collected photos in the modal — `goodsReceivingMutation` sent `photos: item.photos || []` but `ReceivingUnitForm` had no `photos`; this batch makes it explicit so camera capture has somewhere to live).
+
+- [ ] **Step 2: Add `defectReasonOptions` to `constants.ts`**
+
+Append to `constants.ts`:
+
+```typescript
+import { DefectReasonValue } from './types';
+
+export const defectReasonOptions: { value: DefectReasonValue; label: string }[] = [
+  { value: 'SCREEN', label: 'จอเสีย/จอแตก' },
+  { value: 'BATTERY', label: 'แบตเตอรี่เสีย' },
+  { value: 'IMEI_BLOCKED', label: 'IMEI ถูกบล็อก' },
+  { value: 'BOX_MISSING', label: 'ไม่มีกล่อง/อุปกรณ์' },
+  { value: 'WRONG_MODEL', label: 'ผิดรุ่น/ผิดสเปก' },
+  { value: 'DOA', label: 'เปิดไม่ติด (DOA)' },
+  { value: 'COSMETIC', label: 'ตำหนิภายนอก' },
+  { value: 'OTHER', label: 'อื่นๆ' },
+];
+```
+
+> `constants.ts` already imports from `./types` (`ItemForm`), so adding the `DefectReasonValue` import is consistent.
+
+- [ ] **Step 3: Update the existing receiving form seed + GR mutation to carry the new fields**
+
+In `usePurchaseOrdersData.ts`, the `openReceiveModal` unit seed (currently lines 234-250) must include the two new fields so the rebuilt modal compiles:
+
+```typescript
+        units.push({
+          poItemId: item.id,
+          label: `${nameParts.join(' ')} #${item.receivedQty + i + 1}`,
+          category: item.category || '',
+          imeiSerial: '',
+          serialNumber: '',
+          status: 'PASS',
+          rejectReason: '',
+          defectReason: '',
+          batteryHealth: '',
+          warrantyExpired: false,
+          warrantyExpireDate: '',
+          hasBox: true,
+          checklist: defaultChecklist.map((c) => ({ ...c, passed: true, note: '' })),
+          sellingPrice: defaultPrice,
+          photos: [],
+          costPrice: '',
+        });
+```
+
+In the existing `goodsReceivingMutation` payload map (currently lines 130-149), send `defectReason` + `photos` on REJECT/PASS:
+
+```typescript
+          return {
+            poItemId: i.poItemId,
+            imeiSerial: i.imeiSerial || undefined,
+            serialNumber: i.serialNumber || undefined,
+            status: i.status,
+            rejectReason: i.status === 'REJECT' ? i.rejectReason || undefined : undefined,
+            defectReason: i.status === 'REJECT' ? i.defectReason || undefined : undefined,
+            photos: i.photos.length ? i.photos : undefined,
+            ...(isUsed && i.status === 'PASS' ? {
+              batteryHealth: i.batteryHealth ? Number(i.batteryHealth) : undefined,
+              warrantyExpired: i.warrantyExpired,
+              warrantyExpireDate: !i.warrantyExpired && i.warrantyExpireDate ? i.warrantyExpireDate : undefined,
+              hasBox: i.hasBox,
+              checklistResults: i.checklist.map(({ item, category, passed, note }) => ({
+                item, category, passed, ...(note ? { note } : {}),
+              })),
+            } : {}),
+            ...(i.status === 'PASS' && i.sellingPrice ? { sellingPrice: Number(i.sellingPrice) } : {}),
+          };
+```
+
+- [ ] **Step 4: Add direct-receive state + mutation**
+
+In `usePurchaseOrdersData.ts`, add state near the other modal flags (after `isReceiveModalOpen`, ~line 16):
+
+```typescript
+  const [isDirectReceiveOpen, setIsDirectReceiveOpen] = useState(false);
+  const [directLines, setDirectLines] = useState<DirectReceiveLineForm[]>([]);
+  const [directSupplierId, setDirectSupplierId] = useState('');
+  const [directNotes, setDirectNotes] = useState('');
+```
+
+Import the new type at the top:
+
+```typescript
+import { PurchaseOrder, PODetail, ReceivingUnitForm, DirectReceiveLineForm } from '../types';
+```
+
+Add the mutation (after `goodsReceivingMutation`, ~line 160). It accepts already-expanded units (the modal expands lines → units), each unit carrying its own `costPrice`:
+
+```typescript
+  const directReceiveMutation = useMutation({
+    mutationFn: async ({ supplierId, orderDate, notes, items }: { supplierId: string; orderDate: string; notes?: string; items: ReceivingUnitForm[] }) =>
+      api.post('/purchase-orders/direct-receive', {
+        supplierId,
+        orderDate,
+        notes: notes || undefined,
+        items: items.map((i) => {
+          const isUsed = i.category === 'PHONE_USED';
+          return {
+            category: i.category || undefined,
+            // brand/model parsed from the line label is fragile; the modal sets these explicitly (Step in Task 4)
+            brand: i.brand || undefined,
+            model: i.model || undefined,
+            color: i.color || undefined,
+            storage: i.storage || undefined,
+            accessoryType: i.accessoryType || undefined,
+            accessoryBrand: i.accessoryBrand || undefined,
+            quantity: 1,
+            unitPrice: Number(i.costPrice),
+            imeiSerial: i.imeiSerial || undefined,
+            serialNumber: i.serialNumber || undefined,
+            status: i.status,
+            rejectReason: i.status === 'REJECT' ? i.rejectReason || undefined : undefined,
+            defectReason: i.status === 'REJECT' ? i.defectReason || undefined : undefined,
+            photos: i.photos.length ? i.photos : undefined,
+            ...(isUsed && i.status === 'PASS' ? {
+              batteryHealth: i.batteryHealth ? Number(i.batteryHealth) : undefined,
+              warrantyExpired: i.warrantyExpired,
+              warrantyExpireDate: !i.warrantyExpired && i.warrantyExpireDate ? i.warrantyExpireDate : undefined,
+              hasBox: i.hasBox,
+              checklistResults: i.checklist.map(({ item, category, passed, note }) => ({ item, category, passed, ...(note ? { note } : {}) })),
+            } : {}),
+            ...(i.status === 'PASS' && i.sellingPrice ? { sellingPrice: Number(i.sellingPrice) } : {}),
+          };
+        }),
+      }),
+    onSuccess: (res) => {
+      queryClient.invalidateQueries({ queryKey: ['purchase-orders'] });
+      const d = res.data;
+      toast.success(`รับเข้าตรงสำเร็จ (${d.poNumber}): ผ่าน ${d.passed} ชิ้น, ไม่ผ่าน ${d.rejected} ชิ้น → รอ QC ที่คลัง ${d.mainWarehouse}`);
+      setIsDirectReceiveOpen(false);
+    },
+    onError: (err: unknown) => toast.error(getErrorMessage(err)),
+  });
+```
+
+> NOTE: the six optional product attrs (`brand?/model?/color?/storage?/accessoryType?/accessoryBrand?`) the mutation reads above are **already declared on `ReceivingUnitForm` in Step 1** of this task — no further interface edit needed here. PO-based seeds leave them undefined (the PO unit derives its name from the PO line); direct-receive seeds (Task 4 `lineToUnits`) set them.
+
+Add the openers (after `openReceiveModal`, ~line 254):
+
+```typescript
+  const openDirectReceive = () => {
+    setDirectSupplierId('');
+    setDirectNotes('');
+    setDirectLines([{ category: 'PHONE_NEW', brand: '', model: '', color: '', storage: '', accessoryType: '', accessoryBrand: '', quantity: '1', costPrice: '' }]);
+    setIsDirectReceiveOpen(true);
+  };
+```
+
+- [ ] **Step 5: Export the new symbols from the hook**
+
+In the hook's `return { ... }` (lines 356-414), add:
+
+```typescript
+    directReceiveMutation,
+    isDirectReceiveOpen,
+    setIsDirectReceiveOpen,
+    directLines,
+    setDirectLines,
+    directSupplierId,
+    setDirectSupplierId,
+    directNotes,
+    setDirectNotes,
+    openDirectReceive,
+```
+
+- [ ] **Step 6: Write the vitest payload-shape test (genuine value — the map() drops/keeps fields conditionally)**
+
+Create `apps/web/src/pages/PurchaseOrdersPage/hooks/usePurchaseOrdersData.test.tsx`. We test the **pure payload transform** by extracting it. To make it testable without React, add an exported pure helper alongside the hook file:
+
+In `usePurchaseOrdersData.ts`, export a pure builder used by the mutation (refactor the `items.map` body into it, then call it from `directReceiveMutation`):
+
+```typescript
+export function buildDirectReceiveItem(i: ReceivingUnitForm) {
+  const isUsed = i.category === 'PHONE_USED';
+  return {
+    category: i.category || undefined,
+    brand: i.brand || undefined,
+    model: i.model || undefined,
+    color: i.color || undefined,
+    storage: i.storage || undefined,
+    accessoryType: i.accessoryType || undefined,
+    accessoryBrand: i.accessoryBrand || undefined,
+    quantity: 1,
+    unitPrice: Number(i.costPrice),
+    imeiSerial: i.imeiSerial || undefined,
+    serialNumber: i.serialNumber || undefined,
+    status: i.status,
+    rejectReason: i.status === 'REJECT' ? i.rejectReason || undefined : undefined,
+    defectReason: i.status === 'REJECT' ? i.defectReason || undefined : undefined,
+    photos: i.photos.length ? i.photos : undefined,
+    ...(isUsed && i.status === 'PASS' ? {
+      batteryHealth: i.batteryHealth ? Number(i.batteryHealth) : undefined,
+      warrantyExpired: i.warrantyExpired,
+      warrantyExpireDate: !i.warrantyExpired && i.warrantyExpireDate ? i.warrantyExpireDate : undefined,
+      hasBox: i.hasBox,
+      checklistResults: i.checklist.map(({ item, category, passed, note }) => ({ item, category, passed, ...(note ? { note } : {}) })),
+    } : {}),
+    ...(i.status === 'PASS' && i.sellingPrice ? { sellingPrice: Number(i.sellingPrice) } : {}),
+  };
+}
+```
+
+Then in `directReceiveMutation`, replace the inline `items: items.map((i) => { ... })` with `items: items.map(buildDirectReceiveItem)`.
+
+Now the test:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { buildDirectReceiveItem } from './usePurchaseOrdersData';
+import type { ReceivingUnitForm } from '../types';
+
+const baseUnit = (over: Partial<ReceivingUnitForm>): ReceivingUnitForm => ({
+  poItemId: '', label: '', category: 'PHONE_NEW', imeiSerial: '', serialNumber: '',
+  status: 'PASS', rejectReason: '', defectReason: '', batteryHealth: '', warrantyExpired: false,
+  warrantyExpireDate: '', hasBox: true, checklist: [], sellingPrice: '', photos: [], costPrice: '0',
+  ...over,
+});
+
+describe('buildDirectReceiveItem', () => {
+  it('sends costPrice as unitPrice and quantity 1; omits defectReason on PASS', () => {
+    const out = buildDirectReceiveItem(baseUnit({ costPrice: '30000', imeiSerial: 'IMEI-1', sellingPrice: '39900', defectReason: 'SCREEN' }));
+    expect(out.unitPrice).toBe(30000);
+    expect(out.quantity).toBe(1);
+    expect(out.sellingPrice).toBe(39900);
+    expect(out.defectReason).toBeUndefined(); // PASS drops defectReason
+    expect(out.imeiSerial).toBe('IMEI-1');
+  });
+
+  it('includes defectReason + rejectReason only on REJECT, drops sellingPrice', () => {
+    const out = buildDirectReceiveItem(baseUnit({ status: 'REJECT', rejectReason: 'จอแตก', defectReason: 'SCREEN', sellingPrice: '39900', costPrice: '30000' }));
+    expect(out.defectReason).toBe('SCREEN');
+    expect(out.rejectReason).toBe('จอแตก');
+    expect(out.sellingPrice).toBeUndefined();
+  });
+
+  it('attaches used-phone fields + checklistResults only for PHONE_USED PASS', () => {
+    const out = buildDirectReceiveItem(baseUnit({ category: 'PHONE_USED', costPrice: '12000', imeiSerial: 'X', batteryHealth: '88', warrantyExpired: true, checklist: [{ item: 'จอ', category: 'ภายนอก', passed: true, note: '' }] }));
+    expect(out.batteryHealth).toBe(88);
+    expect(out.warrantyExpired).toBe(true);
+    expect(out.checklistResults).toEqual([{ item: 'จอ', category: 'ภายนอก', passed: true }]);
+  });
+
+  it('includes photos only when present', () => {
+    expect(buildDirectReceiveItem(baseUnit({ photos: [] })).photos).toBeUndefined();
+    expect(buildDirectReceiveItem(baseUnit({ photos: ['data:img'] })).photos).toEqual(['data:img']);
+  });
+});
+```
+
+- [ ] **Step 7: Run the test + type-check**
+
+Run: `cd apps/web && npx vitest run src/pages/PurchaseOrdersPage/hooks/usePurchaseOrdersData.test.tsx`
+Expected: PASS (4 tests).
+Run: `./tools/check-types.sh all`
+Expected: 0 errors.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/web/src/pages/PurchaseOrdersPage/types.ts apps/web/src/pages/PurchaseOrdersPage/constants.ts apps/web/src/pages/PurchaseOrdersPage/hooks/usePurchaseOrdersData.ts apps/web/src/pages/PurchaseOrdersPage/hooks/usePurchaseOrdersData.test.tsx
+git commit -m "feat(purchasing-web): direct-receive mutation + defectReason/photos in GR payload + payload-builder test"
+```
+
+---
+
+### Task 3: Mobile-first rebuild of `GoodsReceivingModal` (Drawer on mobile, per-unit IMEI dup feedback, camera, defect select, progress)
+
+**Files:**
+- Modify: `apps/web/src/pages/PurchaseOrdersPage/components/GoodsReceivingModal.tsx` (mobile-first rebuild — desktop modal kept; mobile renders inside `Drawer`)
+- Create: `apps/web/src/pages/PurchaseOrdersPage/components/ReceivingUnitCard.tsx` (the per-unit card, shared desktop + mobile)
+- Create: `apps/web/src/pages/PurchaseOrdersPage/components/useReceivingDuplicates.ts` (pure hook computing in-batch IMEI duplicate set)
+- Create: `apps/web/src/pages/PurchaseOrdersPage/components/useReceivingDuplicates.test.ts` (vitest — the dup logic)
+- Modify: `apps/web/src/pages/PurchaseOrdersPage/index.tsx` (pass new props if signature changes — verify)
+
+**Interfaces:**
+- Produces:
+  - `useReceivingDuplicates(units: ReceivingUnitForm[]): Set<number>` — returns the set of unit **indices** whose non-empty `imeiSerial` collides with another PASS unit's IMEI (live in-batch dup detection mirroring the backend `'พบ IMEI ซ้ำกันในรายการ'` guard at [po-receiving.service.ts:209](../../../apps/api/src/modules/purchase-orders/services/po-receiving.service.ts)).
+  - `ReceivingUnitCard` props: `{ unit: ReceivingUnitForm; idx: number; isDuplicate: boolean; updateReceivingUnit; updateChecklist; onAddPhotos: (idx, files: FileList) => void; onRemovePhoto: (idx, photoIdx) => void }`.
+- Consumes: `Drawer`, `DrawerContent`, `DrawerHeader`, `DrawerTitle`, `DrawerFooter` from `@/components/ui/drawer`; `useIsMobile`; `checklistCategories`, `defectReasonOptions`; `ThaiDateInput`.
+
+- [ ] **Step 1: Write the dup-logic vitest test first**
+
+Create `useReceivingDuplicates.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { computeDuplicateIndices } from './useReceivingDuplicates';
+import type { ReceivingUnitForm } from '../types';
+
+const u = (over: Partial<ReceivingUnitForm>): ReceivingUnitForm => ({
+  poItemId: '', label: '', category: 'PHONE_NEW', imeiSerial: '', serialNumber: '',
+  status: 'PASS', rejectReason: '', defectReason: '', batteryHealth: '', warrantyExpired: false,
+  warrantyExpireDate: '', hasBox: true, checklist: [], sellingPrice: '', photos: [], costPrice: '',
+  ...over,
+});
+
+describe('computeDuplicateIndices', () => {
+  it('flags both PASS units that share an IMEI', () => {
+    const set = computeDuplicateIndices([u({ imeiSerial: 'A' }), u({ imeiSerial: 'A' }), u({ imeiSerial: 'B' })]);
+    expect([...set].sort()).toEqual([0, 1]);
+  });
+
+  it('ignores empty IMEIs and REJECT units', () => {
+    const set = computeDuplicateIndices([u({ imeiSerial: '' }), u({ imeiSerial: '' }), u({ status: 'REJECT', imeiSerial: 'A' }), u({ imeiSerial: 'A' })]);
+    expect(set.size).toBe(0);
+  });
+
+  it('is case/space-insensitive', () => {
+    const set = computeDuplicateIndices([u({ imeiSerial: ' a1 ' }), u({ imeiSerial: 'A1' })]);
+    expect([...set].sort()).toEqual([0, 1]);
+  });
+});
+```
+
+- [ ] **Step 2: Implement `useReceivingDuplicates.ts`**
+
+```typescript
+import { useMemo } from 'react';
+import type { ReceivingUnitForm } from '../types';
+
+/** Pure: indices of PASS units whose normalized IMEI collides with another PASS unit. */
+export function computeDuplicateIndices(units: ReceivingUnitForm[]): Set<number> {
+  const seen = new Map<string, number[]>();
+  units.forEach((unit, idx) => {
+    if (unit.status !== 'PASS') return;
+    const key = unit.imeiSerial.trim().toLowerCase();
+    if (!key) return;
+    const arr = seen.get(key) ?? [];
+    arr.push(idx);
+    seen.set(key, arr);
+  });
+  const dupes = new Set<number>();
+  for (const arr of seen.values()) {
+    if (arr.length > 1) arr.forEach((i) => dupes.add(i));
+  }
+  return dupes;
+}
+
+export function useReceivingDuplicates(units: ReceivingUnitForm[]): Set<number> {
+  return useMemo(() => computeDuplicateIndices(units), [units]);
+}
+```
+
+- [ ] **Step 3: Run the dup test**
+
+Run: `cd apps/web && npx vitest run src/pages/PurchaseOrdersPage/components/useReceivingDuplicates.test.ts`
+Expected: PASS (3 tests).
+
+- [ ] **Step 4: Build `ReceivingUnitCard.tsx` (big touch targets, camera capture, defect select, dup banner)**
+
+This card replaces the inline per-unit JSX of the old modal and is reused on desktop + mobile. Camera capture uses `capture="environment"` + the base64 `FileReader` pattern from `PaymentModal.tsx:283-294`.
+
+```tsx
+import { ReceivingUnitForm, DefectReasonValue } from '../types';
+import { checklistCategories, defectReasonOptions } from '../constants';
+import ThaiDateInput from '@/components/ui/ThaiDateInput';
+import { Camera, X, AlertTriangle } from 'lucide-react';
+
+export interface ReceivingUnitCardProps {
+  unit: ReceivingUnitForm;
+  idx: number;
+  isDuplicate: boolean;
+  showCostPrice?: boolean; // direct-receive only
+  updateReceivingUnit: (idx: number, field: string, value: string) => void;
+  updateChecklist: (unitIdx: number, checkIdx: number, field: 'passed' | 'note', value: boolean | string) => void;
+  onAddPhotos: (idx: number, files: FileList) => void;
+  onRemovePhoto: (idx: number, photoIdx: number) => void;
+}
+
+// 44px-min touch targets per .claude/rules (mobile). Tokens only — no gray/hex/bg-white.
+const segBtn = 'min-h-11 px-4 rounded-lg text-sm font-medium transition-colors';
+const fieldInput = 'w-full min-h-11 px-3 py-2 border border-input rounded-lg text-sm focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:ring-offset-[3px] focus-visible:ring-offset-background outline-hidden';
+
+export function ReceivingUnitCard({ unit, idx, isDuplicate, showCostPrice, updateReceivingUnit, updateChecklist, onAddPhotos, onRemovePhoto }: ReceivingUnitCardProps) {
+  const isUsed = unit.category === 'PHONE_USED';
+  const isAccessory = unit.category === 'ACCESSORY';
+  return (
+    <div className={`border rounded-xl p-3 leading-snug ${unit.status === 'REJECT' ? 'border-destructive/30 bg-destructive/5' : isDuplicate ? 'border-warning/50 bg-warning/5' : 'border-border bg-card'}`}>
+      <div className="flex items-center justify-between gap-2 mb-2">
+        <span className="text-sm font-medium leading-snug">{unit.label}</span>
+        <div className="flex gap-1.5">
+          <button type="button" onClick={() => updateReceivingUnit(idx, 'status', 'PASS')}
+            className={`${segBtn} ${unit.status === 'PASS' ? 'bg-success text-success-foreground' : 'bg-muted text-muted-foreground hover:bg-success/10'}`}>ผ่าน</button>
+          <button type="button" onClick={() => updateReceivingUnit(idx, 'status', 'REJECT')}
+            className={`${segBtn} ${unit.status === 'REJECT' ? 'bg-destructive text-destructive-foreground' : 'bg-muted text-muted-foreground hover:bg-destructive/10'}`}>ไม่ผ่าน</button>
+        </div>
+      </div>
+
+      {showCostPrice && unit.status === 'PASS' && (
+        <div className="mb-2">
+          <label className="block text-xs text-muted-foreground mb-0.5 leading-snug">ราคาทุน (บาท) <span className="text-destructive">*</span></label>
+          <input type="number" min="0" inputMode="decimal" value={unit.costPrice}
+            onChange={(e) => updateReceivingUnit(idx, 'costPrice', e.target.value)} required className={fieldInput} placeholder="เช่น 30000" />
+        </div>
+      )}
+
+      {!isAccessory && unit.status === 'PASS' && (
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+          <div>
+            <label className="block text-xs text-muted-foreground mb-0.5 leading-snug">IMEI <span className="text-destructive">*</span></label>
+            <input type="text" inputMode="numeric" value={unit.imeiSerial}
+              onChange={(e) => updateReceivingUnit(idx, 'imeiSerial', e.target.value)} required
+              className={`${fieldInput} font-mono ${isDuplicate ? 'border-warning' : ''}`} placeholder="IMEI" />
+            {isDuplicate && (
+              <p className="mt-1 flex items-center gap-1 text-xs text-warning leading-snug"><AlertTriangle className="size-3.5 shrink-0" /> IMEI ซ้ำกับเครื่องอื่นในรายการนี้</p>
+            )}
+          </div>
+          <div>
+            <label className="block text-xs text-muted-foreground mb-0.5 leading-snug">หมายเลขซีเรียล <span className="text-destructive">*</span></label>
+            <input type="text" value={unit.serialNumber}
+              onChange={(e) => updateReceivingUnit(idx, 'serialNumber', e.target.value)} required className={`${fieldInput} font-mono`} placeholder="หมายเลขซีเรียล" />
+          </div>
+        </div>
+      )}
+
+      {/* Camera photo capture (mobile rear camera via capture attr) */}
+      {unit.status === 'PASS' && (
+        <div className="mt-2">
+          <label className="block text-xs text-muted-foreground mb-1 leading-snug">รูปถ่ายเครื่อง</label>
+          <div className="flex flex-wrap gap-2">
+            {unit.photos.map((p, pIdx) => (
+              <div key={pIdx} className="relative size-16 rounded-lg overflow-hidden border">
+                <img src={p} alt={`รูป ${pIdx + 1}`} className="size-full object-cover" />
+                <button type="button" onClick={() => onRemovePhoto(idx, pIdx)}
+                  className="absolute top-0.5 right-0.5 size-5 bg-destructive text-destructive-foreground rounded-full flex items-center justify-center"><X className="size-3" /></button>
+              </div>
+            ))}
+            <label className="size-16 border-2 border-dashed border-input rounded-lg flex flex-col items-center justify-center cursor-pointer hover:border-primary/60 hover:bg-primary/5 transition-colors">
+              <Camera className="size-5 text-muted-foreground" />
+              <span className="text-[10px] text-muted-foreground leading-snug">ถ่ายรูป</span>
+              <input type="file" accept="image/*" capture="environment" multiple className="hidden"
+                onChange={(e) => { if (e.target.files?.length) onAddPhotos(idx, e.target.files); e.target.value = ''; }} />
+            </label>
+          </div>
+        </div>
+      )}
+
+      {isUsed && unit.status === 'PASS' && (
+        <div className="mt-2 border border-warning/20 bg-warning/5 dark:bg-warning/10 rounded-xl p-3 space-y-2">
+          <div className="text-xs font-medium text-warning mb-1 leading-snug">ข้อมูลมือสอง</div>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+            <div>
+              <label className="block text-xs text-muted-foreground mb-0.5 leading-snug">% แบตเตอรี่ <span className="text-destructive">*</span></label>
+              <input type="number" inputMode="numeric" min="0" max="100" value={unit.batteryHealth}
+                onChange={(e) => updateReceivingUnit(idx, 'batteryHealth', e.target.value)} required className={fieldInput} placeholder="เช่น 87" />
+            </div>
+            <div>
+              <label className="block text-xs text-muted-foreground mb-0.5 leading-snug">กล่อง</label>
+              <div className="flex gap-2 mt-1">
+                <button type="button" onClick={() => updateReceivingUnit(idx, 'hasBox', 'true')}
+                  className={`${segBtn} ${unit.hasBox ? 'bg-success text-success-foreground' : 'bg-muted text-muted-foreground hover:bg-success/10'}`}>มีกล่อง</button>
+                <button type="button" onClick={() => updateReceivingUnit(idx, 'hasBox', 'false')}
+                  className={`${segBtn} ${!unit.hasBox ? 'bg-destructive text-destructive-foreground' : 'bg-muted text-muted-foreground hover:bg-destructive/10'}`}>ไม่มีกล่อง</button>
+              </div>
+            </div>
+          </div>
+          <div>
+            <label className="block text-xs text-muted-foreground mb-0.5 leading-snug">ประกันศูนย์ <span className="text-destructive">*</span></label>
+            <div className="flex items-center gap-3">
+              <label className="flex items-center gap-1.5 cursor-pointer min-h-11">
+                <input type="checkbox" checked={unit.warrantyExpired}
+                  onChange={(e) => updateReceivingUnit(idx, 'warrantyExpired', e.target.checked ? 'true' : 'false')} className="rounded size-4" />
+                <span className="text-xs text-muted-foreground leading-snug">หมดประกันแล้ว</span>
+              </label>
+              {!unit.warrantyExpired && (
+                <ThaiDateInput value={unit.warrantyExpireDate}
+                  onChange={(e) => updateReceivingUnit(idx, 'warrantyExpireDate', e.target.value)} required className={`flex-1 ${fieldInput}`} />
+              )}
+            </div>
+          </div>
+          <div className="mt-2 border-t border-warning/20 pt-2">
+            <div className="text-xs font-medium text-warning mb-2 leading-snug">เช็คลิสต์ตรวจเครื่อง</div>
+            {checklistCategories.map((cat) => (
+              <div key={cat} className="mb-2">
+                <div className="text-xs font-medium text-muted-foreground mb-1 leading-snug">{cat}</div>
+                <div className="space-y-1">
+                  {unit.checklist.map((c, checkIdx) => c.category !== cat ? null : (
+                    <div key={checkIdx} className="flex items-center gap-2">
+                      <button type="button" onClick={() => updateChecklist(idx, checkIdx, 'passed', !c.passed)}
+                        className={`size-6 rounded flex items-center justify-center text-xs font-bold transition-colors ${c.passed ? 'bg-success text-success-foreground' : 'bg-destructive text-destructive-foreground'}`}>
+                        {c.passed ? '✓' : '✗'}
+                      </button>
+                      <span className={`text-xs flex-1 leading-snug ${c.passed ? 'text-foreground' : 'text-destructive font-medium'}`}>{c.item}</span>
+                      {!c.passed && (
+                        <input type="text" placeholder="หมายเหตุ" value={c.note}
+                          onChange={(e) => updateChecklist(idx, checkIdx, 'note', e.target.value)}
+                          className="w-28 px-2 py-1.5 border border-destructive/30 rounded text-xs focus-visible:ring-1 focus-visible:ring-ring/30 outline-hidden" />
+                      )}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ))}
+            <div className="text-xs text-muted-foreground mt-1 leading-snug">ผ่าน {unit.checklist.filter((c) => c.passed).length}/{unit.checklist.length} รายการ</div>
+          </div>
+        </div>
+      )}
+
+      {unit.status === 'PASS' && (
+        <div className="mt-2 border border-primary/20 bg-primary/5 dark:bg-primary/10 rounded-xl p-3">
+          <label className="block text-xs text-muted-foreground mb-0.5 leading-snug">ราคาขาย (บาท) <span className="text-destructive">*</span></label>
+          <input type="number" inputMode="decimal" min="0" value={unit.sellingPrice}
+            onChange={(e) => updateReceivingUnit(idx, 'sellingPrice', e.target.value)} required className={fieldInput} placeholder="เช่น 15000" />
+        </div>
+      )}
+
+      {unit.status === 'REJECT' && (
+        <div className="mt-2 space-y-2">
+          <div>
+            <label className="block text-xs text-muted-foreground mb-0.5 leading-snug">สาเหตุที่ไม่ผ่าน <span className="text-destructive">*</span></label>
+            <select value={unit.defectReason}
+              onChange={(e) => updateReceivingUnit(idx, 'defectReason', e.target.value as DefectReasonValue)} required
+              className={fieldInput}>
+              <option value="">เลือกสาเหตุ…</option>
+              {defectReasonOptions.map((o) => <option key={o.value} value={o.value}>{o.label}</option>)}
+            </select>
+          </div>
+          <input type="text" placeholder="รายละเอียดเพิ่มเติม (ถ้ามี)" value={unit.rejectReason}
+            onChange={(e) => updateReceivingUnit(idx, 'rejectReason', e.target.value)} className={fieldInput} />
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 5: Rebuild `GoodsReceivingModal.tsx` — desktop modal kept, mobile renders in `Drawer`, shared body**
+
+Rewrite the file so the scrollable body (intro + progress + unit list + notes + footer buttons) is one `<Body/>` used by both the desktop overlay and the mobile `Drawer`. Add `progress` (passed/rejected/total) and per-unit dup highlighting. Add `onAddPhotos`/`onRemovePhoto` handlers that update `unit.photos` via the existing `setReceivingUnits`.
+
+```tsx
+import { UseMutationResult } from '@tanstack/react-query';
+import { PurchaseOrder, ReceivingUnitForm } from '../types';
+import { ReceivingUnitCard } from './ReceivingUnitCard';
+import { useReceivingDuplicates } from './useReceivingDuplicates';
+import { useIsMobile } from '@/hooks/useIsMobile';
+import { Drawer, DrawerContent, DrawerHeader, DrawerTitle } from '@/components/ui/drawer';
+import { ChevronLeft } from 'lucide-react';
+
+export interface GoodsReceivingModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  selectedPO: PurchaseOrder | null;
+  receivingUnits: ReceivingUnitForm[];
+  setReceivingUnits: React.Dispatch<React.SetStateAction<ReceivingUnitForm[]>>;
+  receivingNotes: string;
+  setReceivingNotes: (value: string) => void;
+  goodsReceivingMutation: UseMutationResult<unknown, unknown, { poId: string; items: ReceivingUnitForm[]; notes: string }, unknown>;
+  updateReceivingUnit: (idx: number, field: string, value: string) => void;
+  updateChecklist: (unitIdx: number, checkIdx: number, field: 'passed' | 'note', value: boolean | string) => void;
+  handleGoodsReceiving: (e: React.FormEvent) => void;
+}
+
+const MAX_PHOTOS_PER_UNIT = 6;
+
+export function GoodsReceivingModal(props: GoodsReceivingModalProps) {
+  const { isOpen, onClose, selectedPO, receivingUnits, setReceivingUnits, receivingNotes, setReceivingNotes,
+    goodsReceivingMutation, updateReceivingUnit, updateChecklist, handleGoodsReceiving } = props;
+  const isMobile = useIsMobile();
+  const dupIndices = useReceivingDuplicates(receivingUnits);
+
+  const onAddPhotos = (idx: number, files: FileList) => {
+    Array.from(files).slice(0, MAX_PHOTOS_PER_UNIT).forEach((file) => {
+      const reader = new FileReader();
+      reader.onload = () => setReceivingUnits((prev) => {
+        const next = [...prev];
+        const cur = next[idx];
+        if (cur.photos.length >= MAX_PHOTOS_PER_UNIT) return prev;
+        next[idx] = { ...cur, photos: [...cur.photos, reader.result as string] };
+        return next;
+      });
+      reader.readAsDataURL(file);
+    });
+  };
+  const onRemovePhoto = (idx: number, photoIdx: number) => setReceivingUnits((prev) => {
+    const next = [...prev];
+    next[idx] = { ...next[idx], photos: next[idx].photos.filter((_, i) => i !== photoIdx) };
+    return next;
+  });
+
+  const passCount = receivingUnits.filter((u) => u.status === 'PASS').length;
+  const rejectCount = receivingUnits.filter((u) => u.status === 'REJECT').length;
+
+  if (!isOpen) return null;
+
+  const body = (
+    <form onSubmit={handleGoodsReceiving} className="flex flex-col flex-1 overflow-hidden">
+      {/* Sticky progress strip */}
+      <div className="shrink-0 px-4 sm:px-6 py-3 border-b bg-background/95 backdrop-blur-xs">
+        <div className="flex items-center justify-between text-sm leading-snug">
+          <span className="text-muted-foreground">ตรวจรับ {receivingUnits.length} ชิ้น</span>
+          <span className="flex gap-3">
+            <span className="text-success">ผ่าน {passCount}</span>
+            <span className="text-destructive">ไม่ผ่าน {rejectCount}</span>
+          </span>
+        </div>
+        <div className="mt-2 h-1.5 w-full rounded-full bg-muted overflow-hidden flex">
+          <div className="bg-success h-full" style={{ width: `${receivingUnits.length ? (passCount / receivingUnits.length) * 100 : 0}%` }} />
+          <div className="bg-destructive h-full" style={{ width: `${receivingUnits.length ? (rejectCount / receivingUnits.length) * 100 : 0}%` }} />
+        </div>
+      </div>
+
+      <div className="flex-1 overflow-y-auto p-4 sm:p-6 space-y-3">
+        {receivingUnits.map((unit, idx) => (
+          <ReceivingUnitCard key={idx} unit={unit} idx={idx} isDuplicate={dupIndices.has(idx)}
+            updateReceivingUnit={updateReceivingUnit} updateChecklist={updateChecklist}
+            onAddPhotos={onAddPhotos} onRemovePhoto={onRemovePhoto} />
+        ))}
+        {receivingUnits.length === 0 && (
+          <div className="text-center py-8 text-muted-foreground text-sm leading-snug">ไม่มีรายการที่รอรับสินค้า</div>
+        )}
+        <div>
+          <label className="block text-xs text-muted-foreground mb-1 leading-snug">หมายเหตุ</label>
+          <textarea value={receivingNotes} onChange={(e) => setReceivingNotes(e.target.value)} rows={2}
+            className="w-full px-3 py-2 border border-input rounded-lg text-sm leading-snug focus-visible:ring-2 focus-visible:ring-ring/30 outline-hidden" placeholder="บันทึกเพิ่มเติม…" />
+        </div>
+      </div>
+
+      {/* Sticky footer */}
+      <div className="shrink-0 border-t px-4 sm:px-6 py-3 flex gap-3 bg-background/95 backdrop-blur-xs">
+        <button type="button" onClick={onClose} className="min-h-11 px-4 text-sm text-muted-foreground">ยกเลิก</button>
+        <button type="submit" disabled={goodsReceivingMutation.isPending || receivingUnits.length === 0}
+          className="flex-1 min-h-11 bg-primary text-primary-foreground rounded-lg text-sm font-medium hover:bg-primary/90 disabled:opacity-50 transition-colors">
+          {goodsReceivingMutation.isPending ? 'กำลังรับสินค้า…' : 'ยืนยันรับสินค้า'}
+        </button>
+      </div>
+    </form>
+  );
+
+  if (isMobile) {
+    return (
+      <Drawer open={isOpen} onOpenChange={(o) => { if (!o) onClose(); }}>
+        <DrawerContent className="h-[92dvh]">
+          <DrawerHeader className="text-left">
+            <DrawerTitle className="leading-snug">รับสินค้า — {selectedPO?.poNumber || ''}</DrawerTitle>
+          </DrawerHeader>
+          {body}
+        </DrawerContent>
+      </Drawer>
+    );
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 bg-black/50 backdrop-blur-xs flex items-start justify-center pt-8 pb-8" role="dialog" aria-modal="true" aria-label="รับสินค้า">
+      <div className="w-full max-w-3xl bg-background rounded-xl shadow-2xl overflow-hidden flex flex-col max-h-[calc(100vh-4rem)]">
+        <div className="sticky top-0 z-10 bg-background/95 backdrop-blur-xs border-b px-6 py-4 flex items-center justify-between shrink-0">
+          <button type="button" onClick={onClose} className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors">
+            <ChevronLeft className="size-4" /> กลับ
+          </button>
+          <h2 className="text-lg font-semibold text-foreground leading-snug">รับสินค้า — {selectedPO?.poNumber || ''}</h2>
+          <div className="w-16" />
+        </div>
+        {selectedPO && body}
+      </div>
+    </div>
+  );
+}
+```
+
+> The modal's public prop signature is **unchanged** (still the 11 props the parent passes at [index.tsx:222-234](../../../apps/web/src/pages/PurchaseOrdersPage/index.tsx)), so `index.tsx` needs **no** prop change. `setReceivingUnits` was already passed and is now actually used (photo handlers). `h-[92dvh]` uses dynamic viewport height (mobile-safe, matches the inbox-overhaul Batch-0 `h-dvh` pattern per memory).
+
+- [ ] **Step 6: Verify no `index.tsx` change needed**
+
+Run: `cd apps/web && npx tsc --noEmit -p tsconfig.json 2>&1 | grep -i "GoodsReceivingModal\|index.tsx" | head`
+Expected: no errors referencing the modal/index (signature preserved). If `setReceivingUnits` type mismatches, it already matches `React.Dispatch<React.SetStateAction<ReceivingUnitForm[]>>` from the hook.
+
+- [ ] **Step 7: Run all new web tests + type-check**
+
+Run: `cd apps/web && npx vitest run src/pages/PurchaseOrdersPage`
+Expected: PASS (both `useReceivingDuplicates.test.ts` + `usePurchaseOrdersData.test.tsx`).
+Run: `./tools/check-types.sh all`
+Expected: 0 errors.
+
+- [ ] **Step 8: MANUAL verification (desktop + mobile viewport)**
+
+Start the app (`npm run dev`), log in as `manager.ladprao@bestchoice.com / admin1234`, go to `/purchase-orders`, open an `APPROVED`/`ORDERED` PO with un-received items, click "รับสินค้า":
+- **Desktop (≥1024px):** centered modal appears; progress strip shows `ตรวจรับ N ชิ้น / ผ่าน / ไม่ผ่าน` with a two-color bar. Type the same IMEI into two PASS units → both cards turn warning-bordered and show "IMEI ซ้ำกับเครื่องอื่นในรายการนี้". Switch a unit to ไม่ผ่าน → the defect `<select>` appears with the 8 Thai options; submit is allowed only when each REJECT has a defect (enforced by Task 4 validation). Confirm a PASS unit shows the camera tile + selling-price.
+- **Mobile (DevTools device toolbar, e.g. iPhone 12, width <1024px):** the flow opens as a bottom-sheet `Drawer` filling ~92% of the dynamic viewport height with the drag handle; the per-unit segmented ผ่าน/ไม่ผ่าน buttons are ≥44px tall; the "ถ่ายรูป" tile opens the rear camera (`capture="environment"`) on a real device; the sticky footer "ยืนยันรับสินค้า" is full-width and reachable above the keyboard.
+- Submit a small partial batch (e.g. 2 of 5) → toast "รับ+ตรวจสำเร็จ…", PO list shows progress; reopen and the remaining 3 are still receivable (partial-receive intact).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add apps/web/src/pages/PurchaseOrdersPage/components/GoodsReceivingModal.tsx apps/web/src/pages/PurchaseOrdersPage/components/ReceivingUnitCard.tsx apps/web/src/pages/PurchaseOrdersPage/components/useReceivingDuplicates.ts apps/web/src/pages/PurchaseOrdersPage/components/useReceivingDuplicates.test.ts
+git commit -m "feat(purchasing-web): mobile-first receiving (Drawer + camera + IMEI dup feedback + defect select + progress)"
+```
+
+---
+
+### Task 4: "รับเข้าตรง (supplier)" entry + `DirectReceiveModal` + REJECT-defect submit validation
+
+**Files:**
+- Create: `apps/web/src/pages/PurchaseOrdersPage/components/DirectReceiveModal.tsx` (line builder → expands to units → reuses `ReceivingUnitCard`)
+- Modify: `apps/web/src/pages/PurchaseOrdersPage/index.tsx` (add the "รับเข้าตรง" button + mount `DirectReceiveModal`)
+- Modify: `apps/web/src/pages/PurchaseOrdersPage/hooks/usePurchaseOrdersData.ts` (add `handleGoodsReceiving` defect validation + a `directUnits`/`setDirectUnits` derived state helper)
+
+**Interfaces:**
+- Consumes: `directReceiveMutation`, `isDirectReceiveOpen`, `setIsDirectReceiveOpen`, `directLines`, `setDirectLines`, `directSupplierId`, `setDirectSupplierId`, `directNotes`, `setDirectNotes`, `openDirectReceive` (Task 2); `suppliers` (already loaded); `ReceivingUnitCard`, `useReceivingDuplicates`, `defaultChecklist`, `useIsMobile`, `Drawer`.
+- Produces: `DirectReceiveModal` (self-contained: builds units from lines on submit).
+
+- [ ] **Step 1: Add REJECT-must-have-defect validation to the existing `handleGoodsReceiving`**
+
+In `usePurchaseOrdersData.ts`, `handleGoodsReceiving` (lines 285-339) currently validates `rejectReason`. Replace the `missingReasons` check (lines 294-298) with a defect-reason check (the structured select is now the required field; free-text is optional):
+
+```typescript
+    const missingDefect = receivingUnits.filter((u) => u.status === 'REJECT' && !u.defectReason);
+    if (missingDefect.length > 0) {
+      toast.error('กรุณาเลือกสาเหตุที่ไม่ผ่าน (defect) สำหรับรายการที่ไม่ผ่าน');
+      return;
+    }
+```
+
+- [ ] **Step 2: Build `DirectReceiveModal.tsx`**
+
+Two phases in one sheet: (1) pick supplier + add ad-hoc lines (category/brand/model/cost/qty); (2) "ถัดไป: ตรวจรับ" expands every line into `quantity` units and shows the `ReceivingUnitCard` grid with `showCostPrice`. On submit, validate cost + IMEI + defect, then call `directReceiveMutation`.
+
+```tsx
+import { useState } from 'react';
+import { UseMutationResult } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { ReceivingUnitForm, DirectReceiveLineForm } from '../types';
+import { defaultChecklist } from '../constants';
+import { ReceivingUnitCard } from './ReceivingUnitCard';
+import { useReceivingDuplicates } from './useReceivingDuplicates';
+import { useIsMobile } from '@/hooks/useIsMobile';
+import { Drawer, DrawerContent, DrawerHeader, DrawerTitle } from '@/components/ui/drawer';
+import { Plus, Trash2, ChevronLeft } from 'lucide-react';
+
+interface SupplierLite { id: string; name: string }
+
+export interface DirectReceiveModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  suppliers: SupplierLite[];
+  supplierId: string;
+  setSupplierId: (v: string) => void;
+  lines: DirectReceiveLineForm[];
+  setLines: React.Dispatch<React.SetStateAction<DirectReceiveLineForm[]>>;
+  notes: string;
+  setNotes: (v: string) => void;
+  directReceiveMutation: UseMutationResult<{ data: { poNumber: string; passed: number; rejected: number; mainWarehouse: string } }, unknown, { supplierId: string; orderDate: string; notes?: string; items: ReceivingUnitForm[] }, unknown>;
+}
+
+const emptyLine: DirectReceiveLineForm = { category: 'PHONE_NEW', brand: '', model: '', color: '', storage: '', accessoryType: '', accessoryBrand: '', quantity: '1', costPrice: '' };
+const fieldInput = 'w-full min-h-11 px-3 py-2 border border-input rounded-lg text-sm focus-visible:ring-2 focus-visible:ring-ring/30 outline-hidden';
+
+function lineToUnits(line: DirectReceiveLineForm): ReceivingUnitForm[] {
+  const qty = Math.max(1, Number(line.quantity) || 1);
+  const isAccessory = line.category === 'ACCESSORY';
+  const label = (isAccessory ? [line.accessoryType, line.accessoryBrand, line.model] : [line.brand, line.model, line.color, line.storage]).filter(Boolean).join(' ');
+  return Array.from({ length: qty }, (_, i) => ({
+    poItemId: '', label: `${label || 'สินค้า'} #${i + 1}`,
+    category: line.category,
+    brand: line.brand, model: line.model, color: line.color, storage: line.storage,
+    accessoryType: line.accessoryType, accessoryBrand: line.accessoryBrand,
+    imeiSerial: '', serialNumber: '', status: 'PASS', rejectReason: '', defectReason: '',
+    batteryHealth: '', warrantyExpired: false, warrantyExpireDate: '', hasBox: true,
+    checklist: defaultChecklist.map((c) => ({ ...c, passed: true, note: '' })),
+    sellingPrice: '', photos: [], costPrice: line.costPrice,
+  }));
+}
+
+export function DirectReceiveModal(props: DirectReceiveModalProps) {
+  const { isOpen, onClose, suppliers, supplierId, setSupplierId, lines, setLines, notes, setNotes, directReceiveMutation } = props;
+  const isMobile = useIsMobile();
+  const [step, setStep] = useState<'lines' | 'inspect'>('lines');
+  const [units, setUnits] = useState<ReceivingUnitForm[]>([]);
+  const dupIndices = useReceivingDuplicates(units);
+
+  if (!isOpen) return null;
+
+  const updateLine = (idx: number, field: keyof DirectReceiveLineForm, value: string) =>
+    setLines((prev) => prev.map((l, i) => (i === idx ? { ...l, [field]: value } : l)));
+  const updateUnit = (idx: number, field: string, value: string) =>
+    setUnits((prev) => prev.map((u, i) => {
+      if (i !== idx) return u;
+      const boolFields = ['hasBox', 'warrantyExpired'];
+      return { ...u, [field]: boolFields.includes(field) ? value === 'true' : value };
+    }));
+  const updateUnitChecklist = (unitIdx: number, checkIdx: number, field: 'passed' | 'note', value: boolean | string) =>
+    setUnits((prev) => prev.map((u, i) => (i !== unitIdx ? u : { ...u, checklist: u.checklist.map((c, ci) => (ci === checkIdx ? { ...c, [field]: value } : c)) })));
+  const onAddPhotos = (idx: number, files: FileList) => Array.from(files).slice(0, 6).forEach((file) => {
+    const reader = new FileReader();
+    reader.onload = () => setUnits((prev) => prev.map((u, i) => (i === idx && u.photos.length < 6 ? { ...u, photos: [...u.photos, reader.result as string] } : u)));
+    reader.readAsDataURL(file);
+  });
+  const onRemovePhoto = (idx: number, photoIdx: number) =>
+    setUnits((prev) => prev.map((u, i) => (i === idx ? { ...u, photos: u.photos.filter((_, p) => p !== photoIdx) } : u)));
+
+  const goInspect = () => {
+    if (!supplierId) { toast.error('กรุณาเลือกผู้ขาย (supplier)'); return; }
+    const badCost = lines.find((l) => !(Number(l.costPrice) > 0));
+    if (badCost) { toast.error('กรุณาระบุราคาทุนมากกว่า 0 ให้ครบทุกรายการ'); return; }
+    setUnits(lines.flatMap(lineToUnits));
+    setStep('inspect');
+  };
+
+  const submit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const passUnits = units.filter((u) => u.status === 'PASS');
+    if (passUnits.some((u) => u.category !== 'ACCESSORY' && !u.imeiSerial.trim())) { toast.error('กรุณาระบุ IMEI ให้ครบทุกเครื่องที่ผ่าน'); return; }
+    if (passUnits.some((u) => !u.sellingPrice.trim() || Number(u.sellingPrice) <= 0)) { toast.error('กรุณาระบุราคาขายให้ครบทุกเครื่องที่ผ่าน'); return; }
+    if (units.some((u) => u.status === 'REJECT' && !u.defectReason)) { toast.error('กรุณาเลือกสาเหตุที่ไม่ผ่านให้ครบ'); return; }
+    if (dupIndices.size > 0) { toast.error('มี IMEI ซ้ำกันในรายการ กรุณาแก้ไขก่อนบันทึก'); return; }
+    directReceiveMutation.mutate({ supplierId, orderDate: new Date().toISOString().split('T')[0], notes, items: units });
+  };
+
+  const linesBody = (
+    <div className="flex flex-col flex-1 overflow-hidden">
+      <div className="flex-1 overflow-y-auto p-4 sm:p-6 space-y-3">
+        <div>
+          <label className="block text-xs text-muted-foreground mb-0.5 leading-snug">ผู้ขาย (supplier) <span className="text-destructive">*</span></label>
+          <select value={supplierId} onChange={(e) => setSupplierId(e.target.value)} className={fieldInput}>
+            <option value="">เลือกผู้ขาย…</option>
+            {suppliers.map((s) => <option key={s.id} value={s.id}>{s.name}</option>)}
+          </select>
+        </div>
+        {lines.map((line, idx) => (
+          <div key={idx} className="border border-border rounded-xl p-3 bg-card space-y-2">
+            <div className="flex items-center justify-between">
+              <span className="text-sm font-medium leading-snug">รายการ #{idx + 1}</span>
+              {lines.length > 1 && (
+                <button type="button" onClick={() => setLines((p) => p.filter((_, i) => i !== idx))} className="text-destructive p-2"><Trash2 className="size-4" /></button>
+              )}
+            </div>
+            <select value={line.category} onChange={(e) => updateLine(idx, 'category', e.target.value)} className={fieldInput}>
+              <option value="PHONE_NEW">มือถือใหม่</option>
+              <option value="PHONE_USED">มือถือมือสอง</option>
+              <option value="TABLET">แท็บเล็ต</option>
+              <option value="ACCESSORY">อุปกรณ์เสริม</option>
+            </select>
+            <div className="grid grid-cols-2 gap-2">
+              <input value={line.brand} onChange={(e) => updateLine(idx, 'brand', e.target.value)} placeholder="ยี่ห้อ" className={fieldInput} />
+              <input value={line.model} onChange={(e) => updateLine(idx, 'model', e.target.value)} placeholder="รุ่น" className={fieldInput} />
+              <input value={line.color} onChange={(e) => updateLine(idx, 'color', e.target.value)} placeholder="สี" className={fieldInput} />
+              <input value={line.storage} onChange={(e) => updateLine(idx, 'storage', e.target.value)} placeholder="ความจุ" className={fieldInput} />
+            </div>
+            <div className="grid grid-cols-2 gap-2">
+              <div>
+                <label className="block text-xs text-muted-foreground mb-0.5 leading-snug">จำนวน</label>
+                <input type="number" min="1" value={line.quantity} onChange={(e) => updateLine(idx, 'quantity', e.target.value)} className={fieldInput} />
+              </div>
+              <div>
+                <label className="block text-xs text-muted-foreground mb-0.5 leading-snug">ราคาทุน/ชิ้น <span className="text-destructive">*</span></label>
+                <input type="number" min="0" value={line.costPrice} onChange={(e) => updateLine(idx, 'costPrice', e.target.value)} className={fieldInput} placeholder="เช่น 30000" />
+              </div>
+            </div>
+          </div>
+        ))}
+        <button type="button" onClick={() => setLines((p) => [...p, { ...emptyLine }])}
+          className="w-full min-h-11 border-2 border-dashed border-input rounded-lg text-sm text-muted-foreground hover:border-primary/60 hover:bg-primary/5 flex items-center justify-center gap-1.5"><Plus className="size-4" /> เพิ่มรายการ</button>
+        <div>
+          <label className="block text-xs text-muted-foreground mb-1 leading-snug">หมายเหตุ</label>
+          <textarea value={notes} onChange={(e) => setNotes(e.target.value)} rows={2} className="w-full px-3 py-2 border border-input rounded-lg text-sm leading-snug outline-hidden" placeholder="บันทึกเพิ่มเติม…" />
+        </div>
+      </div>
+      <div className="shrink-0 border-t px-4 sm:px-6 py-3 flex gap-3 bg-background/95">
+        <button type="button" onClick={onClose} className="min-h-11 px-4 text-sm text-muted-foreground">ยกเลิก</button>
+        <button type="button" onClick={goInspect} className="flex-1 min-h-11 bg-primary text-primary-foreground rounded-lg text-sm font-medium hover:bg-primary/90">ถัดไป: ตรวจรับ</button>
+      </div>
+    </div>
+  );
+
+  const inspectBody = (
+    <form onSubmit={submit} className="flex flex-col flex-1 overflow-hidden">
+      <div className="shrink-0 px-4 sm:px-6 py-2 border-b">
+        <button type="button" onClick={() => setStep('lines')} className="flex items-center gap-1 text-sm text-muted-foreground"><ChevronLeft className="size-4" /> กลับไปแก้รายการ</button>
+      </div>
+      <div className="flex-1 overflow-y-auto p-4 sm:p-6 space-y-3">
+        {units.map((unit, idx) => (
+          <ReceivingUnitCard key={idx} unit={unit} idx={idx} isDuplicate={dupIndices.has(idx)} showCostPrice
+            updateReceivingUnit={updateUnit} updateChecklist={updateUnitChecklist} onAddPhotos={onAddPhotos} onRemovePhoto={onRemovePhoto} />
+        ))}
+      </div>
+      <div className="shrink-0 border-t px-4 sm:px-6 py-3 flex gap-3 bg-background/95">
+        <button type="submit" disabled={directReceiveMutation.isPending}
+          className="flex-1 min-h-11 bg-primary text-primary-foreground rounded-lg text-sm font-medium hover:bg-primary/90 disabled:opacity-50">
+          {directReceiveMutation.isPending ? 'กำลังรับเข้า…' : 'ยืนยันรับเข้าตรง'}
+        </button>
+      </div>
+    </form>
+  );
+
+  const body = step === 'lines' ? linesBody : inspectBody;
+  const title = step === 'lines' ? 'รับเข้าตรง — เพิ่มรายการ' : 'รับเข้าตรง — ตรวจรับ';
+
+  if (isMobile) {
+    return (
+      <Drawer open={isOpen} onOpenChange={(o) => { if (!o) onClose(); }}>
+        <DrawerContent className="h-[92dvh]">
+          <DrawerHeader className="text-left"><DrawerTitle className="leading-snug">{title}</DrawerTitle></DrawerHeader>
+          {body}
+        </DrawerContent>
+      </Drawer>
+    );
+  }
+  return (
+    <div className="fixed inset-0 z-50 bg-black/50 backdrop-blur-xs flex items-start justify-center pt-8 pb-8" role="dialog" aria-modal="true" aria-label="รับเข้าตรง">
+      <div className="w-full max-w-3xl bg-background rounded-xl shadow-2xl overflow-hidden flex flex-col max-h-[calc(100vh-4rem)]">
+        <div className="sticky top-0 z-10 bg-background/95 border-b px-6 py-4 flex items-center justify-between shrink-0">
+          <h2 className="text-lg font-semibold text-foreground leading-snug">{title}</h2>
+          <button type="button" onClick={onClose} className="text-sm text-muted-foreground hover:text-foreground">ปิด</button>
+        </div>
+        {body}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Wire the "รับเข้าตรง" button + mount the modal in `index.tsx`**
+
+In `index.tsx`, add the import:
+
+```typescript
+import { DirectReceiveModal } from './components/DirectReceiveModal';
+```
+
+Add a "รับเข้าตรง (supplier)" button to the header action, next to "+ สร้าง PO" (after line 107):
+
+```tsx
+            <button
+              onClick={data.openDirectReceive}
+              className="px-4 py-2 border border-input rounded-lg text-sm font-medium hover:bg-muted transition-colors"
+            >
+              รับเข้าตรง (supplier)
+            </button>
+```
+
+Mount the modal (after the `<GoodsReceivingModal .../>` block, ~line 234):
+
+```tsx
+      <DirectReceiveModal
+        isOpen={data.isDirectReceiveOpen}
+        onClose={() => data.setIsDirectReceiveOpen(false)}
+        suppliers={data.suppliers}
+        supplierId={data.directSupplierId}
+        setSupplierId={data.setDirectSupplierId}
+        lines={data.directLines}
+        setLines={data.setDirectLines}
+        notes={data.directNotes}
+        setNotes={data.setDirectNotes}
+        directReceiveMutation={data.directReceiveMutation}
+      />
+```
+
+> `data.suppliers` is `{ id; name; ... }[]` — assignable to `SupplierLite[]` (structural subtype). The mutation's generic result type matches `directReceiveMutation` from Task 2 (both `{ data: { poNumber; passed; rejected; mainWarehouse } }`).
+
+- [ ] **Step 4: Type-check**
+
+Run: `./tools/check-types.sh all`
+Expected: 0 errors.
+
+- [ ] **Step 5: MANUAL verification (desktop + mobile viewport)**
+
+On `/purchase-orders` as `manager.ladprao@bestchoice.com`:
+- Click "รับเข้าตรง (supplier)". **Desktop:** modal opens at the "เพิ่มรายการ" step. Pick a supplier, add a line (มือถือใหม่, ยี่ห้อ Apple, รุ่น iPhone 16, จำนวน 2, ราคาทุน 30000), click "ถัดไป: ตรวจรับ" → 2 unit cards appear, each showing **ราคาทุน** (pre-filled 30000), IMEI, selling-price, camera. Enter IMEIs + selling prices, submit → toast "รับเข้าตรงสำเร็จ (PO-YYYY-MM-NNN): ผ่าน 2 ชิ้น…". Verify in the PO list a new PO appears badged as direct-receive (B1 badge consumes `isDirectReceive`) at `FULLY_RECEIVED`.
+- Try submitting with cost 0 on a line → blocked with "กรุณาระบุราคาทุนมากกว่า 0…". Set one unit to ไม่ผ่าน without picking a defect → blocked with "กรุณาเลือกสาเหตุที่ไม่ผ่านให้ครบ". Enter duplicate IMEIs on two units → both flagged + submit blocked.
+- **Mobile (<1024px):** the whole flow is a bottom-sheet `Drawer` at ~92dvh; "เพิ่มรายการ" / "ถัดไป: ตรวจรับ" / "ยืนยันรับเข้าตรง" are full-width ≥44px; camera tile opens rear camera on device.
+- Confirm an `AuditLog` row `PO_DIRECT_RECEIVE_APPROVAL_BYPASS` exists (check `/audit-logs` as OWNER, filter entity `purchase_order`).
+
+- [ ] **Step 6: Run the full web PO test folder + backend PO suite once more**
+
+Run: `cd apps/web && npx vitest run src/pages/PurchaseOrdersPage`
+Expected: PASS.
+Run: `cd apps/api && npx jest --runInBand src/modules/purchase-orders`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/web/src/pages/PurchaseOrdersPage/components/DirectReceiveModal.tsx apps/web/src/pages/PurchaseOrdersPage/index.tsx apps/web/src/pages/PurchaseOrdersPage/hooks/usePurchaseOrdersData.ts
+git commit -m "feat(purchasing-web): supplier-direct receive entry (auto-PO) + REJECT defect-required validation"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage (B3 items):**
+- (A) Backend `POST /purchase-orders/direct-receive` auto-PO in ONE Serializable `$transaction` → Task 1 (`directReceive()` wraps create-PO + `update` to `ORDERED` + `runReceiveInTx`, all in `prisma.$transaction(..., Serializable)`). ✅
+- (A) create real PO `isDirectReceive=true`, `unitPrice=costPrice`, supplier required → Task 1 Step 5 (PO `create` with `isDirectReceive: true`, items `unitPrice: i.unitPrice`, supplier `findUnique` guard). ✅
+- (A) advance `APPROVED → ORDERED` bypassing OWNER approval gate + `AuditLog` for the bypass → Task 1 Step 5 (PO starts `APPROVED`, `update` to `ORDERED`+`orderedAt`, `tx.auditLog.create({ action: 'PO_DIRECT_RECEIVE_APPROVAL_BYPASS', entity: 'purchase_order', ... })` — mirrors trade-in's `auditLog.create`, no cross-module import). ✅
+- (A) then run EXISTING `goodsReceiving()` logic to create GR (+grNumber from B0) + products → Task 1 Step 6 extracts the shared `runReceiveInTx(tx,...)` so both flows use the identical pipeline incl. the B0 `grNumber`. ✅
+- (A) `DirectReceiveDto` requires `supplierId` + per-line `costPrice` + product attrs + per-unit receiving fields → Task 1 Step 3. ✅
+- (A) DTO + lifecycle/receiving method + facade + controller wired → Task 1 Steps 3,5,7,8. ✅
+- (A) `costPrice` MANDATORY+validated (COGS reads it) → Task 1 Step 3 (`@Min(0.01)` Thai message) + Step 5 (up-front `badCost` guard) + test (zero-cost rejected). ✅
+- (A) NO JE → Task 1 (only `purchaseOrder`/`auditLog`/`goodsReceiving`/`product`/`productPrice`/`pOItem` writes; zero JournalEntry/Expense; module stays `imports: []`). ✅ (Global Constraints red line.)
+- (B) mobile-first rebuild of `GoodsReceivingModal` using `Drawer` (bottom-sheet) + `useIsMobile` → Task 3 Step 5. ✅
+- (B) per-unit IMEI entry with duplicate feedback → Task 3 Steps 1-2 (`computeDuplicateIndices`/`useReceivingDuplicates`) + Step 4 card warning banner + tested. ✅
+- (B) camera photo capture (`capture` attribute) → Task 3 Step 4 (`<input type="file" accept="image/*" capture="environment">` + base64 handler). ✅
+- (B) checklist for used phones → Task 3 Step 4 (preserved `PHONE_USED` checklist block). ✅
+- (B) PASS/REJECT with structured DEFECT REASON select (`DefectReason` enum from B0) → Task 3 Step 4 (`<select>` from `defectReasonOptions`) + Task 4 Step 1 submit validation; backend persists via Task 1 Step 4. ✅
+- (B) partial-receive progress + big touch targets → Task 3 Step 5 (progress strip + two-color bar; `min-h-11` ≥44px buttons). ✅
+- (B) "รับเข้าตรง (supplier)" entry calling the new endpoint → Task 4 (`DirectReceiveModal` + header button + `directReceiveMutation`). ✅
+- (B) auto-POs badged in the list → consumed via `isDirectReceive` (B1 owns the badge; B0 shipped the column; this batch sets it). ✅ (cross-batch, noted.)
+
+**Placeholder scan:** No "TBD/TODO/implement later". The only "…" prose is the explicit paste instruction in Task 1 Step 6 — and that step quotes the exact source line range (144-349), the three required edits, and the surrounding method skeleton verbatim, so it is a mechanical copy, not a placeholder. Every other code/test block is complete.
+
+**Type/prop-name consistency:**
+- `ReceivingUnitForm` gains `defectReason: DefectReasonValue | ''`, `photos: string[]`, `costPrice: string`, and six optional product attrs (`brand?/model?/color?/storage?/accessoryType?/accessoryBrand?`) — defined once in Task 2 Step 1, used by `openReceiveModal` seed (Task 2 Step 3), `buildDirectReceiveItem` (Task 2 Step 6), `ReceivingUnitCard` (Task 3 Step 4), `lineToUnits` (Task 4 Step 2). Consistent.
+- `DefectReasonValue` (8 values) ≡ B0 Prisma `DefectReason` enum values (SCREEN/BATTERY/IMEI_BLOCKED/BOX_MISSING/WRONG_MODEL/DOA/COSMETIC/OTHER). `defectReasonOptions` keyed on the same union.
+- `directReceive(dto, userId)` signature identical across receiving service / facade / controller; result `{ poId; poNumber; receivingId; grNumber; status; passed; rejected; products; mainWarehouse }` consumed by `directReceiveMutation.onSuccess` (`poNumber/passed/rejected/mainWarehouse`).
+- `DirectReceiveModal` prop `directReceiveMutation` generic result type `{ data: { poNumber; passed; rejected; mainWarehouse } }` matches the hook's mutation declaration in Task 2.
+- `computeDuplicateIndices`/`useReceivingDuplicates` return `Set<number>` (unit indices) used uniformly in both modals via `dupIndices.has(idx)`.
+
+**Deviations found vs spec wording:**
+1. **`runReceiveInTx` extraction.** The spec says "runs the EXISTING `goodsReceiving()` logic." Calling the public `goodsReceiving()` from inside `directReceive()` would open a **nested** `$transaction` (it starts its own Serializable tx), which the auto-PO requires to be the SAME tx for atomicity. I therefore extract the pipeline into a private `runReceiveInTx(tx,...)` and have both `goodsReceiving()` and `directReceive()` call it within their own single tx. This preserves byte-identical logic (verified by re-running the B0 race/IMEI specs in Task 1 Step 10) while honoring "ONE Serializable `$transaction`." Documented here as the one structural deviation.
+2. **`'ORDERED'` added to the receive status allow-list.** The current guard allows `APPROVED`/`PARTIALLY_RECEIVED` only. A direct-receive auto-PO is `ORDERED` at receive time, and B0 added `ORDERED` as a valid pre-receive state, so I add `'ORDERED'` to the allow-list in `runReceiveInTx`. Additive — no existing case regresses (both legacy states still pass). This also lets a B0-`ORDERED` standard PO be received, matching the spec state machine ("Receiving is allowed from `ORDERED` or `APPROVED`").
+3. **B0-assumed fields.** `DefectReason` enum, `grNumber` (+`generateGRNumber`), `isDirectReceive`, `orderedAt`, and the retirement of legacy `receive()`/`ReceivePODto` all land in B0. If executed before B0 merges, Steps that touch the `dto`/import lines (Task 1 Step 3 note, Task 1 Step 5 note, Task 1 Step 7 note) flag the reconciliation. Per the plan brief, B0 is assumed shipped.
+4. **No new migration.** B3 adds zero schema; all columns/enums are B0's. (Spec's "Data model — additive migrations only" is fully consumed by B0.)

--- a/docs/superpowers/plans/2026-06-29-purchasing-b4-qc-center.md
+++ b/docs/superpowers/plans/2026-06-29-purchasing-b4-qc-center.md
@@ -1,0 +1,1253 @@
+# Purchasing v2 — Batch 4: QC Center page + nav badge — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Promote the collapsible `QcPendingPanel` into a dedicated **QC center page** at its own lazy route `/purchase-orders/qc`, with a **sidebar nav badge** showing the pending count, branch/PO/date filters, a **bulk-confirm** action (reusing the existing `POST /purchase-orders/qc-confirm`), and a **reject path** (a small additive `POST /purchase-orders/qc-reject` endpoint that soft-deletes products that fail post-receive QC). Wire the route + menu entry with the same role gating as the PO page (OWNER, BRANCH_MANAGER), and remove the now-redundant inline panel from `PurchaseOrdersPage`.
+
+**Architecture:** Frontend-led batch on top of the existing, accounting-isolated `purchase-orders` module. New web page `QcCenterPage` + a `useQcCenter` data hook (react-query + `@/lib/api`), a `qc-pending-count` `MenuBadgeKey` wired into the existing `NavBadge` mechanism in `Sidebar.tsx`, and a new menu item + lazy route. Backend: two small **additive** changes inside the module — extend `getQCPending` to optionally include `PHOTO_PENDING` (additive `status` filter, default unchanged), and a new `rejectQC(productIds, reason)` service method + route that soft-deletes failed products (JE-free, products-table-only, no cross-module import).
+
+**Tech Stack:** React 18 + Vite + TypeScript + Tailwind + shadcn/ui + Radix + lucide (`apps/web`); NestJS + Prisma (`apps/api`); jest (backend, mock-based) + vitest/RTL (frontend logic).
+
+**Spec:** `docs/superpowers/specs/2026-06-29-purchasing-receiving-ux-v2-design.md`
+
+## Global Constraints
+
+- **RED LINE — no accounting/finance:** introduce **NO** import of any accounting / finance / journal / expense / tax module into `purchase-orders`; do **not** touch `trade-in` or `Product.ownedByCompanyId`; receiving + QC stay **JE-free**. The QC-reject added here only soft-deletes `Product` rows (sets `deletedAt`) — it posts no JE and imports nothing new. (Verified: module is `imports: []`, Prisma-only.)
+- **Additive only:** no rewrite of existing models or endpoints. `getQCPending`'s default output is unchanged (only widened when a new optional flag is passed). `qc-confirm` is reused verbatim.
+- **Frontend rules (`.claude/rules/frontend.md`):**
+  - Data fetching via `useQuery`/`useMutation` + `@/lib/api` only — **no** raw `fetch`/`axios`.
+  - shadcn/ui + Radix + lucide only — no other component libs.
+  - **DESIGN TOKENS ONLY** — no hardcoded gray/hex; no `bg-white` (except print/receipt). Use `bg-card`/`bg-muted`/`text-foreground`/`text-muted-foreground`/`border-border`, status tokens `text-warning`/`text-success`/`text-destructive`.
+  - Thai UI text uses `leading-snug`.
+  - Route is lazy-loaded (`React.lazy`) under `ProtectedRoute`.
+  - Toasts via `sonner` (`toast.success`/`toast.error`); confirmations via `ConfirmDialog` (no `alert()`/`confirm()`).
+  - `useDebounce` for the search input.
+- **Money = `Decimal`** on the backend (no money math added here — QC moves status only).
+- **Soft delete:** every read filters `deletedAt: null`; reject = `update({ data: { deletedAt } })`, never hard-delete.
+- **Backend validation messages in Thai** (`class-validator`); controller guards `@Roles('OWNER', 'BRANCH_MANAGER')` (mirrors the existing `qc-pending`/`qc-confirm` routes).
+- **Tests:** backend jest (mock-based, runs in the normal suite); frontend vitest/RTL for the badge-count + computed-label logic where it adds value, manual verification (desktop **and** mobile viewport) for the page UI.
+- **Type gate:** `./tools/check-types.sh all` must report 0 errors before each commit.
+
+> **Reality note discovered while planning (drives this batch):** B0 has **not** shipped yet — there is no `GET /purchase-orders/summary` and no `waitingQc` field in the codebase (grep: only `:id/goods-receivings/summary` exists). So the nav badge here **must** use the `getQCPending` total, not `summary.waitingQc`. This is the spec's stated fallback ("can reuse … or `getQCPending` total"). B5 can later switch the badge to `summary.waitingQc` once B0 lands — the badge is isolated in one hook (`useQcPendingCount`).
+
+---
+
+### Task 1: Backend — widen `getQCPending` to optionally include `PHOTO_PENDING`
+
+The spec's QC center queue is "`QC_PENDING`/`PHOTO_PENDING`". Today `getQCPending` hard-codes `status: 'QC_PENDING'` ([po-query.service.ts:300](../../../apps/api/src/modules/purchase-orders/services/po-query.service.ts)). Add an **additive** optional filter so the QC center can request both, while every existing caller (which passes no flag) keeps the exact current behavior.
+
+**Files:**
+- Modify: `apps/api/src/modules/purchase-orders/services/po-query.service.ts` (`getQCPending` signature + `where`, lines 299-322)
+- Modify: `apps/api/src/modules/purchase-orders/purchase-orders.service.ts` (facade `getQCPending` signature, line 98-100)
+- Modify: `apps/api/src/modules/purchase-orders/purchase-orders.controller.ts` (`getQCPending` route — accept `includePhotoPending` + `poId`, lines 51-63)
+- Create: `apps/api/src/modules/purchase-orders/purchase-orders.qc-pending.spec.ts`
+
+**Interfaces:**
+- Consumes: `PrismaService.product.findMany/count`.
+- Produces: `PoQueryService.getQCPending(filters: { branchId?: string; poId?: string; includePhotoPending?: boolean; page?: number; limit?: number })` → same `{ data, total, page, limit, totalPages }` shape; `where.status` is `'QC_PENDING'` by default, or `{ in: ['QC_PENDING', 'PHOTO_PENDING'] }` when `includePhotoPending` is true; `where.poId` added when `poId` is given.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/api/src/modules/purchase-orders/purchase-orders.qc-pending.spec.ts`:
+
+```typescript
+import { Test, TestingModule } from '@nestjs/testing';
+import { PurchaseOrdersService } from './purchase-orders.service';
+import { PrismaService } from '../../prisma/prisma.service';
+
+describe('PurchaseOrdersService.getQCPending — additive filters', () => {
+  let service: PurchaseOrdersService;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+
+  const build = async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [PurchaseOrdersService, { provide: PrismaService, useValue: prisma }],
+    }).compile();
+    return module.get<PurchaseOrdersService>(PurchaseOrdersService);
+  };
+
+  beforeEach(() => {
+    prisma = {
+      product: {
+        findMany: jest.fn().mockResolvedValue([{ id: 'p1' }]),
+        count: jest.fn().mockResolvedValue(1),
+      },
+    };
+  });
+
+  it('defaults to QC_PENDING only (back-compat — no flag passed)', async () => {
+    service = await build();
+    await service.getQCPending({});
+    expect(prisma.product.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ status: 'QC_PENDING', deletedAt: null }),
+      }),
+    );
+  });
+
+  it('includes PHOTO_PENDING when includePhotoPending is true', async () => {
+    service = await build();
+    await service.getQCPending({ includePhotoPending: true });
+    expect(prisma.product.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ status: { in: ['QC_PENDING', 'PHOTO_PENDING'] } }),
+      }),
+    );
+  });
+
+  it('filters by poId and branchId when provided', async () => {
+    service = await build();
+    await service.getQCPending({ poId: 'po-9', branchId: 'b-1' });
+    expect(prisma.product.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ poId: 'po-9', branchId: 'b-1', status: 'QC_PENDING' }),
+      }),
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/api && npx jest purchase-orders.qc-pending.spec.ts`
+Expected: FAIL — `includePhotoPending`/`poId` are ignored (the `status: { in: [...] }` and `poId` assertions fail).
+
+- [ ] **Step 3: Widen `getQCPending` in `PoQueryService`**
+
+In `po-query.service.ts`, replace the method (lines 296-322) with:
+
+```typescript
+  /**
+   * Get products pending QC. Defaults to QC_PENDING only (back-compat).
+   * Additive flags: includePhotoPending widens to QC_PENDING + PHOTO_PENDING
+   * (the QC center queue), poId narrows to one PO.
+   */
+  async getQCPending(filters: {
+    branchId?: string;
+    poId?: string;
+    includePhotoPending?: boolean;
+    page?: number;
+    limit?: number;
+  }) {
+    const where: Record<string, unknown> = {
+      deletedAt: null,
+      status: filters.includePhotoPending
+        ? { in: ['QC_PENDING', 'PHOTO_PENDING'] }
+        : 'QC_PENDING',
+    };
+    if (filters.branchId) where.branchId = filters.branchId;
+    if (filters.poId) where.poId = filters.poId;
+
+    const page = Math.max(1, filters.page || 1);
+    const limit = Math.min(100, Math.max(1, filters.limit || 50));
+
+    const [data, total] = await Promise.all([
+      this.prisma.product.findMany({
+        where,
+        include: {
+          branch: { select: { id: true, name: true } },
+          supplier: { select: { id: true, name: true } },
+          po: { select: { id: true, poNumber: true } },
+        },
+        orderBy: { createdAt: 'desc' },
+        skip: (page - 1) * limit,
+        take: limit,
+      }),
+      this.prisma.product.count({ where }),
+    ]);
+
+    return { data, total, page, limit, totalPages: Math.ceil(total / limit) };
+  }
+```
+
+- [ ] **Step 4: Widen the facade signature**
+
+In `purchase-orders.service.ts`, replace the facade method (lines 98-100):
+
+```typescript
+  getQCPending(filters: { branchId?: string; poId?: string; includePhotoPending?: boolean; page?: number; limit?: number }) {
+    return this.query.getQCPending(filters);
+  }
+```
+
+- [ ] **Step 5: Pass the new query params through the controller**
+
+In `purchase-orders.controller.ts`, replace the `getQCPending` route (lines 51-63) with:
+
+```typescript
+  @Get('qc-pending')
+  @Roles('OWNER', 'BRANCH_MANAGER')
+  getQCPending(
+    @Query('branchId') branchId?: string,
+    @Query('poId') poId?: string,
+    @Query('includePhotoPending') includePhotoPending?: string,
+    @Query('page') page?: string,
+    @Query('limit') limit?: string,
+  ) {
+    return this.purchaseOrdersService.getQCPending({
+      branchId,
+      poId,
+      includePhotoPending: includePhotoPending === 'true',
+      page: page ? parseInt(page) : undefined,
+      limit: limit ? parseInt(limit) : undefined,
+    });
+  }
+```
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run: `cd apps/api && npx jest purchase-orders.qc-pending.spec.ts`
+Expected: PASS (3 tests).
+
+- [ ] **Step 7: Type-check + commit**
+
+```bash
+./tools/check-types.sh all
+git add apps/api/src/modules/purchase-orders
+git commit -m "feat(purchasing): widen getQCPending with includePhotoPending + poId filters (additive)"
+```
+
+---
+
+### Task 2: Backend — QC reject endpoint (`POST /purchase-orders/qc-reject`)
+
+`confirmQC` only **promotes** (QC_PENDING → IN_STOCK/PHOTO_PENDING) — there is no way to fail a unit at the post-receive QC stage. Add a minimal **additive** reject path: soft-delete the failed products + record the reason on each. JE-free, products-table-only, no new imports (mirrors the module's soft-delete convention — `Product` has `deletedAt` at [schema.prisma:1655](../../../apps/api/prisma/schema.prisma)).
+
+**Files:**
+- Modify: `apps/api/src/modules/purchase-orders/dto/create-po.dto.ts` (add `RejectQCDto`)
+- Modify: `apps/api/src/modules/purchase-orders/services/po-receiving.service.ts` (add `rejectQC()`)
+- Modify: `apps/api/src/modules/purchase-orders/purchase-orders.service.ts` (facade delegate)
+- Modify: `apps/api/src/modules/purchase-orders/purchase-orders.controller.ts` (new route, next to `qc-confirm`)
+- Create: `apps/api/src/modules/purchase-orders/purchase-orders.qc-reject.spec.ts`
+
+**Interfaces:**
+- Produces: `PurchaseOrdersService.rejectQC(productIds: string[], reason: string): Promise<{ rejected: number; message: string }>` — validates the products exist and are `QC_PENDING`/`PHOTO_PENDING`, then soft-deletes them (sets `deletedAt = now` + `qcRejectReason` stored in the existing `Product.notes` field — see Step 4 for the exact column choice).
+- `RejectQCDto { productIds: string[]; reason: string }`.
+
+- [ ] **Step 1: Confirm there is no free-text note column on `Product` (no schema change in B4)**
+
+Run: `cd apps/api && awk '/^model Product /{f=1} f&&/^}/{f=0} f' prisma/schema.prisma | grep -nE 'notes|qcNote|rejectReason|remark'`
+**Verified at plan time:** `Product` has **no** free-text note field (only `onlineDescription` = catalog copy, which we do **not** reuse). So the reject is a **pure soft-delete** — the reason is surfaced in the return `message` only, and **no** column is written. Do **not** add a new column (that would be a B0-style migration, out of scope for B4). If a future `Product.qcNote` lands, the `updateMany.data` can gain it additively.
+
+- [ ] **Step 2: Write the failing test**
+
+Create `apps/api/src/modules/purchase-orders/purchase-orders.qc-reject.spec.ts`:
+
+```typescript
+import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException } from '@nestjs/common';
+import { PurchaseOrdersService } from './purchase-orders.service';
+import { PrismaService } from '../../prisma/prisma.service';
+
+describe('PurchaseOrdersService.rejectQC', () => {
+  let service: PurchaseOrdersService;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+
+  const buildTx = (products: { id: string; status: string; name: string }[]) => {
+    const tx = {
+      product: {
+        findMany: jest.fn().mockResolvedValue(products),
+        updateMany: jest.fn().mockResolvedValue({ count: products.length }),
+      },
+    };
+    return tx;
+  };
+
+  const build = async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [PurchaseOrdersService, { provide: PrismaService, useValue: prisma }],
+    }).compile();
+    return module.get<PurchaseOrdersService>(PurchaseOrdersService);
+  };
+
+  it('soft-deletes QC_PENDING products and returns the count', async () => {
+    const tx = buildTx([
+      { id: 'p1', status: 'QC_PENDING', name: 'iPhone' },
+      { id: 'p2', status: 'PHOTO_PENDING', name: 'iPhone 2' },
+    ]);
+    prisma = { $transaction: jest.fn().mockImplementation((fn: any) => fn(tx)) };
+    service = await build();
+
+    const res = await service.rejectQC(['p1', 'p2'], 'จอแตก');
+    expect(res.rejected).toBe(2);
+    expect(tx.product.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: { in: ['p1', 'p2'] } },
+        data: expect.objectContaining({ deletedAt: expect.any(Date) }),
+      }),
+    );
+  });
+
+  it('rejects when no productIds are given', async () => {
+    prisma = { $transaction: jest.fn() };
+    service = await build();
+    await expect(service.rejectQC([], 'x')).rejects.toThrow(BadRequestException);
+  });
+
+  it('rejects when a product is not in a QC stage', async () => {
+    const tx = buildTx([{ id: 'p1', status: 'IN_STOCK', name: 'Sold-in' }]);
+    prisma = { $transaction: jest.fn().mockImplementation((fn: any) => fn(tx)) };
+    service = await build();
+    await expect(service.rejectQC(['p1'], 'late')).rejects.toThrow(BadRequestException);
+  });
+});
+```
+
+- [ ] **Step 3: Add `RejectQCDto`**
+
+In `dto/create-po.dto.ts`, add (place near the other small DTOs; reuse the existing `class-validator` imports — add any missing ones to the import list at the top of the file):
+
+```typescript
+export class RejectQCDto {
+  @IsArray()
+  @ArrayNotEmpty({ message: 'กรุณาเลือกสินค้าที่ไม่ผ่าน QC อย่างน้อย 1 ชิ้น' })
+  @IsString({ each: true })
+  productIds!: string[];
+
+  @IsString()
+  @IsNotEmpty({ message: 'กรุณาระบุเหตุผลที่ไม่ผ่าน QC' })
+  reason!: string;
+}
+```
+
+Ensure the top-of-file `class-validator` import includes `IsArray`, `ArrayNotEmpty`, `IsString`, `IsNotEmpty` (add only the ones not already imported).
+
+- [ ] **Step 4: Add `rejectQC()` to `PoReceivingService`**
+
+In `po-receiving.service.ts`, add this method (after `confirmQC`, ~line 408). It mirrors `confirmQC`'s validate-then-mutate-in-`$transaction` shape and writes no JE:
+
+```typescript
+  /**
+   * Reject products at the post-receive QC stage (QC_PENDING / PHOTO_PENDING):
+   * soft-delete the failed units and record the reason. JE-free, products-table
+   * only — no accounting/finance touch.
+   */
+  async rejectQC(productIds: string[], reason: string) {
+    if (!productIds || productIds.length === 0) {
+      throw new BadRequestException('กรุณาเลือกสินค้าที่ไม่ผ่าน QC อย่างน้อย 1 ชิ้น');
+    }
+
+    return this.prisma.$transaction(async (tx) => {
+      const products = await tx.product.findMany({
+        where: { id: { in: productIds }, deletedAt: null },
+      });
+
+      const notFound = productIds.filter((id) => !products.find((p) => p.id === id));
+      if (notFound.length > 0) {
+        throw new BadRequestException(`ไม่พบสินค้า ID: ${notFound.join(', ')}`);
+      }
+
+      const invalid = products.filter((p) => !['QC_PENDING', 'PHOTO_PENDING'].includes(p.status));
+      if (invalid.length > 0) {
+        throw new BadRequestException(
+          `สินค้าต่อไปนี้ไม่ได้อยู่ในขั้นตอน QC: ${invalid.map((p) => p.name).join(', ')}`,
+        );
+      }
+
+      await tx.product.updateMany({
+        where: { id: { in: productIds } },
+        data: { deletedAt: new Date() },
+      });
+
+      return {
+        rejected: productIds.length,
+        reason,
+        message: `บันทึกไม่ผ่าน QC ${productIds.length} ชิ้น (ตัดออกจากคลังแล้ว): ${reason}`,
+      };
+    });
+  }
+```
+
+> `Product` has no note column (Step 1), so the soft-delete is the only row mutation; the `reason` is echoed in the response `message` (and is still server-validated as required by `RejectQCDto`). The Task 2 test (`updateMany` called with `data: { deletedAt }`) matches this exactly.
+
+- [ ] **Step 5: Add the facade delegate**
+
+In `purchase-orders.service.ts`, add (after `confirmQC`, line 96):
+
+```typescript
+  rejectQC(productIds: string[], reason: string) {
+    return this.receiving.rejectQC(productIds, reason);
+  }
+```
+
+- [ ] **Step 6: Add the controller route**
+
+In `purchase-orders.controller.ts`, add `RejectQCDto` to the dto import on line 4, and add the route immediately after `confirmQC` (line 69) — it is a static route, so it stays above the `:id` parametric block:
+
+```typescript
+  @Post('qc-reject')
+  @Roles('OWNER', 'BRANCH_MANAGER')
+  rejectQC(@Body() dto: RejectQCDto) {
+    return this.purchaseOrdersService.rejectQC(dto.productIds, dto.reason);
+  }
+```
+
+- [ ] **Step 7: Run test to verify it passes**
+
+Run: `cd apps/api && npx jest purchase-orders.qc-reject.spec.ts`
+Expected: PASS (3 tests).
+
+- [ ] **Step 8: Type-check + commit**
+
+```bash
+./tools/check-types.sh all
+git add apps/api/src/modules/purchase-orders
+git commit -m "feat(purchasing): POST /qc-reject — soft-delete failed QC units (JE-free, additive)"
+```
+
+---
+
+### Task 3: Frontend — `useQcCenter` data hook + `useQcPendingCount` badge hook
+
+Centralize the QC center's queries/mutations in one hook (react-query + `@/lib/api`), and expose a tiny separate hook for the nav badge count so the badge can be wired without importing the whole page.
+
+**Files:**
+- Create: `apps/web/src/pages/QcCenterPage/useQcCenter.ts`
+- Create: `apps/web/src/hooks/useQcPendingCount.ts`
+- Create: `apps/web/src/hooks/useQcPendingCount.test.ts`
+
+**Interfaces:**
+- `QcPendingProduct` type (the row shape the queue renders):
+  ```typescript
+  export interface QcPendingProduct {
+    id: string;
+    name: string;
+    imeiSerial: string | null;
+    serialNumber: string | null;
+    status: 'QC_PENDING' | 'PHOTO_PENDING';
+    category: string | null;
+    photos: string[];
+    createdAt: string;
+    branch: { id: string; name: string } | null;
+    supplier: { id: string; name: string } | null;
+    po: { id: string; poNumber: string } | null;
+  }
+  ```
+- `useQcPendingCount(enabled: boolean): number | undefined` — total of QC_PENDING + PHOTO_PENDING (limit=1, reads `total`), mirroring `useDraftAssetCount` ([useDraftAssetCount.ts](../../../apps/web/src/hooks/useDraftAssetCount.ts)).
+- `useQcCenter(filters): { products, total, isLoading, isError, error, refetch, confirmMutation, rejectMutation }`.
+
+- [ ] **Step 1: Write the badge-count hook + its test (logic worth a vitest test)**
+
+Create `apps/web/src/hooks/useQcPendingCount.ts` (mirrors `useDraftAssetCount` exactly — same polling cadence + `total` extraction):
+
+```typescript
+import { useQuery } from '@tanstack/react-query';
+import api from '@/lib/api';
+
+/**
+ * Pending-QC count for the sidebar nav badge.
+ * Reuses GET /purchase-orders/qc-pending (includePhotoPending=true) and reads
+ * the `total` field with limit=1 — no full page fetched. Mirrors
+ * useDraftAssetCount's polling shape (B5 may later switch to summary.waitingQc).
+ */
+export function useQcPendingCount(enabled: boolean): number | undefined {
+  const query = useQuery({
+    queryKey: ['qc-pending-count'],
+    queryFn: async () => {
+      const res = await api.get('/purchase-orders/qc-pending', {
+        params: { includePhotoPending: true, limit: 1, page: 1 },
+      });
+      return res.data as { total: number };
+    },
+    enabled,
+    refetchInterval: 30_000,
+    refetchOnWindowFocus: true,
+    staleTime: 10_000,
+  });
+  return query.data?.total;
+}
+```
+
+Create `apps/web/src/hooks/useQcPendingCount.test.ts`:
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+
+const get = vi.fn();
+vi.mock('@/lib/api', () => ({ default: { get: (...a: unknown[]) => get(...a) } }));
+
+import { useQcPendingCount } from './useQcPendingCount';
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return React.createElement(QueryClientProvider, { client }, children);
+}
+
+describe('useQcPendingCount', () => {
+  beforeEach(() => get.mockReset());
+
+  it('returns the total from qc-pending and requests includePhotoPending', async () => {
+    get.mockResolvedValue({ data: { total: 7 } });
+    const { result } = renderHook(() => useQcPendingCount(true), { wrapper });
+    await waitFor(() => expect(result.current).toBe(7));
+    expect(get).toHaveBeenCalledWith(
+      '/purchase-orders/qc-pending',
+      expect.objectContaining({ params: expect.objectContaining({ includePhotoPending: true, limit: 1 }) }),
+    );
+  });
+
+  it('does not fetch when disabled', async () => {
+    const { result } = renderHook(() => useQcPendingCount(false), { wrapper });
+    await waitFor(() => expect(result.current).toBeUndefined());
+    expect(get).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run the badge-count test to verify it passes**
+
+Run: `cd apps/web && npx vitest run src/hooks/useQcPendingCount.test.ts`
+Expected: PASS (2 tests).
+
+- [ ] **Step 3: Create the page data hook**
+
+Create `apps/web/src/pages/QcCenterPage/useQcCenter.ts`:
+
+```typescript
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import api, { getErrorMessage } from '@/lib/api';
+
+export interface QcPendingProduct {
+  id: string;
+  name: string;
+  imeiSerial: string | null;
+  serialNumber: string | null;
+  status: 'QC_PENDING' | 'PHOTO_PENDING';
+  category: string | null;
+  photos: string[];
+  createdAt: string;
+  branch: { id: string; name: string } | null;
+  supplier: { id: string; name: string } | null;
+  po: { id: string; poNumber: string } | null;
+}
+
+interface QcResponse {
+  data: QcPendingProduct[];
+  total: number;
+}
+
+export interface QcCenterFilters {
+  branchId?: string;
+  poId?: string;
+}
+
+export function useQcCenter(filters: QcCenterFilters) {
+  const queryClient = useQueryClient();
+
+  const invalidate = () => {
+    queryClient.invalidateQueries({ queryKey: ['qc-center'] });
+    queryClient.invalidateQueries({ queryKey: ['qc-pending-count'] });
+    queryClient.invalidateQueries({ queryKey: ['purchase-orders'] });
+  };
+
+  const query = useQuery<QcResponse>({
+    queryKey: ['qc-center', filters.branchId ?? '', filters.poId ?? ''],
+    queryFn: async () => {
+      const res = await api.get('/purchase-orders/qc-pending', {
+        params: {
+          includePhotoPending: true,
+          branchId: filters.branchId || undefined,
+          poId: filters.poId || undefined,
+          limit: 100,
+          page: 1,
+        },
+      });
+      const raw = res.data as { data?: QcPendingProduct[]; total?: number };
+      return { data: Array.isArray(raw?.data) ? raw.data : [], total: Number(raw?.total) || 0 };
+    },
+  });
+
+  const confirmMutation = useMutation({
+    mutationFn: async (productIds: string[]) =>
+      api.post('/purchase-orders/qc-confirm', { productIds }),
+    onSuccess: (res) => {
+      invalidate();
+      toast.success(res.data?.message ?? 'ยืนยัน QC สำเร็จ');
+    },
+    onError: (err: unknown) => toast.error(getErrorMessage(err)),
+  });
+
+  const rejectMutation = useMutation({
+    mutationFn: async ({ productIds, reason }: { productIds: string[]; reason: string }) =>
+      api.post('/purchase-orders/qc-reject', { productIds, reason }),
+    onSuccess: (res) => {
+      invalidate();
+      toast.success(res.data?.message ?? 'บันทึกไม่ผ่าน QC สำเร็จ');
+    },
+    onError: (err: unknown) => toast.error(getErrorMessage(err)),
+  });
+
+  return {
+    products: query.data?.data ?? [],
+    total: query.data?.total ?? 0,
+    isLoading: query.isLoading,
+    isError: query.isError,
+    error: query.error,
+    refetch: query.refetch,
+    confirmMutation,
+    rejectMutation,
+  };
+}
+```
+
+> The mutation posts `{ productIds }` — the **correct** body the controller expects (`@Body('productIds')` for confirm; `RejectQCDto.productIds` for reject). The legacy `QcPendingPanel` posted `{ items: [...] }`, which the controller silently ignored (a pre-existing bug — see Self-Review deviation #1). Retiring that panel in Task 6 removes the broken caller.
+
+- [ ] **Step 4: Type-check**
+
+Run: `./tools/check-types.sh all`
+Expected: 0 errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/hooks/useQcPendingCount.ts apps/web/src/hooks/useQcPendingCount.test.ts apps/web/src/pages/QcCenterPage/useQcCenter.ts
+git commit -m "feat(web): useQcCenter + useQcPendingCount hooks (qc-pending/confirm/reject)"
+```
+
+---
+
+### Task 4: Frontend — `QcCenterPage` (queue + filters + bulk confirm + reject)
+
+Build the dedicated page: a status-aware KPI/header count, branch/PO/date filters (`useDebounce` for the PO search), a multi-select queue (shadcn `Checkbox`), a sticky bulk-action bar (ยืนยันทั้งหมด / ไม่ผ่าน), and a reject reason dialog. Responsive: a table-like list on desktop, stacked cards on mobile (`useIsMobile`). All design tokens, no `bg-white`/gray.
+
+**Files:**
+- Create: `apps/web/src/pages/QcCenterPage/index.tsx`
+- Create: `apps/web/src/pages/QcCenterPage/qcLabels.ts` (status labels + computed selection helpers, vitest-tested)
+- Create: `apps/web/src/pages/QcCenterPage/qcLabels.test.ts`
+
+**Interfaces:**
+- Consumes: `useQcCenter` (Task 3), `useAuth` ([contexts/AuthContext.tsx](../../../apps/web/src/contexts/AuthContext.tsx) — `{ user }`, `user?.role` for branch-picker gating), `useIsMobile` ([hooks/useIsMobile.ts](../../../apps/web/src/hooks/useIsMobile.ts)), `useDebounce` ([hooks/useDebounce.ts](../../../apps/web/src/hooks/useDebounce.ts)), `QueryBoundary` ([components/QueryBoundary.tsx](../../../apps/web/src/components/QueryBoundary.tsx)), `PageHeader` ([components/ui/PageHeader.tsx](../../../apps/web/src/components/ui/PageHeader.tsx)), `Checkbox` ([components/ui/checkbox.tsx](../../../apps/web/src/components/ui/checkbox.tsx)), `ConfirmDialog` ([components/ui/ConfirmDialog.tsx](../../../apps/web/src/components/ui/ConfirmDialog.tsx)) — **note: requires the additive `children` + `closeOnConfirm` edits in Step 3** — `Textarea` ([components/ui/textarea.tsx](../../../apps/web/src/components/ui/textarea.tsx), lowercase path, named export), `toast` (`sonner`), `formatDateTime` ([utils/formatters.ts](../../../apps/web/src/utils/formatters.ts)).
+- Branches via `useQuery(['branches'])` (`api.get('/branches')`, `enabled: canPickBranch`) — same shape used across the app ([StockAlertsPage.tsx](../../../apps/web/src/pages/StockAlertsPage.tsx)). The branch `<select>` renders **only for OWNER** (cross-branch role); BRANCH_MANAGER omits `branchId` to avoid a `BranchGuard` 403 (see deviation #6).
+
+- [ ] **Step 1: Write the pure label/selection helpers + test (logic worth a vitest test)**
+
+Create `apps/web/src/pages/QcCenterPage/qcLabels.ts`:
+
+```typescript
+import type { QcPendingProduct } from './useQcCenter';
+
+export const qcStatusLabels: Record<string, string> = {
+  QC_PENDING: 'รอตรวจ QC',
+  PHOTO_PENDING: 'รอถ่ายรูป',
+};
+
+export const qcStatusClasses: Record<string, string> = {
+  QC_PENDING: 'bg-warning/10 text-warning dark:bg-warning/15',
+  PHOTO_PENDING: 'bg-info/10 text-info dark:bg-info/15',
+};
+
+/** Client-side PO-number search (server already filters by branch/poId). */
+export function filterByPoNumber(products: QcPendingProduct[], term: string): QcPendingProduct[] {
+  const t = term.trim().toLowerCase();
+  if (!t) return products;
+  return products.filter(
+    (p) =>
+      (p.po?.poNumber ?? '').toLowerCase().includes(t) ||
+      (p.name ?? '').toLowerCase().includes(t) ||
+      (p.imeiSerial ?? '').toLowerCase().includes(t),
+  );
+}
+
+/** Header checkbox state from the selected-id set vs the visible rows. */
+export function headerCheckState(
+  visibleIds: string[],
+  selected: Set<string>,
+): 'all' | 'some' | 'none' {
+  if (visibleIds.length === 0) return 'none';
+  const n = visibleIds.filter((id) => selected.has(id)).length;
+  if (n === 0) return 'none';
+  return n === visibleIds.length ? 'all' : 'some';
+}
+```
+
+Create `apps/web/src/pages/QcCenterPage/qcLabels.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { filterByPoNumber, headerCheckState } from './qcLabels';
+import type { QcPendingProduct } from './useQcCenter';
+
+const mk = (over: Partial<QcPendingProduct>): QcPendingProduct => ({
+  id: 'x', name: 'iPhone 16', imeiSerial: null, serialNumber: null, status: 'QC_PENDING',
+  category: 'PHONE_NEW', photos: [], createdAt: '', branch: null, supplier: null, po: null, ...over,
+});
+
+describe('filterByPoNumber', () => {
+  const rows = [
+    mk({ id: 'a', po: { id: '1', poNumber: 'PO-2026-06-001' } }),
+    mk({ id: 'b', po: { id: '2', poNumber: 'PO-2026-06-002' }, name: 'Galaxy S24' }),
+    mk({ id: 'c', imeiSerial: '359' }),
+  ];
+  it('returns all when term is blank', () => {
+    expect(filterByPoNumber(rows, '  ')).toHaveLength(3);
+  });
+  it('matches PO number', () => {
+    expect(filterByPoNumber(rows, '06-002').map((r) => r.id)).toEqual(['b']);
+  });
+  it('matches product name and IMEI', () => {
+    expect(filterByPoNumber(rows, 'galaxy').map((r) => r.id)).toEqual(['b']);
+    expect(filterByPoNumber(rows, '359').map((r) => r.id)).toEqual(['c']);
+  });
+});
+
+describe('headerCheckState', () => {
+  it('none / some / all', () => {
+    expect(headerCheckState([], new Set())).toBe('none');
+    expect(headerCheckState(['a', 'b'], new Set())).toBe('none');
+    expect(headerCheckState(['a', 'b'], new Set(['a']))).toBe('some');
+    expect(headerCheckState(['a', 'b'], new Set(['a', 'b']))).toBe('all');
+  });
+});
+```
+
+- [ ] **Step 2: Run the helper test to verify it passes**
+
+Run: `cd apps/web && npx vitest run src/pages/QcCenterPage/qcLabels.test.ts`
+Expected: PASS.
+
+- [ ] **Step 3: Build the page**
+
+Create `apps/web/src/pages/QcCenterPage/index.tsx`:
+
+```tsx
+import { useMemo, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { ClipboardCheck, Check, X, Search, Image as ImageIcon } from 'lucide-react';
+import api from '@/lib/api';
+import PageHeader from '@/components/ui/PageHeader';
+import QueryBoundary from '@/components/QueryBoundary';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Textarea } from '@/components/ui/textarea';
+import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
+import { useAuth } from '@/contexts/AuthContext';
+import { useDebounce } from '@/hooks/useDebounce';
+import { useIsMobile } from '@/hooks/useIsMobile';
+import { formatDateTime } from '@/utils/formatters';
+import { useQcCenter } from './useQcCenter';
+import { qcStatusLabels, qcStatusClasses, filterByPoNumber, headerCheckState } from './qcLabels';
+
+interface Branch { id: string; name: string }
+
+export default function QcCenterPage() {
+  const { user } = useAuth();
+  // BranchGuard 403s a branch-scoped role (BRANCH_MANAGER) that passes another
+  // branch's id. Only cross-branch roles (here: OWNER) may pick a branch; BM
+  // sends no branchId and sees the queue exactly as the legacy panel did
+  // (per-branch BM scoping is a backend follow-up, out of B4 scope).
+  const canPickBranch = user?.role === 'OWNER';
+  const [branchId, setBranchId] = useState('');
+  const [search, setSearch] = useState('');
+  const debouncedSearch = useDebounce(search, 300);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [rejectOpen, setRejectOpen] = useState(false);
+  const [rejectReason, setRejectReason] = useState('');
+  const isMobile = useIsMobile();
+
+  const { data: branches } = useQuery<Branch[]>({
+    queryKey: ['branches'],
+    queryFn: async () => (await api.get('/branches')).data,
+    enabled: canPickBranch,
+  });
+
+  const { products, total, isLoading, isError, error, refetch, confirmMutation, rejectMutation } =
+    useQcCenter({ branchId: branchId || undefined });
+
+  const visible = useMemo(
+    () => filterByPoNumber(products, debouncedSearch),
+    [products, debouncedSearch],
+  );
+  const visibleIds = useMemo(() => visible.map((p) => p.id), [visible]);
+  const checkState = headerCheckState(visibleIds, selected);
+  const selectedVisible = visibleIds.filter((id) => selected.has(id));
+
+  const toggle = (id: string) =>
+    setSelected((prev) => {
+      const next = new Set(prev);
+      next.has(id) ? next.delete(id) : next.add(id);
+      return next;
+    });
+  const toggleAll = () =>
+    setSelected((prev) => {
+      if (checkState === 'all') {
+        const next = new Set(prev);
+        visibleIds.forEach((id) => next.delete(id));
+        return next;
+      }
+      return new Set([...prev, ...visibleIds]);
+    });
+  const clearSelection = () => setSelected(new Set());
+
+  const onConfirm = () => {
+    if (selectedVisible.length === 0) return;
+    confirmMutation.mutate(selectedVisible, { onSuccess: clearSelection });
+  };
+  const onRejectConfirm = () => {
+    if (selectedVisible.length === 0) return;
+    if (!rejectReason.trim()) {
+      toast.error('กรุณาระบุเหตุผลที่ไม่ผ่าน QC');
+      return;
+    }
+    rejectMutation.mutate(
+      { productIds: selectedVisible, reason: rejectReason },
+      {
+        onSuccess: () => {
+          clearSelection();
+          setRejectReason('');
+          setRejectOpen(false);
+        },
+      },
+    );
+  };
+
+  return (
+    <div className="pb-24">
+      <PageHeader
+        title="ศูนย์ตรวจ QC"
+        subtitle="ยืนยันหรือปฏิเสธสินค้าที่รอตรวจคุณภาพก่อนเข้าคลัง"
+        icon={<ClipboardCheck className="size-5" />}
+        badge={
+          total > 0 ? (
+            <span className="inline-flex items-center justify-center min-w-[24px] h-6 px-2 rounded-full text-xs font-bold bg-warning/10 text-warning dark:bg-warning/15 leading-snug">
+              {total}
+            </span>
+          ) : undefined
+        }
+      />
+
+      {/* Filters */}
+      <div className="flex flex-col sm:flex-row gap-2 mb-4">
+        <div className="relative flex-1">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-muted-foreground" />
+          <input
+            type="text"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="ค้นหาเลข PO / ชื่อสินค้า / IMEI"
+            className="w-full pl-9 pr-3 py-2 text-sm rounded-lg border border-input bg-background leading-snug focus:outline-none focus:ring-2 focus:ring-ring"
+          />
+        </div>
+        {canPickBranch && (
+          <select
+            value={branchId}
+            onChange={(e) => setBranchId(e.target.value)}
+            className="px-3 py-2 text-sm rounded-lg border border-input bg-background leading-snug"
+          >
+            <option value="">ทุกสาขา</option>
+            {(branches ?? []).map((b) => (
+              <option key={b.id} value={b.id}>{b.name}</option>
+            ))}
+          </select>
+        )}
+      </div>
+
+      <QueryBoundary
+        isLoading={isLoading}
+        isError={isError}
+        error={error}
+        onRetry={refetch}
+        errorTitle="ไม่สามารถโหลดรายการรอตรวจ QC ได้"
+      >
+        {visible.length === 0 ? (
+          <div className="flex flex-col items-center justify-center py-20 text-center">
+            <ClipboardCheck className="size-10 text-muted-foreground/40 mb-3" />
+            <p className="text-sm font-medium text-foreground leading-snug">ไม่มีสินค้ารอตรวจ QC</p>
+            <p className="text-xs text-muted-foreground mt-1 leading-snug">
+              {debouncedSearch || branchId ? 'ลองล้างตัวกรอง' : 'รายการที่รับเข้าจะปรากฏที่นี่'}
+            </p>
+          </div>
+        ) : (
+          <div className="rounded-xl border border-border bg-card overflow-hidden">
+            {/* Header row (select-all) */}
+            <div className="flex items-center gap-3 px-4 py-2.5 border-b border-border bg-muted/40">
+              <Checkbox
+                checked={checkState === 'all' ? true : checkState === 'some' ? 'indeterminate' : false}
+                onCheckedChange={toggleAll}
+                aria-label="เลือกทั้งหมด"
+              />
+              <span className="text-xs font-semibold text-muted-foreground leading-snug">
+                {selectedVisible.length > 0 ? `เลือก ${selectedVisible.length} ชิ้น` : `${visible.length} รายการ`}
+              </span>
+            </div>
+
+            <ul className="divide-y divide-border">
+              {visible.map((p) => {
+                const checked = selected.has(p.id);
+                return (
+                  <li
+                    key={p.id}
+                    className={`flex ${isMobile ? 'flex-col' : 'items-center'} gap-3 px-4 py-3 ${checked ? 'bg-primary/5' : ''}`}
+                  >
+                    <div className="flex items-start gap-3 flex-1 min-w-0">
+                      <Checkbox
+                        checked={checked}
+                        onCheckedChange={() => toggle(p.id)}
+                        aria-label={`เลือก ${p.name}`}
+                        className="mt-0.5"
+                      />
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-center gap-2 flex-wrap">
+                          <p className="text-sm font-medium text-foreground truncate leading-snug">{p.name}</p>
+                          <span className={`px-2 py-0.5 rounded-full text-[11px] font-semibold leading-snug ${qcStatusClasses[p.status] ?? 'bg-muted text-foreground'}`}>
+                            {qcStatusLabels[p.status] ?? p.status}
+                          </span>
+                          {p.photos.length > 0 && (
+                            <span className="inline-flex items-center gap-1 text-[11px] text-muted-foreground">
+                              <ImageIcon className="size-3" />{p.photos.length}
+                            </span>
+                          )}
+                        </div>
+                        <p className="text-xs text-muted-foreground mt-0.5 leading-snug">
+                          {p.imeiSerial ? `IMEI: ${p.imeiSerial}` : 'ไม่มี IMEI'}
+                          {p.po?.poNumber ? ` · ${p.po.poNumber}` : ''}
+                          {p.branch?.name ? ` · ${p.branch.name}` : ''}
+                        </p>
+                        <p className="text-[11px] text-muted-foreground/80 mt-0.5 leading-snug">
+                          {p.supplier?.name ? `${p.supplier.name} · ` : ''}{formatDateTime(p.createdAt)}
+                        </p>
+                      </div>
+                    </div>
+                    <div className={`flex gap-2 ${isMobile ? 'w-full' : 'shrink-0'}`}>
+                      <button
+                        onClick={() => confirmMutation.mutate([p.id], { onSuccess: () => toggle(p.id) })}
+                        className={`inline-flex items-center justify-center gap-1 px-3 py-1.5 rounded-lg text-xs font-medium bg-success text-success-foreground hover:bg-success/90 transition-colors ${isMobile ? 'flex-1' : ''}`}
+                      >
+                        <Check className="size-3.5" /> ผ่าน
+                      </button>
+                      <button
+                        onClick={() => { setSelected(new Set([p.id])); setRejectOpen(true); }}
+                        className={`inline-flex items-center justify-center gap-1 px-3 py-1.5 rounded-lg text-xs font-medium bg-destructive text-destructive-foreground hover:bg-destructive/90 transition-colors ${isMobile ? 'flex-1' : ''}`}
+                      >
+                        <X className="size-3.5" /> ไม่ผ่าน
+                      </button>
+                    </div>
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        )}
+      </QueryBoundary>
+
+      {/* Sticky bulk action bar */}
+      {selectedVisible.length > 0 && (
+        <div className="fixed bottom-0 left-0 right-0 lg:left-[var(--sidebar-w,264px)] z-30 border-t border-border bg-card/95 backdrop-blur px-4 py-3 flex items-center justify-between gap-3">
+          <span className="text-sm font-medium text-foreground leading-snug">เลือก {selectedVisible.length} ชิ้น</span>
+          <div className="flex gap-2">
+            <button
+              onClick={() => setRejectOpen(true)}
+              disabled={rejectMutation.isPending}
+              className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg text-sm font-medium border border-destructive/40 text-destructive hover:bg-destructive/10 transition-colors disabled:opacity-50"
+            >
+              <X className="size-4" /> ไม่ผ่าน
+            </button>
+            <button
+              onClick={onConfirm}
+              disabled={confirmMutation.isPending}
+              className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg text-sm font-medium bg-success text-success-foreground hover:bg-success/90 transition-colors disabled:opacity-50"
+            >
+              <Check className="size-4" /> ยืนยันผ่านทั้งหมด
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Reject reason dialog */}
+      <ConfirmDialog
+        open={rejectOpen}
+        onOpenChange={(open) => { setRejectOpen(open); if (!open) setRejectReason(''); }}
+        title={`ไม่ผ่าน QC (${selectedVisible.length} ชิ้น)`}
+        description="ระบุเหตุผลที่ไม่ผ่าน — สินค้าจะถูกตัดออกจากคลัง"
+        variant="destructive"
+        confirmLabel="บันทึกไม่ผ่าน"
+        loading={rejectMutation.isPending}
+        closeOnConfirm={false}
+        onConfirm={onRejectConfirm}
+      >
+        <Textarea
+          value={rejectReason}
+          onChange={(e) => setRejectReason(e.target.value)}
+          placeholder="เช่น จอแตก / IMEI ถูกบล็อก / ไม่ตรงรุ่น"
+          className="mt-1 leading-snug"
+          rows={3}
+        />
+      </ConfirmDialog>
+    </div>
+  );
+}
+```
+
+> **Adapt `ConfirmDialog` for the children + async-reject flow (two verified, additive changes).** The component in [ConfirmDialog.tsx](../../../apps/web/src/components/ui/ConfirmDialog.tsx) (verified at plan time) currently (a) does **not** render `{children}` and (b) hard-codes `onClick={() => { onConfirm(); onOpenChange(false); }}` on the confirm button — i.e. it **closes the dialog synchronously on every confirm**, ignoring `loading`. That second behavior breaks the reject flow: the async `rejectMutation` is still in flight when the dialog vanishes, so the `loading` spinner + disabled-confirm never show, and a server-side validation error (e.g. empty reason) would toast after the dialog is already gone. Run `grep -n "children\|onConfirm()" apps/web/src/components/ui/ConfirmDialog.tsx` first, then make these two **additive, backward-compatible** edits (every existing caller passes no `children` and relies on synchronous confirm — both keep working):
+>   1. Add `children?: ReactNode` to `ConfirmDialogProps` (import `ReactNode` from `react`) and render `{children}` between the `DialogHeader` and `DialogFooter` (paste the Textarea there).
+>   2. Change the confirm button to **not** auto-close when the caller manages closing itself. The minimal safe change: only auto-close when not `loading` — `onClick={() => { onConfirm(); if (!loading) onOpenChange(false); }}`. Because `loading={rejectMutation.isPending}` is `false` at click time and flips to `true` synchronously inside `onConfirm`'s `mutate`, gate the close on a new optional `closeOnConfirm` prop instead: add `closeOnConfirm = true` to props, render `onClick={() => { onConfirm(); if (closeOnConfirm) onOpenChange(false); }}`, and pass `closeOnConfirm={false}` from the reject dialog (its `onRejectConfirm` already closes via `onSuccess`). Existing callers omit the prop → default `true` → unchanged behavior.
+>
+> Do not introduce a second dialog component. After editing, the reject dialog: opens → user types reason → "บันทึกไม่ผ่าน" stays visible with a spinner while `isPending` → `onSuccess` closes it; an empty reason is blocked client-side by the `onRejectConfirm` guard above before any request fires.
+
+- [ ] **Step 4: Run the full QcCenterPage vitest folder + type-check**
+
+Run: `cd apps/web && npx vitest run src/pages/QcCenterPage && ../../tools/check-types.sh web`
+Expected: helper tests PASS; 0 type errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/pages/QcCenterPage apps/web/src/components/ui/ConfirmDialog.tsx
+git commit -m "feat(web): QC center page — queue, branch/PO search filters, bulk confirm + reject"
+```
+
+---
+
+### Task 5: Wire the lazy route + menu entries + nav badge + CommandPalette
+
+Register `/purchase-orders/qc` as a lazy `ProtectedRoute` (OWNER, BRANCH_MANAGER), add the menu item with the new `qc-pending-count` badge under the existing inventory section for OWNER + BRANCH_MANAGER, wire the badge into `NavBadge`, and add a CommandPalette entry.
+
+**Files:**
+- Modify: `apps/web/src/App.tsx` (lazy import ~line 94; new route after the `/purchase-orders` route ~line 345)
+- Modify: `apps/web/src/config/menu.ts` (`MenuBadgeKey` union line 65; menu items in `owner-inventory` ~line 491 and `bm-inventory` ~line 240)
+- Modify: `apps/web/src/components/layout/Sidebar.tsx` (`NavBadge` line 62-71 — handle `qc-pending-count`)
+- Modify: `apps/web/src/components/CommandPalette.tsx` (entry after line 65)
+
+**Interfaces:**
+- Consumes: `useQcPendingCount` (Task 3), the existing `NavBadge`/`badgeKey` plumbing.
+- Produces: route `/purchase-orders/qc`; `MenuBadgeKey` gains `'qc-pending-count'`.
+
+- [ ] **Step 1: Add the lazy import in `App.tsx`**
+
+Next to the existing PurchaseOrders import (line 94):
+
+```tsx
+const QcCenterPage = lazy(() => import('@/pages/QcCenterPage'));
+```
+
+- [ ] **Step 2: Register the route**
+
+In `App.tsx`, add immediately **after** the `/purchase-orders` route block (after line 345), mirroring its `ProtectedRoute roles`:
+
+```tsx
+          <Route
+            path="/purchase-orders/qc"
+            element={
+              <ProtectedRoute roles={['OWNER', 'BRANCH_MANAGER']}>
+                <QcCenterPage />
+              </ProtectedRoute>
+            }
+          />
+```
+
+> Order does not matter for react-router v6 object/element routes (it matches by specificity, not declaration order), but keeping `/purchase-orders/qc` directly under `/purchase-orders` keeps the file readable.
+
+- [ ] **Step 3: Extend the `MenuBadgeKey` union**
+
+In `menu.ts` line 65:
+
+```typescript
+export type MenuBadgeKey = 'chat-unread' | 'asset-draft-count' | 'qc-pending-count';
+```
+
+- [ ] **Step 4: Add the menu item to both inventory sections**
+
+The icon `ClipboardCheck` is **already imported** in `menu.ts` (line 43). In the `bm-inventory` section, add after the PO item (line 240):
+
+```typescript
+        { label: 'ศูนย์ตรวจ QC', path: '/purchase-orders/qc', icon: ClipboardCheck, badgeKey: 'qc-pending-count' },
+```
+
+In the `owner-inventory` section, add after the PO item (line 491):
+
+```typescript
+        { label: 'ศูนย์ตรวจ QC', path: '/purchase-orders/qc', icon: ClipboardCheck, badgeKey: 'qc-pending-count' },
+```
+
+> This **adds an item** to existing sections — it does **not** change the section `key`s, so the `menu.test.ts` "exact expected keys" regression guard (lines 75-85) stays green. The new path resolves to the `shop` zone via `resolveZoneForPath` (it now matches a menu item), so `MainLayout`'s zone guard won't bounce OWNER/BM ([MainLayout.tsx:91-111](../../../apps/web/src/components/layout/MainLayout.tsx)).
+
+- [ ] **Step 5: Teach `NavBadge` the new key**
+
+In `Sidebar.tsx`, replace `NavBadge` (lines 61-71). Add the import for `useQcPendingCount` near the other hook imports (after line 39):
+
+```tsx
+import { useQcPendingCount } from '@/hooks/useQcPendingCount';
+```
+
+```tsx
+/* ── NavBadge — dynamic count badge for sidebar items ── */
+function NavBadge({ badgeKey }: { badgeKey: MenuBadgeKey }) {
+  const draftCount = useDraftAssetCount(badgeKey === 'asset-draft-count');
+  const qcCount = useQcPendingCount(badgeKey === 'qc-pending-count');
+  const count = badgeKey === 'asset-draft-count' ? draftCount
+    : badgeKey === 'qc-pending-count' ? qcCount
+    : undefined;
+  if (!count || count === 0) return null;
+  return (
+    <span className="ml-auto inline-flex items-center justify-center min-w-[20px] h-5 px-1.5 rounded-full text-[11px] font-medium bg-warning/10 text-warning dark:bg-warning/15">
+      {count}
+    </span>
+  );
+}
+```
+
+> Both hooks are always called (rules-of-hooks safe) and self-gate via their `enabled` arg — only the one matching `badgeKey` actually fetches. The `asset-draft-count` badge keeps its `bg-primary/15 text-primary` look via the conditional class is dropped in favor of a single warning-tinted badge; to preserve the asset badge's original primary tint, branch the className:
+
+```tsx
+  const cls = badgeKey === 'qc-pending-count'
+    ? 'bg-warning/10 text-warning dark:bg-warning/15'
+    : 'bg-primary/15 text-primary';
+  return (
+    <span className={`ml-auto inline-flex items-center justify-center min-w-[20px] h-5 px-1.5 rounded-full text-[11px] font-medium ${cls}`}>
+      {count}
+    </span>
+  );
+```
+
+Use this className-branched version (replace the single-class `<span>` above with it) so the asset badge stays primary-tinted and QC is warning-tinted.
+
+- [ ] **Step 6: Add a CommandPalette entry**
+
+In `CommandPalette.tsx`, add after the existing PO entry (line 65):
+
+```tsx
+  { label: 'ศูนย์ตรวจ QC', path: '/purchase-orders/qc', icon: ClipboardCheck, keywords: 'qc quality check ตรวจ คุณภาพ qc center', roles: ['OWNER', 'BRANCH_MANAGER'] },
+```
+
+Confirm `ClipboardCheck` is imported in `CommandPalette.tsx`; if not, add it to the `lucide-react` import. Run `grep -n "ClipboardCheck" apps/web/src/components/CommandPalette.tsx` first.
+
+- [ ] **Step 7: Run the menu regression test + type-check**
+
+Run: `cd apps/web && npx vitest run src/config/menu.test.ts && ../../tools/check-types.sh web`
+Expected: menu.test.ts PASS (regression guards intact — section keys unchanged); 0 type errors.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/web/src/App.tsx apps/web/src/config/menu.ts apps/web/src/components/layout/Sidebar.tsx apps/web/src/components/CommandPalette.tsx
+git commit -m "feat(web): wire /purchase-orders/qc route + nav badge + menu/palette entries"
+```
+
+---
+
+### Task 6: Retire the inline `QcPendingPanel` from `PurchaseOrdersPage`
+
+The collapsible panel is now superseded by the QC center page. Remove it (and its dead `qc-pending`/`qcNotes`/`showQcPanel` state + the broken `{ items: [...] }` confirm mutation) from `PurchaseOrdersPage`, leaving a link/empty so the PO page stays focused.
+
+**Files:**
+- Delete: `apps/web/src/pages/PurchaseOrdersPage/components/QcPendingPanel.tsx`
+- Modify: `apps/web/src/pages/PurchaseOrdersPage/index.tsx` (remove `<QcPendingPanel/>` import + render, lines 12, 112-119)
+- Modify: `apps/web/src/pages/PurchaseOrdersPage/hooks/usePurchaseOrdersData.ts` (remove `qcPendingItems` query, `qcConfirmMutation`, `showQcPanel`, `qcNotes` state + returns)
+
+**Interfaces:**
+- Removes: `QcPendingPanel` component; `usePurchaseOrdersData`'s `qcPendingItems`, `qcConfirmMutation`, `showQcPanel`, `setShowQcPanel`, `qcNotes`, `setQcNotes`.
+
+- [ ] **Step 1: Remove the panel render + import in `index.tsx`**
+
+Delete the import on line 12:
+
+```tsx
+import { QcPendingPanel } from './components/QcPendingPanel';
+```
+
+Delete the render block (lines 112-119):
+
+```tsx
+      <QcPendingPanel
+        qcPendingItems={data.qcPendingItems}
+        showQcPanel={data.showQcPanel}
+        setShowQcPanel={data.setShowQcPanel}
+        qcNotes={data.qcNotes}
+        setQcNotes={data.setQcNotes}
+        qcConfirmMutation={data.qcConfirmMutation}
+      />
+```
+
+Optionally add a lightweight link to the new page in the `PageHeader` action `<div className="flex gap-2">` (before the "+ สร้าง PO" button) so PO users can jump to QC:
+
+```tsx
+            <Link
+              to="/purchase-orders/qc"
+              className="inline-flex items-center gap-1.5 px-3 py-2 text-sm border border-input rounded-lg hover:bg-muted transition-colors"
+            >
+              <ClipboardCheck className="size-4" />
+              ศูนย์ตรวจ QC
+            </Link>
+```
+
+If you add the link, add `import { Link } from 'react-router';` and `import { ClipboardCheck } from 'lucide-react';` (extend the existing lucide import on line 7 which already imports `Download`).
+
+- [ ] **Step 2: Remove the dead QC state + query + mutation in `usePurchaseOrdersData.ts`**
+
+Delete:
+- the `showQcPanel`/`setShowQcPanel` state (line 14): `const [showQcPanel, setShowQcPanel] = useState(false);`
+- the `qcNotes`/`setQcNotes` state (line 15): `const [qcNotes, setQcNotes] = useState<Record<string, string>>({});`
+- the `qcPendingItems` query (lines 67-75)
+- the `qcConfirmMutation` (lines 77-86)
+- their entries from the `return { ... }` object (lines 364, 366, 386-389): `qcPendingItems`, `qcConfirmMutation`, `showQcPanel`, `setShowQcPanel`, `qcNotes`, `setQcNotes`
+
+- [ ] **Step 3: Delete the component file**
+
+```bash
+git rm apps/web/src/pages/PurchaseOrdersPage/components/QcPendingPanel.tsx
+```
+
+- [ ] **Step 4: Type-check (catches any lingering reference)**
+
+Run: `./tools/check-types.sh all`
+Expected: 0 errors — no remaining references to `QcPendingPanel`, `qcPendingItems`, `qcConfirmMutation`, `showQcPanel`, or `qcNotes`.
+
+- [ ] **Step 5: Manual verification (desktop + mobile)**
+
+Run the app (`cd apps/web && npm run dev`), log in as OWNER (`admin@bestchoice.com` / `admin1234`), then as BRANCH_MANAGER (`manager.ladprao@bestchoice.com` / `admin1234`).
+
+Desktop (≥1024px):
+1. Sidebar → "คลัง & จัดซื้อ" → confirm **"ศูนย์ตรวจ QC"** item appears with a warning-tinted count badge when there are QC_PENDING/PHOTO_PENDING products (receive a PO first via `/purchase-orders` if the DB is empty).
+2. Click it → lands on `/purchase-orders/qc` with no "ไม่มีสิทธิ์" toast and no zone bounce.
+3. Header count matches the badge. Search "PO-" narrows the list; branch dropdown filters.
+4. Select 2 rows → sticky bar shows "เลือก 2 ชิ้น" → "ยืนยันผ่านทั้งหมด" → toast success → rows leave the queue, badge decrements (≤30s or on window focus).
+5. Per-row "ไม่ผ่าน" → reason dialog → "บันทึกไม่ผ่าน" → toast success → rows leave; "ผ่าน"/"บันทึก" disabled while pending (spinner state).
+6. `/purchase-orders` no longer shows the collapsible QC panel; the optional "ศูนย์ตรวจ QC" header link navigates correctly.
+7. Open `Cmd/Ctrl+K` → type "QC" → entry navigates to the page.
+
+Mobile (≤1023px, devtools responsive ~390px):
+8. Rows stack vertically; the ผ่าน/ไม่ผ่าน buttons are full-width and tappable; the sticky bar spans full width (no sidebar offset); the reject dialog Textarea is reachable and the keyboard does not cover the confirm button.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/pages/PurchaseOrdersPage
+git commit -m "refactor(web): retire inline QcPendingPanel — QC now lives at /purchase-orders/qc"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage (B4 items — from spec §"QC center" + Batches §B4):**
+- **Dedicated QC page** (`QcPendingPanel.tsx` → page) at a lazy route → Task 4 (`QcCenterPage`) + Task 5 (route `/purchase-orders/qc`). ✅
+- **Queue of `QC_PENDING`/`PHOTO_PENDING`** → Task 1 (backend `includePhotoPending` widening) consumed by Task 3 hook + Task 4 list. ✅
+- **Filters (branch/PO/date)** → Task 4: branch `<select>` (server-side via `getQCPending.branchId`, **OWNER-only** — BranchGuard blocks a BM from passing another branch's id, see deviation #6), PO/name/IMEI search (`useDebounce`, client-side over the fetched page). *Date:* the queue is sorted newest-first (`createdAt desc`) and every row shows `formatDateTime(createdAt)`; an explicit date-range picker is **not** added because QC_PENDING items are a small live queue (intended for immediate action, not historical search) — documented scope trim, consistent with the spec's "filter by branch/PO/date" intent being satisfied by branch+PO filters + visible/ordered dates. ⚠️ (scope note, see deviation #3)
+- **Bulk confirm (reuse `POST /purchase-orders/qc-confirm`)** → Task 3 `confirmMutation` (posts `{ productIds }`) + Task 4 sticky bar "ยืนยันผ่านทั้งหมด". ✅
+- **Reject path** → Task 2 (new additive `POST /purchase-orders/qc-reject`) + Task 4 reject dialog. ✅
+- **Reuse existing `getQCPending`** → Task 1 keeps the same method/shape, only widened additively. ✅
+- **Nav badge of pending count** → Task 3 `useQcPendingCount` + Task 5 `MenuBadgeKey 'qc-pending-count'` wired into the existing `NavBadge`. Count source = `getQCPending` total (B0's `summary.waitingQc` does not exist yet — spec's stated fallback). ✅
+- **Route + menu entry per repo conventions, role gating (OWNER, BRANCH_MANAGER)** → Task 5: lazy `ProtectedRoute roles={['OWNER','BRANCH_MANAGER']}`, menu items in `owner-inventory` + `bm-inventory`, backend routes `@Roles('OWNER','BRANCH_MANAGER')` (mirrors existing `qc-pending`/`qc-confirm`). ✅
+
+**Placeholder scan:** none. Every code/JSX/test step contains full content; the conditional spots (`Product` note-column existence in Task 2; `ConfirmDialog` `children` + `closeOnConfirm` edits in Task 4) include the exact grep to run and both concrete branches.
+
+**Type/prop-name consistency across tasks:**
+- `getQCPending` filter shape `{ branchId?, poId?, includePhotoPending?, page?, limit? }` is identical in `PoQueryService` (Task 1 Step 3), the facade (Task 1 Step 4), and the controller mapping (Task 1 Step 5).
+- `rejectQC(productIds: string[], reason: string)` signature identical in service (Task 2 Step 4), facade (Task 2 Step 5), and controller `RejectQCDto` (Task 2 Step 3/6).
+- `QcPendingProduct` defined once in `useQcCenter.ts` (Task 3) and imported by `qcLabels.ts` + its test (Task 4) — no duplicate definition.
+- `MenuBadgeKey` value `'qc-pending-count'` is declared in `menu.ts` (Task 5 Step 3), referenced by the menu items (Step 4) and matched in `NavBadge` (Step 5) and the hook gate (Task 3).
+- Mutation bodies match the backend contract: `qc-confirm` reads `@Body('productIds')` → hook posts `{ productIds }`; `qc-reject` uses `RejectQCDto.productIds`/`reason` → hook posts `{ productIds, reason }`.
+
+**Deviations found vs spec wording:**
+1. **Pre-existing bug fixed in passing:** the retired `QcPendingPanel` posted `{ items: [{ productId, passed, notes }] }` to `/purchase-orders/qc-confirm`, but the controller reads `@Body('productIds')` ([purchase-orders.controller.ts:67](../../../apps/api/src/modules/purchase-orders/purchase-orders.controller.ts)) — so the old "ผ่าน" button silently sent `productIds: undefined` and could not work. The new hook posts the correct `{ productIds }`. This is an improvement, not a regression.
+2. **B0 not shipped:** the spec said the badge "can reuse `GET /purchase-orders/summary.waitingQc` (from B0) **or** `getQCPending` total." Grep confirms B0 hasn't landed (no `summary`/`waitingQc` endpoint; latest migration is `20260977000000_add_payment_drafts`, which also means B0's planned timestamp is already taken). This batch uses the `getQCPending` fallback, isolated in `useQcPendingCount` so B5 can swap it later in one place. No spec violation — the fallback is explicitly sanctioned.
+3. **Date filter scope trim:** spec lists "filter by branch/PO/date." Implemented branch + PO (+name/IMEI) filters and surfaced per-row dates with newest-first ordering, but did **not** add a date-range picker — the QC queue is a small actionable live list, not a historical archive (the dated/searchable archive is the GR history in B1). Branch+PO+visible-dates satisfy the operator need; a date-range picker can be added in B5 if the owner asks. Stated here so it's a conscious trim, not an omission.
+4. **`PHOTO_PENDING` was not in `getQCPending`:** the spec assumed the queue already covered `QC_PENDING`/`PHOTO_PENDING`, but `getQCPending` hard-coded `QC_PENDING` only. Task 1 adds the additive `includePhotoPending` flag (default behavior unchanged) so the page can show both without breaking existing callers.
+5. **Reject = soft-delete (no note column exists):** the spec says "reject→defect" but the structured `DefectReason` enum lives in B0 (not shipped) and the per-unit defect capture is B3's `goodsReceiving` reject branch. At the **post-receive QC** stage there is no existing reject endpoint, so Task 2 adds a minimal additive one. Verified at plan time that `Product` has **no** free-text note column, so the unit is soft-deleted and the operator's reason is server-validated (required) and echoed in the response `message` — **no** schema change in B4. When B0's `DefectReason` lands, `RejectQCDto` can gain an optional `defectReason` (and a `Product.qcNote` could persist the reason) additively — noted for B0/B5 follow-up.
+6. **`BranchGuard` 403 trap → OWNER-only branch picker (NEW behavior in B4):** the PO controller is `@UseGuards(JwtAuthGuard, RolesGuard, BranchGuard)` ([purchase-orders.controller.ts:14](../../../apps/api/src/modules/purchase-orders/purchase-orders.controller.ts)). `BranchGuard` ([branch.guard.ts](../../../apps/api/src/modules/auth/guards/branch.guard.ts)) throws `ไม่สามารถเข้าถึงข้อมูลของสาขาอื่นได้` when a branch-scoped role (BRANCH_MANAGER) passes a `branchId` ≠ their own. The legacy `QcPendingPanel` never hit this because it called `qc-pending` with **no** `branchId`. The new page's branch `<select>` *would* let a BM pick another branch → guaranteed 403. Fix in Task 4: the branch picker (and its `['branches']` query, `enabled`-gated) renders **only for OWNER** (`user?.role === 'OWNER'` via `useAuth`); BM sends no `branchId` and sees the queue exactly as the legacy panel did. A proper per-branch BM scope (service auto-filters by `user.branchId`) is a backend follow-up, **out of B4 scope** (it would change `getQCPending` behavior for existing callers). OWNER/FM/ACC are `CROSS_BRANCH_ROLES` so they are unaffected — but only OWNER reaches this page (route + menu gated to OWNER/BM).
+7. **`ConfirmDialog` adapted additively (children + `closeOnConfirm`):** the existing `ConfirmDialog` ([ConfirmDialog.tsx](../../../apps/web/src/components/ui/ConfirmDialog.tsx)) did **not** render `{children}` and auto-closed synchronously on confirm (`onConfirm(); onOpenChange(false);`), which is wrong for an async mutation (spinner/disabled-confirm + post-submit validation toast would never show). Task 4 Step 3 adds an optional `children?: ReactNode` (render between header/footer) and an optional `closeOnConfirm = true` prop (gate the auto-close), passing `closeOnConfirm={false}` from the reject dialog so the page controls closing via `onSuccess`. Both changes default to the old behavior for every existing caller — backward compatible, no other call site touched.

--- a/docs/superpowers/plans/2026-06-29-purchasing-b5-dashboard-overdue-ap.md
+++ b/docs/superpowers/plans/2026-06-29-purchasing-b5-dashboard-overdue-ap.md
@@ -1,0 +1,876 @@
+# Purchasing v2 — Batch 5: Dashboard Strip + Overdue + AP Polish — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give the Purchase Orders page a glanceable **ภาพรวมจัดซื้อ** summary strip — 7 KPI/alert cards (รออนุมัติ · รอสั่ง · กำลังมา · เลยกำหนด · รอรับ · รอ QC · ค้างจ่าย) built on the exact `DashboardKPIs` card pattern (colored left-border, `size-10` icon box, count pill, hover-lift) and wired to the B0 `GET /purchase-orders/summary` endpoint. Each card is a **filter shortcut** that jumps the list/tab to the matching slice. Surface the **เลยกำหนด (overdue)** count on the strip and as a per-row badge on the list. Polish the `AccountsPayableTab` (clearer remaining/paid, due-date urgency, deep-links into PO detail).
+
+**Architecture:** Pure-frontend batch. Add a `PurchasingSummaryStrip` component + a config/helper module (`summaryStrip.ts`) that maps the 7 summary keys → label/icon/color-token/filter-action; extend `usePurchaseOrdersData` with a `useQuery` for `/purchase-orders/summary` and an `overdueOnly` client filter flag; wire the strip into `PurchaseOrdersPage/index.tsx`; add the `overdueOnly` client filter to `POListTab` (REUSING B1's existing `isOverdue` helper + per-row overdue badge — not re-implementing them); polish `AccountsPayableTab`. No backend changes — `GET /purchase-orders/summary` ships in B0; the `ORDERED` status + overdue badge/helper ship in B1.
+
+**Tech Stack:** React 18 + TypeScript + Vite + Tailwind + shadcn/ui (`Card`/`CardContent`) + Radix + lucide-react (`apps/web`); `@tanstack/react-query` + `@/lib/api`; vitest + RTL for logic tests.
+
+**Spec:** `docs/superpowers/specs/2026-06-29-purchasing-receiving-ux-v2-design.md`
+
+## Global Constraints
+
+- **Red line — no accounting/finance:** this batch is frontend-only and touches **no** API code. Introduce **no** import of any accounting/finance/journal/expense/tax module into `purchase-orders`; do not touch `trade-in` or `Product.ownedByCompanyId`; receiving stays JE-free. **Additive only** — no rewrite of existing components, no data-model change.
+- **Dependency on B0:** this batch consumes `GET /purchase-orders/summary` → `{ pendingApproval, toOrder, incoming, overdue, receiving, waitingQc, unpaid }` (all `number`), shipped in `docs/superpowers/plans/2026-06-29-purchasing-b0-backend-foundation.md` Task 5. **Do not implement that endpoint here.** If it is missing at runtime, the strip query fails gracefully (see Task 2 — render nothing on error, never crash the page).
+- **Dependency on B1 (`docs/superpowers/plans/2026-06-29-purchasing-b1-list-detail.md`):** B1 ships before B5 (one-deploy-per-batch order B0→B1→…→B5) and ALREADY adds, in `POListTab.tsx` and friends, everything the `incoming`/`overdue`/`receiving` filter shortcuts rely on: the `ORDERED` status in `constants.ts` (`statusLabels`/`statusColors`), in `@/lib/status-badges.ts` (`poStatusMap.ORDERED`), in the status `<select>` dropdown, and in the active-filter-chip status-label map; a tested pure helper `isOverdue(po, now?)` at `apps/web/src/pages/PurchaseOrdersPage/po-list.util.ts`; and the per-row red "เลยกำหนด" badge in the status column. **B5 MUST NOT re-implement any of these.** Task 5 below therefore (a) imports `isOverdue` from `../po-list.util` instead of defining a new helper, (b) does NOT touch the status column / `AlertTriangle` import (B1 owns the per-row badge), and (c) adds ONLY the genuinely-new `overdueOnly` client filter + its clear-chip wiring. If B5 is ever picked up before B1 has landed, STOP and ship B1 first — the strip's status-based shortcuts (`ORDERED` filtering, the dropdown reflecting "สั่งซื้อแล้ว", the chip label, the row badge) will be incomplete otherwise.
+- **Frontend rules (`.claude/rules/frontend.md`):**
+  - Data fetching via `useQuery`/`useMutation` from `@tanstack/react-query` **only**; API calls via `api.get()` from `@/lib/api` **only** — **no** raw `fetch`/`axios`.
+  - UI = **shadcn/ui + Radix + lucide-react only** (reuse `Card`/`CardContent` from `@/components/ui/card`, mirror `DashboardKPIs`). No MUI/AntD.
+  - **Design tokens only** — no hardcoded gray/hex, no `text-gray-*`/`bg-gray-*`, no `bg-white` (print/receipt context only). Use `bg-primary`, `bg-destructive`, `bg-warning`, `bg-success`, `bg-card`, `bg-muted`, `text-muted-foreground`, `border-border`, etc. The strip card colors come from a fixed token set (`primary`/`warning`/`destructive`/`success`/`info`), NOT inline hex.
+  - **Thai UI text uses `leading-snug`** (never `leading-none`).
+  - Routes stay lazy-loaded (no route change in this batch — `/purchase-orders` already lazy-loads).
+  - `sonner` toasts for notifications (`toast.success`/`toast.error`); `useDebounce` for search (search already exists in `POListTab`; this batch adds no new search input).
+- **Money = display formatting only** — AP money already arrives as numbers from the backend; format via `.toLocaleString()` (existing pattern in `AccountsPayableTab`). No client-side money math.
+- **Type gate:** `./tools/check-types.sh all` must report **0 errors** before each commit.
+- **Web tests:** vitest (`apps/web` runs `vitest run` via `npm test`; test files match `src/**/*.{test,spec}.{ts,tsx}`). Write an RTL/vitest test ONLY where it adds genuine value (the strip config/mapping logic) — UI wiring is verified manually on desktop AND mobile viewports.
+
+---
+
+### Task 1: Summary-strip config + filter-mapping helper (`summaryStrip.ts`) + unit test
+
+**Files:**
+- Create: `apps/web/src/pages/PurchaseOrdersPage/summaryStrip.ts`
+- Create: `apps/web/src/pages/PurchaseOrdersPage/summaryStrip.test.ts`
+
+**Interfaces:**
+- Consumes: nothing (pure config + a `lucide-react` icon component reference per card).
+- Produces:
+  - `interface PurchasingSummary { pendingApproval: number; toOrder: number; incoming: number; overdue: number; receiving: number; waitingQc: number; unpaid: number; }` — **identical** key set to B0's `getSummary()` return (B0 plan Task 5).
+  - `type SummaryFilterAction = { tab: 'list'; status: string; overdueOnly: boolean } | { tab: 'payable' } | { panel: 'qc' };`
+  - `interface SummaryCardDef { key: keyof PurchasingSummary; label: string; icon: LucideIcon; tone: 'primary' | 'warning' | 'destructive' | 'success' | 'info'; action: SummaryFilterAction; }`
+  - `const SUMMARY_CARDS: SummaryCardDef[]` (7 entries, in display order).
+  - `const TONE_STYLES: Record<SummaryCardDef['tone'], { border: string; iconBox: string; icon: string; pill: string }>` — token-only Tailwind classes.
+
+- [ ] **Step 1: Write the failing test first**
+
+Create `apps/web/src/pages/PurchaseOrdersPage/summaryStrip.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { SUMMARY_CARDS, TONE_STYLES, type PurchasingSummary } from './summaryStrip';
+
+describe('SUMMARY_CARDS', () => {
+  it('defines exactly the 7 B0 summary keys, in order, with no duplicates', () => {
+    const keys = SUMMARY_CARDS.map((c) => c.key);
+    expect(keys).toEqual([
+      'pendingApproval',
+      'toOrder',
+      'incoming',
+      'overdue',
+      'receiving',
+      'waitingQc',
+      'unpaid',
+    ]);
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+
+  it('covers every key of the PurchasingSummary type (compile-time + runtime parity)', () => {
+    const sample: PurchasingSummary = {
+      pendingApproval: 1, toOrder: 2, incoming: 3, overdue: 4, receiving: 5, waitingQc: 6, unpaid: 7,
+    };
+    for (const card of SUMMARY_CARDS) {
+      expect(typeof sample[card.key]).toBe('number');
+    }
+  });
+
+  it('every card has a Thai label and a defined lucide icon', () => {
+    for (const card of SUMMARY_CARDS) {
+      expect(card.label.length).toBeGreaterThan(0);
+      // lucide icons are forwardRef components → function (object in some builds)
+      expect(['function', 'object']).toContain(typeof card.icon);
+    }
+  });
+
+  it('overdue card routes to list+overdueOnly; toOrder→APPROVED; incoming→ORDERED; receiving→PARTIALLY_RECEIVED; pendingApproval→DRAFT', () => {
+    const byKey = Object.fromEntries(SUMMARY_CARDS.map((c) => [c.key, c.action]));
+    expect(byKey.overdue).toEqual({ tab: 'list', status: 'ORDERED', overdueOnly: true });
+    expect(byKey.toOrder).toEqual({ tab: 'list', status: 'APPROVED', overdueOnly: false });
+    expect(byKey.incoming).toEqual({ tab: 'list', status: 'ORDERED', overdueOnly: false });
+    expect(byKey.receiving).toEqual({ tab: 'list', status: 'PARTIALLY_RECEIVED', overdueOnly: false });
+    expect(byKey.pendingApproval).toEqual({ tab: 'list', status: 'DRAFT', overdueOnly: false });
+  });
+
+  it('unpaid card routes to the payable tab; waitingQc opens the qc panel', () => {
+    const byKey = Object.fromEntries(SUMMARY_CARDS.map((c) => [c.key, c.action]));
+    expect(byKey.unpaid).toEqual({ tab: 'payable' });
+    expect(byKey.waitingQc).toEqual({ panel: 'qc' });
+  });
+
+  it('TONE_STYLES uses only design-token classes (no hardcoded gray/hex/white)', () => {
+    const blob = JSON.stringify(TONE_STYLES);
+    expect(blob).not.toMatch(/#[0-9a-fA-F]{3,6}/); // no hex
+    expect(blob).not.toMatch(/\bbg-white\b/);
+    expect(blob).not.toMatch(/-gray-/);
+    // every tone present
+    expect(Object.keys(TONE_STYLES).sort()).toEqual(
+      ['destructive', 'info', 'primary', 'success', 'warning'].sort(),
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to confirm it fails**
+
+Run: `cd apps/web && npx vitest run src/pages/PurchaseOrdersPage/summaryStrip.test.ts`
+Expected: FAIL — `Cannot find module './summaryStrip'`.
+
+- [ ] **Step 3: Implement `summaryStrip.ts`**
+
+Create `apps/web/src/pages/PurchaseOrdersPage/summaryStrip.ts`. The 7 cards mirror the spec's strip order (`รออนุมัติ · รอสั่ง · กำลังมา (⚠️ เลยกำหนด) · รอรับ · รอ QC · ค้างจ่าย`) — split "กำลังมา / เลยกำหนด" into two cards so overdue gets its own loud red card per the spec ("Surface the OVERDUE count/badge on the strip"). Icons are reused from lucide (same family as `DashboardKPIs`: `FileClock`, `ShoppingCart`, `Truck`, `AlertTriangle`, `PackageCheck`, `ClipboardCheck`, `Wallet`).
+
+```typescript
+import type { LucideIcon } from 'lucide-react';
+import {
+  FileClock,
+  ShoppingCart,
+  Truck,
+  AlertTriangle,
+  PackageCheck,
+  ClipboardCheck,
+  Wallet,
+} from 'lucide-react';
+
+/**
+ * Compute-on-read purchasing counts from GET /purchase-orders/summary (B0).
+ * Keys MUST stay identical to po-query.service.ts getSummary() return shape.
+ */
+export interface PurchasingSummary {
+  pendingApproval: number;
+  toOrder: number;
+  incoming: number;
+  overdue: number;
+  receiving: number;
+  waitingQc: number;
+  unpaid: number;
+}
+
+/** What clicking a card does to the page. */
+export type SummaryFilterAction =
+  | { tab: 'list'; status: string; overdueOnly: boolean }
+  | { tab: 'payable' }
+  | { panel: 'qc' };
+
+export type SummaryTone = 'primary' | 'warning' | 'destructive' | 'success' | 'info';
+
+export interface SummaryCardDef {
+  key: keyof PurchasingSummary;
+  label: string;
+  icon: LucideIcon;
+  tone: SummaryTone;
+  action: SummaryFilterAction;
+}
+
+/** Display order matches the spec's summary-strip zone. */
+export const SUMMARY_CARDS: SummaryCardDef[] = [
+  {
+    key: 'pendingApproval',
+    label: 'รออนุมัติ',
+    icon: FileClock,
+    tone: 'warning',
+    action: { tab: 'list', status: 'DRAFT', overdueOnly: false },
+  },
+  {
+    key: 'toOrder',
+    label: 'รอสั่งซื้อ',
+    icon: ShoppingCart,
+    tone: 'primary',
+    action: { tab: 'list', status: 'APPROVED', overdueOnly: false },
+  },
+  {
+    key: 'incoming',
+    label: 'กำลังมา',
+    icon: Truck,
+    tone: 'info',
+    action: { tab: 'list', status: 'ORDERED', overdueOnly: false },
+  },
+  {
+    key: 'overdue',
+    label: 'เลยกำหนดส่ง',
+    icon: AlertTriangle,
+    tone: 'destructive',
+    action: { tab: 'list', status: 'ORDERED', overdueOnly: true },
+  },
+  {
+    key: 'receiving',
+    label: 'รับบางส่วน',
+    icon: PackageCheck,
+    tone: 'warning',
+    action: { tab: 'list', status: 'PARTIALLY_RECEIVED', overdueOnly: false },
+  },
+  {
+    key: 'waitingQc',
+    label: 'รอตรวจ QC',
+    icon: ClipboardCheck,
+    tone: 'warning',
+    action: { panel: 'qc' },
+  },
+  {
+    key: 'unpaid',
+    label: 'ค้างจ่าย',
+    icon: Wallet,
+    tone: 'destructive',
+    action: { tab: 'payable' },
+  },
+];
+
+/**
+ * Token-only Tailwind classes per tone — mirrors the DashboardKPIs card anatomy
+ * (left border-strip, size-10 rounded icon box, count pill). No hex, no gray, no bg-white.
+ */
+export const TONE_STYLES: Record<SummaryTone, { border: string; iconBox: string; icon: string; pill: string }> = {
+  primary: {
+    border: 'bg-primary',
+    iconBox: 'bg-primary/10 group-hover:bg-primary/20',
+    icon: 'text-primary',
+    pill: 'text-primary bg-primary/10',
+  },
+  warning: {
+    border: 'bg-warning',
+    iconBox: 'bg-warning/10 group-hover:bg-warning/20',
+    icon: 'text-warning',
+    pill: 'text-warning bg-warning/10',
+  },
+  destructive: {
+    border: 'bg-destructive',
+    iconBox: 'bg-destructive/10 group-hover:bg-destructive/20',
+    icon: 'text-destructive',
+    pill: 'text-destructive bg-destructive/10',
+  },
+  success: {
+    border: 'bg-success',
+    iconBox: 'bg-success/10 group-hover:bg-success/20',
+    icon: 'text-success',
+    pill: 'text-success bg-success/10',
+  },
+  info: {
+    border: 'bg-info',
+    iconBox: 'bg-info/10 group-hover:bg-info/20',
+    icon: 'text-info',
+    pill: 'text-info bg-info/10',
+  },
+};
+```
+
+> Note on `success` tone: defined for completeness/token-coverage parity (the test asserts all 5 tones exist) even though no current card uses it — keeps the palette consistent with `DashboardKPIs` (which uses primary/destructive/success/warning) and lets B-follow-ups add a "รับครบ" card without editing `TONE_STYLES`.
+
+- [ ] **Step 4: Run the test to confirm it passes**
+
+Run: `cd apps/web && npx vitest run src/pages/PurchaseOrdersPage/summaryStrip.test.ts`
+Expected: PASS (7 tests).
+
+- [ ] **Step 5: Verify the `info` token exists (token-only constraint)**
+
+The `info` tone uses `bg-info` / `text-info`. Confirm these tokens exist so the build doesn't ship a dead class.
+
+Run: `cd apps/web && grep -rn "\-\-info\|text-info\|bg-info" src/index.css tailwind.config.* 2>/dev/null | head`
+Expected: at least one match (the `info` semantic token is defined — `getStatusBadgeProps` already uses `variant: 'info'` across `status-badges.ts`, and `DashboardAlerts`/Badge render it). If `bg-info`/`text-info` are NOT defined as Tailwind utilities (only the Badge `info` variant exists), change the `incoming` card `tone` from `'info'` to `'primary'` in `SUMMARY_CARDS` and drop the `info` entry expectation — but FIRST confirm with the grep; do not guess.
+
+- [ ] **Step 6: Type-check + commit**
+
+```bash
+./tools/check-types.sh all
+git add apps/web/src/pages/PurchaseOrdersPage/summaryStrip.ts apps/web/src/pages/PurchaseOrdersPage/summaryStrip.test.ts
+git commit -m "feat(purchasing): summary-strip card config + filter-action mapping (B5)"
+```
+
+---
+
+### Task 2: Summary `useQuery` + `overdueOnly` filter flag in `usePurchaseOrdersData`
+
+**Files:**
+- Modify: `apps/web/src/pages/PurchaseOrdersPage/hooks/usePurchaseOrdersData.ts` (add summary query + `overdueOnly` state + expose both; imports/state near the top, return block at the bottom)
+
+> Line numbers in the steps below are for the PRE-B1 source. B1 also edits this hook (adds an `orderMutation` + its `POST /:id/order` mutation), so anchors will drift a few lines after B1 lands — match on the quoted code, not the raw number.
+
+**Interfaces:**
+- Consumes: `api.get('/purchase-orders/summary')` → bare `PurchasingSummary` (B0; defensively also tolerates a `{ data: PurchasingSummary }` envelope).
+- Produces (added to the hook's return object):
+  - `summary: PurchasingSummary | undefined`
+  - `overdueOnly: boolean`
+  - `setOverdueOnly: (v: boolean) => void`
+
+- [ ] **Step 1: Import the `PurchasingSummary` type**
+
+In `usePurchaseOrdersData.ts`, add to the imports (after line 6 `import { defaultChecklist } from '../constants';`):
+
+```typescript
+import { PurchasingSummary } from '../summaryStrip';
+```
+
+- [ ] **Step 2: Add the `overdueOnly` state**
+
+In `usePurchaseOrdersData.ts`, next to the existing `statusFilter` state (line 10 `const [statusFilter, setStatusFilter] = useState('');`), add below it:
+
+```typescript
+  const [overdueOnly, setOverdueOnly] = useState(false);
+```
+
+- [ ] **Step 3: Add the summary query**
+
+In `usePurchaseOrdersData.ts`, add this query right after the `suppliers` query block (after line 32 `const suppliers = suppliersRes?.data || [];`):
+
+```typescript
+  const { data: summaryRes } = useQuery<{ data?: PurchasingSummary } | PurchasingSummary>({
+    queryKey: ['purchase-orders-summary'],
+    queryFn: async () => (await api.get('/purchase-orders/summary')).data,
+    // Stale-while-refresh so the strip stays snappy; counts are compute-on-read and cheap.
+    staleTime: 30_000,
+    retry: 1,
+  });
+  // Backend returns the bare object; tolerate a { data } envelope defensively.
+  const summary: PurchasingSummary | undefined = summaryRes
+    ? ('pendingApproval' in summaryRes ? summaryRes : (summaryRes as { data?: PurchasingSummary }).data)
+    : undefined;
+```
+
+- [ ] **Step 4: Invalidate the summary after the mutations that change counts**
+
+The summary counts shift when a PO is created / approved / rejected / cancelled / ordered / received / QC-confirmed / paid. Add `queryClient.invalidateQueries({ queryKey: ['purchase-orders-summary'] });` to the `onSuccess` of **every** mutation that already invalidates `['purchase-orders']`. Concretely, in `usePurchaseOrdersData.ts` add the line directly beneath each existing `queryClient.invalidateQueries({ queryKey: ['purchase-orders'] });` inside these `onSuccess` blocks (line numbers are for the PRE-B1 source — match on the mutation name, not the number): `qcConfirmMutation` (~line 82), `createMutation` (~line 91), `approveMutation` (~line 102), `rejectPOMutation` (~line 112), `cancelMutation` (~line 121), `goodsReceivingMutation` (~line 153), `paymentMutation` (~line 166). **Also `orderMutation`** — B1 adds this mutation (`POST /:id/order`, APPROVED→ORDERED) to the same hook; it shifts `toOrder`↓ / `incoming`↑ so it MUST get the summary-invalidation line too. (Grep `queryClient.invalidateQueries({ queryKey: ['purchase-orders'] })` and add the summary line under every hit — that catches `orderMutation` automatically regardless of B1's exact placement.)
+
+Example — `approveMutation` becomes:
+
+```typescript
+  const approveMutation = useMutation({
+    mutationFn: async (id: string) => api.post(`/purchase-orders/${id}/approve`),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['purchase-orders'] });
+      queryClient.invalidateQueries({ queryKey: ['purchase-orders-summary'] });
+      toast.success('อนุมัติ PO สำเร็จ');
+    },
+    onError: (err: unknown) => toast.error(getErrorMessage(err)),
+  });
+```
+
+Apply the identical one-line addition to every other listed mutation (including B1's `orderMutation`).
+
+- [ ] **Step 5: Reset `overdueOnly` whenever the user manually changes the status filter**
+
+The overdue shortcut sets `statusFilter='ORDERED'` + `overdueOnly=true`. If the user then picks a different status from the dropdown, `overdueOnly` must clear so the list isn't silently double-filtered. Rather than wrap `setStatusFilter`, expose a small wrapper the page passes to `POListTab`. In `usePurchaseOrdersData.ts`, add this memo-free helper near the other action functions (e.g. just above `openDetailModal`, line 181):
+
+```typescript
+  const setStatusFilterAndResetOverdue = (value: string) => {
+    setStatusFilter(value);
+    setOverdueOnly(false);
+  };
+```
+
+- [ ] **Step 6: Expose the new values from the hook**
+
+In the returned object (lines 356-414), add to the **Queries** group (after `pos,` line):
+
+```typescript
+    summary,
+```
+
+and add to the **State** group (after the `statusFilter`/`setStatusFilter` lines, ~line 375):
+
+```typescript
+    overdueOnly,
+    setOverdueOnly,
+    setStatusFilterAndResetOverdue,
+```
+
+- [ ] **Step 7: Type-check**
+
+Run: `./tools/check-types.sh all`
+Expected: 0 errors. (`summary` is `PurchasingSummary | undefined`; `overdueOnly` is `boolean`.)
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/web/src/pages/PurchaseOrdersPage/hooks/usePurchaseOrdersData.ts
+git commit -m "feat(purchasing): summary query + overdueOnly filter state in usePurchaseOrdersData (B5)"
+```
+
+---
+
+### Task 3: `PurchasingSummaryStrip` component (DashboardKPIs card pattern, filter shortcuts)
+
+**Files:**
+- Create: `apps/web/src/pages/PurchaseOrdersPage/components/PurchasingSummaryStrip.tsx`
+
+**Interfaces:**
+- Consumes: `summary: PurchasingSummary | undefined`, `onCardClick: (action: SummaryFilterAction) => void` (from Task 1 types).
+- Produces: a responsive grid of up-to-7 cards mirroring `DashboardKPIs` anatomy. Renders `null` when `summary` is undefined (loading/error) so the page never crashes if B0's endpoint is missing.
+
+- [ ] **Step 1: Implement the component**
+
+Create `apps/web/src/pages/PurchaseOrdersPage/components/PurchasingSummaryStrip.tsx`. This mirrors the `DashboardKPIs` card exactly — `Card`/`CardContent`, `p-5 relative`, `absolute inset-y-0 left-0 w-1` left border (token bg), `pl-2` content, `size-10 rounded-xl` icon box, hover-lift (`hover:shadow-md hover:-translate-y-0.5 transition-all`), count pill — but as a clickable filter shortcut (`role="button"` via native `<button>` wrapping for a11y, like `DashboardAlerts`). Uses `AnimatedCounter` for the count to match the dashboard feel.
+
+```tsx
+import { Card, CardContent } from '@/components/ui/card';
+import AnimatedCounter from '@/components/ui/animated-counter';
+import { cn } from '@/lib/utils';
+import { SUMMARY_CARDS, TONE_STYLES, type PurchasingSummary, type SummaryFilterAction } from '../summaryStrip';
+
+interface PurchasingSummaryStripProps {
+  summary: PurchasingSummary | undefined;
+  onCardClick: (action: SummaryFilterAction) => void;
+}
+
+export function PurchasingSummaryStrip({ summary, onCardClick }: PurchasingSummaryStripProps) {
+  // No data yet (loading) or the B0 endpoint is unavailable → render nothing rather than crash.
+  if (!summary) return null;
+
+  return (
+    <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-7 gap-3 lg:gap-4 mb-5">
+      {SUMMARY_CARDS.map((card) => {
+        const Icon = card.icon;
+        const styles = TONE_STYLES[card.tone];
+        const count = summary[card.key] ?? 0;
+        return (
+          <button
+            key={card.key}
+            type="button"
+            onClick={() => onCardClick(card.action)}
+            aria-label={`${card.label}: ${count} รายการ — คลิกเพื่อกรอง`}
+            className="text-left focus:outline-hidden focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 rounded-xl"
+          >
+            <Card className="cursor-pointer group hover:shadow-md hover:-translate-y-0.5 transition-all duration-200 overflow-hidden h-full">
+              <CardContent className="p-4 relative">
+                <div className={cn('absolute inset-y-0 left-0 w-1 rounded-l-xl', styles.border)} />
+                <div className="pl-2">
+                  <div className="flex items-center justify-between mb-3">
+                    <div
+                      className={cn(
+                        'size-10 rounded-xl flex items-center justify-center transition-colors',
+                        styles.iconBox,
+                      )}
+                    >
+                      <Icon className={cn('size-5', styles.icon)} />
+                    </div>
+                    {count > 0 && (
+                      <span className={cn('text-2xs font-semibold px-2 py-0.5 rounded-full', styles.pill)}>
+                        {count}
+                      </span>
+                    )}
+                  </div>
+                  <AnimatedCounter value={count} className="text-2xl font-bold text-foreground" />
+                  <div className="text-xs font-medium text-muted-foreground mt-1 leading-snug">{card.label}</div>
+                </div>
+              </CardContent>
+            </Card>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Type-check**
+
+Run: `./tools/check-types.sh all`
+Expected: 0 errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/src/pages/PurchaseOrdersPage/components/PurchasingSummaryStrip.tsx
+git commit -m "feat(purchasing): PurchasingSummaryStrip cards (DashboardKPIs pattern) (B5)"
+```
+
+---
+
+### Task 4: Wire the strip into `PurchaseOrdersPage` + implement card-click filter shortcuts
+
+**Files:**
+- Modify: `apps/web/src/pages/PurchaseOrdersPage/index.tsx` (imports lines 1-18; render the strip after `PageHeader`, ~line 110; pass `setStatusFilterAndResetOverdue` to `POListTab`, line 142)
+
+**Interfaces:**
+- Consumes: `data.summary`, `data.setActiveTab`, `data.setStatusFilter`, `data.setOverdueOnly`, `data.setShowQcPanel`, `SummaryFilterAction`.
+- Produces: an `onSummaryCardClick` handler that translates a `SummaryFilterAction` into page state.
+
+- [ ] **Step 1: Import the strip + the action type**
+
+In `index.tsx`, add after line 18 (`import { GoodsReceivingModal } from './components/GoodsReceivingModal';`):
+
+```typescript
+import { PurchasingSummaryStrip } from './components/PurchasingSummaryStrip';
+import type { SummaryFilterAction } from './summaryStrip';
+```
+
+- [ ] **Step 2: Add the card-click handler**
+
+In `index.tsx`, inside `PurchaseOrdersPage` after the `onSupplierSelect` callback (after line 58, before `return (`), add:
+
+```typescript
+  const onSummaryCardClick = useCallback(
+    (action: SummaryFilterAction) => {
+      if ('panel' in action) {
+        // รอ QC → switch to list tab + open the QC panel and scroll it into view.
+        data.setActiveTab('list');
+        data.setShowQcPanel(true);
+        requestAnimationFrame(() => {
+          document.getElementById('po-qc-panel')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        });
+        return;
+      }
+      if (action.tab === 'payable') {
+        data.setActiveTab('payable');
+        return;
+      }
+      // list filter shortcut
+      data.setActiveTab('list');
+      data.setStatusFilter(action.status);
+      data.setOverdueOnly(action.overdueOnly);
+    },
+    [data],
+  );
+```
+
+- [ ] **Step 3: Render the strip between `PageHeader` and `QcPendingPanel`**
+
+In `index.tsx`, insert the strip immediately after the `</PageHeader>`-equivalent close (after line 110, before `<QcPendingPanel`):
+
+```tsx
+      <PurchasingSummaryStrip summary={data.summary} onCardClick={onSummaryCardClick} />
+
+```
+
+- [ ] **Step 4: Give the QC panel a scroll anchor**
+
+The `waitingQc` card scrolls to `#po-qc-panel`. The `QcPendingPanel` root has no id. Wrap it (in `index.tsx`) so we add the anchor without editing the panel component:
+
+Change (lines 112-119) from:
+
+```tsx
+      <QcPendingPanel
+        qcPendingItems={data.qcPendingItems}
+        showQcPanel={data.showQcPanel}
+        setShowQcPanel={data.setShowQcPanel}
+        qcNotes={data.qcNotes}
+        setQcNotes={data.setQcNotes}
+        qcConfirmMutation={data.qcConfirmMutation}
+      />
+```
+
+to:
+
+```tsx
+      <div id="po-qc-panel">
+        <QcPendingPanel
+          qcPendingItems={data.qcPendingItems}
+          showQcPanel={data.showQcPanel}
+          setShowQcPanel={data.setShowQcPanel}
+          qcNotes={data.qcNotes}
+          setQcNotes={data.setQcNotes}
+          qcConfirmMutation={data.qcConfirmMutation}
+        />
+      </div>
+```
+
+(`QcPendingPanel` returns `null` when there are no pending items, so the wrapper is an empty div in that case — harmless, and the `waitingQc` card count is 0 then anyway.)
+
+- [ ] **Step 5: Pass the overdue-resetting setter + the new props to `POListTab`**
+
+So a manual status-dropdown change clears `overdueOnly`. In `index.tsx`, in the `<POListTab … />` JSX block, change the `setStatusFilter` prop from:
+
+```tsx
+          setStatusFilter={data.setStatusFilter}
+```
+
+to:
+
+```tsx
+          setStatusFilter={data.setStatusFilterAndResetOverdue}
+```
+
+and add the two new props to the same `<POListTab>` block (e.g. after `suppliers={data.suppliers}`). NOTE: B1 already added an `orderMutation={data.orderMutation}` prop to this same block — keep it; just append:
+
+```tsx
+          overdueOnly={data.overdueOnly}
+          setOverdueOnly={data.setOverdueOnly}
+```
+
+- [ ] **Step 6: Type-check**
+
+Run: `./tools/check-types.sh all`
+Expected: this will FAIL with `POListTab` prop errors (`overdueOnly`/`setOverdueOnly` not in `POListTabProps`) — that is expected and fixed in Task 5. If any OTHER error appears (e.g. a typo in the handler), fix it now.
+
+- [ ] **Step 7: Commit (after Task 5 makes types green — do NOT commit a red build)**
+
+This task's commit is deferred to the end of Task 5 (they form one type-consistent unit). Proceed to Task 5.
+
+---
+
+### Task 5: `overdueOnly` client filter + clear-chip in `POListTab` (reuses B1's `isOverdue`/badge/ORDERED)
+
+> **B1 already did the heavy lifting** (see Global Constraints → "Dependency on B1"): the `ORDERED` status (constants + `poStatusMap` + the `<select>` option + the chip-label map), the tested `isOverdue(po, now?)` helper at `../po-list.util`, the `AlertTriangle` lucide import, and the per-row red "เลยกำหนด" badge in the status column ALL ship in B1. This task therefore does **NOT** re-create any helper, re-touch the status column, or re-add `AlertTriangle` — it only adds the brand-new `overdueOnly` client filter (the strip's "เลยกำหนดส่ง" shortcut) and its UI wiring. **Line anchors below are relative to the POST-B1 `POListTab.tsx`**, so prefer the quoted code context over raw line numbers.
+
+**Files:**
+- Modify: `apps/web/src/pages/PurchaseOrdersPage/components/POListTab.tsx` (props interface; `filteredPos` `useMemo`; `hasFilter`; the active-filter-chip row; `clearAll`)
+
+**Interfaces:**
+- Consumes: `overdueOnly: boolean`, `setOverdueOnly: (v: boolean) => void` (new props from the hook via `index.tsx`); `isOverdue` from `../po-list.util` (B1, already imported into `POListTab.tsx` by B1 Task 3 Step 1); `PurchaseOrder.expectedDate`/`.status` (`types.ts:37,39`).
+- Produces: list rows filtered to overdue when `overdueOnly` is set; an active-filter chip to clear it; `overdueOnly` reflected in `hasFilter` + `clearAll`. (The per-row overdue badge already exists — B1 — and is NOT re-added here.)
+
+- [ ] **Step 1: Confirm B1 has landed (the helper + badge + ORDERED must already exist)**
+
+Before editing, verify B1's artifacts are present so this task is purely additive:
+
+```bash
+cd apps/web
+grep -n "isOverdue" src/pages/PurchaseOrdersPage/po-list.util.ts          # B1 Task 2 helper
+grep -n "isOverdue\|AlertTriangle\|เลยกำหนด" src/pages/PurchaseOrdersPage/components/POListTab.tsx   # B1 Task 3 import + badge
+grep -n "ORDERED" src/pages/PurchaseOrdersPage/components/POListTab.tsx src/lib/status-badges.ts      # B1 Task 1+3 dropdown + map
+```
+Expected: all three match. If `po-list.util.ts` or the `ORDERED` `<select>` option is missing, **B1 has not shipped — stop and ship B1 first** (see Global Constraints). Do NOT re-create `isOverdue` here; reuse the B1 one.
+
+- [ ] **Step 2: Add the two new props to `POListTabProps`**
+
+In `POListTab.tsx`, add to the `POListTabProps` interface (after the `suppliers: { id: string; name: string }[];` line):
+
+```typescript
+  overdueOnly: boolean;
+  setOverdueOnly: (value: boolean) => void;
+```
+
+and destructure them in the component signature (after `suppliers,`):
+
+```typescript
+  overdueOnly,
+  setOverdueOnly,
+```
+
+- [ ] **Step 3: Apply the overdue filter in the `filteredPos` `useMemo`**
+
+In `POListTab.tsx`, in the `filteredPos` memo, add the overdue guard as the first check in the `.filter` callback and add `overdueOnly` to the dependency array. Reuse B1's `isOverdue` (already imported from `../po-list.util` by B1). The memo's first line that derives the search term may read `const q = debouncedSearch.trim().toLowerCase();` (B1 added `useDebounce`) — keep whatever B1 left; only the highlighted lines change:
+
+```typescript
+    return pos.filter((po) => {
+      if (overdueOnly && !isOverdue(po)) return false;   // NEW — strip "เลยกำหนดส่ง" shortcut
+      if (supplierFilter && po.supplier.id !== supplierFilter) return false;
+      // … existing range / search checks unchanged …
+      return true;
+    });
+  }, [pos, /* search-or-debouncedSearch (keep B1's) */, supplierFilter, periodFilter, overdueOnly]);
+```
+
+Add `overdueOnly` to the dependency array (append it to whatever B1 left, e.g. `[pos, debouncedSearch, supplierFilter, periodFilter, overdueOnly]`).
+
+- [ ] **Step 4: Reflect the overdue filter in `hasFilter` + add a clear chip**
+
+In `POListTab.tsx`, update `hasFilter` to include `overdueOnly`:
+
+```typescript
+  const hasFilter = Boolean(search || statusFilter || supplierFilter || periodFilter || overdueOnly);
+```
+
+and add an "เลยกำหนดส่ง" chip inside the active-filter chip row (place it after the `periodFilter` chip block, before the "ล้างทั้งหมด" button):
+
+```tsx
+          {overdueOnly && (
+            <FilterChip label="เฉพาะที่เลยกำหนดส่ง" onRemove={() => setOverdueOnly(false)} />
+          )}
+```
+
+- [ ] **Step 5: Make "ล้างทั้งหมด" also clear overdue**
+
+In `POListTab.tsx`, update `clearAll` to reset `overdueOnly`:
+
+```typescript
+  const clearAll = () => {
+    setSearch('');
+    setStatusFilter('');
+    setSupplierFilter('');
+    setPeriodFilter('');
+    setOverdueOnly(false);
+  };
+```
+
+> No status-column change and no `AlertTriangle` import here — B1 owns the per-row "เลยกำหนด" badge (B1 Task 3 Step 4) which renders automatically for every overdue row, including inside the `overdueOnly`-filtered view.
+
+- [ ] **Step 6: Type-check (now Task 4 + Task 5 are type-consistent)**
+
+Run: `./tools/check-types.sh all`
+Expected: 0 errors.
+
+- [ ] **Step 7: Run the PO web test suite (no regressions)**
+
+Run: `cd apps/web && npx vitest run src/pages/PurchaseOrdersPage`
+Expected: PASS — runs B5's `summaryStrip.test.ts` plus B1's `po-list.util.test.ts` (B1 shipped first); confirms the new module is green and B1's helper tests still pass.
+
+- [ ] **Step 8: Commit Task 4 + Task 5 together**
+
+```bash
+git add apps/web/src/pages/PurchaseOrdersPage/index.tsx apps/web/src/pages/PurchaseOrdersPage/components/POListTab.tsx
+git commit -m "feat(purchasing): wire summary strip + overdueOnly filter into PO list (B5)"
+```
+
+- [ ] **Step 9: Manual verification — strip + shortcuts + overdue (desktop AND mobile)**
+
+Start the app: `cd apps/web && npm run dev` (API must be running with B0 merged so `/purchase-orders/summary` exists). Log in as `admin@bestchoice.com / admin1234`, go to `/purchase-orders`.
+
+Desktop (≥1280px wide):
+- The strip shows up to **7 cards** in a single row (`xl:grid-cols-7`), each with a colored left border, a `size-10` icon box, the count, a count pill (when >0), and the Thai label. Hovering lifts the card (`-translate-y-0.5` + shadow). Confirm NO `bg-white`/gray — borders/icons use primary/warning/destructive/info tokens.
+- Click **รออนุมัติ** → list tab active, status dropdown shows "รออนุมัติ", only DRAFT rows; an active-filter chip appears. Click **รอสั่งซื้อ** → APPROVED rows. Click **กำลังมา** → ORDERED rows. Click **รับบางส่วน** → PARTIALLY_RECEIVED rows.
+- Click **เลยกำหนดส่ง** → list shows only ORDERED rows whose `expectedDate` is in the past; each such row shows a red "⚠ เลยกำหนด" badge next to its status; the "เฉพาะที่เลยกำหนดส่ง" chip appears. Now change the status dropdown to a different value → the overdue chip disappears (overdueOnly cleared). Click "ล้างทั้งหมด" → all filters cleared including overdue.
+- Click **ค้างจ่าย** → switches to the "ยอดค้างชำระ" tab.
+- Click **รอตรวจ QC** → list tab, the QC panel expands and scrolls into view (only if there are QC-pending items; otherwise count is 0 and there is nothing to show).
+
+Mobile (DevTools responsive, 390px wide):
+- The strip wraps to **2 columns** (`grid-cols-2`) — cards stack neatly, labels use `leading-snug` (no clipped Thai tone marks), touch targets are the full card. Tap each card → same filter behavior; the list/tab updates and the page scrolls so the user sees the result.
+
+Record what you saw (counts shown, filters applied) in the PR description.
+
+---
+
+### Task 6: Polish `AccountsPayableTab` — clearer remaining/paid, due-date urgency, deep-link affordance
+
+**Files:**
+- Modify: `apps/web/src/pages/PurchaseOrdersPage/components/AccountsPayableTab.tsx` (supplier header lines 47-50; per-PO row rendering lines 67-92; empty/loading states)
+
+**Interfaces:**
+- Consumes: existing `payableData` prop shape (unchanged), `onOpenDetail` (unchanged). No backend change.
+- Produces: a clearer per-supplier header (paid-vs-remaining progress), a more legible PO row (explicit "คงค้าง" emphasis + due-soon hint), and a hover/cursor affordance on the whole row that opens PO detail.
+
+- [ ] **Step 1: Add a paid-progress bar to each supplier header**
+
+In `AccountsPayableTab.tsx`, the supplier header (lines 47-50) shows remaining + "จาก X (จ่ายแล้ว Y)". Add a slim progress bar under it so the user sees paid-vs-total at a glance. Replace the `<div className="text-right">…</div>` block (lines 47-50) with:
+
+```tsx
+            <div className="text-right min-w-[180px]">
+              <div className="text-lg font-bold text-destructive tabular-nums font-mono">{(Number(entry.totalRemaining) || 0).toLocaleString()} บาท</div>
+              <div className="text-xs text-muted-foreground tabular-nums">
+                จ่ายแล้ว {(Number(entry.totalPaid) || 0).toLocaleString()} / {(Number(entry.totalNet) || 0).toLocaleString()}
+              </div>
+              {Number(entry.totalNet) > 0 && (
+                <div className="mt-1.5 w-full bg-secondary rounded-full h-1.5">
+                  <div
+                    className="bg-success h-1.5 rounded-full"
+                    style={{ width: `${Math.min((Number(entry.totalPaid) / Number(entry.totalNet)) * 100, 100)}%` }}
+                  />
+                </div>
+              )}
+            </div>
+```
+
+(The progress-bar markup mirrors `POListTab`'s received-progress bar — `bg-secondary` track + `bg-success` fill, both tokens — so styling stays consistent.)
+
+- [ ] **Step 2: Make the whole PO row open detail + add a due-soon hint**
+
+Today only the PO# is a link. Make the entire row clickable (cursor + hover) while keeping the PO# button as the primary affordance. In `AccountsPayableTab.tsx`, change the `<tr>` opening (line 68) to carry the click + cursor:
+
+```tsx
+                <tr
+                  key={po.id}
+                  className="hover:bg-muted/30 cursor-pointer"
+                  onClick={async () => { try { const { data } = await api.get(`/purchase-orders/${po.id}`); onOpenDetail(data, data); } catch {} }}
+                >
+```
+
+Then the PO# cell button must stop propagation so it doesn't double-fire. Change the PO# button (lines 70-72) to:
+
+```tsx
+                  <td className="px-4 py-2">
+                    <button
+                      onClick={async (e) => { e.stopPropagation(); try { const { data } = await api.get(`/purchase-orders/${po.id}`); onOpenDetail(data, data); } catch {} }}
+                      className="text-primary hover:underline font-medium"
+                    >
+                      {po.poNumber}
+                    </button>
+                  </td>
+```
+
+The existing due-date cell already renders a red "เลยกำหนด" pill when `po.dueDate < now` (lines 75-84) — that stays. Add a "ใกล้ครบกำหนด" amber hint for due-within-7-days (not yet overdue). Replace the inner `{po.dueDate ? (…) : (…)}` content (lines 76-83) with:
+
+```tsx
+                    {po.dueDate ? (() => {
+                      const due = new Date(po.dueDate);
+                      const now = new Date();
+                      const isLate = due < now;
+                      const inSevenDays = new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000);
+                      const dueSoon = !isLate && due <= inSevenDays;
+                      return (
+                        <span className={`text-sm ${isLate ? 'text-destructive font-semibold' : dueSoon ? 'text-warning font-medium' : 'text-muted-foreground'}`}>
+                          {formatDateShort(po.dueDate)}
+                          {isLate && <span className="ml-1 text-2xs bg-destructive/10 text-destructive dark:bg-destructive/15 px-1.5 py-0.5 rounded-full leading-snug">เลยกำหนด</span>}
+                          {dueSoon && <span className="ml-1 text-2xs bg-warning/10 text-warning dark:bg-warning/15 px-1.5 py-0.5 rounded-full leading-snug">ใกล้ครบกำหนด</span>}
+                        </span>
+                      );
+                    })() : (
+                      <span className="text-muted-foreground text-xs">-</span>
+                    )}
+```
+
+- [ ] **Step 3: Emphasize the "คงค้าง" column header + a tiny "ดูรายละเอียด" cue**
+
+The "คงค้าง" amount is the action-driving number. Make its header carry the destructive tint so the eye lands there. In `AccountsPayableTab.tsx`, change the "คงค้าง" header cell (line 62) from:
+
+```tsx
+                <th className="px-4 py-2.5 text-right font-semibold">คงค้าง</th>
+```
+
+to:
+
+```tsx
+                <th className="px-4 py-2.5 text-right font-semibold text-destructive">คงค้าง</th>
+```
+
+- [ ] **Step 4: Handle the not-yet-loaded state**
+
+Currently the empty state only shows when `payableData && payableData.suppliers.length === 0` (line 99). When `payableData` is still `undefined` (query loading, since it's `enabled: activeTab === 'payable'`), nothing renders — looks blank. Add a loading hint. After the grand-total block (after line 34 `</div>` that closes the grand-total card) — actually before the per-supplier map — add an early loading guard. Insert directly after the grand-total `</div>` (line 34) and before the `{payableData?.suppliers.map(…)}` (line 37):
+
+```tsx
+      {!payableData && (
+        <div className="text-center py-12 text-muted-foreground">กำลังโหลดยอดค้างจ่าย…</div>
+      )}
+```
+
+- [ ] **Step 5: Type-check**
+
+Run: `./tools/check-types.sh all`
+Expected: 0 errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/pages/PurchaseOrdersPage/components/AccountsPayableTab.tsx
+git commit -m "feat(purchasing): AP tab polish — paid progress, due-soon hint, row deep-link (B5)"
+```
+
+- [ ] **Step 7: Manual verification — AP tab (desktop AND mobile)**
+
+With the app running (Task 5 Step 9), go to `/purchase-orders` → tab "ยอดค้างชำระ ( ผู้จัดจำหน่าย )" (or click the **ค้างจ่าย** summary card).
+
+Desktop:
+- While the query loads you briefly see "กำลังโหลดยอดค้างจ่าย…" (not a blank screen).
+- Each supplier header shows "จ่ายแล้ว X / Y" with a green progress bar reflecting paid ratio; the bold red number is the remaining.
+- The "คงค้าง" column header is red-tinted; per-row remaining is bold red, paid is green.
+- A PO with `dueDate` in the past shows the red "เลยกำหนด" pill; a PO due within 7 days shows the amber "ใกล้ครบกำหนด" pill; far-future due dates are plain.
+- Hovering any PO row highlights it with a pointer cursor; clicking anywhere on the row opens the PO detail modal (clicking the PO# link also opens it, exactly once — no double-open).
+- When everything is paid: "ไม่มียอดค้างจ่าย - จ่ายครบทุก PO แล้ว".
+
+Mobile (390px): the supplier cards stack; the PO table scrolls horizontally if needed; tapping a row opens detail. Thai pills use `leading-snug` (no clipped tone marks).
+
+---
+
+## Self-Review
+
+**Spec coverage (B5 items, from spec §"Batches" B5 + §"Information architecture" summary-strip row):**
+- *Summary strip on `/purchase-orders` using the `DashboardKPIs` card pattern, wired to `GET /purchase-orders/summary`* → Task 1 (config), Task 2 (query), Task 3 (component mirrors `DashboardKPIs` anatomy exactly: left border, `size-10` icon box, count pill, hover-lift, `AnimatedCounter`), Task 4 (wire into page). ✅
+- *Each card = a filter shortcut (click → filter the list/tab)* → Task 1 (`SummaryFilterAction` mapping, unit-tested), Task 4 (`onSummaryCardClick` translates action → `setActiveTab`/`setStatusFilter`/`setOverdueOnly`/`setShowQcPanel`). ✅
+- *Counts: รออนุมัติ · รอสั่ง · กำลังมา (⚠️ เลยกำหนด) · รอรับ · รอ QC · ค้างจ่าย* → all 7 B0 keys mapped to cards in Task 1 (`pendingApproval/toOrder/incoming/overdue/receiving/waitingQc/unpaid`); overdue split into its own loud red card per spec emphasis. ✅
+- *Overdue badge/count (compute-on-read) surfaced on strip + list* → strip: the `overdue` card (Task 1/3); list: the red "เลยกำหนด" per-row badge + the `isOverdue` helper ALREADY SHIP IN B1 (B1 Task 2/3) — B5 reuses them and adds ONLY the `overdueOnly` filter + clear chip (Task 5). Overdue derived client-side as `status==='ORDERED' && expectedDate < now`, matching B0's `getSummary` overdue query (B0 plan Task 5 Step 3) and B1's `isOverdue` exactly. ✅
+- *AP tab polish (clearer remaining/paid, links into PO detail)* → Task 6: per-supplier paid-progress bar, "จ่ายแล้ว X / Y", red "คงค้าง" header, due-soon amber hint, whole-row deep-link into PO detail, loading state. ✅
+- *Reuse Card/CardContent from card.tsx; mirror DashboardKPIs; design tokens only* → Task 3 imports `Card`/`CardContent` from `@/components/ui/card` and `AnimatedCounter` (same as `DashboardKPIs`); `TONE_STYLES` is token-only and the unit test (Task 1) asserts no hex/gray/white. ✅
+
+**Placeholder scan:** none. Every step shows the exact code/JSX to add or the exact before→after replacement, with real file paths. Tasks 1–3, 4, and 6 use line anchors verified against the CURRENT (pre-batch) source; Task 5 deliberately uses code-context anchors (not raw line numbers) because B1 ships before B5 and shifts `POListTab.tsx` — the quoted symbols (`filteredPos`, `hasFilter`, `clearAll`, the chip row) are stable. No "TBD"/"TODO"/"similar to Task N"/"add error handling".
+
+**Type/prop-name consistency across tasks:**
+- `PurchasingSummary` (keys `pendingApproval/toOrder/incoming/overdue/receiving/waitingQc/unpaid`) — defined in Task 1, imported by Task 2 (hook) and Task 3 (component); identical to B0's `getSummary()` return.
+- `SummaryFilterAction` — defined Task 1, consumed by Task 3 (`onCardClick` prop) and Task 4 (`onSummaryCardClick`).
+- `summary` / `overdueOnly` / `setOverdueOnly` / `setStatusFilterAndResetOverdue` — produced by the hook (Task 2), consumed in `index.tsx` (Task 4) and forwarded to `POListTab` (Task 4 → Task 5 adds `overdueOnly`/`setOverdueOnly` to `POListTabProps`). `index.tsx` passes `data.setStatusFilterAndResetOverdue` as `POListTab`'s `setStatusFilter` (same `(value: string) => void` signature as the existing prop — type-compatible).
+- `isOverdue` — NOT redefined by B5. It is the single tested helper from B1 (`apps/web/src/pages/PurchaseOrdersPage/po-list.util.ts`); Task 5 imports it (already in scope via B1's import in `POListTab.tsx`) and uses it for the `overdueOnly` filter. The per-row badge that also uses it is B1's. No duplicate helper.
+- `PurchaseOrder.expectedDate` / `.status` — already on the type (`types.ts:37,39`); no type change needed.
+
+**Deviations / notes found vs spec wording:**
+1. **Strip has 7 cards, not the spec's 6-label list.** The spec's IA row lists "กำลังมา (⚠️ เลยกำหนด)" as one cell, but the B0 endpoint returns `incoming` and `overdue` as **separate** counts and the B5 task text says "Surface the OVERDUE count/badge on the strip." I split them into two cards (กำลังมา = info, เลยกำหนดส่ง = destructive) so overdue is loud and independently clickable. This consumes all 7 B0 keys — no key is dropped. Documented, intentional.
+2. **`waitingQc` shortcut targets the existing collapsible `QcPendingPanel`, not a dedicated QC page.** B4 promotes QC to its own page/route; B5 may ship before/independently of B4. To avoid coupling B5 to B4, the `waitingQc` card expands the existing panel (`setShowQcPanel(true)` + scroll to `#po-qc-panel`). If B4 has already landed and added a QC route, a one-line change to `SUMMARY_CARDS` (`{ panel: 'qc' }` → a `navigate` action) is all that's needed — but that is B4's concern, not B5's. Documented.
+3. **`info` tone depends on a `bg-info`/`text-info` Tailwind utility.** The `info` Badge variant exists project-wide, but Task 1 Step 5 explicitly verifies the raw `bg-info`/`text-info` utilities exist before relying on them, with a concrete fallback (use `primary` tone) — not a guess.
+4. **No new RTL render test for the strip component itself.** Per the testing-reality rule, the genuinely logic-bearing part (card definitions, key parity with the type, filter-action mapping, token-only styles) is unit-tested in `summaryStrip.test.ts`; the presentational `PurchasingSummaryStrip` + page wiring + AP polish are verified via concrete manual desktop+mobile steps (Task 5 Step 9, Task 6 Step 7). A render test that only re-asserts the same config would be a trivial duplicate — deliberately omitted.
+5. **Backend untouched.** B5 adds zero API code; it consumes B0's `GET /purchase-orders/summary`. The red line (no accounting/finance import, JE-free receiving) is trivially satisfied since no `apps/api` file is modified.
+6. **Depends on B1, not just B0 (anti-duplication).** B5's `incoming`/`overdue`/`receiving` filter shortcuts and the per-row overdue badge rely on B1 (`ORDERED` in `constants.ts`/`poStatusMap`/the status `<select>`/the chip-label map; the tested `isOverdue` helper; the per-row "เลยกำหนด" badge). B1 ships before B5 in the one-deploy-per-batch order, so B5 REUSES those rather than re-implementing them — Task 5 was tightened to add only the new `overdueOnly` client filter + its clear-chip. This avoids a duplicate `isOverdue`, a duplicate status-column badge, and a conflicting `AlertTriangle` import. Task 5 Step 1 is a guard that aborts if B1 hasn't landed. Documented, intentional.

--- a/docs/superpowers/specs/2026-06-29-purchasing-receiving-ux-v2-design.md
+++ b/docs/superpowers/specs/2026-06-29-purchasing-receiving-ux-v2-design.md
@@ -1,0 +1,144 @@
+# Purchasing & Receiving UX Overhaul (v2) — Design
+
+**Date:** 2026-06-29
+**Status:** Approved (brainstormed + scrutinized twice — approach + spec-vs-source — + accounting-boundary verified)
+**Scope:** `apps/web/src/pages/PurchaseOrdersPage/**` (+ a new QC page + a purchasing summary strip) and `apps/api/src/modules/purchase-orders/**` (+ `suppliers` polish). **Additive only** — no data-model rewrite, no accounting/finance changes.
+**Source:** Two-agent exploration of the live system + a 3-track verification sweep, all traced against source. See "Evidence base" at the bottom.
+
+---
+
+## Goal
+
+Make the purchasing flow — **สั่งซื้อ → อนุมัติ → สั่ง → รับเข้า → QC** — materially more user-friendly for a Thai phone-shop, on **both desktop (สร้าง/อนุมัติ PO) and mobile (รับเข้าหน้างาน)**, by rebuilding the *experience* on top of the existing (already well-factored, accounting-isolated) backend. The four pains the owner named, all in scope:
+
+1. **มองภาพรวมไม่ออก** — no overview; can't see what's pending approval / on the way / late / waiting QC / unpaid.
+2. **สร้าง PO ยุ่งยาก** — one long modal; VAT/discount math is opaque.
+3. **ตอนรับของวุ่น** — two receive buttons, slow per-unit entry, no partial-receive clarity.
+4. **QC ตกหล่น** — QC state hidden in a collapsible panel; no real queue.
+
+## Hard constraints (red lines)
+
+- **ห้ามยุ่ง/กระทบ ACCOUNTING และ FINANCE.** Verified: the `purchase-orders` module is architecturally sealed — `imports: []`, only `PrismaService` injected, **creates zero JournalEntry / GeneralLedger / ExpenseDocument rows**. Receiving today posts **no JE** (the SHOP inventory JE templates incl. `ShopTradeInTemplate` are scaffolded but **not wired** to production callers per `.claude/rules/accounting.md`). This rebuild **keeps receiving 100% JE-free** and introduces **no** cross-module import into accounting/finance/journal/expense/tax. Wiring SHOP inventory JEs is a separate, owner-gated decision — explicitly **out of scope**.
+- **One indirect touchpoint to respect:** `Product.costPrice` is set at receive time from `POItem.unitPrice` ([po-receiving.service.ts:86,250](../../../apps/api/src/modules/purchase-orders/services/po-receiving.service.ts)) and is later read by COGS at *sale* time (`accounting/transactional-report.service.ts` aggregates `costPrice` for SOLD products). We do not change that path — but the new **supplier-direct receive** must **require + validate costPrice**, or COGS silently breaks.
+- **Don't touch `trade-in`** (the B2C buy-back module — its own appraisal/consent/photo/anti-theft flow) and **don't touch `Product.ownedByCompanyId`** (owned by the `contracts` module's `transferOwnership`).
+- **No new dependencies.** Reuse existing infra (see below).
+
+## Approach
+
+- **Experience rebuild + additive backend** (chosen over a data-model rewrite). The owner picked "รื้อทั้งระบบ", but scrutiny showed the *backend is already clean and isolated* and **all** the pain is front-of-glass + a few additive fields. A full data-model rewrite would force re-touching the `costPrice`/ownership write paths — i.e. the exact accounting-adjacent code the red line forbids. So: rebuild every screen, extend the schema **additively** (one new `POStatus` value, a few new columns, one new `DefectReason` enum), reuse the rest.
+- **Batch-by-batch, one-deploy-per-batch** (the proven inbox-overhaul cadence): each batch is a coherent branch → main → deploy → owner review, then the next.
+- **Reuse, don't reinvent** (verified to exist):
+  - Mobile: `components/ui/drawer.tsx` (bottom-sheet) + `hooks/useIsMobile.ts`. `apps/web` is already responsive (`grid-cols-2 lg:grid-cols-4`, viewport-aware modals).
+  - Dashboard/cards: `DashboardPage/components/DashboardKPIs.tsx` + `DashboardAlerts.tsx` card pattern; the `/dashboard/alerts` `computeAlerts()` compute-on-read pattern in `dashboard/services/dashboard-ops.service.ts`.
+  - Running numbers: the existing `poNumber` generator (PO-YYYY-MM-NNN) — GR numbers follow the same operational pattern (see decision 2).
+  - Cron infra (`notifications/scheduler.service.ts`, `@nestjs/schedule`) exists but is **not** used in MVP (overdue = compute-on-read; cron is a later upgrade only if the owner wants proactive LINE pushes).
+- **YAGNI on the long tail.** The high-value items are the 6 batches below. No GR PDF e-mailing to suppliers, no SLA engine, no QC analytics dashboards in v2.
+
+## Cross-cutting decisions
+
+1. **Direct receive = SUPPLIER-ONLY B2B, implemented as auto-PO** (owner-confirmed model, chosen over nullable-FK after scrutiny). "รับเข้าตรงไม่มี PO" covers urgent buys from a vendor with no pre-made PO. Instead of threading nullable `poId`/`poItemId` through the PO-centric read paths, the backend **auto-creates a real PO** (supplier + line items, `unitPrice = costPrice`) and advances it `DRAFT→APPROVED→ORDERED` in **one Serializable `$transaction`**, then runs the **existing** `goodsReceiving()` flow. Net effect: `GoodsReceiving.poId` is **never null**, so GR history / AP / timeline / progress / the T5-C16 ceiling check all work unchanged with **zero null-guards**. It **requires `supplierId` + per-line `costPrice`** (validated; COGS reads it), **posts no JE**, **bypasses the OWNER approval gate** (BM acts on the spot — write an `AuditLog` for the bypass), and flags the PO `isDirectReceive = true` so the list can badge it. It does **not** absorb used-phone buy-back (that's `trade-in`, untouched).
+2. **GR number = operational, follows `poNumber`.** `GoodsReceiving.grNumber` is `GR-YYYY-MM-NNN`, generated by mirroring `generatePONumber()` ([sequence.util.ts:129](../../../apps/api/src/utils/sequence.util.ts)) — a **count-based** monthly sequence. Because count-based numbering is **not** collision-proof on its own, it MUST be generated **inside the existing Serializable receive `$transaction`**, with the `@unique` constraint as the backstop and a **retry on P2002**. It is **not** an accounting document number — deliberately not routed through `DocNumberService`'s `<TYPE>-YYYYMMDD-NNNN` accounting convention, to keep purchasing out of the accounting surface.
+3. **`ORDERED` is an additive state, not a rewrite.** New PO status `ORDERED` + `orderedAt DateTime?` sits between `APPROVED` and the receive states. "กดสั่งซื้อ" stamps `orderedAt` and confirms `expectedDate`. Receiving is allowed from `ORDERED` **or** `APPROVED` (back-compat). The unused `PENDING` enum value is left in place but documented as dead (removing an enum value is a breaking migration — not worth it). **AP needs no change for `ORDERED`:** `getAccountsPayable` filters `status notIn ['CANCELLED','DRAFT']` ([po-query.service.ts:86](../../../apps/api/src/modules/purchase-orders/services/po-query.service.ts)), so an `ORDERED` PO appears in AP exactly as an `APPROVED` PO already does today — verified no-op, no regression.
+4. **Overdue = computed-on-read, no cron.** "เลยกำหนดส่ง" = `status = ORDERED AND expectedDate < now() AND deletedAt IS NULL`. Surfaced as a badge on the list + a count in the summary strip, piggybacking the existing dashboard-alerts cache pattern. (Proactive LINE notification via the existing cron infra is a documented future upgrade, not built.)
+5. **Retire the legacy `receive()` path.** Verified functionally dead: zero UI callers (the frontend posts only to `/goods-receiving`, [usePurchaseOrdersData.ts:129](../../../apps/web/src/pages/PurchaseOrdersPage/hooks/usePurchaseOrdersData.ts)), zero internal callers, only 3 race-condition unit tests. "Unify the two flows" is therefore just *delete the dead one* + migrate those 3 tests onto `goodsReceiving()` (the race defense is identical). Done in B0.
+6. **Structured defect reasons.** Replace free-text `GoodsReceivingItem.rejectReason` (kept as an optional note) with a `DefectReason` enum (e.g. `SCREEN`, `BATTERY`, `IMEI_BLOCKED`, `BOX_MISSING`, `WRONG_MODEL`, `DOA`, `OTHER`) so QC rejections are reportable. Additive column.
+7. **IMEI duplicate guard at receive.** Before creating a `Product` for a phone unit, reject if a non-deleted `Product` already has that `imeiSerial` (reuse the existing partial-unique convention; no schema change). Applies to both PO receive and supplier-direct receive.
+
+## State machine (additive)
+
+```
+DRAFT ──approve──▶ APPROVED ──กดสั่งซื้อ──▶ ORDERED ──รับของ──▶ PARTIALLY_RECEIVED ──รับครบ──▶ FULLY_RECEIVED
+  │                   │  (back-compat: รับของ allowed straight from APPROVED)        │
+  └──reject──┐        └──cancel──▶ CANCELLED                                          └──(optional later) CLOSED
+             ▼
+          CANCELLED  (reject = set status CANCELLED + rejectReason; there is NO separate REJECTED value)
+```
+
+- Verified against `enum POStatus` ([schema.prisma:191](../../../apps/api/prisma/schema.prisma)): values are `DRAFT / APPROVED / PENDING(unused) / PARTIALLY_RECEIVED / FULLY_RECEIVED / CANCELLED`. **There is no `REJECTED`** — reject sets `CANCELLED`.
+- New: `ORDERED` value + `PurchaseOrder.orderedAt DateTime?`. `expectedDate` already exists.
+- Overdue is **derived**, not a stored status.
+- `CLOSED` (received-in-full *and* paid-in-full) is **deferred** — `FULLY_RECEIVED` + the independent payment chip already convey this; add `CLOSED` only if the owner later wants an explicit archive bucket.
+
+## Data model — additive migrations only
+
+> Next API migration timestamp **must be ≥ `20260977000000`** (per memory: `20260976000000` is already taken). Follow `workflows/prisma-changes.md`. Prod is throwaway test data (forward-fix, no historical backfill), but still use safe 2-step or `@default` for any required column.
+
+> **Shrunk by the auto-PO decision.** Because direct-receive creates a real PO, `GoodsReceiving.poId` and `GoodsReceivingItem.poItemId` **stay `NOT NULL`** — no nullable-FK churn, no inline attrs, no `supplierId` on GR, no `onDelete` rework. Verified current state: both are `String` (required) at [schema.prisma:1816,1834](../../../apps/api/prisma/schema.prisma).
+
+- `PurchaseOrder`: add enum value `ORDERED`; add `orderedAt DateTime?`; add `isDirectReceive Boolean @default(false)` (marks an auto-PO from walk-in/urgent receive; drives the list badge). `@default(false)` makes this safe on existing rows.
+- `GoodsReceiving`: add `grNumber String?` then backfill then promote to `@unique NOT NULL` (2-step — a `@unique NOT NULL` column **cannot** take a static `@default` on a populated table); add `@@index([grNumber])`. (Prod is throwaway test data so backfill is trivial, but keep the migration shape correct for dev.)
+- `GoodsReceivingItem`: add `defectReason DefectReason?` (enum). Keep `rejectReason String?` as a free-text note. **No** nullable `poItemId`, **no** inline attrs.
+- New enum `DefectReason` (SCREAMING_SNAKE_CASE values).
+- **No changes** to `Product`, `Supplier` core, accounting/finance tables.
+
+## Information architecture — split the mega-page into zones
+
+Today: one `PurchaseOrdersPage` = 2 tabs (รายการ PO / ยอดค้างชำระ) + 4 modals + a collapsible QC panel. New structure (all under the existing `/purchase-orders` + one new route):
+
+| Zone | Today | v2 |
+|---|---|---|
+| **ภาพรวมจัดซื้อ** (summary strip) | none | KPI/alert cards (reuse `DashboardKPIs` pattern): รออนุมัติ · รอสั่ง · กำลังมา (⚠️ เลยกำหนด) · รอรับ · รอ QC · ค้างจ่าย. Each card = a filter shortcut. Counts from a new `GET /purchase-orders/summary` (compute-on-read). |
+| **รายการ PO** (desktop list) | raw table + status filter | status **pill**, **partial-receive progress** (รับแล้ว 3/10), payment **chip**, **overdue badge**, search by PO#/supplier, clearer empty states. |
+| **PO detail** | read-only modal | **status timeline** (Draft→อนุมัติ→สั่งแล้ว→รับ→ครบ), per-item received/QC progress, **GR history** (each GR shows grNumber + receiver + time, **printable ใบรับของ**), contextual actions, payment section. |
+| **สร้าง PO** (desktop) | one long modal | **4-step wizard**: (1) เลือกผู้ขาย (+inline create, show credit terms → due-date preview) → (2) เพิ่มรายการ (product picker + running subtotal) → (3) ส่วนลด/VAT (**transparent breakdown** — show how VAT & net are computed and rounded) → (4) ทบทวน+บันทึก. Auto-save draft (reuse the ContractCreate localStorage-draft pattern). |
+| **รับเข้า** (mobile-first) | modal | full-screen / `Drawer` flow: pick PO **or "รับเข้าตรง (supplier)"** → per unit: scan/enter **IMEI (dup-checked)** + camera photos + checklist (used phones) + PASS/REJECT with **structured defect** → big touch targets, progress, partial-receive supported. |
+| **QC center** | collapsible panel | **dedicated page** (e.g. `/purchase-orders/qc` or a top-level tab) + **nav badge** of pending count: queue of `QC_PENDING`/`PHOTO_PENDING`, filter by branch/PO/date, bulk confirm, reject→defect. |
+| **Suppliers** | full CRUD + history (fine) | light polish only. |
+
+All frontend work obeys `.claude/rules/frontend.md`: react-query + `@/lib/api`, shadcn/ui + Radix + lucide, **design tokens only** (no hardcoded gray/hex), `leading-snug` on Thai, lazy-loaded routes, `sonner` toasts, `useDebounce` for search.
+
+## Batches (one-deploy-per-batch)
+
+Each item: primary location + (impact / effort). Every backend change ships with jest specs (`--runInBand` for DB-backed specs per memory). Follow the WAT workflows (`add-api-endpoint.md`, `prisma-changes.md`, `create-page.md`).
+
+### B0 — Backend additive foundation
+- Migration (timestamp ≥ `20260977000000`): `ORDERED` + `orderedAt` + `isDirectReceive` on `PurchaseOrder`; `GoodsReceiving.grNumber` (2-step: nullable → backfill → `@unique NOT NULL`) + `@@index([grNumber])`; `GoodsReceivingItem.defectReason`; `DefectReason` enum. (high / M)
+- `grNumber` generation mirroring `generatePONumber()`, **inside the Serializable receive `$tx`** + P2002 retry. (high / S)
+- `POST /purchase-orders/:id/order` → `APPROVED → ORDERED` (sets `orderedAt`, confirms `expectedDate`). (high / S)
+- `GET /purchase-orders/summary` → counts for the strip (compute-on-read). (high / S)
+- IMEI duplicate guard in the receive `$tx`. (high / S)
+- **Retire legacy `receive()`**: delete route + service method + `ReceivePODto`; migrate the 3 race tests onto `goodsReceiving()`. (medium / S)
+
+### B1 — PO list + detail redesign
+- Status pills, partial-receive progress bar, payment chip, overdue badge, PO#/supplier search, empty states. `POListTab.tsx`. (high / M)
+- PO detail: status timeline + per-item received/QC progress + GR history list. `PODetailModal.tsx` (or promote to a detail view). (high / M)
+- **Printable ใบรับของ (GR)** per receiving record (grNumber, supplier, items, receiver, time). (high / M)
+
+### B2 — สร้าง PO wizard (desktop)
+- 4-step wizard with product picker + running totals; supplier inline-create + credit-term/due-date preview. `CreatePOModal.tsx` → stepper. (high / L)
+- **Transparent VAT/discount breakdown** (mirror the service's `ROUND_HALF_UP`/net math so the UI shows the same numbers). (high / M)
+- Auto-save draft (localStorage, reuse ContractCreate pattern). (medium / S)
+
+### B3 — รับเข้า mobile-first + supplier-direct receive
+- Mobile receive flow in `Drawer`/full-screen: per-unit IMEI (with dup feedback), camera photo capture, checklist, PASS/REJECT + structured defect, partial-receive progress. `GoodsReceivingModal.tsx` → mobile-first rebuild. (high / L)
+- **Supplier-direct receive (auto-PO)**: `POST /purchase-orders/direct-receive` — in one Serializable `$tx`: create PO (`isDirectReceive = true`, `unitPrice = costPrice`, supplier required) → set `APPROVED`/`ORDERED` (approval-bypass + `AuditLog`) → run existing `goodsReceiving()`. Requires `supplierId` + per-line `costPrice` (validated). Frontend entry "รับเข้าตรง" in the mobile receive flow; auto-POs badged in the list. (high / L)
+
+### B4 — QC center
+- Dedicated QC page + nav badge (pending count): queue, branch/PO/date filters, bulk confirm, reject→defect. Reuses `getQCPending` + `qc-confirm`. `QcPendingPanel.tsx` → page. (high / M)
+
+### B5 — Purchasing dashboard strip + overdue + AP polish
+- Summary strip on `/purchase-orders` using `DashboardKPIs` card pattern, wired to `GET /purchase-orders/summary`. (high / M)
+- Overdue badge/count (compute-on-read) surfaced on strip + list. (medium / S)
+- AP tab polish (clearer remaining/paid, links into PO detail). (medium / S)
+
+## Out of scope (documented, not built)
+
+- **SHOP inventory JE wiring** (S11-2001/2002/2003 + S21-1101/1102) on receive — owner-gated accounting decision; keep receive JE-free.
+- **Hardening the `POST /products` backdoor** (BM can create `PHONE_USED` with arbitrary `costPrice`, no appraisal) — real risk found during scrutiny, but it lives in the `products` module and would touch the trade-in boundary. Logged here; fix later.
+- Used-phone buy-back changes (owned by `trade-in`).
+- Branch-to-branch incoming (`/stock/transfers?view=incoming`) — separate from supplier receiving; untouched.
+- Proactive overdue LINE notifications (cron), GR e-mail to suppliers, SLA engine, QC analytics.
+- `CLOSED` PO status, GR↔contract back-reference, receiving-batch sign-off/lock.
+
+## Testing & verification
+
+- API: jest per batch; DB-backed specs run `--runInBand` (parallel-DB flaky per memory). Keep the T5-C16 receive race coverage alive on `goodsReceiving()`.
+- Types: `./tools/check-types.sh all` must be 0 before each ship.
+- Web: vitest where used; manual mobile pass for B3 on a real phone viewport.
+- Per batch: `code-reviewer` agent → fix → `/pre-deploy` → branch → main → deploy → owner review.
+
+## Evidence base
+
+- System map: `purchase-orders` module = facade ([purchase-orders.service.ts](../../../apps/api/src/modules/purchase-orders/purchase-orders.service.ts), 101 LOC) over query/lifecycle/receiving; models `PurchaseOrder`/`POItem`/`GoodsReceiving`/`GoodsReceivingItem`/`Supplier`; statuses `DRAFT/APPROVED/PENDING(unused)/PARTIALLY_RECEIVED/FULLY_RECEIVED/CANCELLED`; product lifecycle `PO_RECEIVED→QC_PENDING→PHOTO_PENDING→IN_STOCK`.
+- Accounting boundary: module `imports: []`, only Prisma injected; receiving/QC create no JE; `getAccountsPayable` + VAT are display-only (tax reports source from `JournalLine`, not PO); `ownedByCompanyId` set by `contracts`, not PO; `costPrice` read by COGS for SOLD products only.
+- Verification sweep: trade-in module is the existing B2C used-phone path (untouched); legacy `receive()` is dead (safe to retire); mobile/dashboard/alert infra all exist to reuse.


### PR DESCRIPTION
## Purchasing & Receiving v2 — Batch B0 (backend additive foundation)

Purely-additive backend foundation for the purchasing UX overhaul. **No accounting/finance changes; receiving stays JE-free.** B1–B5 depend on this.

Spec: `docs/superpowers/specs/2026-06-29-purchasing-receiving-ux-v2-design.md`
Plan: `docs/superpowers/plans/2026-06-29-purchasing-b0-backend-foundation.md`

### What's in it
| # | Change |
|---|---|
| 1 | Schema (additive): `POStatus.ORDERED`, `PurchaseOrder.orderedAt` + `isDirectReceive`, `GoodsReceiving.grNumber` (`NOT NULL @unique`, `GR-YYYY-MM-NNN`), `GoodsReceivingItem.defectReason`, new `DefectReason` enum. Migration `20260978000000_purchasing_v2_foundation`. `generateGRNumber` generated **inside** the Serializable receive tx. |
| 2 | `POST /purchase-orders/:id/order` — `APPROVED → ORDERED`, stamps `orderedAt`, optional `expectedDate`. `@Roles(OWNER, BRANCH_MANAGER)`. |
| 3 | Bounded **P2002/P2034 retry** around `goodsReceiving()` (count-based grNumber collision recovery; `@unique` is the backstop). |
| 4 | Persist structured `defectReason` on rejected receiving items (additive optional enum; `rejectReason` free-text kept). |
| 5 | `GET /purchase-orders/summary` — compute-on-read counts `{ pendingApproval, toOrder, incoming, overdue, receiving, waitingQc, unpaid }`. Static route before `:id`. |
| 6 | Retire the **dead** legacy `receive()` (zero UI/internal callers); migrate the race + IMEI-dup tests onto `goodsReceiving()`. |

### Red lines (verified holistically)
- ✅ No import of accounting / finance / journal / expense / tax into `purchase-orders`; receiving posts **zero** JournalEntry.
- ✅ `trade-in` and `Product.ownedByCompanyId` untouched.
- ✅ Additive only — `GoodsReceiving.poId` + `GoodsReceivingItem.poItemId` stay `NOT NULL`.

### Migration deploy-safety
- Timestamp `20260978000000` (next free). `ALTER TYPE "POStatus" ADD VALUE 'ORDERED'` is **not used elsewhere in the same migration** (safe on PG12+ / Cloud SQL; 27 prior migrations use the same pattern). 2-step `gr_number` (nullable → window-fn backfill → `SET NOT NULL` → unique index `goods_receivings_gr_number_key`). `is_direct_receive NOT NULL DEFAULT false` is safe on existing rows.

### Verification
- `./tools/check-types.sh all` → **0 errors** (API + Web)
- Purchase-orders jest suite (+ `sequence.gr.spec`) → **20/20 pass** (`--runInBand`)
- Each task: TDD (red → green) + two-stage subagent review; final whole-branch review on Opus = **READY TO MERGE** (no Critical/Important).

### ⚖️ One owner decision before B5
`GET /summary`'s `waitingQc` counts `QC_PENDING`/`PHOTO_PENDING` products **company-wide**, not scoped to active POs. Recommended **keep as-is**: it matches the existing unscoped `getQCPending` (so the badge equals the list the user clicks into), and `cancel()` blocks cancelling a PO after receiving — so QC-pending products under a cancelled PO are effectively unreachable.

### Notes
- Local DB was unreachable, so the migration was hand-authored + `prisma generate` (offline); it applies at deploy via `prisma migrate deploy`. Prod is throwaway test data (forward-fix, trivial backfill).
- Plan Task 1 + Task 3's grNumber generator/wiring were merged into one commit because `grNumber NOT NULL` forces the `goodsReceiving.create` (service + `seed.ts`) to set it immediately — end-state matches the plan exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
