### PR TITLE
Purchasing v2 — B2: สร้าง PO 4-step wizard + transparent VAT (frontend)

### DIFF
--- a/apps/web/src/pages/PurchaseOrdersPage/components/CreatePOModal.tsx
+++ b/apps/web/src/pages/PurchaseOrdersPage/components/CreatePOModal.tsx
@@ -1,10 +1,13 @@
 import { UseMutationResult } from '@tanstack/react-query';
-import { brands, getModels, getModelInfo } from '@/data/productCatalog';
+import { Check, Users, Package, Calculator, FileText } from 'lucide-react';
+import { cn } from '@/lib/utils';
 import { ItemForm } from '../types';
-import { accessoryTypes, chargerConnectorTypes } from '../constants';
-import ThaiDateInput from '@/components/ui/ThaiDateInput';
-import { ContactCombobox } from '@/components/contacts/ContactCombobox';
 import type { ContactPickResult } from '@/components/contacts/ContactCombobox';
+import { WIZARD_STEPS } from '../hooks/useCreatePoWizard';
+import { StepSupplier } from './wizard/StepSupplier';
+import { StepItems } from './wizard/StepItems';
+import { StepDiscountVat } from './wizard/StepDiscountVat';
+import { StepReview } from './wizard/StepReview';
 
 export interface CreatePOModalProps {
   isOpen: boolean;
@@ -28,7 +31,20 @@ export interface CreatePOModalProps {
   removeItem: (idx: number) => void;
   updateItem: (idx: number, field: string, value: string) => void;
   toggleModel: (idx: number, modelName: string) => void;
-  suppliers: { id: string; name: string; contactName: string | null; hasVat: boolean; paymentMethods: { paymentMethod: string; bankName?: string; bankAccountName?: string; bankAccountNumber?: string; creditTermDays?: number; isDefault: boolean }[] }[];
+  suppliers: {
+    id: string;
+    name: string;
+    contactName: string | null;
+    hasVat: boolean;
+    paymentMethods: {
+      paymentMethod: string;
+      bankName?: string;
+      bankAccountName?: string;
+      bankAccountNumber?: string;
+      creditTermDays?: number;
+      isDefault: boolean;
+    }[];
+  }[];
   suppliersLoading: boolean;
   suppliersError: boolean;
   selectedSupplier: CreatePOModalProps['suppliers'][number] | undefined;
@@ -47,6 +63,8 @@ export interface CreatePOModalProps {
   setAttachmentUrl: (value: string) => void;
   formAttachments: string[];
   setFormAttachments: React.Dispatch<React.SetStateAction<string[]>>;
+  wizard: import('../hooks/useCreatePoWizard').CreatePoWizardApi;
+  totals: import('../poTotals').PoTotals;
 }
 
 export function CreatePOModal({
@@ -60,685 +78,207 @@ export function CreatePOModal({
   removeItem,
   updateItem,
   toggleModel,
-  suppliers,
   suppliersLoading,
   suppliersError,
   selectedSupplier,
   onSupplierSelect,
   supplierHasVat,
   subtotal,
-  discountNum,
-  subtotalAfterDiscount,
-  vatAmount,
-  totalWithVat,
-  discountAfterVatNum,
-  netAmount,
   createMutation,
   handleCreate,
   attachmentUrl,
   setAttachmentUrl,
   formAttachments,
   setFormAttachments,
+  wizard,
+  totals,
 }: CreatePOModalProps) {
   if (!isOpen) return null;
 
-  const selectClass = 'w-full px-3 py-2 border border-input rounded-lg text-sm focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:ring-offset-[3px] focus-visible:ring-offset-background outline-hidden';
+  const selectClass =
+    'w-full px-3 py-2 border border-input rounded-lg text-sm focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:ring-offset-[3px] focus-visible:ring-offset-background outline-hidden';
   const inputClass = selectClass;
 
-  return (
-    <div className="fixed inset-0 z-50 bg-black/50 backdrop-blur-xs flex items-start justify-center pt-8 pb-8" role="dialog" aria-modal="true" aria-label="สร้างใบสั่งซื้อ">
-      <div className="w-full max-w-3xl bg-background rounded-xl shadow-2xl overflow-hidden flex flex-col max-h-[calc(100vh-4rem)]">
+  const stepIcons = [Users, Package, Calculator, FileText];
+  const { step, goToStep, next, back, canNext } = wizard;
+  const isLast = step === WIZARD_STEPS.length - 1;
 
-        {/* Sticky Header */}
+  return (
+    <div
+      className="fixed inset-0 z-50 bg-black/50 backdrop-blur-xs flex items-start justify-center pt-8 pb-8"
+      role="dialog"
+      aria-modal="true"
+      aria-label="สร้างใบสั่งซื้อ"
+    >
+      <div className="w-full max-w-3xl bg-background rounded-xl shadow-2xl overflow-hidden flex flex-col max-h-[calc(100vh-4rem)]">
+        {/* Header */}
         <div className="sticky top-0 z-10 bg-background/95 backdrop-blur-xs border-b px-6 py-4 flex items-center justify-between shrink-0">
-          <button type="button" onClick={onClose} className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors">
-            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="m15 18-6-6 6-6"/></svg>
-            กลับ
+          <button
+            type="button"
+            onClick={onClose}
+            className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="m15 18-6-6 6-6" />
+            </svg>
+            ปิด
           </button>
-          <h2 className="text-lg font-semibold text-foreground">สร้างใบสั่งซื้อ</h2>
+          <h2 className="text-lg font-semibold text-foreground leading-snug">สร้างใบสั่งซื้อ</h2>
           <div className="w-16" />
         </div>
 
-        {/* Scrollable Content */}
-        <form onSubmit={handleCreate} className="flex-1 overflow-y-auto">
-          <div className="p-6 space-y-5">
-
-            {/* Section 1: Supplier Info (emerald) */}
-            <div className="rounded-xl border border-border/50 bg-card p-5 shadow-sm">
-              <div className="flex items-center gap-2.5 mb-4">
-                <div className="flex items-center justify-center size-8 rounded-lg bg-success/10 text-success">
-                  <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M22 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>
-                </div>
-                <div>
-                  <h3 className="text-sm font-semibold text-foreground">ข้อมูลผู้จัดจำหน่าย</h3>
-                  <p className="text-xs text-muted-foreground">เลือกผู้จัดจำหน่ายและวันที่สั่งซื้อ</p>
-                </div>
-              </div>
-
-              <div className="space-y-3">
-                <div>
-                  <label className="block text-2xs font-medium text-muted-foreground uppercase tracking-wider mb-2">ผู้จัดจำหน่าย <span className="text-destructive">*</span></label>
-                  <ContactCombobox
-                    roleNeeded="SUPPLIER"
-                    value={selectedSupplier?.name ?? (suppliersLoading ? 'กำลังโหลด...' : '')}
-                    onSelect={onSupplierSelect}
-                    invalid={!form.supplierId && suppliersError}
-                    placeholder="เลือก/ค้นหาผู้จัดจำหน่าย"
-                  />
-                  <input type="hidden" value={form.supplierId} />
-                  {selectedSupplier && (
-                    <div className="mt-1 flex gap-2 flex-wrap">
-                      <span
-                        className={`px-2 py-0.5 rounded-full text-xs font-medium ${
-                          supplierHasVat ? 'bg-primary/10 text-primary dark:bg-primary/15' : 'bg-muted text-muted-foreground'
-                        }`}
-                      >
-                        {supplierHasVat ? 'ผู้จัดจำหน่ายมี VAT - จะคำนวณ VAT 7% อัตโนมัติ' : 'ผู้จัดจำหน่ายไม่มี VAT'}
-                      </span>
-                      {selectedSupplier.paymentMethods?.length > 0 && (
-                        <span className="px-2 py-0.5 rounded-full text-xs font-medium bg-primary/10 text-primary">
-                          ชำระ: {selectedSupplier.paymentMethods.map((pm) => {
-                            const labels: Record<string, string> = { CASH: 'เงินสด', BANK_TRANSFER: 'โอนธนาคาร', CHECK: 'เช็ค', CREDIT: 'เครดิต' };
-                            return labels[pm.paymentMethod] || pm.paymentMethod;
-                          }).join(', ')}
-                        </span>
-                      )}
-                    </div>
-                  )}
-                </div>
-                <div className="grid grid-cols-2 gap-4">
-                  <div>
-                    <label className="block text-2xs font-medium text-muted-foreground uppercase tracking-wider mb-2">วันที่สั่ง <span className="text-destructive">*</span></label>
-                    <ThaiDateInput
-                      value={form.orderDate}
-                      onChange={(e) => setForm({ ...form, orderDate: e.target.value })}
-                      className={inputClass}
-                      required
-                    />
-                  </div>
-                  <div>
-                    <label className="block text-2xs font-medium text-muted-foreground uppercase tracking-wider mb-2">วันที่คาดรับสินค้า</label>
-                    <ThaiDateInput
-                      value={form.expectedDate}
-                      onChange={(e) => setForm({ ...form, expectedDate: e.target.value })}
-                      className={inputClass}
-                    />
-                  </div>
-                </div>
-              </div>
-            </div>
-
-            {/* Section 2: Items/Products (primary/blue) */}
-            <div className="rounded-xl border border-border/50 bg-card p-5 shadow-sm">
-              <div className="flex items-center gap-2.5 mb-4">
-                <div className="flex items-center justify-center size-8 rounded-lg bg-primary/10 text-primary">
-                  <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="m7.5 4.27 9 5.15"/><path d="M21 8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16Z"/><path d="m3.3 7 8.7 5 8.7-5"/><path d="M12 22V12"/></svg>
-                </div>
-                <div className="flex-1">
-                  <h3 className="text-sm font-semibold text-foreground">รายการสินค้า</h3>
-                  <p className="text-xs text-muted-foreground">เพิ่มสินค้าที่ต้องการสั่งซื้อ</p>
-                </div>
-                <button type="button" onClick={addItem} className="text-sm text-primary hover:text-primary/90 font-medium">
-                  + เพิ่มรายการ
-                </button>
-              </div>
-
-              <div className="space-y-4">
-                {items.map((item, idx) => {
-                  const isAccessory = item.category === 'ACCESSORY';
-                  const isCharger = isAccessory && item.accessoryType === 'ชุดชาร์จ';
-                  const availableModels = item.brand ? getModels(item.brand, isAccessory ? 'ACCESSORY' : (item.category || undefined)) : [];
-                  const modelInfo = item.brand && item.model ? getModelInfo(item.brand, item.model) : undefined;
-                  const availableColors = modelInfo?.colors || [];
-                  const availableStorage = modelInfo?.storage || [];
-                  const selectedModels = isAccessory && item.model ? item.model.split(', ').filter(Boolean) : [];
-
-                  const accessoryAutoName = isAccessory ? (() => {
-                    if (isCharger) {
-                      return [item.accessoryType, item.accessoryBrand, item.model].filter(Boolean).join(' ');
-                    }
-                    const accParts = [item.accessoryType, item.accessoryBrand].filter(Boolean);
-                    const modelStr = item.model;
-                    return modelStr
-                      ? `${accParts.join(' ')} สำหรับ ${modelStr}`
-                      : accParts.join(' ');
-                  })() : '';
-
-                  return (
-                    <div key={idx} className={`border rounded-lg p-3 space-y-2 relative ${isAccessory ? 'border-primary/30 bg-primary/5 dark:bg-primary/10' : 'border-border bg-muted/50'}`}>
-                      {items.length > 1 && (
-                        <button
-                          type="button"
-                          onClick={() => removeItem(idx)}
-                          className="absolute top-2 right-2 text-destructive/70 hover:text-destructive text-lg leading-none"
-                        >
-                          &times;
-                        </button>
-                      )}
-                      <div className="text-xs font-medium text-muted-foreground mb-1">
-                        รายการ #{idx + 1}
-                        {isAccessory && <span className="ml-2 px-1.5 py-0.5 bg-primary/15 text-primary dark:bg-primary/20 rounded text-xs">อุปกรณ์เสริม</span>}
-                      </div>
-
-                      {/* Row 1: Category FIRST, then Brand/Model or AccessoryType */}
-                      <div className={`grid ${isAccessory ? 'grid-cols-3' : 'grid-cols-3'} gap-2`}>
-                        <div>
-                          <label className="block text-xs text-muted-foreground mb-0.5">ประเภท <span className="text-destructive">*</span></label>
-                          <select
-                            value={item.category}
-                            onChange={(e) => updateItem(idx, 'category', e.target.value)}
-                            className={selectClass}
-                          >
-                            <option value="">-- เลือกประเภท --</option>
-                            <option value="PHONE_NEW">โทรศัพท์ (ใหม่)</option>
-                            <option value="PHONE_USED">โทรศัพท์ (มือสอง)</option>
-                            <option value="TABLET">แท็บเล็ต</option>
-                            <option value="ACCESSORY">อุปกรณ์เสริม</option>
-                          </select>
-                        </div>
-
-                        {isAccessory ? (
-                          <>
-                            <div>
-                              <label className="block text-xs text-muted-foreground mb-0.5">ประเภทอุปกรณ์ <span className="text-destructive">*</span></label>
-                              <select
-                                value={item.accessoryType}
-                                onChange={(e) => updateItem(idx, 'accessoryType', e.target.value)}
-                                className={selectClass}
-                                required
-                              >
-                                <option value="">-- เลือก --</option>
-                                {accessoryTypes.map((t) => (
-                                  <option key={t.value} value={t.value}>{t.label}</option>
-                                ))}
-                              </select>
-                            </div>
-
-                            {isCharger ? (
-                              <div>
-                                <label className="block text-xs text-muted-foreground mb-0.5">ชนิด <span className="text-destructive">*</span></label>
-                                <select
-                                  value={item.model}
-                                  onChange={(e) => { const ni = [...items]; ni[idx] = { ...ni[idx], model: e.target.value }; setItems(ni); }}
-                                  className={selectClass}
-                                  required
-                                >
-                                  <option value="">-- เลือก --</option>
-                                  {chargerConnectorTypes.map((t) => (
-                                    <option key={t.value} value={t.value}>{t.label}</option>
-                                  ))}
-                                </select>
-                              </div>
-                            ) : (
-                              <div>
-                                <label className="block text-xs text-muted-foreground mb-0.5">สำหรับยี่ห้อ</label>
-                                <select
-                                  value={item.brand}
-                                  onChange={(e) => updateItem(idx, 'brand', e.target.value)}
-                                  className={selectClass}
-                                >
-                                  <option value="">-- เลือกยี่ห้อโทรศัพท์ --</option>
-                                  {brands.map((b) => (
-                                    <option key={b} value={b}>{b}</option>
-                                  ))}
-                                </select>
-                              </div>
-                            )}
-                          </>
-                        ) : (
-                          <>
-                            <div>
-                              <label className="block text-xs text-muted-foreground mb-0.5">ยี่ห้อ <span className="text-destructive">*</span></label>
-                              <select
-                                value={item.brand}
-                                onChange={(e) => updateItem(idx, 'brand', e.target.value)}
-                                className={selectClass}
-                                required
-                                disabled={!item.category}
-                              >
-                                <option value="">-- เลือกยี่ห้อ --</option>
-                                {brands.map((b) => (
-                                  <option key={b} value={b}>{b}</option>
-                                ))}
-                              </select>
-                            </div>
-                            <div>
-                              <label className="block text-xs text-muted-foreground mb-0.5">รุ่น <span className="text-destructive">*</span></label>
-                              <select
-                                value={item.model}
-                                onChange={(e) => updateItem(idx, 'model', e.target.value)}
-                                className={selectClass}
-                                required
-                                disabled={!item.brand}
-                              >
-                                <option value="">-- เลือกรุ่น --</option>
-                                {availableModels.map((m) => (
-                                  <option key={m.name} value={m.name}>{m.name}</option>
-                                ))}
-                              </select>
-                            </div>
-                          </>
-                        )}
-                      </div>
-
-                      {/* Multi-model selection for accessories (non-charger) */}
-                      {isAccessory && !isCharger && item.accessoryType && item.brand && availableModels.length > 0 && (
-                        <div>
-                          <label className="block text-2xs font-medium text-muted-foreground uppercase tracking-wider mb-2">สำหรับรุ่น (เลือกได้หลายรุ่น)</label>
-                          <div className="flex flex-wrap gap-1.5">
-                            {availableModels.map((m) => {
-                              const isSelected = selectedModels.includes(m.name);
-                              return (
-                                <button
-                                  key={m.name}
-                                  type="button"
-                                  onClick={() => toggleModel(idx, m.name)}
-                                  className={`px-2 py-0.5 rounded-full text-xs font-medium border transition-colors ${
-                                    isSelected
-                                      ? 'bg-primary text-primary-foreground border-primary'
-                                      : 'bg-background text-muted-foreground border-input hover:border-primary/50 hover:text-primary'
-                                  }`}
-                                >
-                                  {m.name}
-                                </button>
-                              );
-                            })}
-                          </div>
-                          {selectedModels.length > 0 && (
-                            <div className="text-xs text-primary mt-1">เลือกแล้ว {selectedModels.length} รุ่น</div>
-                          )}
-                        </div>
-                      )}
-
-                      {isAccessory ? (
-                        <>
-                          <div className="grid grid-cols-3 gap-2">
-                            <div>
-                              <label className="block text-xs text-muted-foreground mb-0.5">ยี่ห้ออุปกรณ์</label>
-                              <input
-                                type="text"
-                                value={item.accessoryBrand}
-                                onChange={(e) => updateItem(idx, 'accessoryBrand', e.target.value)}
-                                className={inputClass}
-                                placeholder="เช่น Spigen, Anker"
-                              />
-                            </div>
-                            <div>
-                              <label className="block text-xs text-muted-foreground mb-0.5">จำนวน <span className="text-destructive">*</span></label>
-                              <input
-                                type="number"
-                                value={item.quantity}
-                                onChange={(e) => updateItem(idx, 'quantity', e.target.value)}
-                                className={inputClass}
-                                min="1"
-                                required
-                              />
-                            </div>
-                            <div>
-                              <label className="block text-xs text-muted-foreground mb-0.5">ราคา/ชิ้น <span className="text-destructive">*</span></label>
-                              <input
-                                type="number"
-                                value={item.unitPrice}
-                                onChange={(e) => updateItem(idx, 'unitPrice', e.target.value)}
-                                className={inputClass}
-                                required
-                              />
-                            </div>
-                          </div>
-                          {accessoryAutoName && (
-                            <div className="text-xs text-primary bg-primary/10 dark:bg-primary/15 rounded px-2 py-1">
-                              ชื่อสินค้า: {accessoryAutoName}
-                            </div>
-                          )}
-                        </>
-                      ) : (
-                        <div className="grid grid-cols-4 gap-2">
-                          <div>
-                            <label className="block text-xs text-muted-foreground mb-0.5">สี</label>
-                            <select
-                              value={item.color}
-                              onChange={(e) => updateItem(idx, 'color', e.target.value)}
-                              className={selectClass}
-                              disabled={availableColors.length === 0}
-                            >
-                              <option value="">-- เลือกสี --</option>
-                              {availableColors.map((c) => (
-                                <option key={c} value={c}>{c}</option>
-                              ))}
-                            </select>
-                          </div>
-                          <div>
-                            <label className="block text-xs text-muted-foreground mb-0.5">ความจุ</label>
-                            <select
-                              value={item.storage}
-                              onChange={(e) => updateItem(idx, 'storage', e.target.value)}
-                              className={selectClass}
-                              disabled={availableStorage.length === 0}
-                            >
-                              <option value="">-- เลือกความจุ --</option>
-                              {availableStorage.map((s) => (
-                                <option key={s} value={s}>{s}</option>
-                              ))}
-                            </select>
-                          </div>
-                          <div>
-                            <label className="block text-xs text-muted-foreground mb-0.5">จำนวน <span className="text-destructive">*</span></label>
-                            <input
-                              type="number"
-                              value={item.quantity}
-                              onChange={(e) => updateItem(idx, 'quantity', e.target.value)}
-                              className={inputClass}
-                              min="1"
-                              required
-                            />
-                          </div>
-                          <div>
-                            <label className="block text-xs text-muted-foreground mb-0.5">ราคา/ชิ้น <span className="text-destructive">*</span></label>
-                            <input
-                              type="number"
-                              value={item.unitPrice}
-                              onChange={(e) => updateItem(idx, 'unitPrice', e.target.value)}
-                              className={inputClass}
-                              required
-                            />
-                          </div>
-                        </div>
-                      )}
-                    </div>
-                  );
-                })}
-              </div>
-            </div>
-
-            {/* Section 3: Summary/Pricing (violet) */}
-            <div className="rounded-xl border border-border/50 bg-card p-5 shadow-sm">
-              <div className="flex items-center gap-2.5 mb-4">
-                <div className="flex items-center justify-center size-8 rounded-lg bg-primary/10 text-primary">
-                  <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M12 2v20M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"/></svg>
-                </div>
-                <div>
-                  <h3 className="text-sm font-semibold text-foreground">สรุปยอด</h3>
-                  <p className="text-xs text-muted-foreground">ยอดรวม ส่วนลด และ VAT</p>
-                </div>
-              </div>
-
-              <div className="bg-muted/50 rounded-lg p-3 space-y-1.5 text-sm">
-                {supplierHasVat ? (
-                  <>
-                    <div className="flex justify-between">
-                      <span className="text-muted-foreground">มูลค่าสินค้า (ก่อน VAT 7%)</span>
-                      <span className="font-medium tabular-nums font-mono">{subtotal.toLocaleString()} บาท</span>
-                    </div>
-                    <div className="flex justify-between items-center">
-                      <span className="text-muted-foreground">ส่วนลด (ก่อน VAT 7%)</span>
-                      <input
-                        type="number"
-                        value={form.discount}
-                        onChange={(e) => setForm({ ...form, discount: e.target.value })}
-                        className="w-32 px-2 py-1 border border-input rounded text-sm text-right focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:ring-offset-[3px] focus-visible:ring-offset-background outline-hidden"
-                        min="0"
-                        placeholder="0"
-                      />
-                    </div>
-                    <div className="flex justify-between text-muted-foreground">
-                      <span>VAT 7%</span>
-                      <span className="tabular-nums font-mono">{vatAmount.toLocaleString()} บาท</span>
-                    </div>
-                    <div className="flex justify-between text-muted-foreground">
-                      <span>มูลค่าสินค้า (รวม VAT 7%)</span>
-                      <span className="tabular-nums font-mono">{totalWithVat.toLocaleString()} บาท</span>
-                    </div>
-                    <div className="flex justify-between items-center">
-                      <span className="text-muted-foreground">ส่วนลด (หลัง VAT 7%)</span>
-                      <input
-                        type="number"
-                        value={form.discountAfterVat}
-                        onChange={(e) => setForm({ ...form, discountAfterVat: e.target.value })}
-                        className="w-32 px-2 py-1 border border-input rounded text-sm text-right focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:ring-offset-[3px] focus-visible:ring-offset-background outline-hidden"
-                        min="0"
-                        placeholder="0"
-                      />
-                    </div>
-                  </>
-                ) : (
-                  <>
-                    <div className="flex justify-between">
-                      <span className="text-muted-foreground">ยอดรวมสินค้า</span>
-                      <span className="font-medium tabular-nums font-mono">{subtotal.toLocaleString()} บาท</span>
-                    </div>
-                    <div className="flex justify-between items-center">
-                      <span className="text-muted-foreground">ส่วนลด</span>
-                      <input
-                        type="number"
-                        value={form.discount}
-                        onChange={(e) => setForm({ ...form, discount: e.target.value })}
-                        className="w-32 px-2 py-1 border border-input rounded text-sm text-right focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:ring-offset-[3px] focus-visible:ring-offset-background outline-hidden"
-                        min="0"
-                        placeholder="0"
-                      />
-                    </div>
-                    {discountNum > 0 && (
-                      <div className="flex justify-between text-muted-foreground">
-                        <span>หลังหักส่วนลด</span>
-                        <span className="tabular-nums font-mono">{subtotalAfterDiscount.toLocaleString()} บาท</span>
-                      </div>
-                    )}
-                  </>
-                )}
-                <div className="flex justify-between border-t pt-1.5 mt-1.5 font-semibold text-base">
-                  <span>ยอดสุทธิ</span>
-                  <span className="text-primary tabular-nums font-mono">{netAmount.toLocaleString()} บาท</span>
-                </div>
-              </div>
-            </div>
-
-            {/* Section 4: Payment (orange) */}
-            <div className="rounded-xl border border-border/50 bg-card p-5 shadow-sm">
-              <div className="flex items-center gap-2.5 mb-4">
-                <div className="flex items-center justify-center size-8 rounded-lg bg-warning/10 text-warning">
-                  <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><rect width="20" height="14" x="2" y="5" rx="2"/><line x1="2" x2="22" y1="10" y2="10"/></svg>
-                </div>
-                <div>
-                  <h3 className="text-sm font-semibold text-foreground">การจ่ายเงิน</h3>
-                  <p className="text-xs text-muted-foreground">สถานะและวิธีการชำระเงิน</p>
-                </div>
-              </div>
-
-              <div className="grid grid-cols-3 gap-3">
-                <div>
-                  <label className="block text-xs text-muted-foreground mb-0.5">สถานะ</label>
-                  <select
-                    value={form.paymentStatus}
-                    onChange={(e) => {
-                      const newStatus = e.target.value;
-                      setForm({
-                        ...form,
-                        paymentStatus: newStatus,
-                        paidAmount: newStatus === 'FULLY_PAID' ? String(Math.round(netAmount * 100) / 100) : newStatus === 'UNPAID' ? '' : form.paidAmount,
-                      });
-                    }}
-                    className={selectClass}
-                  >
-                    <option value="UNPAID">ยังไม่จ่าย</option>
-                    <option value="DEPOSIT_PAID">จ่ายมัดจำ</option>
-                    <option value="PARTIALLY_PAID">จ่ายบางส่วน</option>
-                    <option value="FULLY_PAID">จ่ายครบแล้ว</option>
-                  </select>
-                </div>
-                <div>
-                  <label className="block text-xs text-muted-foreground mb-0.5">วิธีจ่ายเงิน</label>
-                  <select
-                    value={form.paymentMethod}
-                    onChange={(e) => setForm({ ...form, paymentMethod: e.target.value })}
-                    className={selectClass}
-                    disabled={form.paymentStatus === 'UNPAID'}
-                  >
-                    <option value="">-- เลือก --</option>
-                    {selectedSupplier?.paymentMethods?.length ? (
-                      selectedSupplier.paymentMethods.map((pm, idx) => {
-                        const labels: Record<string, string> = { CASH: 'เงินสด', BANK_TRANSFER: 'โอนธนาคาร', CHECK: 'เช็ค', CREDIT: 'เครดิต' };
-                        const label = labels[pm.paymentMethod] || pm.paymentMethod;
-                        const detail = pm.bankName ? ` - ${pm.bankName}${pm.bankAccountNumber ? ` (${pm.bankAccountNumber})` : ''}` : '';
-                        const credit = pm.creditTermDays ? ` ${pm.creditTermDays} วัน` : '';
-                        return <option key={idx} value={pm.paymentMethod}>{label}{detail}{credit}{pm.isDefault ? ' (ค่าเริ่มต้น)' : ''}</option>;
-                      })
-                    ) : (
-                      <>
-                        <option value="CASH">เงินสด</option>
-                        <option value="BANK_TRANSFER">โอนธนาคาร</option>
-                        <option value="CHECK">เช็ค</option>
-                        <option value="CREDIT">เครดิต</option>
-                      </>
-                    )}
-                  </select>
-                </div>
-                <div>
-                  <label className="block text-xs text-muted-foreground mb-0.5">จำนวนที่จ่าย (บาท)</label>
-                  <input
-                    type="number"
-                    value={form.paidAmount}
-                    onChange={(e) => setForm({ ...form, paidAmount: e.target.value })}
-                    className={inputClass}
-                    min="0"
-                    step="0.01"
-                    disabled={form.paymentStatus === 'UNPAID'}
-                    placeholder={form.paymentStatus === 'UNPAID' ? '-' : '0'}
-                  />
-                  {form.paymentStatus !== 'UNPAID' && form.paymentStatus !== 'FULLY_PAID' && netAmount > 0 && (
-                    <div className="flex gap-2 mt-1">
-                      <button type="button" onClick={() => setForm({ ...form, paidAmount: String(Math.round(netAmount * 0.3)) })} className="text-xs text-primary hover:underline">30%</button>
-                      <button type="button" onClick={() => setForm({ ...form, paidAmount: String(Math.round(netAmount * 0.5)) })} className="text-xs text-primary hover:underline">50%</button>
-                    </div>
-                  )}
-                </div>
-              </div>
-              {form.paymentStatus !== 'UNPAID' && (
-                <div className="mt-2">
-                  <label className="block text-xs text-muted-foreground mb-0.5">หมายเหตุการจ่ายเงิน</label>
-                  <input
-                    type="text"
-                    value={form.paymentNotes}
-                    onChange={(e) => setForm({ ...form, paymentNotes: e.target.value })}
-                    className={inputClass}
-                    placeholder="เช่น เลขอ้างอิง, ชื่อบัญชี"
-                  />
-                </div>
-              )}
-            </div>
-
-            {/* Section 5: Attachments (sky) - only shown when payment is not UNPAID */}
-            {form.paymentStatus !== 'UNPAID' && (
-              <div className="rounded-xl border border-border/50 bg-card p-5 shadow-sm">
-                <div className="flex items-center gap-2.5 mb-4">
-                  <div className="flex items-center justify-center size-8 rounded-lg bg-info/10 text-info">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="m21.44 11.05-9.19 9.19a6 6 0 0 1-8.49-8.49l8.57-8.57A4 4 0 1 1 18 8.84l-8.59 8.57a2 2 0 0 1-2.83-2.83l8.49-8.48"/></svg>
-                  </div>
-                  <div>
-                    <h3 className="text-sm font-semibold text-foreground">แนบสลิป/เอกสาร</h3>
-                    <p className="text-xs text-muted-foreground">แนบหลักฐานการชำระเงิน</p>
-                  </div>
-                </div>
-
-                <div className="flex gap-2">
-                  <label className="flex items-center gap-1 px-3 py-2 bg-primary/10 text-primary border border-primary/30 rounded-lg text-xs cursor-pointer hover:bg-primary/15 dark:bg-primary/15 dark:hover:bg-primary/20 whitespace-nowrap">
-                    <svg xmlns="http://www.w3.org/2000/svg" className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" /></svg>
-                    เลือกรูป
-                    <input
-                      type="file"
-                      accept="image/*"
-                      multiple
-                      className="hidden"
-                      onChange={(e) => {
-                        const files = Array.from(e.target.files || []);
-                        files.forEach((file) => {
-                          const reader = new FileReader();
-                          reader.onload = () => {
-                            setFormAttachments((prev) => [...prev, reader.result as string]);
-                          };
-                          reader.readAsDataURL(file);
-                        });
-                        e.target.value = '';
-                      }}
-                    />
-                  </label>
-                  <input
-                    type="text"
-                    value={attachmentUrl}
-                    onChange={(e) => setAttachmentUrl(e.target.value)}
-                    className={inputClass}
-                    placeholder="หรือวาง URL"
-                  />
+        {/* Stepper */}
+        <div className="px-6 pt-4 shrink-0">
+          <div className="flex items-center">
+            {WIZARD_STEPS.map((label, i) => {
+              const completed = i < step;
+              const current = i === step;
+              const clickable = i < step;
+              const Icon = stepIcons[i] || Package;
+              return (
+                <div key={label} className="flex items-center flex-1 last:flex-none">
                   <button
                     type="button"
-                    onClick={() => {
-                      if (attachmentUrl.trim()) {
-                        setFormAttachments([...formAttachments, attachmentUrl.trim()]);
-                        setAttachmentUrl('');
-                      }
-                    }}
-                    className="px-3 py-2 bg-secondary rounded-lg text-sm hover:bg-muted/50 whitespace-nowrap"
+                    disabled={!clickable}
+                    onClick={() => clickable && goToStep(i)}
+                    className={cn(
+                      'flex items-center gap-2 group',
+                      clickable ? 'cursor-pointer' : 'cursor-default',
+                    )}
                   >
-                    + เพิ่ม
+                    <div
+                      className={cn(
+                        'size-8 rounded-lg flex items-center justify-center shrink-0 transition-all',
+                        completed && 'bg-primary text-primary-foreground',
+                        current && 'bg-primary text-primary-foreground ring-4 ring-primary/20',
+                        !completed && !current && 'bg-muted text-muted-foreground',
+                      )}
+                    >
+                      {completed ? (
+                        <Check className="size-4" strokeWidth={2.5} />
+                      ) : (
+                        <Icon className="size-4" />
+                      )}
+                    </div>
+                    <div
+                      className={cn(
+                        'text-sm font-medium leading-snug hidden sm:block',
+                        current ? 'text-foreground' : 'text-muted-foreground',
+                      )}
+                    >
+                      {label}
+                    </div>
                   </button>
-                </div>
-                {formAttachments.length > 0 && (
-                  <div className="mt-2 flex flex-wrap gap-2">
-                    {formAttachments.map((att, idx) => (
-                      <div key={idx} className="relative group">
-                        {att.startsWith('data:image') ? (
-                          <img src={att} alt={`แนบ ${idx + 1}`} className="h-16 w-16 object-cover rounded-lg border" />
-                        ) : (
-                          <div className="h-16 w-16 flex items-center justify-center bg-primary/10 dark:bg-primary/15 rounded-lg border text-2xs text-primary p-1 break-all overflow-hidden">
-                            <a href={att} target="_blank" rel="noopener noreferrer" className="hover:underline">{att.length > 20 ? att.slice(0, 20) + '...' : att}</a>
-                          </div>
+                  {i < WIZARD_STEPS.length - 1 && (
+                    <div className="flex-1 mx-3 h-0.5 rounded-full bg-muted overflow-hidden">
+                      <div
+                        className={cn(
+                          'h-full rounded-full transition-all',
+                          i < step ? 'bg-primary w-full' : 'w-0',
                         )}
-                        <button
-                          type="button"
-                          onClick={() => setFormAttachments(formAttachments.filter((_, i) => i !== idx))}
-                          className="absolute -top-1.5 -right-1.5 w-4 h-4 bg-destructive text-destructive-foreground rounded-full text-2xs flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity"
-                        >
-                          &times;
-                        </button>
-                      </div>
-                    ))}
-                  </div>
-                )}
-              </div>
-            )}
+                      />
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </div>
 
-            {/* Notes - simple field at the bottom */}
-            <div className="rounded-xl border border-border/50 bg-card p-5 shadow-sm">
-              <div className="flex items-center gap-2.5 mb-4">
-                <div className="flex items-center justify-center size-8 rounded-lg bg-muted text-muted-foreground">
-                  <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z"/><polyline points="14 2 14 8 20 8"/><line x1="16" x2="8" y1="13" y2="13"/><line x1="16" x2="8" y1="17" y2="17"/><line x1="10" x2="8" y1="9" y2="9"/></svg>
-                </div>
-                <div>
-                  <h3 className="text-sm font-semibold text-foreground">หมายเหตุ</h3>
-                  <p className="text-xs text-muted-foreground">บันทึกเพิ่มเติมสำหรับใบสั่งซื้อ</p>
-                </div>
-              </div>
-              <textarea
-                value={form.notes}
-                onChange={(e) => setForm({ ...form, notes: e.target.value })}
-                rows={2}
-                className={inputClass}
+        {/* Active step panel */}
+        <form onSubmit={handleCreate} className="flex-1 overflow-y-auto">
+          <div className="p-6">
+            {step === 0 && (
+              <StepSupplier
+                form={form}
+                setForm={setForm}
+                suppliersLoading={suppliersLoading}
+                suppliersError={suppliersError}
+                selectedSupplier={selectedSupplier}
+                onSupplierSelect={onSupplierSelect}
+                supplierHasVat={supplierHasVat}
+                creditTermDays={wizard.creditTermDays}
+                dueDatePreview={wizard.dueDatePreview}
+                inputClass={inputClass}
               />
-            </div>
-
+            )}
+            {step === 1 && (
+              <StepItems
+                items={items}
+                setItems={setItems}
+                addItem={addItem}
+                removeItem={removeItem}
+                updateItem={updateItem}
+                toggleModel={toggleModel}
+                subtotal={subtotal}
+                selectClass={selectClass}
+                inputClass={inputClass}
+              />
+            )}
+            {step === 2 && (
+              <StepDiscountVat
+                form={form}
+                setForm={setForm}
+                supplierHasVat={supplierHasVat}
+                totals={totals}
+              />
+            )}
+            {step === 3 && (
+              <StepReview
+                form={form}
+                setForm={setForm}
+                items={items}
+                selectedSupplier={selectedSupplier}
+                supplierHasVat={supplierHasVat}
+                totals={totals}
+                dueDatePreview={wizard.dueDatePreview}
+                attachmentUrl={attachmentUrl}
+                setAttachmentUrl={setAttachmentUrl}
+                formAttachments={formAttachments}
+                setFormAttachments={setFormAttachments}
+                selectClass={selectClass}
+                inputClass={inputClass}
+              />
+            )}
           </div>
 
-          {/* Sticky Footer */}
-          <div className="sticky bottom-0 bg-background/95 backdrop-blur-xs border-t px-6 py-4 flex justify-end gap-3 shrink-0">
-            <button type="button" onClick={onClose} className="px-6 py-2.5 text-sm border border-input rounded-lg hover:bg-muted transition-colors">
-              ยกเลิก
-            </button>
+          {/* Footer */}
+          <div className="sticky bottom-0 bg-background/95 backdrop-blur-xs border-t px-6 py-4 flex justify-between gap-3 shrink-0">
             <button
-              type="submit"
-              disabled={createMutation.isPending}
-              className="px-6 py-2.5 text-sm bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 disabled:opacity-50 font-semibold transition-colors shadow-sm"
+              type="button"
+              onClick={() => (step === 0 ? onClose() : back())}
+              className="px-6 py-2.5 text-sm border border-input rounded-lg hover:bg-muted transition-colors"
             >
-              {createMutation.isPending ? 'กำลังสร้าง...' : 'สร้าง PO'}
+              {step === 0 ? 'ยกเลิก' : 'ย้อนกลับ'}
             </button>
+            {isLast ? (
+              <button
+                type="submit"
+                disabled={createMutation.isPending}
+                className="px-6 py-2.5 text-sm bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 disabled:opacity-50 font-semibold transition-colors shadow-sm"
+              >
+                {createMutation.isPending ? 'กำลังสร้าง...' : 'สร้าง PO'}
+              </button>
+            ) : (
+              <button
+                type="button"
+                onClick={() => canNext && next()}
+                disabled={!canNext}
+                className="px-6 py-2.5 text-sm bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 disabled:opacity-50 font-semibold transition-colors shadow-sm"
+              >
+                ถัดไป
+              </button>
+            )}
           </div>
         </form>
       </div>

--- a/apps/web/src/pages/PurchaseOrdersPage/components/wizard/StepDiscountVat.tsx
+++ b/apps/web/src/pages/PurchaseOrdersPage/components/wizard/StepDiscountVat.tsx
@@ -1,0 +1,128 @@
+import { formatNumberDecimal } from '@/utils/formatters';
+import type { CreatePOModalProps } from '../CreatePOModal';
+import type { PoTotals } from '../../poTotals';
+
+interface StepDiscountVatProps {
+  form: CreatePOModalProps['form'];
+  setForm: CreatePOModalProps['setForm'];
+  supplierHasVat: boolean;
+  totals: PoTotals;
+}
+
+const baht = (n: number) => `${formatNumberDecimal(n, 2)} บาท`;
+const discountInput =
+  'w-36 px-2 py-1 border border-input rounded text-sm text-right tabular-nums font-mono focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:ring-offset-[3px] focus-visible:ring-offset-background outline-hidden';
+
+export function StepDiscountVat({ form, setForm, supplierHasVat, totals }: StepDiscountVatProps) {
+  const {
+    subtotal,
+    discountNum,
+    subtotalAfterDiscount,
+    vatAmount,
+    totalWithVat,
+    discountAfterVatNum,
+    netAmount,
+  } = totals;
+  return (
+    <div className="rounded-xl border border-border/50 bg-card p-5 shadow-sm">
+      <div className="flex items-center gap-2.5 mb-4">
+        <div className="flex items-center justify-center size-8 rounded-lg bg-primary/10 text-primary">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="18"
+            height="18"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d="M12 2v20M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6" />
+          </svg>
+        </div>
+        <div>
+          <h3 className="text-sm font-semibold text-foreground leading-snug">ส่วนลด และ VAT</h3>
+          <p className="text-xs text-muted-foreground leading-snug">
+            {supplierHasVat
+              ? 'คำนวณ VAT 7% หลังหักส่วนลด แล้วจึงหักส่วนลดหลัง VAT'
+              : 'ผู้จัดจำหน่ายไม่มี VAT'}
+          </p>
+        </div>
+      </div>
+
+      <div className="bg-muted/50 rounded-lg p-4 space-y-2 text-sm">
+        {/* 1. subtotal */}
+        <div className="flex justify-between">
+          <span className="text-muted-foreground leading-snug">
+            มูลค่าสินค้า{supplierHasVat ? ' (ก่อน VAT)' : ''}
+          </span>
+          <span className="font-medium tabular-nums font-mono">{baht(subtotal)}</span>
+        </div>
+
+        {/* 2. discount before VAT (editable) */}
+        <div className="flex justify-between items-center">
+          <span className="text-muted-foreground leading-snug">
+            หัก ส่วนลด{supplierHasVat ? ' (ก่อน VAT)' : ''}
+          </span>
+          <input
+            type="number"
+            min="0"
+            placeholder="0"
+            value={form.discount}
+            onChange={(e) => setForm({ ...form, discount: e.target.value })}
+            className={discountInput}
+          />
+        </div>
+
+        {/* 3. subtotalAfterDiscount */}
+        <div className="flex justify-between border-t border-border/60 pt-2">
+          <span className="text-muted-foreground leading-snug">= มูลค่าหลังหักส่วนลด</span>
+          <span className="tabular-nums font-mono">{baht(subtotalAfterDiscount)}</span>
+        </div>
+
+        {supplierHasVat && (
+          <>
+            {/* 4. VAT */}
+            <div className="flex justify-between">
+              <span className="text-muted-foreground leading-snug">
+                + VAT 7% (ปัดเศษขึ้นครึ่งสตางค์)
+              </span>
+              <span className="tabular-nums font-mono">{baht(vatAmount)}</span>
+            </div>
+            {/* 5. totalWithVat */}
+            <div className="flex justify-between border-t border-border/60 pt-2">
+              <span className="text-muted-foreground leading-snug">= มูลค่ารวม VAT</span>
+              <span className="tabular-nums font-mono">{baht(totalWithVat)}</span>
+            </div>
+            {/* 6. discount after VAT (editable) */}
+            <div className="flex justify-between items-center">
+              <span className="text-muted-foreground leading-snug">หัก ส่วนลด (หลัง VAT)</span>
+              <input
+                type="number"
+                min="0"
+                placeholder="0"
+                value={form.discountAfterVat}
+                onChange={(e) => setForm({ ...form, discountAfterVat: e.target.value })}
+                className={discountInput}
+              />
+            </div>
+          </>
+        )}
+
+        {/* 7. net */}
+        <div className="flex justify-between border-t-2 border-border pt-2.5 mt-1 font-semibold text-base">
+          <span className="leading-snug">ยอดสุทธิ</span>
+          <span className="text-primary tabular-nums font-mono">{baht(netAmount)}</span>
+        </div>
+
+        {/* explainer */}
+        <p className="text-2xs text-muted-foreground leading-snug pt-1">
+          {supplierHasVat
+            ? `วิธีคิด: (${formatNumberDecimal(subtotal, 2)} − ${formatNumberDecimal(discountNum, 2)}) × 1.07 − ${formatNumberDecimal(discountAfterVatNum, 2)} = ${formatNumberDecimal(netAmount, 2)} บาท`
+            : `วิธีคิด: ${formatNumberDecimal(subtotal, 2)} − ${formatNumberDecimal(discountNum, 2)} = ${formatNumberDecimal(netAmount, 2)} บาท`}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/pages/PurchaseOrdersPage/components/wizard/StepItems.tsx
+++ b/apps/web/src/pages/PurchaseOrdersPage/components/wizard/StepItems.tsx
@@ -1,0 +1,313 @@
+import { brands, getModels, getModelInfo } from '@/data/productCatalog';
+import { accessoryTypes, chargerConnectorTypes } from '../../constants';
+import { formatNumberDecimal } from '@/utils/formatters';
+import type { ItemForm } from '../../types';
+
+interface StepItemsProps {
+  items: ItemForm[];
+  setItems: React.Dispatch<React.SetStateAction<ItemForm[]>>;
+  addItem: () => void;
+  removeItem: (idx: number) => void;
+  updateItem: (idx: number, field: string, value: string) => void;
+  toggleModel: (idx: number, modelName: string) => void;
+  subtotal: number;
+  selectClass: string;
+  inputClass: string;
+}
+
+export function StepItems({
+  items, setItems, addItem, removeItem, updateItem, toggleModel, subtotal, selectClass, inputClass,
+}: StepItemsProps) {
+  return (
+    <div className="rounded-xl border border-border/50 bg-card p-5 shadow-sm">
+      <div className="flex items-center gap-2.5 mb-4">
+        <div className="flex items-center justify-center size-8 rounded-lg bg-primary/10 text-primary">
+          <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="m7.5 4.27 9 5.15"/><path d="M21 8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16Z"/><path d="m3.3 7 8.7 5 8.7-5"/><path d="M12 22V12"/></svg>
+        </div>
+        <div className="flex-1">
+          <h3 className="text-sm font-semibold text-foreground leading-snug">รายการสินค้า</h3>
+          <p className="text-xs text-muted-foreground leading-snug">เพิ่มสินค้าที่ต้องการสั่งซื้อ</p>
+        </div>
+        <button type="button" onClick={addItem} className="text-sm text-primary hover:text-primary/90 font-medium">
+          + เพิ่มรายการ
+        </button>
+      </div>
+
+      <div className="space-y-4">
+        {items.map((item, idx) => {
+                  const isAccessory = item.category === 'ACCESSORY';
+                  const isCharger = isAccessory && item.accessoryType === 'ชุดชาร์จ';
+                  const availableModels = item.brand ? getModels(item.brand, isAccessory ? 'ACCESSORY' : (item.category || undefined)) : [];
+                  const modelInfo = item.brand && item.model ? getModelInfo(item.brand, item.model) : undefined;
+                  const availableColors = modelInfo?.colors || [];
+                  const availableStorage = modelInfo?.storage || [];
+                  const selectedModels = isAccessory && item.model ? item.model.split(', ').filter(Boolean) : [];
+
+                  const accessoryAutoName = isAccessory ? (() => {
+                    if (isCharger) {
+                      return [item.accessoryType, item.accessoryBrand, item.model].filter(Boolean).join(' ');
+                    }
+                    const accParts = [item.accessoryType, item.accessoryBrand].filter(Boolean);
+                    const modelStr = item.model;
+                    return modelStr
+                      ? `${accParts.join(' ')} สำหรับ ${modelStr}`
+                      : accParts.join(' ');
+                  })() : '';
+
+                  return (
+                    <div key={idx} className={`border rounded-lg p-3 space-y-2 relative ${isAccessory ? 'border-primary/30 bg-primary/5 dark:bg-primary/10' : 'border-border bg-muted/50'}`}>
+                      {items.length > 1 && (
+                        <button
+                          type="button"
+                          onClick={() => removeItem(idx)}
+                          className="absolute top-2 right-2 text-destructive/70 hover:text-destructive text-lg leading-none"
+                        >
+                          &times;
+                        </button>
+                      )}
+                      <div className="text-xs font-medium text-muted-foreground mb-1">
+                        รายการ #{idx + 1}
+                        {isAccessory && <span className="ml-2 px-1.5 py-0.5 bg-primary/15 text-primary dark:bg-primary/20 rounded text-xs">อุปกรณ์เสริม</span>}
+                      </div>
+
+                      {/* Row 1: Category FIRST, then Brand/Model or AccessoryType */}
+                      <div className={`grid ${isAccessory ? 'grid-cols-3' : 'grid-cols-3'} gap-2`}>
+                        <div>
+                          <label className="block text-xs text-muted-foreground mb-0.5">ประเภท <span className="text-destructive">*</span></label>
+                          <select
+                            value={item.category}
+                            onChange={(e) => updateItem(idx, 'category', e.target.value)}
+                            className={selectClass}
+                          >
+                            <option value="">-- เลือกประเภท --</option>
+                            <option value="PHONE_NEW">โทรศัพท์ (ใหม่)</option>
+                            <option value="PHONE_USED">โทรศัพท์ (มือสอง)</option>
+                            <option value="TABLET">แท็บเล็ต</option>
+                            <option value="ACCESSORY">อุปกรณ์เสริม</option>
+                          </select>
+                        </div>
+
+                        {isAccessory ? (
+                          <>
+                            <div>
+                              <label className="block text-xs text-muted-foreground mb-0.5">ประเภทอุปกรณ์ <span className="text-destructive">*</span></label>
+                              <select
+                                value={item.accessoryType}
+                                onChange={(e) => updateItem(idx, 'accessoryType', e.target.value)}
+                                className={selectClass}
+                                required
+                              >
+                                <option value="">-- เลือก --</option>
+                                {accessoryTypes.map((t) => (
+                                  <option key={t.value} value={t.value}>{t.label}</option>
+                                ))}
+                              </select>
+                            </div>
+
+                            {isCharger ? (
+                              <div>
+                                <label className="block text-xs text-muted-foreground mb-0.5">ชนิด <span className="text-destructive">*</span></label>
+                                <select
+                                  value={item.model}
+                                  onChange={(e) => { const ni = [...items]; ni[idx] = { ...ni[idx], model: e.target.value }; setItems(ni); }}
+                                  className={selectClass}
+                                  required
+                                >
+                                  <option value="">-- เลือก --</option>
+                                  {chargerConnectorTypes.map((t) => (
+                                    <option key={t.value} value={t.value}>{t.label}</option>
+                                  ))}
+                                </select>
+                              </div>
+                            ) : (
+                              <div>
+                                <label className="block text-xs text-muted-foreground mb-0.5">สำหรับยี่ห้อ</label>
+                                <select
+                                  value={item.brand}
+                                  onChange={(e) => updateItem(idx, 'brand', e.target.value)}
+                                  className={selectClass}
+                                >
+                                  <option value="">-- เลือกยี่ห้อโทรศัพท์ --</option>
+                                  {brands.map((b) => (
+                                    <option key={b} value={b}>{b}</option>
+                                  ))}
+                                </select>
+                              </div>
+                            )}
+                          </>
+                        ) : (
+                          <>
+                            <div>
+                              <label className="block text-xs text-muted-foreground mb-0.5">ยี่ห้อ <span className="text-destructive">*</span></label>
+                              <select
+                                value={item.brand}
+                                onChange={(e) => updateItem(idx, 'brand', e.target.value)}
+                                className={selectClass}
+                                required
+                                disabled={!item.category}
+                              >
+                                <option value="">-- เลือกยี่ห้อ --</option>
+                                {brands.map((b) => (
+                                  <option key={b} value={b}>{b}</option>
+                                ))}
+                              </select>
+                            </div>
+                            <div>
+                              <label className="block text-xs text-muted-foreground mb-0.5">รุ่น <span className="text-destructive">*</span></label>
+                              <select
+                                value={item.model}
+                                onChange={(e) => updateItem(idx, 'model', e.target.value)}
+                                className={selectClass}
+                                required
+                                disabled={!item.brand}
+                              >
+                                <option value="">-- เลือกรุ่น --</option>
+                                {availableModels.map((m) => (
+                                  <option key={m.name} value={m.name}>{m.name}</option>
+                                ))}
+                              </select>
+                            </div>
+                          </>
+                        )}
+                      </div>
+
+                      {/* Multi-model selection for accessories (non-charger) */}
+                      {isAccessory && !isCharger && item.accessoryType && item.brand && availableModels.length > 0 && (
+                        <div>
+                          <label className="block text-2xs font-medium text-muted-foreground uppercase tracking-wider mb-2">สำหรับรุ่น (เลือกได้หลายรุ่น)</label>
+                          <div className="flex flex-wrap gap-1.5">
+                            {availableModels.map((m) => {
+                              const isSelected = selectedModels.includes(m.name);
+                              return (
+                                <button
+                                  key={m.name}
+                                  type="button"
+                                  onClick={() => toggleModel(idx, m.name)}
+                                  className={`px-2 py-0.5 rounded-full text-xs font-medium border transition-colors ${
+                                    isSelected
+                                      ? 'bg-primary text-primary-foreground border-primary'
+                                      : 'bg-background text-muted-foreground border-input hover:border-primary/50 hover:text-primary'
+                                  }`}
+                                >
+                                  {m.name}
+                                </button>
+                              );
+                            })}
+                          </div>
+                          {selectedModels.length > 0 && (
+                            <div className="text-xs text-primary mt-1">เลือกแล้ว {selectedModels.length} รุ่น</div>
+                          )}
+                        </div>
+                      )}
+
+                      {isAccessory ? (
+                        <>
+                          <div className="grid grid-cols-3 gap-2">
+                            <div>
+                              <label className="block text-xs text-muted-foreground mb-0.5">ยี่ห้ออุปกรณ์</label>
+                              <input
+                                type="text"
+                                value={item.accessoryBrand}
+                                onChange={(e) => updateItem(idx, 'accessoryBrand', e.target.value)}
+                                className={inputClass}
+                                placeholder="เช่น Spigen, Anker"
+                              />
+                            </div>
+                            <div>
+                              <label className="block text-xs text-muted-foreground mb-0.5">จำนวน <span className="text-destructive">*</span></label>
+                              <input
+                                type="number"
+                                value={item.quantity}
+                                onChange={(e) => updateItem(idx, 'quantity', e.target.value)}
+                                className={inputClass}
+                                min="1"
+                                required
+                              />
+                            </div>
+                            <div>
+                              <label className="block text-xs text-muted-foreground mb-0.5">ราคา/ชิ้น <span className="text-destructive">*</span></label>
+                              <input
+                                type="number"
+                                value={item.unitPrice}
+                                onChange={(e) => updateItem(idx, 'unitPrice', e.target.value)}
+                                className={inputClass}
+                                required
+                              />
+                            </div>
+                          </div>
+                          {accessoryAutoName && (
+                            <div className="text-xs text-primary bg-primary/10 dark:bg-primary/15 rounded px-2 py-1">
+                              ชื่อสินค้า: {accessoryAutoName}
+                            </div>
+                          )}
+                        </>
+                      ) : (
+                        <div className="grid grid-cols-4 gap-2">
+                          <div>
+                            <label className="block text-xs text-muted-foreground mb-0.5">สี</label>
+                            <select
+                              value={item.color}
+                              onChange={(e) => updateItem(idx, 'color', e.target.value)}
+                              className={selectClass}
+                              disabled={availableColors.length === 0}
+                            >
+                              <option value="">-- เลือกสี --</option>
+                              {availableColors.map((c) => (
+                                <option key={c} value={c}>{c}</option>
+                              ))}
+                            </select>
+                          </div>
+                          <div>
+                            <label className="block text-xs text-muted-foreground mb-0.5">ความจุ</label>
+                            <select
+                              value={item.storage}
+                              onChange={(e) => updateItem(idx, 'storage', e.target.value)}
+                              className={selectClass}
+                              disabled={availableStorage.length === 0}
+                            >
+                              <option value="">-- เลือกความจุ --</option>
+                              {availableStorage.map((s) => (
+                                <option key={s} value={s}>{s}</option>
+                              ))}
+                            </select>
+                          </div>
+                          <div>
+                            <label className="block text-xs text-muted-foreground mb-0.5">จำนวน <span className="text-destructive">*</span></label>
+                            <input
+                              type="number"
+                              value={item.quantity}
+                              onChange={(e) => updateItem(idx, 'quantity', e.target.value)}
+                              className={inputClass}
+                              min="1"
+                              required
+                            />
+                          </div>
+                          <div>
+                            <label className="block text-xs text-muted-foreground mb-0.5">ราคา/ชิ้น <span className="text-destructive">*</span></label>
+                            <input
+                              type="number"
+                              value={item.unitPrice}
+                              onChange={(e) => updateItem(idx, 'unitPrice', e.target.value)}
+                              className={inputClass}
+                              required
+                            />
+                          </div>
+                        </div>
+                      )}
+                    </div>
+                  );
+                })}
+      </div>
+
+      {/* Running subtotal footer (new) */}
+      <div className="mt-4 flex items-center justify-between rounded-lg bg-muted/50 px-3 py-2.5">
+        <span className="text-sm text-muted-foreground leading-snug">
+          รวม {items.length} รายการ · {items.reduce((n, i) => n + (Number(i.quantity) || 0), 0)} ชิ้น
+        </span>
+        <span className="text-base font-semibold text-foreground tabular-nums font-mono">
+          {formatNumberDecimal(subtotal, 2)} บาท
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/pages/PurchaseOrdersPage/components/wizard/StepItems.tsx
+++ b/apps/web/src/pages/PurchaseOrdersPage/components/wizard/StepItems.tsx
@@ -16,293 +16,384 @@ interface StepItemsProps {
 }
 
 export function StepItems({
-  items, setItems, addItem, removeItem, updateItem, toggleModel, subtotal, selectClass, inputClass,
+  items,
+  setItems,
+  addItem,
+  removeItem,
+  updateItem,
+  toggleModel,
+  subtotal,
+  selectClass,
+  inputClass,
 }: StepItemsProps) {
   return (
     <div className="rounded-xl border border-border/50 bg-card p-5 shadow-sm">
       <div className="flex items-center gap-2.5 mb-4">
         <div className="flex items-center justify-center size-8 rounded-lg bg-primary/10 text-primary">
-          <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="m7.5 4.27 9 5.15"/><path d="M21 8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16Z"/><path d="m3.3 7 8.7 5 8.7-5"/><path d="M12 22V12"/></svg>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="18"
+            height="18"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d="m7.5 4.27 9 5.15" />
+            <path d="M21 8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16Z" />
+            <path d="m3.3 7 8.7 5 8.7-5" />
+            <path d="M12 22V12" />
+          </svg>
         </div>
         <div className="flex-1">
           <h3 className="text-sm font-semibold text-foreground leading-snug">รายการสินค้า</h3>
-          <p className="text-xs text-muted-foreground leading-snug">เพิ่มสินค้าที่ต้องการสั่งซื้อ</p>
+          <p className="text-xs text-muted-foreground leading-snug">
+            เพิ่มสินค้าที่ต้องการสั่งซื้อ
+          </p>
         </div>
-        <button type="button" onClick={addItem} className="text-sm text-primary hover:text-primary/90 font-medium">
+        <button
+          type="button"
+          onClick={addItem}
+          className="text-sm text-primary hover:text-primary/90 font-medium"
+        >
           + เพิ่มรายการ
         </button>
       </div>
 
       <div className="space-y-4">
         {items.map((item, idx) => {
-                  const isAccessory = item.category === 'ACCESSORY';
-                  const isCharger = isAccessory && item.accessoryType === 'ชุดชาร์จ';
-                  const availableModels = item.brand ? getModels(item.brand, isAccessory ? 'ACCESSORY' : (item.category || undefined)) : [];
-                  const modelInfo = item.brand && item.model ? getModelInfo(item.brand, item.model) : undefined;
-                  const availableColors = modelInfo?.colors || [];
-                  const availableStorage = modelInfo?.storage || [];
-                  const selectedModels = isAccessory && item.model ? item.model.split(', ').filter(Boolean) : [];
+          const isAccessory = item.category === 'ACCESSORY';
+          const isCharger = isAccessory && item.accessoryType === 'ชุดชาร์จ';
+          const availableModels = item.brand
+            ? getModels(item.brand, isAccessory ? 'ACCESSORY' : item.category || undefined)
+            : [];
+          const modelInfo =
+            item.brand && item.model ? getModelInfo(item.brand, item.model) : undefined;
+          const availableColors = modelInfo?.colors || [];
+          const availableStorage = modelInfo?.storage || [];
+          const selectedModels =
+            isAccessory && item.model ? item.model.split(', ').filter(Boolean) : [];
 
-                  const accessoryAutoName = isAccessory ? (() => {
-                    if (isCharger) {
-                      return [item.accessoryType, item.accessoryBrand, item.model].filter(Boolean).join(' ');
-                    }
-                    const accParts = [item.accessoryType, item.accessoryBrand].filter(Boolean);
-                    const modelStr = item.model;
-                    return modelStr
-                      ? `${accParts.join(' ')} สำหรับ ${modelStr}`
-                      : accParts.join(' ');
-                  })() : '';
+          const accessoryAutoName = isAccessory
+            ? (() => {
+                if (isCharger) {
+                  return [item.accessoryType, item.accessoryBrand, item.model]
+                    .filter(Boolean)
+                    .join(' ');
+                }
+                const accParts = [item.accessoryType, item.accessoryBrand].filter(Boolean);
+                const modelStr = item.model;
+                return modelStr ? `${accParts.join(' ')} สำหรับ ${modelStr}` : accParts.join(' ');
+              })()
+            : '';
 
-                  return (
-                    <div key={idx} className={`border rounded-lg p-3 space-y-2 relative ${isAccessory ? 'border-primary/30 bg-primary/5 dark:bg-primary/10' : 'border-border bg-muted/50'}`}>
-                      {items.length > 1 && (
-                        <button
-                          type="button"
-                          onClick={() => removeItem(idx)}
-                          className="absolute top-2 right-2 text-destructive/70 hover:text-destructive text-lg leading-none"
-                        >
-                          &times;
-                        </button>
-                      )}
-                      <div className="text-xs font-medium text-muted-foreground mb-1">
-                        รายการ #{idx + 1}
-                        {isAccessory && <span className="ml-2 px-1.5 py-0.5 bg-primary/15 text-primary dark:bg-primary/20 rounded text-xs">อุปกรณ์เสริม</span>}
-                      </div>
+          return (
+            <div
+              key={idx}
+              className={`border rounded-lg p-3 space-y-2 relative ${isAccessory ? 'border-primary/30 bg-primary/5 dark:bg-primary/10' : 'border-border bg-muted/50'}`}
+            >
+              {items.length > 1 && (
+                <button
+                  type="button"
+                  onClick={() => removeItem(idx)}
+                  className="absolute top-2 right-2 text-destructive/70 hover:text-destructive text-lg leading-none"
+                >
+                  &times;
+                </button>
+              )}
+              <div className="text-xs font-medium text-muted-foreground mb-1">
+                รายการ #{idx + 1}
+                {isAccessory && (
+                  <span className="ml-2 px-1.5 py-0.5 bg-primary/15 text-primary dark:bg-primary/20 rounded text-xs">
+                    อุปกรณ์เสริม
+                  </span>
+                )}
+              </div>
 
-                      {/* Row 1: Category FIRST, then Brand/Model or AccessoryType */}
-                      <div className={`grid ${isAccessory ? 'grid-cols-3' : 'grid-cols-3'} gap-2`}>
-                        <div>
-                          <label className="block text-xs text-muted-foreground mb-0.5">ประเภท <span className="text-destructive">*</span></label>
-                          <select
-                            value={item.category}
-                            onChange={(e) => updateItem(idx, 'category', e.target.value)}
-                            className={selectClass}
-                          >
-                            <option value="">-- เลือกประเภท --</option>
-                            <option value="PHONE_NEW">โทรศัพท์ (ใหม่)</option>
-                            <option value="PHONE_USED">โทรศัพท์ (มือสอง)</option>
-                            <option value="TABLET">แท็บเล็ต</option>
-                            <option value="ACCESSORY">อุปกรณ์เสริม</option>
-                          </select>
-                        </div>
+              {/* Row 1: Category FIRST, then Brand/Model or AccessoryType */}
+              <div className={`grid ${isAccessory ? 'grid-cols-3' : 'grid-cols-3'} gap-2`}>
+                <div>
+                  <label className="block text-xs text-muted-foreground mb-0.5">
+                    ประเภท <span className="text-destructive">*</span>
+                  </label>
+                  <select
+                    value={item.category}
+                    onChange={(e) => updateItem(idx, 'category', e.target.value)}
+                    className={selectClass}
+                  >
+                    <option value="">-- เลือกประเภท --</option>
+                    <option value="PHONE_NEW">โทรศัพท์ (ใหม่)</option>
+                    <option value="PHONE_USED">โทรศัพท์ (มือสอง)</option>
+                    <option value="TABLET">แท็บเล็ต</option>
+                    <option value="ACCESSORY">อุปกรณ์เสริม</option>
+                  </select>
+                </div>
 
-                        {isAccessory ? (
-                          <>
-                            <div>
-                              <label className="block text-xs text-muted-foreground mb-0.5">ประเภทอุปกรณ์ <span className="text-destructive">*</span></label>
-                              <select
-                                value={item.accessoryType}
-                                onChange={(e) => updateItem(idx, 'accessoryType', e.target.value)}
-                                className={selectClass}
-                                required
-                              >
-                                <option value="">-- เลือก --</option>
-                                {accessoryTypes.map((t) => (
-                                  <option key={t.value} value={t.value}>{t.label}</option>
-                                ))}
-                              </select>
-                            </div>
-
-                            {isCharger ? (
-                              <div>
-                                <label className="block text-xs text-muted-foreground mb-0.5">ชนิด <span className="text-destructive">*</span></label>
-                                <select
-                                  value={item.model}
-                                  onChange={(e) => { const ni = [...items]; ni[idx] = { ...ni[idx], model: e.target.value }; setItems(ni); }}
-                                  className={selectClass}
-                                  required
-                                >
-                                  <option value="">-- เลือก --</option>
-                                  {chargerConnectorTypes.map((t) => (
-                                    <option key={t.value} value={t.value}>{t.label}</option>
-                                  ))}
-                                </select>
-                              </div>
-                            ) : (
-                              <div>
-                                <label className="block text-xs text-muted-foreground mb-0.5">สำหรับยี่ห้อ</label>
-                                <select
-                                  value={item.brand}
-                                  onChange={(e) => updateItem(idx, 'brand', e.target.value)}
-                                  className={selectClass}
-                                >
-                                  <option value="">-- เลือกยี่ห้อโทรศัพท์ --</option>
-                                  {brands.map((b) => (
-                                    <option key={b} value={b}>{b}</option>
-                                  ))}
-                                </select>
-                              </div>
-                            )}
-                          </>
-                        ) : (
-                          <>
-                            <div>
-                              <label className="block text-xs text-muted-foreground mb-0.5">ยี่ห้อ <span className="text-destructive">*</span></label>
-                              <select
-                                value={item.brand}
-                                onChange={(e) => updateItem(idx, 'brand', e.target.value)}
-                                className={selectClass}
-                                required
-                                disabled={!item.category}
-                              >
-                                <option value="">-- เลือกยี่ห้อ --</option>
-                                {brands.map((b) => (
-                                  <option key={b} value={b}>{b}</option>
-                                ))}
-                              </select>
-                            </div>
-                            <div>
-                              <label className="block text-xs text-muted-foreground mb-0.5">รุ่น <span className="text-destructive">*</span></label>
-                              <select
-                                value={item.model}
-                                onChange={(e) => updateItem(idx, 'model', e.target.value)}
-                                className={selectClass}
-                                required
-                                disabled={!item.brand}
-                              >
-                                <option value="">-- เลือกรุ่น --</option>
-                                {availableModels.map((m) => (
-                                  <option key={m.name} value={m.name}>{m.name}</option>
-                                ))}
-                              </select>
-                            </div>
-                          </>
-                        )}
-                      </div>
-
-                      {/* Multi-model selection for accessories (non-charger) */}
-                      {isAccessory && !isCharger && item.accessoryType && item.brand && availableModels.length > 0 && (
-                        <div>
-                          <label className="block text-2xs font-medium text-muted-foreground uppercase tracking-wider mb-2">สำหรับรุ่น (เลือกได้หลายรุ่น)</label>
-                          <div className="flex flex-wrap gap-1.5">
-                            {availableModels.map((m) => {
-                              const isSelected = selectedModels.includes(m.name);
-                              return (
-                                <button
-                                  key={m.name}
-                                  type="button"
-                                  onClick={() => toggleModel(idx, m.name)}
-                                  className={`px-2 py-0.5 rounded-full text-xs font-medium border transition-colors ${
-                                    isSelected
-                                      ? 'bg-primary text-primary-foreground border-primary'
-                                      : 'bg-background text-muted-foreground border-input hover:border-primary/50 hover:text-primary'
-                                  }`}
-                                >
-                                  {m.name}
-                                </button>
-                              );
-                            })}
-                          </div>
-                          {selectedModels.length > 0 && (
-                            <div className="text-xs text-primary mt-1">เลือกแล้ว {selectedModels.length} รุ่น</div>
-                          )}
-                        </div>
-                      )}
-
-                      {isAccessory ? (
-                        <>
-                          <div className="grid grid-cols-3 gap-2">
-                            <div>
-                              <label className="block text-xs text-muted-foreground mb-0.5">ยี่ห้ออุปกรณ์</label>
-                              <input
-                                type="text"
-                                value={item.accessoryBrand}
-                                onChange={(e) => updateItem(idx, 'accessoryBrand', e.target.value)}
-                                className={inputClass}
-                                placeholder="เช่น Spigen, Anker"
-                              />
-                            </div>
-                            <div>
-                              <label className="block text-xs text-muted-foreground mb-0.5">จำนวน <span className="text-destructive">*</span></label>
-                              <input
-                                type="number"
-                                value={item.quantity}
-                                onChange={(e) => updateItem(idx, 'quantity', e.target.value)}
-                                className={inputClass}
-                                min="1"
-                                required
-                              />
-                            </div>
-                            <div>
-                              <label className="block text-xs text-muted-foreground mb-0.5">ราคา/ชิ้น <span className="text-destructive">*</span></label>
-                              <input
-                                type="number"
-                                value={item.unitPrice}
-                                onChange={(e) => updateItem(idx, 'unitPrice', e.target.value)}
-                                className={inputClass}
-                                required
-                              />
-                            </div>
-                          </div>
-                          {accessoryAutoName && (
-                            <div className="text-xs text-primary bg-primary/10 dark:bg-primary/15 rounded px-2 py-1">
-                              ชื่อสินค้า: {accessoryAutoName}
-                            </div>
-                          )}
-                        </>
-                      ) : (
-                        <div className="grid grid-cols-4 gap-2">
-                          <div>
-                            <label className="block text-xs text-muted-foreground mb-0.5">สี</label>
-                            <select
-                              value={item.color}
-                              onChange={(e) => updateItem(idx, 'color', e.target.value)}
-                              className={selectClass}
-                              disabled={availableColors.length === 0}
-                            >
-                              <option value="">-- เลือกสี --</option>
-                              {availableColors.map((c) => (
-                                <option key={c} value={c}>{c}</option>
-                              ))}
-                            </select>
-                          </div>
-                          <div>
-                            <label className="block text-xs text-muted-foreground mb-0.5">ความจุ</label>
-                            <select
-                              value={item.storage}
-                              onChange={(e) => updateItem(idx, 'storage', e.target.value)}
-                              className={selectClass}
-                              disabled={availableStorage.length === 0}
-                            >
-                              <option value="">-- เลือกความจุ --</option>
-                              {availableStorage.map((s) => (
-                                <option key={s} value={s}>{s}</option>
-                              ))}
-                            </select>
-                          </div>
-                          <div>
-                            <label className="block text-xs text-muted-foreground mb-0.5">จำนวน <span className="text-destructive">*</span></label>
-                            <input
-                              type="number"
-                              value={item.quantity}
-                              onChange={(e) => updateItem(idx, 'quantity', e.target.value)}
-                              className={inputClass}
-                              min="1"
-                              required
-                            />
-                          </div>
-                          <div>
-                            <label className="block text-xs text-muted-foreground mb-0.5">ราคา/ชิ้น <span className="text-destructive">*</span></label>
-                            <input
-                              type="number"
-                              value={item.unitPrice}
-                              onChange={(e) => updateItem(idx, 'unitPrice', e.target.value)}
-                              className={inputClass}
-                              required
-                            />
-                          </div>
-                        </div>
-                      )}
+                {isAccessory ? (
+                  <>
+                    <div>
+                      <label className="block text-xs text-muted-foreground mb-0.5">
+                        ประเภทอุปกรณ์ <span className="text-destructive">*</span>
+                      </label>
+                      <select
+                        value={item.accessoryType}
+                        onChange={(e) => updateItem(idx, 'accessoryType', e.target.value)}
+                        className={selectClass}
+                        required
+                      >
+                        <option value="">-- เลือก --</option>
+                        {accessoryTypes.map((t) => (
+                          <option key={t.value} value={t.value}>
+                            {t.label}
+                          </option>
+                        ))}
+                      </select>
                     </div>
-                  );
-                })}
+
+                    {isCharger ? (
+                      <div>
+                        <label className="block text-xs text-muted-foreground mb-0.5">
+                          ชนิด <span className="text-destructive">*</span>
+                        </label>
+                        <select
+                          value={item.model}
+                          onChange={(e) => {
+                            const ni = [...items];
+                            ni[idx] = { ...ni[idx], model: e.target.value };
+                            setItems(ni);
+                          }}
+                          className={selectClass}
+                          required
+                        >
+                          <option value="">-- เลือก --</option>
+                          {chargerConnectorTypes.map((t) => (
+                            <option key={t.value} value={t.value}>
+                              {t.label}
+                            </option>
+                          ))}
+                        </select>
+                      </div>
+                    ) : (
+                      <div>
+                        <label className="block text-xs text-muted-foreground mb-0.5">
+                          สำหรับยี่ห้อ
+                        </label>
+                        <select
+                          value={item.brand}
+                          onChange={(e) => updateItem(idx, 'brand', e.target.value)}
+                          className={selectClass}
+                        >
+                          <option value="">-- เลือกยี่ห้อโทรศัพท์ --</option>
+                          {brands.map((b) => (
+                            <option key={b} value={b}>
+                              {b}
+                            </option>
+                          ))}
+                        </select>
+                      </div>
+                    )}
+                  </>
+                ) : (
+                  <>
+                    <div>
+                      <label className="block text-xs text-muted-foreground mb-0.5">
+                        ยี่ห้อ <span className="text-destructive">*</span>
+                      </label>
+                      <select
+                        value={item.brand}
+                        onChange={(e) => updateItem(idx, 'brand', e.target.value)}
+                        className={selectClass}
+                        required
+                        disabled={!item.category}
+                      >
+                        <option value="">-- เลือกยี่ห้อ --</option>
+                        {brands.map((b) => (
+                          <option key={b} value={b}>
+                            {b}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+                    <div>
+                      <label className="block text-xs text-muted-foreground mb-0.5">
+                        รุ่น <span className="text-destructive">*</span>
+                      </label>
+                      <select
+                        value={item.model}
+                        onChange={(e) => updateItem(idx, 'model', e.target.value)}
+                        className={selectClass}
+                        required
+                        disabled={!item.brand}
+                      >
+                        <option value="">-- เลือกรุ่น --</option>
+                        {availableModels.map((m) => (
+                          <option key={m.name} value={m.name}>
+                            {m.name}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+                  </>
+                )}
+              </div>
+
+              {/* Multi-model selection for accessories (non-charger) */}
+              {isAccessory &&
+                !isCharger &&
+                item.accessoryType &&
+                item.brand &&
+                availableModels.length > 0 && (
+                  <div>
+                    <label className="block text-2xs font-medium text-muted-foreground uppercase tracking-wider mb-2">
+                      สำหรับรุ่น (เลือกได้หลายรุ่น)
+                    </label>
+                    <div className="flex flex-wrap gap-1.5">
+                      {availableModels.map((m) => {
+                        const isSelected = selectedModels.includes(m.name);
+                        return (
+                          <button
+                            key={m.name}
+                            type="button"
+                            onClick={() => toggleModel(idx, m.name)}
+                            className={`px-2 py-0.5 rounded-full text-xs font-medium border transition-colors ${
+                              isSelected
+                                ? 'bg-primary text-primary-foreground border-primary'
+                                : 'bg-background text-muted-foreground border-input hover:border-primary/50 hover:text-primary'
+                            }`}
+                          >
+                            {m.name}
+                          </button>
+                        );
+                      })}
+                    </div>
+                    {selectedModels.length > 0 && (
+                      <div className="text-xs text-primary mt-1">
+                        เลือกแล้ว {selectedModels.length} รุ่น
+                      </div>
+                    )}
+                  </div>
+                )}
+
+              {isAccessory ? (
+                <>
+                  <div className="grid grid-cols-3 gap-2">
+                    <div>
+                      <label className="block text-xs text-muted-foreground mb-0.5">
+                        ยี่ห้ออุปกรณ์
+                      </label>
+                      <input
+                        type="text"
+                        value={item.accessoryBrand}
+                        onChange={(e) => updateItem(idx, 'accessoryBrand', e.target.value)}
+                        className={inputClass}
+                        placeholder="เช่น Spigen, Anker"
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-xs text-muted-foreground mb-0.5">
+                        จำนวน <span className="text-destructive">*</span>
+                      </label>
+                      <input
+                        type="number"
+                        value={item.quantity}
+                        onChange={(e) => updateItem(idx, 'quantity', e.target.value)}
+                        className={inputClass}
+                        min="1"
+                        required
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-xs text-muted-foreground mb-0.5">
+                        ราคา/ชิ้น <span className="text-destructive">*</span>
+                      </label>
+                      <input
+                        type="number"
+                        value={item.unitPrice}
+                        onChange={(e) => updateItem(idx, 'unitPrice', e.target.value)}
+                        className={inputClass}
+                        required
+                      />
+                    </div>
+                  </div>
+                  {accessoryAutoName && (
+                    <div className="text-xs text-primary bg-primary/10 dark:bg-primary/15 rounded px-2 py-1">
+                      ชื่อสินค้า: {accessoryAutoName}
+                    </div>
+                  )}
+                </>
+              ) : (
+                <div className="grid grid-cols-4 gap-2">
+                  <div>
+                    <label className="block text-xs text-muted-foreground mb-0.5">สี</label>
+                    <select
+                      value={item.color}
+                      onChange={(e) => updateItem(idx, 'color', e.target.value)}
+                      className={selectClass}
+                      disabled={availableColors.length === 0}
+                    >
+                      <option value="">-- เลือกสี --</option>
+                      {availableColors.map((c) => (
+                        <option key={c} value={c}>
+                          {c}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                  <div>
+                    <label className="block text-xs text-muted-foreground mb-0.5">ความจุ</label>
+                    <select
+                      value={item.storage}
+                      onChange={(e) => updateItem(idx, 'storage', e.target.value)}
+                      className={selectClass}
+                      disabled={availableStorage.length === 0}
+                    >
+                      <option value="">-- เลือกความจุ --</option>
+                      {availableStorage.map((s) => (
+                        <option key={s} value={s}>
+                          {s}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                  <div>
+                    <label className="block text-xs text-muted-foreground mb-0.5">
+                      จำนวน <span className="text-destructive">*</span>
+                    </label>
+                    <input
+                      type="number"
+                      value={item.quantity}
+                      onChange={(e) => updateItem(idx, 'quantity', e.target.value)}
+                      className={inputClass}
+                      min="1"
+                      required
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-xs text-muted-foreground mb-0.5">
+                      ราคา/ชิ้น <span className="text-destructive">*</span>
+                    </label>
+                    <input
+                      type="number"
+                      value={item.unitPrice}
+                      onChange={(e) => updateItem(idx, 'unitPrice', e.target.value)}
+                      className={inputClass}
+                      required
+                    />
+                  </div>
+                </div>
+              )}
+            </div>
+          );
+        })}
       </div>
 
       {/* Running subtotal footer (new) */}
       <div className="mt-4 flex items-center justify-between rounded-lg bg-muted/50 px-3 py-2.5">
         <span className="text-sm text-muted-foreground leading-snug">
-          รวม {items.length} รายการ · {items.reduce((n, i) => n + (Number(i.quantity) || 0), 0)} ชิ้น
+          รวม {items.length} รายการ · {items.reduce((n, i) => n + (Number(i.quantity) || 0), 0)}{' '}
+          ชิ้น
         </span>
         <span className="text-base font-semibold text-foreground tabular-nums font-mono">
           {formatNumberDecimal(subtotal, 2)} บาท

--- a/apps/web/src/pages/PurchaseOrdersPage/components/wizard/StepReview.tsx
+++ b/apps/web/src/pages/PurchaseOrdersPage/components/wizard/StepReview.tsx
@@ -1,0 +1,427 @@
+import { formatNumberDecimal, formatDateShort } from '@/utils/formatters';
+import type { CreatePOModalProps } from '../CreatePOModal';
+import type { ItemForm } from '../../types';
+import type { PoTotals } from '../../poTotals';
+
+interface StepReviewProps {
+  form: CreatePOModalProps['form'];
+  setForm: CreatePOModalProps['setForm'];
+  items: ItemForm[];
+  selectedSupplier: CreatePOModalProps['selectedSupplier'];
+  supplierHasVat: boolean;
+  totals: PoTotals;
+  dueDatePreview: Date | null;
+  attachmentUrl: string;
+  setAttachmentUrl: (v: string) => void;
+  formAttachments: string[];
+  setFormAttachments: React.Dispatch<React.SetStateAction<string[]>>;
+  selectClass: string;
+  inputClass: string;
+}
+
+const baht = (n: number) => `${formatNumberDecimal(n, 2)} บาท`;
+
+function itemLabel(i: ItemForm): string {
+  if (i.category === 'ACCESSORY') {
+    const isCharger = i.accessoryType === 'ชุดชาร์จ';
+    return isCharger
+      ? [i.accessoryType, i.accessoryBrand, i.model].filter(Boolean).join(' ')
+      : [i.accessoryType, i.accessoryBrand, i.model ? `สำหรับ ${i.model}` : '']
+          .filter(Boolean)
+          .join(' ');
+  }
+  return [i.brand, i.model, i.color, i.storage].filter(Boolean).join(' ');
+}
+
+export function StepReview({
+  form,
+  setForm,
+  items,
+  selectedSupplier,
+  supplierHasVat,
+  totals,
+  dueDatePreview,
+  attachmentUrl,
+  setAttachmentUrl,
+  formAttachments,
+  setFormAttachments,
+  selectClass,
+  inputClass,
+}: StepReviewProps) {
+  const netAmount = totals.netAmount;
+  return (
+    <div className="space-y-5">
+      {/* Read-only summary */}
+      <div className="rounded-xl border border-border/50 bg-card p-5 shadow-sm space-y-3">
+        <h3 className="text-sm font-semibold text-foreground leading-snug">ทบทวนใบสั่งซื้อ</h3>
+        <div className="grid grid-cols-2 gap-3 text-sm">
+          <div>
+            <div className="text-2xs text-muted-foreground uppercase tracking-wider leading-snug">
+              ผู้จัดจำหน่าย
+            </div>
+            <div className="text-foreground leading-snug">{selectedSupplier?.name ?? '-'}</div>
+          </div>
+          <div>
+            <div className="text-2xs text-muted-foreground uppercase tracking-wider leading-snug">
+              วันที่สั่ง
+            </div>
+            <div className="text-foreground leading-snug">
+              {form.orderDate ? formatDateShort(form.orderDate) : '-'}
+            </div>
+          </div>
+          {dueDatePreview && (
+            <div>
+              <div className="text-2xs text-muted-foreground uppercase tracking-wider leading-snug">
+                ครบกำหนดชำระ
+              </div>
+              <div className="text-foreground leading-snug">{formatDateShort(dueDatePreview)}</div>
+            </div>
+          )}
+        </div>
+        <div className="border-t border-border/60 pt-3 space-y-1.5">
+          {items.map((i, idx) => (
+            <div key={idx} className="flex justify-between text-sm">
+              <span className="text-muted-foreground leading-snug">
+                {itemLabel(i)} × {i.quantity || 0}
+              </span>
+              <span className="tabular-nums font-mono">
+                {baht((Number(i.quantity) || 0) * (Number(i.unitPrice) || 0))}
+              </span>
+            </div>
+          ))}
+        </div>
+        <div className="border-t border-border/60 pt-3 space-y-1 text-sm">
+          <div className="flex justify-between">
+            <span className="text-muted-foreground leading-snug">มูลค่าสินค้า</span>
+            <span className="tabular-nums font-mono">{baht(totals.subtotal)}</span>
+          </div>
+          {totals.discountNum > 0 && (
+            <div className="flex justify-between">
+              <span className="text-muted-foreground leading-snug">ส่วนลด</span>
+              <span className="tabular-nums font-mono">−{baht(totals.discountNum)}</span>
+            </div>
+          )}
+          {supplierHasVat && (
+            <div className="flex justify-between">
+              <span className="text-muted-foreground leading-snug">VAT 7%</span>
+              <span className="tabular-nums font-mono">{baht(totals.vatAmount)}</span>
+            </div>
+          )}
+          {totals.discountAfterVatNum > 0 && (
+            <div className="flex justify-between">
+              <span className="text-muted-foreground leading-snug">ส่วนลด (หลัง VAT)</span>
+              <span className="tabular-nums font-mono">−{baht(totals.discountAfterVatNum)}</span>
+            </div>
+          )}
+          <div className="flex justify-between border-t border-border pt-1.5 font-semibold text-base">
+            <span className="leading-snug">ยอดสุทธิ</span>
+            <span className="text-primary tabular-nums font-mono">{baht(netAmount)}</span>
+          </div>
+        </div>
+      </div>
+
+      {/* Section 4: Payment (orange) */}
+      <div className="rounded-xl border border-border/50 bg-card p-5 shadow-sm">
+        <div className="flex items-center gap-2.5 mb-4">
+          <div className="flex items-center justify-center size-8 rounded-lg bg-warning/10 text-warning">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="18"
+              height="18"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <rect width="20" height="14" x="2" y="5" rx="2" />
+              <line x1="2" x2="22" y1="10" y2="10" />
+            </svg>
+          </div>
+          <div>
+            <h3 className="text-sm font-semibold text-foreground leading-snug">การจ่ายเงิน</h3>
+            <p className="text-xs text-muted-foreground leading-snug">สถานะและวิธีการชำระเงิน</p>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-3 gap-3">
+          <div>
+            <label className="block text-xs text-muted-foreground mb-0.5 leading-snug">สถานะ</label>
+            <select
+              value={form.paymentStatus}
+              onChange={(e) => {
+                const newStatus = e.target.value;
+                setForm({
+                  ...form,
+                  paymentStatus: newStatus,
+                  paidAmount:
+                    newStatus === 'FULLY_PAID'
+                      ? String(Math.round(netAmount * 100) / 100)
+                      : newStatus === 'UNPAID'
+                        ? ''
+                        : form.paidAmount,
+                });
+              }}
+              className={selectClass}
+            >
+              <option value="UNPAID">ยังไม่จ่าย</option>
+              <option value="DEPOSIT_PAID">จ่ายมัดจำ</option>
+              <option value="PARTIALLY_PAID">จ่ายบางส่วน</option>
+              <option value="FULLY_PAID">จ่ายครบแล้ว</option>
+            </select>
+          </div>
+          <div>
+            <label className="block text-xs text-muted-foreground mb-0.5 leading-snug">
+              วิธีจ่ายเงิน
+            </label>
+            <select
+              value={form.paymentMethod}
+              onChange={(e) => setForm({ ...form, paymentMethod: e.target.value })}
+              className={selectClass}
+              disabled={form.paymentStatus === 'UNPAID'}
+            >
+              <option value="">-- เลือก --</option>
+              {selectedSupplier?.paymentMethods?.length ? (
+                selectedSupplier.paymentMethods.map((pm, idx) => {
+                  const labels: Record<string, string> = {
+                    CASH: 'เงินสด',
+                    BANK_TRANSFER: 'โอนธนาคาร',
+                    CHECK: 'เช็ค',
+                    CREDIT: 'เครดิต',
+                  };
+                  const label = labels[pm.paymentMethod] || pm.paymentMethod;
+                  const detail = pm.bankName
+                    ? ` - ${pm.bankName}${pm.bankAccountNumber ? ` (${pm.bankAccountNumber})` : ''}`
+                    : '';
+                  const credit = pm.creditTermDays ? ` ${pm.creditTermDays} วัน` : '';
+                  return (
+                    <option key={idx} value={pm.paymentMethod}>
+                      {label}
+                      {detail}
+                      {credit}
+                      {pm.isDefault ? ' (ค่าเริ่มต้น)' : ''}
+                    </option>
+                  );
+                })
+              ) : (
+                <>
+                  <option value="CASH">เงินสด</option>
+                  <option value="BANK_TRANSFER">โอนธนาคาร</option>
+                  <option value="CHECK">เช็ค</option>
+                  <option value="CREDIT">เครดิต</option>
+                </>
+              )}
+            </select>
+          </div>
+          <div>
+            <label className="block text-xs text-muted-foreground mb-0.5 leading-snug">
+              จำนวนที่จ่าย (บาท)
+            </label>
+            <input
+              type="number"
+              value={form.paidAmount}
+              onChange={(e) => setForm({ ...form, paidAmount: e.target.value })}
+              className={inputClass}
+              min="0"
+              step="0.01"
+              disabled={form.paymentStatus === 'UNPAID'}
+              placeholder={form.paymentStatus === 'UNPAID' ? '-' : '0'}
+            />
+            {form.paymentStatus !== 'UNPAID' &&
+              form.paymentStatus !== 'FULLY_PAID' &&
+              netAmount > 0 && (
+                <div className="flex gap-2 mt-1">
+                  <button
+                    type="button"
+                    onClick={() =>
+                      setForm({ ...form, paidAmount: String(Math.round(netAmount * 0.3)) })
+                    }
+                    className="text-xs text-primary hover:underline"
+                  >
+                    30%
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() =>
+                      setForm({ ...form, paidAmount: String(Math.round(netAmount * 0.5)) })
+                    }
+                    className="text-xs text-primary hover:underline"
+                  >
+                    50%
+                  </button>
+                </div>
+              )}
+          </div>
+        </div>
+        {form.paymentStatus !== 'UNPAID' && (
+          <div className="mt-2">
+            <label className="block text-xs text-muted-foreground mb-0.5 leading-snug">
+              หมายเหตุการจ่ายเงิน
+            </label>
+            <input
+              type="text"
+              value={form.paymentNotes}
+              onChange={(e) => setForm({ ...form, paymentNotes: e.target.value })}
+              className={inputClass}
+              placeholder="เช่น เลขอ้างอิง, ชื่อบัญชี"
+            />
+          </div>
+        )}
+      </div>
+
+      {/* Section 5: Attachments (sky) - only shown when payment is not UNPAID */}
+      {form.paymentStatus !== 'UNPAID' && (
+        <div className="rounded-xl border border-border/50 bg-card p-5 shadow-sm">
+          <div className="flex items-center gap-2.5 mb-4">
+            <div className="flex items-center justify-center size-8 rounded-lg bg-info/10 text-info">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="18"
+                height="18"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <path d="m21.44 11.05-9.19 9.19a6 6 0 0 1-8.49-8.49l8.57-8.57A4 4 0 1 1 18 8.84l-8.59 8.57a2 2 0 0 1-2.83-2.83l8.49-8.48" />
+              </svg>
+            </div>
+            <div>
+              <h3 className="text-sm font-semibold text-foreground leading-snug">แนบสลิป/เอกสาร</h3>
+              <p className="text-xs text-muted-foreground leading-snug">แนบหลักฐานการชำระเงิน</p>
+            </div>
+          </div>
+
+          <div className="flex gap-2">
+            <label className="flex items-center gap-1 px-3 py-2 bg-primary/10 text-primary border border-primary/30 rounded-lg text-xs cursor-pointer hover:bg-primary/15 dark:bg-primary/15 dark:hover:bg-primary/20 whitespace-nowrap">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                className="h-3.5 w-3.5"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"
+                />
+              </svg>
+              เลือกรูป
+              <input
+                type="file"
+                accept="image/*"
+                multiple
+                className="hidden"
+                onChange={(e) => {
+                  const files = Array.from(e.target.files || []);
+                  files.forEach((file) => {
+                    const reader = new FileReader();
+                    reader.onload = () => {
+                      setFormAttachments((prev) => [...prev, reader.result as string]);
+                    };
+                    reader.readAsDataURL(file);
+                  });
+                  e.target.value = '';
+                }}
+              />
+            </label>
+            <input
+              type="text"
+              value={attachmentUrl}
+              onChange={(e) => setAttachmentUrl(e.target.value)}
+              className={inputClass}
+              placeholder="หรือวาง URL"
+            />
+            <button
+              type="button"
+              onClick={() => {
+                if (attachmentUrl.trim()) {
+                  setFormAttachments([...formAttachments, attachmentUrl.trim()]);
+                  setAttachmentUrl('');
+                }
+              }}
+              className="px-3 py-2 bg-secondary rounded-lg text-sm hover:bg-muted/50 whitespace-nowrap"
+            >
+              + เพิ่ม
+            </button>
+          </div>
+          {formAttachments.length > 0 && (
+            <div className="mt-2 flex flex-wrap gap-2">
+              {formAttachments.map((att, idx) => (
+                <div key={idx} className="relative group">
+                  {att.startsWith('data:image') ? (
+                    <img
+                      src={att}
+                      alt={`แนบ ${idx + 1}`}
+                      className="h-16 w-16 object-cover rounded-lg border"
+                    />
+                  ) : (
+                    <div className="h-16 w-16 flex items-center justify-center bg-primary/10 dark:bg-primary/15 rounded-lg border text-2xs text-primary p-1 break-all overflow-hidden">
+                      <a
+                        href={att}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="hover:underline"
+                      >
+                        {att.length > 20 ? att.slice(0, 20) + '...' : att}
+                      </a>
+                    </div>
+                  )}
+                  <button
+                    type="button"
+                    onClick={() => setFormAttachments(formAttachments.filter((_, i) => i !== idx))}
+                    className="absolute -top-1.5 -right-1.5 w-4 h-4 bg-destructive text-destructive-foreground rounded-full text-2xs flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity"
+                  >
+                    &times;
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Notes - simple field at the bottom */}
+      <div className="rounded-xl border border-border/50 bg-card p-5 shadow-sm">
+        <div className="flex items-center gap-2.5 mb-4">
+          <div className="flex items-center justify-center size-8 rounded-lg bg-muted text-muted-foreground">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="18"
+              height="18"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z" />
+              <polyline points="14 2 14 8 20 8" />
+              <line x1="16" x2="8" y1="13" y2="13" />
+              <line x1="16" x2="8" y1="17" y2="17" />
+              <line x1="10" x2="8" y1="9" y2="9" />
+            </svg>
+          </div>
+          <div>
+            <h3 className="text-sm font-semibold text-foreground leading-snug">หมายเหตุ</h3>
+            <p className="text-xs text-muted-foreground leading-snug">
+              บันทึกเพิ่มเติมสำหรับใบสั่งซื้อ
+            </p>
+          </div>
+        </div>
+        <textarea
+          value={form.notes}
+          onChange={(e) => setForm({ ...form, notes: e.target.value })}
+          rows={2}
+          className={inputClass}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/pages/PurchaseOrdersPage/components/wizard/StepSupplier.tsx
+++ b/apps/web/src/pages/PurchaseOrdersPage/components/wizard/StepSupplier.tsx
@@ -1,0 +1,89 @@
+import ThaiDateInput from '@/components/ui/ThaiDateInput';
+import { ContactCombobox } from '@/components/contacts/ContactCombobox';
+import { formatDateShort } from '@/utils/formatters';
+import type { CreatePOModalProps } from '../CreatePOModal';
+
+interface StepSupplierProps {
+  form: CreatePOModalProps['form'];
+  setForm: CreatePOModalProps['setForm'];
+  suppliersLoading: boolean;
+  suppliersError: boolean;
+  selectedSupplier: CreatePOModalProps['selectedSupplier'];
+  onSupplierSelect: CreatePOModalProps['onSupplierSelect'];
+  supplierHasVat: boolean;
+  creditTermDays: number | null;
+  dueDatePreview: Date | null;
+  inputClass: string;
+}
+
+export function StepSupplier({
+  form, setForm, suppliersLoading, suppliersError, selectedSupplier,
+  onSupplierSelect, supplierHasVat, creditTermDays, dueDatePreview, inputClass,
+}: StepSupplierProps) {
+  return (
+    <div className="rounded-xl border border-border/50 bg-card p-5 shadow-sm">
+      <div className="flex items-center gap-2.5 mb-4">
+        <div className="flex items-center justify-center size-8 rounded-lg bg-success/10 text-success">
+          <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M22 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>
+        </div>
+        <div>
+          <h3 className="text-sm font-semibold text-foreground leading-snug">ข้อมูลผู้จัดจำหน่าย</h3>
+          <p className="text-xs text-muted-foreground leading-snug">เลือกผู้จัดจำหน่ายและวันที่สั่งซื้อ</p>
+        </div>
+      </div>
+
+      <div className="space-y-3">
+        <div>
+          <label className="block text-2xs font-medium text-muted-foreground uppercase tracking-wider mb-2">ผู้จัดจำหน่าย <span className="text-destructive">*</span></label>
+          <ContactCombobox
+            roleNeeded="SUPPLIER"
+            value={selectedSupplier?.name ?? (suppliersLoading ? 'กำลังโหลด...' : '')}
+            onSelect={onSupplierSelect}
+            invalid={!form.supplierId && suppliersError}
+            placeholder="เลือก/ค้นหาผู้จัดจำหน่าย"
+          />
+          <input type="hidden" value={form.supplierId} />
+          {selectedSupplier && (
+            <div className="mt-1 flex gap-2 flex-wrap">
+              <span className={`px-2 py-0.5 rounded-full text-xs font-medium leading-snug ${supplierHasVat ? 'bg-primary/10 text-primary dark:bg-primary/15' : 'bg-muted text-muted-foreground'}`}>
+                {supplierHasVat ? 'ผู้จัดจำหน่ายมี VAT - จะคำนวณ VAT 7% อัตโนมัติ' : 'ผู้จัดจำหน่ายไม่มี VAT'}
+              </span>
+              {selectedSupplier.paymentMethods?.length > 0 && (
+                <span className="px-2 py-0.5 rounded-full text-xs font-medium leading-snug bg-primary/10 text-primary">
+                  ชำระ: {selectedSupplier.paymentMethods.map((pm) => {
+                    const labels: Record<string, string> = { CASH: 'เงินสด', BANK_TRANSFER: 'โอนธนาคาร', CHECK: 'เช็ค', CREDIT: 'เครดิต' };
+                    return labels[pm.paymentMethod] || pm.paymentMethod;
+                  }).join(', ')}
+                </span>
+              )}
+            </div>
+          )}
+        </div>
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <label className="block text-2xs font-medium text-muted-foreground uppercase tracking-wider mb-2">วันที่สั่ง <span className="text-destructive">*</span></label>
+            <ThaiDateInput value={form.orderDate} onChange={(e) => setForm({ ...form, orderDate: e.target.value })} className={inputClass} required />
+          </div>
+          <div>
+            <label className="block text-2xs font-medium text-muted-foreground uppercase tracking-wider mb-2">วันที่คาดรับสินค้า</label>
+            <ThaiDateInput value={form.expectedDate} onChange={(e) => setForm({ ...form, expectedDate: e.target.value })} className={inputClass} />
+          </div>
+        </div>
+
+        {/* Due-date preview (credit-term driven) */}
+        {selectedSupplier && (
+          <div className="rounded-lg bg-muted/50 px-3 py-2 text-sm leading-snug">
+            {creditTermDays && dueDatePreview ? (
+              <span className="text-foreground">
+                เครดิต <span className="font-semibold">{creditTermDays}</span> วัน → ครบกำหนดชำระ{' '}
+                <span className="font-semibold text-primary">{formatDateShort(dueDatePreview)}</span>
+              </span>
+            ) : (
+              <span className="text-muted-foreground">ไม่มีเครดิต (ชำระทันที) — ไม่มีวันครบกำหนด</span>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/pages/PurchaseOrdersPage/components/wizard/StepSupplier.tsx
+++ b/apps/web/src/pages/PurchaseOrdersPage/components/wizard/StepSupplier.tsx
@@ -17,24 +17,53 @@ interface StepSupplierProps {
 }
 
 export function StepSupplier({
-  form, setForm, suppliersLoading, suppliersError, selectedSupplier,
-  onSupplierSelect, supplierHasVat, creditTermDays, dueDatePreview, inputClass,
+  form,
+  setForm,
+  suppliersLoading,
+  suppliersError,
+  selectedSupplier,
+  onSupplierSelect,
+  supplierHasVat,
+  creditTermDays,
+  dueDatePreview,
+  inputClass,
 }: StepSupplierProps) {
   return (
     <div className="rounded-xl border border-border/50 bg-card p-5 shadow-sm">
       <div className="flex items-center gap-2.5 mb-4">
         <div className="flex items-center justify-center size-8 rounded-lg bg-success/10 text-success">
-          <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M22 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="18"
+            height="18"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
+            <circle cx="9" cy="7" r="4" />
+            <path d="M22 21v-2a4 4 0 0 0-3-3.87" />
+            <path d="M16 3.13a4 4 0 0 1 0 7.75" />
+          </svg>
         </div>
         <div>
-          <h3 className="text-sm font-semibold text-foreground leading-snug">ข้อมูลผู้จัดจำหน่าย</h3>
-          <p className="text-xs text-muted-foreground leading-snug">เลือกผู้จัดจำหน่ายและวันที่สั่งซื้อ</p>
+          <h3 className="text-sm font-semibold text-foreground leading-snug">
+            ข้อมูลผู้จัดจำหน่าย
+          </h3>
+          <p className="text-xs text-muted-foreground leading-snug">
+            เลือกผู้จัดจำหน่ายและวันที่สั่งซื้อ
+          </p>
         </div>
       </div>
 
       <div className="space-y-3">
         <div>
-          <label className="block text-2xs font-medium text-muted-foreground uppercase tracking-wider mb-2">ผู้จัดจำหน่าย <span className="text-destructive">*</span></label>
+          <label className="block text-2xs font-medium text-muted-foreground uppercase tracking-wider mb-2">
+            ผู้จัดจำหน่าย <span className="text-destructive">*</span>
+          </label>
           <ContactCombobox
             roleNeeded="SUPPLIER"
             value={selectedSupplier?.name ?? (suppliersLoading ? 'กำลังโหลด...' : '')}
@@ -45,15 +74,27 @@ export function StepSupplier({
           <input type="hidden" value={form.supplierId} />
           {selectedSupplier && (
             <div className="mt-1 flex gap-2 flex-wrap">
-              <span className={`px-2 py-0.5 rounded-full text-xs font-medium leading-snug ${supplierHasVat ? 'bg-primary/10 text-primary dark:bg-primary/15' : 'bg-muted text-muted-foreground'}`}>
-                {supplierHasVat ? 'ผู้จัดจำหน่ายมี VAT - จะคำนวณ VAT 7% อัตโนมัติ' : 'ผู้จัดจำหน่ายไม่มี VAT'}
+              <span
+                className={`px-2 py-0.5 rounded-full text-xs font-medium leading-snug ${supplierHasVat ? 'bg-primary/10 text-primary dark:bg-primary/15' : 'bg-muted text-muted-foreground'}`}
+              >
+                {supplierHasVat
+                  ? 'ผู้จัดจำหน่ายมี VAT - จะคำนวณ VAT 7% อัตโนมัติ'
+                  : 'ผู้จัดจำหน่ายไม่มี VAT'}
               </span>
               {selectedSupplier.paymentMethods?.length > 0 && (
                 <span className="px-2 py-0.5 rounded-full text-xs font-medium leading-snug bg-primary/10 text-primary">
-                  ชำระ: {selectedSupplier.paymentMethods.map((pm) => {
-                    const labels: Record<string, string> = { CASH: 'เงินสด', BANK_TRANSFER: 'โอนธนาคาร', CHECK: 'เช็ค', CREDIT: 'เครดิต' };
-                    return labels[pm.paymentMethod] || pm.paymentMethod;
-                  }).join(', ')}
+                  ชำระ:{' '}
+                  {selectedSupplier.paymentMethods
+                    .map((pm) => {
+                      const labels: Record<string, string> = {
+                        CASH: 'เงินสด',
+                        BANK_TRANSFER: 'โอนธนาคาร',
+                        CHECK: 'เช็ค',
+                        CREDIT: 'เครดิต',
+                      };
+                      return labels[pm.paymentMethod] || pm.paymentMethod;
+                    })
+                    .join(', ')}
                 </span>
               )}
             </div>
@@ -61,12 +102,25 @@ export function StepSupplier({
         </div>
         <div className="grid grid-cols-2 gap-4">
           <div>
-            <label className="block text-2xs font-medium text-muted-foreground uppercase tracking-wider mb-2">วันที่สั่ง <span className="text-destructive">*</span></label>
-            <ThaiDateInput value={form.orderDate} onChange={(e) => setForm({ ...form, orderDate: e.target.value })} className={inputClass} required />
+            <label className="block text-2xs font-medium text-muted-foreground uppercase tracking-wider mb-2">
+              วันที่สั่ง <span className="text-destructive">*</span>
+            </label>
+            <ThaiDateInput
+              value={form.orderDate}
+              onChange={(e) => setForm({ ...form, orderDate: e.target.value })}
+              className={inputClass}
+              required
+            />
           </div>
           <div>
-            <label className="block text-2xs font-medium text-muted-foreground uppercase tracking-wider mb-2">วันที่คาดรับสินค้า</label>
-            <ThaiDateInput value={form.expectedDate} onChange={(e) => setForm({ ...form, expectedDate: e.target.value })} className={inputClass} />
+            <label className="block text-2xs font-medium text-muted-foreground uppercase tracking-wider mb-2">
+              วันที่คาดรับสินค้า
+            </label>
+            <ThaiDateInput
+              value={form.expectedDate}
+              onChange={(e) => setForm({ ...form, expectedDate: e.target.value })}
+              className={inputClass}
+            />
           </div>
         </div>
 
@@ -76,10 +130,14 @@ export function StepSupplier({
             {creditTermDays && dueDatePreview ? (
               <span className="text-foreground">
                 เครดิต <span className="font-semibold">{creditTermDays}</span> วัน → ครบกำหนดชำระ{' '}
-                <span className="font-semibold text-primary">{formatDateShort(dueDatePreview)}</span>
+                <span className="font-semibold text-primary">
+                  {formatDateShort(dueDatePreview)}
+                </span>
               </span>
             ) : (
-              <span className="text-muted-foreground">ไม่มีเครดิต (ชำระทันที) — ไม่มีวันครบกำหนด</span>
+              <span className="text-muted-foreground">
+                ไม่มีเครดิต (ชำระทันที) — ไม่มีวันครบกำหนด
+              </span>
             )}
           </div>
         )}

--- a/apps/web/src/pages/PurchaseOrdersPage/hooks/useCreatePoWizard.test.ts
+++ b/apps/web/src/pages/PurchaseOrdersPage/hooks/useCreatePoWizard.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useCreatePoWizard } from './useCreatePoWizard';
+import type { ItemForm } from '../types';
+
+const baseItem: ItemForm = { brand: 'Apple', category: 'PHONE_NEW', model: 'iPhone 16', color: '', storage: '', quantity: '2', unitPrice: '30000', accessoryType: '', accessoryBrand: '' };
+
+function makeOpts(overrides: Partial<Parameters<typeof useCreatePoWizard>[0]> = {}) {
+  const form = {
+    supplierId: 's1', orderDate: '2026-07-01', expectedDate: '', discount: '', discountAfterVat: '',
+    notes: '', paymentStatus: 'UNPAID', paymentMethod: '', paidAmount: '', paymentNotes: '',
+  };
+  return {
+    isOpen: true,
+    form,
+    setForm: vi.fn(),
+    items: [baseItem],
+    setItems: vi.fn(),
+    selectedSupplier: { id: 's1', name: 'ผู้ขาย ก', hasVat: true, paymentMethods: [{ paymentMethod: 'CREDIT', creditTermDays: 30, isDefault: true }] },
+    ...overrides,
+  } as Parameters<typeof useCreatePoWizard>[0];
+}
+
+describe('useCreatePoWizard', () => {
+  beforeEach(() => localStorage.clear());
+
+  it('step 0 (supplier) gate: requires a supplierId', () => {
+    const { result, rerender } = renderHook((p) => useCreatePoWizard(p), { initialProps: makeOpts({ selectedSupplier: undefined, form: { ...makeOpts().form, supplierId: '' } }) });
+    expect(result.current.step).toBe(0);
+    expect(result.current.canNext).toBe(false);
+    rerender(makeOpts()); // now supplier selected
+    expect(result.current.canNext).toBe(true);
+  });
+
+  it('step 1 (items) gate: every item needs category, quantity>0, unitPrice>0', () => {
+    const { result, rerender } = renderHook((p) => useCreatePoWizard(p), { initialProps: makeOpts() });
+    act(() => result.current.next()); // -> step 1
+    expect(result.current.step).toBe(1);
+    expect(result.current.canNext).toBe(true);
+    rerender(makeOpts({ items: [{ ...baseItem, unitPrice: '' }] }));
+    expect(result.current.canNext).toBe(false);
+  });
+
+  it('computes dueDatePreview = orderDate + default creditTermDays', () => {
+    const { result } = renderHook((p) => useCreatePoWizard(p), { initialProps: makeOpts() });
+    expect(result.current.creditTermDays).toBe(30);
+    // 2026-07-01 + 30 days = 2026-07-31
+    expect(result.current.dueDatePreview?.toISOString().slice(0, 10)).toBe('2026-07-31');
+  });
+
+  it('dueDatePreview follows the selected paymentMethod credit term', () => {
+    const opts = makeOpts({
+      form: { ...makeOpts().form, paymentMethod: 'CASH' },
+      selectedSupplier: { id: 's1', name: 'ก', hasVat: true, paymentMethods: [
+        { paymentMethod: 'CASH', creditTermDays: 0, isDefault: false },
+        { paymentMethod: 'CREDIT', creditTermDays: 45, isDefault: true },
+      ] },
+    });
+    const { result } = renderHook((p) => useCreatePoWizard(p), { initialProps: opts });
+    expect(result.current.creditTermDays).toBe(0); // CASH selected -> no credit term
+    expect(result.current.dueDatePreview).toBeNull();
+  });
+
+  it('saves a draft to localStorage and recovers it on a fresh mount', () => {
+    const setForm = vi.fn();
+    const setItems = vi.fn();
+    const { unmount } = renderHook((p) => useCreatePoWizard(p), { initialProps: makeOpts() });
+    // force an immediate save (the hook saves on form/items/step change, debounced via effect)
+    expect(localStorage.getItem('bestchoice-po-draft')).not.toBeNull();
+    unmount();
+    const { result } = renderHook((p) => useCreatePoWizard(p), { initialProps: makeOpts({ setForm, setItems }) });
+    expect(result.current.draftRecovered).toBe(true);
+    expect(setForm).toHaveBeenCalled();
+    expect(setItems).toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/pages/PurchaseOrdersPage/hooks/useCreatePoWizard.ts
+++ b/apps/web/src/pages/PurchaseOrdersPage/hooks/useCreatePoWizard.ts
@@ -1,0 +1,135 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { toast } from 'sonner';
+import { formatDateShort } from '@/utils/formatters';
+import type { ItemForm } from '../types';
+
+export const WIZARD_STEPS = ['เลือกผู้ขาย', 'เพิ่มรายการ', 'ส่วนลด/VAT', 'ทบทวน+บันทึก'];
+const LAST_STEP = WIZARD_STEPS.length - 1;
+
+const DRAFT_KEY = 'bestchoice-po-draft';
+const DRAFT_TTL_MS = 24 * 60 * 60 * 1000; // 24h, matches the contract-draft TTL
+
+type WizardForm = {
+  supplierId: string; orderDate: string; expectedDate: string; discount: string;
+  discountAfterVat: string; notes: string; paymentStatus: string; paymentMethod: string;
+  paidAmount: string; paymentNotes: string;
+};
+
+interface PoDraft {
+  step: number;
+  form: WizardForm;
+  items: ItemForm[];
+  savedAt: string;
+}
+
+export interface UseCreatePoWizardOptions {
+  isOpen: boolean;
+  form: WizardForm;
+  setForm: React.Dispatch<React.SetStateAction<WizardForm>>;
+  items: ItemForm[];
+  setItems: React.Dispatch<React.SetStateAction<ItemForm[]>>;
+  selectedSupplier:
+    | { id: string; name: string; hasVat: boolean; paymentMethods: { paymentMethod: string; creditTermDays?: number; isDefault: boolean }[] }
+    | undefined;
+}
+
+export interface CreatePoWizardApi {
+  step: number;
+  goToStep: (s: number) => void;
+  next: () => void;
+  back: () => void;
+  canNext: boolean;
+  dueDatePreview: Date | null;
+  creditTermDays: number | null;
+  draftRecovered: boolean;
+  clearDraft: () => void;
+}
+
+export function useCreatePoWizard(opts: UseCreatePoWizardOptions): CreatePoWizardApi {
+  const { isOpen, form, setForm, items, setItems, selectedSupplier } = opts;
+  const [step, setStep] = useState(0);
+  const [draftRecovered, setDraftRecovered] = useState(false);
+  const recoveredRef = useRef(false);
+
+  const clearDraft = useCallback(() => {
+    localStorage.removeItem(DRAFT_KEY);
+  }, []);
+
+  // Restore draft once per open
+  useEffect(() => {
+    if (!isOpen || recoveredRef.current) return;
+    recoveredRef.current = true;
+    const raw = localStorage.getItem(DRAFT_KEY);
+    if (!raw) return;
+    try {
+      const draft = JSON.parse(raw) as PoDraft;
+      if (new Date().getTime() - new Date(draft.savedAt).getTime() > DRAFT_TTL_MS) {
+        localStorage.removeItem(DRAFT_KEY);
+        return;
+      }
+      setForm(draft.form);
+      setItems(draft.items);
+      setStep(draft.step);
+      setDraftRecovered(true);
+      toast('พบใบสั่งซื้อร่างที่บันทึกไว้ — กู้คืนแล้ว', {
+        description: `บันทึกเมื่อ ${new Date(draft.savedAt).toLocaleString('th-TH')}`,
+        duration: 5000,
+      });
+    } catch {
+      localStorage.removeItem(DRAFT_KEY);
+    }
+  }, [isOpen, setForm, setItems]);
+
+  // Reset recovery latch when the modal closes so reopening recovers again
+  useEffect(() => {
+    if (!isOpen) {
+      recoveredRef.current = false;
+      setDraftRecovered(false);
+      setStep(0);
+    }
+  }, [isOpen]);
+
+  // Auto-save: persist on every form/items/step change while open (only if there is content)
+  useEffect(() => {
+    if (!isOpen) return;
+    const hasContent = !!form.supplierId || items.some((i) => i.category || i.unitPrice);
+    if (!hasContent) return;
+    const draft: PoDraft = { step, form, items, savedAt: new Date().toISOString() };
+    localStorage.setItem(DRAFT_KEY, JSON.stringify(draft));
+  }, [isOpen, step, form, items]);
+
+  // Credit-term-driven due-date preview (mirrors po-lifecycle.service.create():69-77)
+  const selectedPm = form.paymentMethod
+    ? selectedSupplier?.paymentMethods.find((pm) => pm.paymentMethod === form.paymentMethod)
+    : selectedSupplier?.paymentMethods.find((pm) => pm.isDefault) ?? selectedSupplier?.paymentMethods[0];
+  const creditTermDays = selectedPm?.creditTermDays ?? null;
+  let dueDatePreview: Date | null = null;
+  if (creditTermDays && form.orderDate) {
+    const dd = new Date(form.orderDate);
+    if (!Number.isNaN(dd.getTime())) {
+      dd.setDate(dd.getDate() + creditTermDays);
+      dueDatePreview = dd;
+    }
+  }
+
+  // Per-step advance gate
+  const itemsValid = items.length > 0 && items.every(
+    (i) => i.category && Number(i.quantity) > 0 && Number(i.unitPrice) > 0,
+  );
+  const canNext =
+    step === 0 ? !!form.supplierId :
+    step === 1 ? itemsValid :
+    true; // steps 2 & 3 are always advanceable (3 = submit handled by the form)
+
+  const goToStep = useCallback((s: number) => {
+    if (s >= 0 && s <= LAST_STEP) setStep(s);
+  }, []);
+  const next = useCallback(() => setStep((s) => Math.min(s + 1, LAST_STEP)), []);
+  const back = useCallback(() => setStep((s) => Math.max(s - 1, 0)), []);
+
+  // formatDateShort referenced so callers may render the preview consistently;
+  // exported preview is a Date so the panel can choose its own formatting.
+  void formatDateShort;
+
+  return { step, goToStep, next, back, canNext, dueDatePreview, creditTermDays, draftRecovered, clearDraft };
+}

--- a/apps/web/src/pages/PurchaseOrdersPage/hooks/useCreatePoWizard.ts
+++ b/apps/web/src/pages/PurchaseOrdersPage/hooks/useCreatePoWizard.ts
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';
-import { formatDateShort } from '@/utils/formatters';
 import type { ItemForm } from '../types';
 
 export const WIZARD_STEPS = ['เลือกผู้ขาย', 'เพิ่มรายการ', 'ส่วนลด/VAT', 'ทบทวน+บันทึก'];
@@ -127,9 +126,6 @@ export function useCreatePoWizard(opts: UseCreatePoWizardOptions): CreatePoWizar
   const next = useCallback(() => setStep((s) => Math.min(s + 1, LAST_STEP)), []);
   const back = useCallback(() => setStep((s) => Math.max(s - 1, 0)), []);
 
-  // formatDateShort referenced so callers may render the preview consistently;
-  // exported preview is a Date so the panel can choose its own formatting.
-  void formatDateShort;
-
+  // dueDatePreview is exported as a Date so each panel formats it (formatDateShort) itself.
   return { step, goToStep, next, back, canNext, dueDatePreview, creditTermDays, draftRecovered, clearDraft };
 }

--- a/apps/web/src/pages/PurchaseOrdersPage/hooks/usePOForm.ts
+++ b/apps/web/src/pages/PurchaseOrdersPage/hooks/usePOForm.ts
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { toast } from 'sonner';
 import { ItemForm } from '../types';
 import { emptyItem } from '../constants';
+import { computePoTotals } from '../poTotals';
 import { UseMutationResult } from '@tanstack/react-query';
 
 interface UsePOFormOptions {
@@ -119,17 +120,22 @@ export function usePOForm({ createMutation, suppliers }: UsePOFormOptions) {
     });
   };
 
-  const subtotal = items.reduce((sum, i) => sum + Number(i.quantity || 0) * Number(i.unitPrice || 0), 0);
   const selectedSupplier = suppliers.find((s) => s.id === form.supplierId);
   const supplierHasVat = selectedSupplier?.hasVat ?? false;
-  const discountNum = Math.min(Number(form.discount) || 0, subtotal);
-  const subtotalAfterDiscount = subtotal - discountNum;
-  const vatAmount = supplierHasVat ? Math.round(subtotalAfterDiscount * 0.07 * 100) / 100 : 0;
-  const totalWithVat = subtotalAfterDiscount + vatAmount;
-  const discountAfterVatNum = supplierHasVat
-    ? Math.min(Number(form.discountAfterVat) || 0, totalWithVat)
-    : 0;
-  const netAmount = totalWithVat - discountAfterVatNum;
+  const {
+    subtotal,
+    discountNum,
+    subtotalAfterDiscount,
+    vatAmount,
+    totalWithVat,
+    discountAfterVatNum,
+    netAmount,
+  } = computePoTotals({
+    items,
+    discount: form.discount,
+    discountAfterVat: form.discountAfterVat,
+    supplierHasVat,
+  });
 
   return {
     form,

--- a/apps/web/src/pages/PurchaseOrdersPage/index.tsx
+++ b/apps/web/src/pages/PurchaseOrdersPage/index.tsx
@@ -8,6 +8,8 @@ import { Download } from 'lucide-react';
 import { formatDateShort } from '@/utils/formatters';
 import { usePurchaseOrdersData } from './hooks/usePurchaseOrdersData';
 import { usePOForm } from './hooks/usePOForm';
+import { useCreatePoWizard } from './hooks/useCreatePoWizard';
+import { computePoTotals } from './poTotals';
 import { statusLabels, paymentStatusLabels } from './constants';
 import { QcPendingPanel } from './components/QcPendingPanel';
 import { POListTab } from './components/POListTab';
@@ -21,8 +23,10 @@ export default function PurchaseOrdersPage() {
   const resetFormRef = useRef<() => void>(() => {});
   const queryClient = useQueryClient();
 
+  const wizardClearRef = useRef<() => void>(() => {});
   const onCreateSuccess = useCallback(() => {
     resetFormRef.current();
+    wizardClearRef.current();
   }, []);
 
   const data = usePurchaseOrdersData({ onCreateSuccess });
@@ -35,6 +39,24 @@ export default function PurchaseOrdersPage() {
   // Keep ref in sync
   resetFormRef.current = poForm.resetForm;
 
+  const wizard = useCreatePoWizard({
+    isOpen: data.isCreateModalOpen,
+    form: poForm.form,
+    setForm: poForm.setForm,
+    items: poForm.items,
+    setItems: poForm.setItems,
+    selectedSupplier: poForm.selectedSupplier,
+  });
+
+  const totals = computePoTotals({
+    items: poForm.items,
+    discount: poForm.form.discount,
+    discountAfterVat: poForm.form.discountAfterVat,
+    supplierHasVat: poForm.supplierHasVat,
+  });
+
+  wizardClearRef.current = wizard.clearDraft;
+
   // Supplier selection handler: invalidate + refetch suppliers-for-po so a newly-created
   // supplier appears in the array, then set supplierId. The selectedSupplier/VAT/payment-method
   // computation in usePOForm keys off form.supplierId against the (refetched) suppliers array
@@ -44,7 +66,9 @@ export default function PurchaseOrdersPage() {
       // Invalidate and await refetch so the refetched suppliers array includes the chosen/newly-created supplier
       await queryClient.invalidateQueries({ queryKey: ['suppliers-for-po'] });
       // After invalidation the query will refetch; grab the updated list from the cache
-      const cached = queryClient.getQueryData<{ data: typeof data.suppliers }>(['suppliers-for-po']);
+      const cached = queryClient.getQueryData<{ data: typeof data.suppliers }>([
+        'suppliers-for-po',
+      ]);
       const updatedSuppliers = cached?.data ?? data.suppliers;
       const sup = updatedSuppliers.find((s) => s.id === childId);
       const defaultPm = sup?.paymentMethods?.find((pm) => pm.isDefault) ?? sup?.paymentMethods?.[0];
@@ -132,7 +156,9 @@ export default function PurchaseOrdersPage() {
         >
           ยอดค้างชำระ ( ผู้จัดจำหน่าย )
           {data.payableData && data.payableData.grandTotal > 0 && (
-            <span className="ml-1.5 px-2 py-0.5 rounded-full text-xs font-semibold bg-destructive/10 text-destructive dark:bg-destructive/15">{(Number(data.payableData.grandTotal) || 0).toLocaleString()}</span>
+            <span className="ml-1.5 px-2 py-0.5 rounded-full text-xs font-semibold bg-destructive/10 text-destructive dark:bg-destructive/15">
+              {(Number(data.payableData.grandTotal) || 0).toLocaleString()}
+            </span>
           )}
         </button>
       </div>
@@ -194,11 +220,16 @@ export default function PurchaseOrdersPage() {
         setAttachmentUrl={poForm.setAttachmentUrl}
         formAttachments={poForm.formAttachments}
         setFormAttachments={poForm.setFormAttachments}
+        wizard={wizard}
+        totals={totals}
       />
 
       <PODetailModal
         isOpen={data.isDetailModalOpen}
-        onClose={() => { data.setIsDetailModalOpen(false); data.setPODetail(null); }}
+        onClose={() => {
+          data.setIsDetailModalOpen(false);
+          data.setPODetail(null);
+        }}
         selectedPO={data.selectedPO}
         poDetail={data.poDetail}
         openReceiveModal={data.openReceiveModal}
@@ -222,7 +253,11 @@ export default function PurchaseOrdersPage() {
 
       <GoodsReceivingModal
         isOpen={data.isReceiveModalOpen}
-        onClose={() => { data.setIsReceiveModalOpen(false); data.setReceivingUnits([]); data.setReceivingNotes(''); }}
+        onClose={() => {
+          data.setIsReceiveModalOpen(false);
+          data.setReceivingUnits([]);
+          data.setReceivingNotes('');
+        }}
         selectedPO={data.selectedPO}
         receivingUnits={data.receivingUnits}
         setReceivingUnits={data.setReceivingUnits}

--- a/apps/web/src/pages/PurchaseOrdersPage/poTotals.test.ts
+++ b/apps/web/src/pages/PurchaseOrdersPage/poTotals.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { computePoTotals } from './poTotals';
+
+describe('computePoTotals — mirrors po-lifecycle.service.create()', () => {
+  it('no-VAT supplier: net = subtotal - discount, no VAT line', () => {
+    const t = computePoTotals({
+      items: [{ quantity: '2', unitPrice: '1000' }, { quantity: '1', unitPrice: '500' }],
+      discount: '300',
+      discountAfterVat: '999', // must be ignored when !hasVat
+      supplierHasVat: false,
+    });
+    expect(t.subtotal).toBe(2500);
+    expect(t.discountNum).toBe(300);
+    expect(t.subtotalAfterDiscount).toBe(2200);
+    expect(t.vatAmount).toBe(0);
+    expect(t.totalWithVat).toBe(2200);
+    expect(t.discountAfterVatNum).toBe(0);
+    expect(t.netAmount).toBe(2200);
+  });
+
+  it('VAT supplier: VAT = subtotalAfterDiscount * 0.07 ROUND_HALF_UP (half-satang rounds up)', () => {
+    // 1050 * 0.07 = 73.5 -> HALF_UP -> 73.5 (exact); use a value that lands on a half-satang
+    // 107.35 * 0.07 = 7.5145 -> 7.51 ; choose 100.50 -> 7.035 -> 7.04 (HALF_UP at 3rd dp 5)
+    const t = computePoTotals({
+      items: [{ quantity: '1', unitPrice: '100.50' }],
+      discount: '0',
+      discountAfterVat: '0',
+      supplierHasVat: true,
+    });
+    expect(t.subtotalAfterDiscount).toBe(100.5);
+    expect(t.vatAmount).toBe(7.04); // 7.035 rounds HALF_UP to 7.04
+    expect(t.totalWithVat).toBe(107.54);
+    expect(t.netAmount).toBe(107.54);
+  });
+
+  it('VAT supplier with both discounts: net = (sub-disc) + vat - discAfterVat', () => {
+    const t = computePoTotals({
+      items: [{ quantity: '10', unitPrice: '1000' }], // 10000
+      discount: '1000',                                // -> 9000
+      discountAfterVat: '500',
+      supplierHasVat: true,
+    });
+    expect(t.subtotalAfterDiscount).toBe(9000);
+    expect(t.vatAmount).toBe(630);        // 9000 * 0.07
+    expect(t.totalWithVat).toBe(9630);
+    expect(t.discountAfterVatNum).toBe(500);
+    expect(t.netAmount).toBe(9130);
+  });
+
+  it('clamps discount to subtotal and discountAfterVat to totalWithVat', () => {
+    const t = computePoTotals({
+      items: [{ quantity: '1', unitPrice: '100' }],
+      discount: '999',          // clamps to 100
+      discountAfterVat: '999',  // clamps to totalWithVat
+      supplierHasVat: true,
+    });
+    expect(t.discountNum).toBe(100);
+    expect(t.subtotalAfterDiscount).toBe(0);
+    expect(t.vatAmount).toBe(0);
+    expect(t.totalWithVat).toBe(0);
+    expect(t.discountAfterVatNum).toBe(0);
+    expect(t.netAmount).toBe(0);
+  });
+
+  it('treats empty/NaN quantity & price as 0', () => {
+    const t = computePoTotals({
+      items: [{ quantity: '', unitPrice: '' }, { quantity: '2', unitPrice: '50' }],
+      discount: '',
+      discountAfterVat: '',
+      supplierHasVat: false,
+    });
+    expect(t.subtotal).toBe(100);
+    expect(t.netAmount).toBe(100);
+  });
+});

--- a/apps/web/src/pages/PurchaseOrdersPage/poTotals.ts
+++ b/apps/web/src/pages/PurchaseOrdersPage/poTotals.ts
@@ -1,0 +1,56 @@
+// Single source of truth for the PO money breakdown shown in the create wizard.
+// Mirrors apps/api/src/modules/purchase-orders/services/po-lifecycle.service.ts
+// create() EXACTLY: subtotal -> minus discount -> VAT = subtotalAfterDiscount *
+// vatRate ROUND_HALF_UP (only when supplier.hasVat) -> minus discountAfterVat = net.
+// Backend uses Prisma.Decimal + ROUND_HALF_UP; on the client Math.round(x*100)/100
+// is HALF_UP at the satang place, matching usePOForm's prior inline math.
+
+export const VAT_RATE = 0.07;
+
+export interface PoTotalsInput {
+  items: { quantity: string; unitPrice: string }[];
+  discount: string;
+  discountAfterVat: string;
+  supplierHasVat: boolean;
+}
+
+export interface PoTotals {
+  subtotal: number;
+  discountNum: number;
+  subtotalAfterDiscount: number;
+  vatAmount: number;
+  totalWithVat: number;
+  discountAfterVatNum: number;
+  netAmount: number;
+}
+
+const round2 = (n: number) => Math.round(n * 100) / 100;
+
+export function computePoTotals({
+  items,
+  discount,
+  discountAfterVat,
+  supplierHasVat,
+}: PoTotalsInput): PoTotals {
+  const subtotal = items.reduce(
+    (sum, i) => sum + Number(i.quantity || 0) * Number(i.unitPrice || 0),
+    0,
+  );
+  const discountNum = Math.min(Number(discount) || 0, subtotal);
+  const subtotalAfterDiscount = subtotal - discountNum;
+  const vatAmount = supplierHasVat ? round2(subtotalAfterDiscount * VAT_RATE) : 0;
+  const totalWithVat = subtotalAfterDiscount + vatAmount;
+  const discountAfterVatNum = supplierHasVat
+    ? Math.min(Number(discountAfterVat) || 0, totalWithVat)
+    : 0;
+  const netAmount = totalWithVat - discountAfterVatNum;
+  return {
+    subtotal,
+    discountNum,
+    subtotalAfterDiscount,
+    vatAmount,
+    totalWithVat,
+    discountAfterVatNum,
+    netAmount,
+  };
+}


### PR DESCRIPTION
## Purchasing & Receiving v2 — Batch B2 (สร้าง PO 4-step wizard + transparent VAT)

> ⚠️ **Stacked on B1 (#1303) → B0 (#1302).** Base is `feat/purchasing-v2-b1`, so this PR's diff shows ONLY B2's changes. **Merge order: #1302 → #1303 → this.** GitHub auto-retargets each PR's base when its parent merges.

**Frontend-only.** Rebuilds the one-long "สร้างใบสั่งซื้อ" modal into a guided 4-step wizard. The `POST /purchase-orders` (`CreatePODto`) contract and `usePOForm.handleCreate` payload are **UNCHANGED** — pure front-of-glass.

Spec: `docs/superpowers/specs/2026-06-29-purchasing-receiving-ux-v2-design.md`
Plan: `docs/superpowers/plans/2026-06-29-purchasing-b2-create-wizard.md`

### What's in it
| # | Change |
|---|---|
| 1 | `computePoTotals` — a pure, unit-tested breakdown calculator extracted from `usePOForm`, the **single source of truth** that mirrors `po-lifecycle.service.create()` (subtotal → −discount → VAT 7% ROUND_HALF_UP if hasVat → −discountAfterVat = net). |
| 2 | `useCreatePoWizard` — step index + per-step `canNext` gate + credit-term due-date preview + a localStorage draft (`bestchoice-po-draft`, 24h TTL, recover-on-open, clear-on-success). |
| 3 | `StepSupplier` (supplier + **due-date preview**) and `StepItems` (item editor + **running subtotal**). |
| 4 | `StepDiscountVat` — a **transparent line-by-line breakdown** (subtotal → ส่วนลด → หลังหักส่วนลด → VAT 7% → รวม VAT → ส่วนลดหลัง VAT → ยอดสุทธิ) with a "วิธีคิด:" explainer; VAT lines hidden for no-VAT suppliers. |
| 5 | `StepReview` — read-only summary + the existing payment/attachments/notes controls (lifted verbatim). |
| 6 | `CreatePOModal` rebuilt as the wizard shell (header + clickable stepper + active panel + step-aware footer). |

### Why the math is trustworthy
`computePoTotals` is consumed by BOTH `usePOForm` (which still builds the POST payload from the raw form) and the page-level `totals` fed to the wizard — so **the net the user reviews is provably the same number that builds the saved PO**. Five golden tests pin the chain, including the half-satang ROUND_HALF_UP case (`100.50 × 0.07 = 7.035 → 7.04`) and both clamp directions. (Documented deviation: the client keeps `VAT_RATE = 0.07` hardcoded to match the prior `usePOForm` behavior and avoid a network call; the backend's saved `netAmount` remains authoritative.)

### Frontend rules & red line (verified holistically)
- ✅ Design **tokens only** — no `text-gray-*`/`bg-gray-*`/hex/`bg-white` (no print page in this batch).
- ✅ `leading-snug` on all Thai text; react-query + `@/lib/api` only; `sonner`.
- ✅ **No** accounting/finance/journal/expense/tax import; zero backend/schema/money-posting touch.
- ✅ Submit-safe: the wizard `<form>` has exactly one `type="submit"` (step 4); steps 1-3 advance via `type="button"`.
- ✅ Draft excludes base64 attachments (no localStorage bloat); cleared on successful create.

### Verification
- `./tools/check-types.sh all` → **0 errors** (API + Web)
- Full web `vitest run` → **801/801 pass** (incl. 10 new `poTotals` + `useCreatePoWizard` tests)
- Each task: TDD for the pure units + two-stage subagent review; final whole-branch review on Opus = **READY TO MERGE** (no Critical/Important; all Minors triaged acceptable).

### Notes
- The local DB/app was unreachable, so verification is type-check + vitest + review (no manual browser pass). A manual desktop run of the wizard (incl. the draft recover + the net-matches-saved cross-check) is recommended before final sign-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
