### PR TITLE
Purchasing v2 — B3: mobile-first receiving + supplier-direct receive (auto-PO, JE-free)

### DIFF
--- a/apps/api/src/modules/purchase-orders/dto/create-po.dto.ts
+++ b/apps/api/src/modules/purchase-orders/dto/create-po.dto.ts
@@ -224,3 +224,46 @@ export class GoodsReceivingDto {
   @IsOptional()
   notes?: string;
 }
+
+export class DirectReceiveItemDto {
+  // Product spec (mirrors POItemDto)
+  @IsString() @IsOptional() brand?: string;
+  @IsString() @IsOptional() model?: string;
+  @IsString() @IsOptional() color?: string;
+  @IsString() @IsOptional() storage?: string;
+  @IsString() @IsOptional() category?: string;
+  @IsString() @IsOptional() accessoryType?: string;
+  @IsString() @IsOptional() accessoryBrand?: string;
+
+  // One DTO item = one physical unit.
+  @IsNumber() @Min(1) quantity: number;
+
+  // costPrice (booked as POItem.unitPrice; copied into Product.costPrice by goodsReceiving). MANDATORY for COGS.
+  @IsNumber() @Min(0.01, { message: 'กรุณาระบุราคาทุน (costPrice) มากกว่า 0' }) unitPrice: number;
+
+  // Per-unit receiving fields (mirror GoodsReceivingItemDto)
+  @IsString() @IsOptional() imeiSerial?: string;
+  @IsString() @IsOptional() serialNumber?: string;
+  @IsArray() @IsOptional() photos?: string[];
+  @IsIn(['PASS', 'REJECT']) status: 'PASS' | 'REJECT';
+  @IsString() @IsOptional() rejectReason?: string;
+  @IsEnum(DefectReason) @IsOptional() defectReason?: DefectReason;
+  @IsNumber() @IsOptional() batteryHealth?: number;
+  @IsBoolean() @IsOptional() warrantyExpired?: boolean;
+  @IsString() @IsOptional() warrantyExpireDate?: string;
+  @IsBoolean() @IsOptional() hasBox?: boolean;
+  @IsArray() @IsOptional() @ValidateNested({ each: true }) @Type(() => ChecklistResultDto)
+  checklistResults?: ChecklistResultDto[];
+  @IsNumber() @IsOptional() @Min(0) sellingPrice?: number;
+}
+
+export class DirectReceiveDto {
+  @IsString() supplierId: string;
+
+  @IsDateString() orderDate: string;
+
+  @IsString() @IsOptional() notes?: string;
+
+  @IsArray() @ArrayMinSize(1) @ValidateNested({ each: true }) @Type(() => DirectReceiveItemDto)
+  items: DirectReceiveItemDto[];
+}

--- a/apps/api/src/modules/purchase-orders/purchase-orders.controller.ts
+++ b/apps/api/src/modules/purchase-orders/purchase-orders.controller.ts
@@ -1,7 +1,7 @@
 import { Controller, Get, Post, Patch, Body, Param, Query, UseGuards } from '@nestjs/common';
 import { ApiTags, ApiBearerAuth } from '@nestjs/swagger';
 import { PurchaseOrdersService } from './purchase-orders.service';
-import { CreatePODto, UpdatePODto, GoodsReceivingDto, UpdatePaymentDto, RejectPODto, OrderPODto } from './dto/create-po.dto';
+import { CreatePODto, UpdatePODto, GoodsReceivingDto, UpdatePaymentDto, RejectPODto, OrderPODto, DirectReceiveDto } from './dto/create-po.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { RolesGuard } from '../auth/guards/roles.guard';
 import { BranchGuard } from '../auth/guards/branch.guard';
@@ -72,6 +72,15 @@ export class PurchaseOrdersController {
   @Roles('OWNER', 'BRANCH_MANAGER')
   confirmQC(@Body('productIds') productIds: string[]) {
     return this.purchaseOrdersService.confirmQC(productIds);
+  }
+
+  @Post('direct-receive')
+  @Roles('OWNER', 'BRANCH_MANAGER')
+  directReceive(
+    @Body() dto: DirectReceiveDto,
+    @CurrentUser() user: { id: string },
+  ) {
+    return this.purchaseOrdersService.directReceive(dto, user.id);
   }
 
   // === Parametric :id routes ===

--- a/apps/api/src/modules/purchase-orders/purchase-orders.direct-receive.spec.ts
+++ b/apps/api/src/modules/purchase-orders/purchase-orders.direct-receive.spec.ts
@@ -1,0 +1,117 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { PurchaseOrdersService } from './purchase-orders.service';
+import { PrismaService } from '../../prisma/prisma.service';
+
+/**
+ * B3 supplier-direct receive = auto-PO. ONE $transaction:
+ *  create PO (isDirectReceive, unitPrice=costPrice) -> set APPROVED/ORDERED
+ *  (approval-bypass + AuditLog) -> run goodsReceiving() to make GR + products.
+ * No JE; poId never null.
+ */
+describe('PurchaseOrdersService.directReceive — auto-PO supplier receive', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const makeTx = () => {
+    const created: Record<string, unknown[]> = {
+      po: [], poUpdate: [], audit: [], gr: [], gri: [], product: [], price: [], poItemUpdate: [],
+    };
+    const poItems = [{ id: 'poi-1', category: 'PHONE_NEW', brand: 'Apple', model: 'iPhone 16',
+      color: null, storage: '256GB', accessoryType: null, accessoryBrand: null,
+      quantity: 1, receivedQty: 0, unitPrice: 30000 }];
+    const tx: any = {
+      purchaseOrder: {
+        count: jest.fn().mockResolvedValue(2),
+        create: jest.fn().mockImplementation(({ data }) => {
+          created.po.push(data);
+          return Promise.resolve({ id: 'po-new', poNumber: 'PO-2099-01-003', supplierId: data.supplierId,
+            status: data.status, isDirectReceive: data.isDirectReceive, deletedAt: null,
+            supplier: { id: data.supplierId, name: 'ACME' },
+            items: poItems });
+        }),
+        findUnique: jest.fn().mockImplementation(() => Promise.resolve({ id: 'po-new', status: 'ORDERED',
+          deletedAt: null, supplierId: 'sup-1', supplier: { id: 'sup-1', name: 'ACME' },
+          items: poItems.map((i) => ({ ...i })) })),
+        update: jest.fn().mockImplementation(({ data }) => { created.poUpdate.push(data); return Promise.resolve({ id: 'po-new', status: data.status }); }),
+      },
+      auditLog: { create: jest.fn().mockImplementation(({ data }) => { created.audit.push(data); return Promise.resolve({}); }) },
+      supplier: { findUnique: jest.fn().mockResolvedValue({ id: 'sup-1', deletedAt: null }) },
+      branch: { findFirst: jest.fn().mockResolvedValue({ id: 'wh', name: 'คลังกลาง' }) },
+      goodsReceiving: { create: jest.fn().mockResolvedValue({ id: 'gr1' }), count: jest.fn().mockResolvedValue(0) },
+      goodsReceivingItem: { create: jest.fn().mockImplementation(({ data }) => { created.gri.push(data); return Promise.resolve({ id: 'gri1', ...data }); }) },
+      pOItem: {
+        findMany: jest.fn().mockImplementation(({ where: { id: { in: ids } } }) =>
+          Promise.resolve(poItems.filter((i) => ids.includes(i.id)).map((i) => ({ ...i })))),
+        update: jest.fn().mockImplementation(({ data }) => { created.poItemUpdate.push(data); return Promise.resolve({}); }),
+      },
+      product: {
+        create: jest.fn().mockImplementation(({ data }) => { created.product.push(data); return Promise.resolve({ id: 'prod-1', ...data }); }),
+        findMany: jest.fn().mockResolvedValue([]),
+      },
+      productPrice: { create: jest.fn().mockImplementation(({ data }) => { created.price.push(data); return Promise.resolve({}); }) },
+    };
+    return { tx, created };
+  };
+
+  const build = async (prisma: any) => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [PurchaseOrdersService, { provide: PrismaService, useValue: prisma }],
+    }).compile();
+    return module.get<PurchaseOrdersService>(PurchaseOrdersService);
+  };
+
+  const baseDto = () => ({
+    supplierId: 'sup-1',
+    orderDate: '2099-01-15',
+    items: [{
+      category: 'PHONE_NEW', brand: 'Apple', model: 'iPhone 16', storage: '256GB',
+      quantity: 1, unitPrice: 30000, status: 'PASS', imeiSerial: 'IMEI-1', serialNumber: 'SN-1', sellingPrice: 39900,
+    }],
+  });
+
+  it('creates an isDirectReceive PO at ORDERED, writes an approval-bypass AuditLog, and runs goodsReceiving', async () => {
+    const { tx, created } = makeTx();
+    const prisma: any = { $transaction: jest.fn().mockImplementation((fn: any) => fn(tx)) };
+    const service = await build(prisma);
+
+    const result = await service.directReceive(baseDto() as never, 'user-1');
+
+    // PO created with the auto-PO flags + cost as unitPrice
+    expect(created.po[0]).toEqual(expect.objectContaining({ supplierId: 'sup-1', isDirectReceive: true, status: 'APPROVED' }));
+    expect((created.po[0] as any).items.create[0]).toEqual(expect.objectContaining({ unitPrice: 30000, quantity: 1 }));
+    // advanced APPROVED -> ORDERED
+    expect(created.poUpdate.some((u: any) => u.status === 'ORDERED' && u.orderedAt instanceof Date)).toBe(true);
+    // approval-bypass audit row
+    expect(created.audit[0]).toEqual(expect.objectContaining({ userId: 'user-1', action: 'PO_DIRECT_RECEIVE_APPROVAL_BYPASS', entity: 'purchase_order', entityId: 'po-new' }));
+    // product created with costPrice from unitPrice
+    expect(created.product[0]).toEqual(expect.objectContaining({ costPrice: 30000, imeiSerial: 'IMEI-1' }));
+    // GR result surfaced
+    expect(result).toEqual(expect.objectContaining({ poId: 'po-new', poNumber: 'PO-2099-01-003', receivingId: 'gr1', passed: 1, rejected: 0 }));
+  });
+
+  it('rejects a missing/zero costPrice (COGS would silently break)', async () => {
+    const { tx } = makeTx();
+    const prisma: any = { $transaction: jest.fn().mockImplementation((fn: any) => fn(tx)) };
+    const service = await build(prisma);
+    const dto = baseDto();
+    dto.items[0].unitPrice = 0;
+    await expect(service.directReceive(dto as never, 'user-1')).rejects.toThrow(BadRequestException);
+  });
+
+  it('rejects when the supplier does not exist', async () => {
+    const { tx } = makeTx();
+    tx.supplier.findUnique = jest.fn().mockResolvedValue(null);
+    const prisma: any = { $transaction: jest.fn().mockImplementation((fn: any) => fn(tx)) };
+    const service = await build(prisma);
+    await expect(service.directReceive(baseDto() as never, 'user-1')).rejects.toThrow(NotFoundException);
+  });
+
+  it('persists structured defectReason on a REJECT unit', async () => {
+    const { tx, created } = makeTx();
+    const prisma: any = { $transaction: jest.fn().mockImplementation((fn: any) => fn(tx)) };
+    const service = await build(prisma);
+    const dto = baseDto();
+    dto.items[0] = { ...dto.items[0], status: 'REJECT', rejectReason: 'จอแตก', defectReason: 'SCREEN' } as never;
+    await service.directReceive(dto as never, 'user-1');
+    expect(created.gri[0]).toEqual(expect.objectContaining({ status: 'REJECT', defectReason: 'SCREEN', rejectReason: 'จอแตก' }));
+  });
+});

--- a/apps/api/src/modules/purchase-orders/purchase-orders.service.ts
+++ b/apps/api/src/modules/purchase-orders/purchase-orders.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../../prisma/prisma.service';
-import { CreatePODto, UpdatePODto, GoodsReceivingDto, UpdatePaymentDto, OrderPODto } from './dto/create-po.dto';
+import { CreatePODto, UpdatePODto, GoodsReceivingDto, UpdatePaymentDto, OrderPODto, DirectReceiveDto } from './dto/create-po.dto';
 import { PoQueryService } from './services/po-query.service';
 import { PoLifecycleService } from './services/po-lifecycle.service';
 import { PoReceivingService } from './services/po-receiving.service';
@@ -89,6 +89,10 @@ export class PurchaseOrdersService {
 
   goodsReceiving(id: string, dto: GoodsReceivingDto, userId: string) {
     return this.receiving.goodsReceiving(id, dto, userId);
+  }
+
+  directReceive(dto: DirectReceiveDto, userId: string) {
+    return this.receiving.directReceive(dto, userId);
   }
 
   confirmQC(productIds: string[]) {

--- a/apps/api/src/modules/purchase-orders/services/po-receiving.service.ts
+++ b/apps/api/src/modules/purchase-orders/services/po-receiving.service.ts
@@ -1,9 +1,9 @@
 import { NotFoundException, BadRequestException } from '@nestjs/common';
 import { Prisma, ProductCategory } from '@prisma/client';
 import { PrismaService } from '../../../prisma/prisma.service';
-import { GoodsReceivingDto } from '../dto/create-po.dto';
+import { GoodsReceivingDto, DirectReceiveDto } from '../dto/create-po.dto';
 import { buildProductName } from './po-product-naming.util';
-import { generateGRNumber } from '../../../utils/sequence.util';
+import { generateGRNumber, generatePONumber } from '../../../utils/sequence.util';
 
 /**
  * Inventory-mutating goods-receiving flows. Owns the 2 write transactions:
@@ -34,227 +34,357 @@ export class PoReceivingService {
     for (let attempt = 1; ; attempt++) {
       try {
         return await this.prisma.$transaction(
+          async (tx) => this.runReceiveInTx(tx, id, dto, userId),
+          { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
+        );
+      } catch (e) {
+        const code = (e as { code?: string })?.code;
+        if ((code === 'P2002' || code === 'P2034') && attempt < MAX_ATTEMPTS) continue;
+        throw e;
+      }
+    }
+  }
+
+  /**
+   * Shared per-unit receiving pipeline. Runs INSIDE a caller-provided
+   * Serializable tx (standard goodsReceiving OR direct-receive auto-PO).
+   * Closure-bound tx — never crosses a service boundary. T5-C16 ceiling
+   * re-read + IMEI dup guard + product create + POItem.update + status
+   * recompute all live here, unchanged.
+   */
+  private async runReceiveInTx(
+    tx: Prisma.TransactionClient,
+    id: string,
+    dto: GoodsReceivingDto,
+    userId: string,
+  ) {
+    const po = await tx.purchaseOrder.findUnique({
+      where: { id },
+      include: { items: true, supplier: true },
+    });
+
+    if (!po || po.deletedAt) throw new NotFoundException('ไม่พบใบสั่งซื้อ');
+    if (!['APPROVED', 'ORDERED', 'PARTIALLY_RECEIVED'].includes(po.status)) {
+      throw new BadRequestException('PO นี้ไม่อยู่ในสถานะที่สามารถรับสินค้าได้ (ต้อง APPROVED, ORDERED หรือ PARTIALLY_RECEIVED)');
+    }
+
+    // Find main warehouse branch
+    let mainWarehouse = await tx.branch.findFirst({
+      where: { isMainWarehouse: true, isActive: true, deletedAt: null },
+    });
+    if (!mainWarehouse) {
+      // Fallback: use first active branch
+      mainWarehouse = await tx.branch.findFirst({
+        where: { isActive: true, deletedAt: null },
+        orderBy: { createdAt: 'asc' },
+      });
+    }
+    if (!mainWarehouse) {
+      throw new BadRequestException('ไม่พบคลังกลาง กรุณาตั้งค่าสาขาคลังกลางก่อน');
+    }
+
+    // Generate GR number inside the serializable tx; @unique is the backstop.
+    const grNumber = await generateGRNumber(tx);
+    const receiving = await tx.goodsReceiving.create({
+      data: {
+        grNumber,
+        poId: id,
+        receivedById: userId,
+        notes: dto.notes,
+      },
+    });
+
+    const passedProducts: Awaited<ReturnType<typeof tx.product.update>>[] = [];
+    const rejectedItems: Awaited<ReturnType<typeof tx.goodsReceivingItem.create>>[] = [];
+
+    // Group items by poItemId to count per PO item
+    const countByPoItem: Record<string, number> = {};
+    for (const item of dto.items) {
+      if (item.status === 'PASS') {
+        countByPoItem[item.poItemId] = (countByPoItem[item.poItemId] || 0) + 1;
+      }
+    }
+
+    // T5-C16: Re-read POItem rows inside the serializable tx to get the
+    // authoritative receivedQty at this instant. Any parallel GR batch
+    // that committed before us will be visible here; any that commits
+    // after us will be serialized and retry. `countByPoItem` inside this
+    // batch is already aggregated to avoid double-counting when the same
+    // poItemId appears twice in dto.items.
+    const freshPoItems = await tx.pOItem.findMany({
+      where: { id: { in: Object.keys(countByPoItem) } },
+      select: { id: true, quantity: true, receivedQty: true, brand: true, model: true },
+    });
+    const freshByPoItem = new Map(freshPoItems.map((p) => [p.id, p]));
+
+    // Validate quantities using fresh DB rows (not cached po.items)
+    for (const [poItemId, passCount] of Object.entries(countByPoItem)) {
+      const fresh = freshByPoItem.get(poItemId);
+      if (!fresh) throw new NotFoundException(`ไม่พบรายการ PO: ${poItemId}`);
+
+      const totalReceived = fresh.receivedQty + passCount;
+      if (totalReceived > fresh.quantity) {
+        throw new BadRequestException(
+          `จำนวนรับเกิน: ${fresh.brand ?? ''} ${fresh.model ?? ''} (สั่ง ${fresh.quantity}, รับแล้ว ${fresh.receivedQty}, กำลังรับ ${passCount})`,
+        );
+      }
+    }
+
+    // Validate duplicate IMEI/Serial in this batch
+    const imeiList = dto.items
+      .filter((i) => i.status === 'PASS' && i.imeiSerial)
+      .map((i) => i.imeiSerial!);
+    const uniqueImeis = new Set(imeiList);
+    if (uniqueImeis.size !== imeiList.length) {
+      throw new BadRequestException('พบ IMEI ซ้ำกันในรายการที่กำลังรับเข้า');
+    }
+
+    // Validate IMEI not already exists in system (include soft-deleted due to DB unique constraint)
+    if (imeiList.length > 0) {
+      const existingProducts = await tx.product.findMany({
+        where: { imeiSerial: { in: imeiList } },
+        select: { imeiSerial: true, name: true, deletedAt: true },
+      });
+      if (existingProducts.length > 0) {
+        const dupes = existingProducts.map((p) => {
+          const suffix = p.deletedAt ? ' [ตัดจำหน่ายแล้ว]' : '';
+          return `${p.imeiSerial} (${p.name}${suffix})`;
+        }).join(', ');
+        throw new BadRequestException(`IMEI ซ้ำกับสินค้าที่มีในระบบแล้ว: ${dupes}`);
+      }
+    }
+
+    // Process each item
+    for (const item of dto.items) {
+      const poItem = po.items.find((i) => i.id === item.poItemId);
+      if (!poItem) throw new NotFoundException(`ไม่พบรายการ PO: ${item.poItemId}`);
+
+      if (item.status === 'PASS') {
+        // Build product name from PO item details
+        const productCategory = (poItem.category as ProductCategory) || 'PHONE_NEW';
+        const productName = buildProductName(poItem, productCategory);
+
+        // Create product for passed items
+        // PHONE_USED → PHOTO_PENDING (ต้องถ่ายรูป 6 มุมก่อนเข้าคลัง)
+        // PHONE_NEW / ACCESSORY → IN_STOCK (เข้าคลังได้เลย)
+        const initialStatus = productCategory === 'PHONE_USED' ? 'PHOTO_PENDING' : 'IN_STOCK';
+        const product = await tx.product.create({
+          data: {
+            name: productName,
+            brand: poItem.brand || '',
+            model: poItem.model || '',
+            color: poItem.color || null,
+            storage: poItem.storage || null,
+            category: productCategory,
+            costPrice: Number(poItem.unitPrice),
+            supplierId: po.supplierId,
+            poId: po.id,
+            branchId: mainWarehouse!.id,
+            status: initialStatus,
+            imeiSerial: item.imeiSerial || null,
+            serialNumber: item.serialNumber || null,
+            photos: item.photos || [],
+            batteryHealth: item.batteryHealth ?? null,
+            warrantyExpired: item.warrantyExpired ?? null,
+            warrantyExpireDate: item.warrantyExpireDate ? new Date(item.warrantyExpireDate) : null,
+            hasBox: item.hasBox ?? null,
+            checklistResults: item.checklistResults ? (item.checklistResults as unknown as Prisma.InputJsonValue) : undefined,
+            accessoryType: poItem.accessoryType || null,
+            accessoryBrand: poItem.accessoryBrand || null,
+          },
+        });
+
+        // Create selling price if provided
+        if (item.sellingPrice && item.sellingPrice > 0) {
+          await tx.productPrice.create({
+            data: {
+              productId: product.id,
+              label: 'ราคาขาย',
+              amount: item.sellingPrice,
+              isDefault: true,
+            },
+          });
+        }
+
+        // Create receiving item linked to product
+        await tx.goodsReceivingItem.create({
+          data: {
+            receivingId: receiving.id,
+            poItemId: item.poItemId,
+            imeiSerial: item.imeiSerial,
+            serialNumber: item.serialNumber,
+            photos: item.photos || [],
+            status: 'PASS',
+            productId: product.id,
+            batteryHealth: item.batteryHealth ?? null,
+            warrantyExpired: item.warrantyExpired ?? null,
+            warrantyExpireDate: item.warrantyExpireDate ? new Date(item.warrantyExpireDate) : null,
+            hasBox: item.hasBox ?? null,
+            checklistResults: item.checklistResults ? (item.checklistResults as unknown as Prisma.InputJsonValue) : undefined,
+          },
+        });
+
+        passedProducts.push(product);
+      } else {
+        // Create receiving item for rejected items (no product created)
+        const rejectedItem = await tx.goodsReceivingItem.create({
+          data: {
+            receivingId: receiving.id,
+            poItemId: item.poItemId,
+            imeiSerial: item.imeiSerial,
+            serialNumber: item.serialNumber,
+            photos: item.photos || [],
+            status: 'REJECT',
+            rejectReason: item.rejectReason,
+            defectReason: item.defectReason ?? null,
+          },
+        });
+
+        rejectedItems.push(rejectedItem);
+      }
+    }
+
+    // T5-C16: Update PO item received quantities using fresh values
+    // (not cached po.items which could be stale against a parallel tx).
+    for (const [poItemId, passCount] of Object.entries(countByPoItem)) {
+      const fresh = freshByPoItem.get(poItemId)!;
+      await tx.pOItem.update({
+        where: { id: poItemId },
+        data: { receivedQty: fresh.receivedQty + passCount },
+      });
+    }
+
+    // Check if all items fully received
+    const updatedPO = await tx.purchaseOrder.findUnique({
+      where: { id },
+      include: { items: true },
+    });
+
+    const allReceived = updatedPO!.items.every((item) => item.receivedQty >= item.quantity);
+    const newStatus = allReceived ? 'FULLY_RECEIVED' : 'PARTIALLY_RECEIVED';
+
+    await tx.purchaseOrder.update({
+      where: { id },
+      data: { status: newStatus },
+    });
+
+    return {
+      receivingId: receiving.id,
+      grNumber,
+      poId: id,
+      status: newStatus,
+      passed: passedProducts.length,
+      rejected: rejectedItems.length,
+      products: passedProducts,
+      mainWarehouse: mainWarehouse!.name,
+    };
+  }
+
+  /**
+   * B3 — Supplier-direct receive ("รับเข้าตรง") = auto-PO.
+   *
+   * Urgent buys from a vendor with no pre-made PO. Instead of threading a
+   * nullable poId through the PO-centric read paths, we auto-create a REAL PO
+   * (supplier + line items, unitPrice = costPrice) and advance it
+   * APPROVED -> ORDERED in ONE Serializable $transaction, bypassing the OWNER
+   * approval gate (audited), then run the existing receiving pipeline.
+   * Net: GoodsReceiving.poId is never null; GR history / AP / progress / the
+   * T5-C16 ceiling check all work unchanged. JE-FREE — no accounting touch.
+   */
+  async directReceive(dto: DirectReceiveDto, userId: string) {
+    // Up-front guard: every line must carry a positive costPrice (COGS reads it).
+    const badCost = dto.items.find((i) => !(Number(i.unitPrice) > 0));
+    if (badCost) {
+      throw new BadRequestException('กรุณาระบุราคาทุน (costPrice) มากกว่า 0 ให้ครบทุกรายการ');
+    }
+
+    const MAX_ATTEMPTS = 3;
+    for (let attempt = 1; ; attempt++) {
+      try {
+        return await this.prisma.$transaction(
           async (tx) => {
-            const po = await tx.purchaseOrder.findUnique({
-              where: { id },
-              include: { items: true, supplier: true },
-            });
+            // 1) Validate supplier
+            const supplier = await tx.supplier.findUnique({ where: { id: dto.supplierId } });
+            if (!supplier || supplier.deletedAt) throw new NotFoundException('ไม่พบ Supplier');
 
-            if (!po || po.deletedAt) throw new NotFoundException('ไม่พบใบสั่งซื้อ');
-            if (!['APPROVED', 'PARTIALLY_RECEIVED'].includes(po.status)) {
-              throw new BadRequestException('PO นี้ไม่อยู่ในสถานะที่สามารถรับสินค้าได้ (ต้อง APPROVED หรือ PARTIALLY_RECEIVED)');
-            }
-
-            // Find main warehouse branch
-            let mainWarehouse = await tx.branch.findFirst({
-              where: { isMainWarehouse: true, isActive: true, deletedAt: null },
-            });
-            if (!mainWarehouse) {
-              // Fallback: use first active branch
-              mainWarehouse = await tx.branch.findFirst({
-                where: { isActive: true, deletedAt: null },
-                orderBy: { createdAt: 'asc' },
-              });
-            }
-            if (!mainWarehouse) {
-              throw new BadRequestException('ไม่พบคลังกลาง กรุณาตั้งค่าสาขาคลังกลางก่อน');
-            }
-
-            // Generate GR number inside the serializable tx; @unique is the backstop.
-            const grNumber = await generateGRNumber(tx);
-            const receiving = await tx.goodsReceiving.create({
+            // 2) Create the auto-PO (unitPrice = costPrice). Starts APPROVED so the
+            //    OWNER approval gate is structurally bypassed (audited at step 4).
+            const poNumber = await generatePONumber(tx);
+            const totalAmount = dto.items.reduce((s, i) => s + Number(i.unitPrice) * i.quantity, 0);
+            const po = await tx.purchaseOrder.create({
               data: {
-                grNumber,
-                poId: id,
-                receivedById: userId,
-                notes: dto.notes,
+                poNumber,
+                supplierId: dto.supplierId,
+                orderDate: new Date(dto.orderDate),
+                totalAmount,
+                netAmount: totalAmount, // direct receive: no VAT/discount math
+                notes: dto.notes ?? null,
+                createdById: userId,
+                approvedById: userId,
+                status: 'APPROVED',
+                isDirectReceive: true,
+                paymentStatus: 'UNPAID',
+                items: {
+                  create: dto.items.map((i) => ({
+                    brand: i.brand || null,
+                    model: i.model || null,
+                    color: i.color || null,
+                    storage: i.storage || null,
+                    category: i.category || null,
+                    accessoryType: i.accessoryType || null,
+                    accessoryBrand: i.accessoryBrand || null,
+                    quantity: i.quantity,
+                    unitPrice: i.unitPrice,
+                  })),
+                },
+              },
+              include: { items: true, supplier: { select: { id: true, name: true } } },
+            });
+
+            // 3) Advance APPROVED -> ORDERED (mirrors PoLifecycleService.order from B0)
+            await tx.purchaseOrder.update({
+              where: { id: po.id },
+              data: { status: 'ORDERED', orderedAt: new Date() },
+            });
+
+            // 4) Audit the approval-bypass (no cross-module import — auditLog is on PrismaService)
+            await tx.auditLog.create({
+              data: {
+                userId,
+                action: 'PO_DIRECT_RECEIVE_APPROVAL_BYPASS',
+                entity: 'purchase_order',
+                entityId: po.id,
+                newValue: {
+                  poNumber: po.poNumber,
+                  supplierId: dto.supplierId,
+                  isDirectReceive: true,
+                  reason: 'รับเข้าตรงจาก supplier (ไม่มี PO ล่วงหน้า) — ข้ามขั้นอนุมัติ',
+                  itemCount: dto.items.length,
+                },
               },
             });
 
-            const passedProducts: Awaited<ReturnType<typeof tx.product.update>>[] = [];
-            const rejectedItems: Awaited<ReturnType<typeof tx.goodsReceivingItem.create>>[] = [];
+            // 5) Map each DTO line onto the freshly-created POItem id, then run the
+            //    SAME per-unit receiving pipeline (in this tx) the standard flow uses.
+            const grItems = dto.items.map((line, idx) => ({
+              poItemId: po.items[idx].id,
+              imeiSerial: line.imeiSerial,
+              serialNumber: line.serialNumber,
+              photos: line.photos,
+              status: line.status,
+              rejectReason: line.rejectReason,
+              defectReason: line.defectReason,
+              batteryHealth: line.batteryHealth,
+              warrantyExpired: line.warrantyExpired,
+              warrantyExpireDate: line.warrantyExpireDate,
+              hasBox: line.hasBox,
+              checklistResults: line.checklistResults,
+              sellingPrice: line.sellingPrice,
+            }));
 
-            // Group items by poItemId to count per PO item
-            const countByPoItem: Record<string, number> = {};
-            for (const item of dto.items) {
-              if (item.status === 'PASS') {
-                countByPoItem[item.poItemId] = (countByPoItem[item.poItemId] || 0) + 1;
-              }
-            }
+            const gr = await this.runReceiveInTx(tx, po.id, { items: grItems, notes: dto.notes }, userId);
 
-            // T5-C16: Re-read POItem rows inside the serializable tx to get the
-            // authoritative receivedQty at this instant. Any parallel GR batch
-            // that committed before us will be visible here; any that commits
-            // after us will be serialized and retry. `countByPoItem` inside this
-            // batch is already aggregated to avoid double-counting when the same
-            // poItemId appears twice in dto.items.
-            const freshPoItems = await tx.pOItem.findMany({
-              where: { id: { in: Object.keys(countByPoItem) } },
-              select: { id: true, quantity: true, receivedQty: true, brand: true, model: true },
-            });
-            const freshByPoItem = new Map(freshPoItems.map((p) => [p.id, p]));
-
-            // Validate quantities using fresh DB rows (not cached po.items)
-            for (const [poItemId, passCount] of Object.entries(countByPoItem)) {
-              const fresh = freshByPoItem.get(poItemId);
-              if (!fresh) throw new NotFoundException(`ไม่พบรายการ PO: ${poItemId}`);
-
-              const totalReceived = fresh.receivedQty + passCount;
-              if (totalReceived > fresh.quantity) {
-                throw new BadRequestException(
-                  `จำนวนรับเกิน: ${fresh.brand ?? ''} ${fresh.model ?? ''} (สั่ง ${fresh.quantity}, รับแล้ว ${fresh.receivedQty}, กำลังรับ ${passCount})`,
-                );
-              }
-            }
-
-            // Validate duplicate IMEI/Serial in this batch
-            const imeiList = dto.items
-              .filter((i) => i.status === 'PASS' && i.imeiSerial)
-              .map((i) => i.imeiSerial!);
-            const uniqueImeis = new Set(imeiList);
-            if (uniqueImeis.size !== imeiList.length) {
-              throw new BadRequestException('พบ IMEI ซ้ำกันในรายการที่กำลังรับเข้า');
-            }
-
-            // Validate IMEI not already exists in system (include soft-deleted due to DB unique constraint)
-            if (imeiList.length > 0) {
-              const existingProducts = await tx.product.findMany({
-                where: { imeiSerial: { in: imeiList } },
-                select: { imeiSerial: true, name: true, deletedAt: true },
-              });
-              if (existingProducts.length > 0) {
-                const dupes = existingProducts.map((p) => {
-                  const suffix = p.deletedAt ? ' [ตัดจำหน่ายแล้ว]' : '';
-                  return `${p.imeiSerial} (${p.name}${suffix})`;
-                }).join(', ');
-                throw new BadRequestException(`IMEI ซ้ำกับสินค้าที่มีในระบบแล้ว: ${dupes}`);
-              }
-            }
-
-            // Process each item
-            for (const item of dto.items) {
-              const poItem = po.items.find((i) => i.id === item.poItemId);
-              if (!poItem) throw new NotFoundException(`ไม่พบรายการ PO: ${item.poItemId}`);
-
-              if (item.status === 'PASS') {
-                // Build product name from PO item details
-                const productCategory = (poItem.category as ProductCategory) || 'PHONE_NEW';
-                const productName = buildProductName(poItem, productCategory);
-
-                // Create product for passed items
-                // PHONE_USED → PHOTO_PENDING (ต้องถ่ายรูป 6 มุมก่อนเข้าคลัง)
-                // PHONE_NEW / ACCESSORY → IN_STOCK (เข้าคลังได้เลย)
-                const initialStatus = productCategory === 'PHONE_USED' ? 'PHOTO_PENDING' : 'IN_STOCK';
-                const product = await tx.product.create({
-                  data: {
-                    name: productName,
-                    brand: poItem.brand || '',
-                    model: poItem.model || '',
-                    color: poItem.color || null,
-                    storage: poItem.storage || null,
-                    category: productCategory,
-                    costPrice: Number(poItem.unitPrice),
-                    supplierId: po.supplierId,
-                    poId: po.id,
-                    branchId: mainWarehouse!.id,
-                    status: initialStatus,
-                    imeiSerial: item.imeiSerial || null,
-                    serialNumber: item.serialNumber || null,
-                    photos: item.photos || [],
-                    batteryHealth: item.batteryHealth ?? null,
-                    warrantyExpired: item.warrantyExpired ?? null,
-                    warrantyExpireDate: item.warrantyExpireDate ? new Date(item.warrantyExpireDate) : null,
-                    hasBox: item.hasBox ?? null,
-                    checklistResults: item.checklistResults ? (item.checklistResults as unknown as Prisma.InputJsonValue) : undefined,
-                    accessoryType: poItem.accessoryType || null,
-                    accessoryBrand: poItem.accessoryBrand || null,
-                  },
-                });
-
-                // Create selling price if provided
-                if (item.sellingPrice && item.sellingPrice > 0) {
-                  await tx.productPrice.create({
-                    data: {
-                      productId: product.id,
-                      label: 'ราคาขาย',
-                      amount: item.sellingPrice,
-                      isDefault: true,
-                    },
-                  });
-                }
-
-                // Create receiving item linked to product
-                await tx.goodsReceivingItem.create({
-                  data: {
-                    receivingId: receiving.id,
-                    poItemId: item.poItemId,
-                    imeiSerial: item.imeiSerial,
-                    serialNumber: item.serialNumber,
-                    photos: item.photos || [],
-                    status: 'PASS',
-                    productId: product.id,
-                    batteryHealth: item.batteryHealth ?? null,
-                    warrantyExpired: item.warrantyExpired ?? null,
-                    warrantyExpireDate: item.warrantyExpireDate ? new Date(item.warrantyExpireDate) : null,
-                    hasBox: item.hasBox ?? null,
-                    checklistResults: item.checklistResults ? (item.checklistResults as unknown as Prisma.InputJsonValue) : undefined,
-                  },
-                });
-
-                passedProducts.push(product);
-              } else {
-                // Create receiving item for rejected items (no product created)
-                const rejectedItem = await tx.goodsReceivingItem.create({
-                  data: {
-                    receivingId: receiving.id,
-                    poItemId: item.poItemId,
-                    imeiSerial: item.imeiSerial,
-                    serialNumber: item.serialNumber,
-                    photos: item.photos || [],
-                    status: 'REJECT',
-                    rejectReason: item.rejectReason,
-                    defectReason: item.defectReason ?? null,
-                  },
-                });
-
-                rejectedItems.push(rejectedItem);
-              }
-            }
-
-            // T5-C16: Update PO item received quantities using fresh values
-            // (not cached po.items which could be stale against a parallel tx).
-            for (const [poItemId, passCount] of Object.entries(countByPoItem)) {
-              const fresh = freshByPoItem.get(poItemId)!;
-              await tx.pOItem.update({
-                where: { id: poItemId },
-                data: { receivedQty: fresh.receivedQty + passCount },
-              });
-            }
-
-            // Check if all items fully received
-            const updatedPO = await tx.purchaseOrder.findUnique({
-              where: { id },
-              include: { items: true },
-            });
-
-            const allReceived = updatedPO!.items.every((item) => item.receivedQty >= item.quantity);
-            const newStatus = allReceived ? 'FULLY_RECEIVED' : 'PARTIALLY_RECEIVED';
-
-            await tx.purchaseOrder.update({
-              where: { id },
-              data: { status: newStatus },
-            });
-
-            return {
-              receivingId: receiving.id,
-              grNumber,
-              poId: id,
-              status: newStatus,
-              passed: passedProducts.length,
-              rejected: rejectedItems.length,
-              products: passedProducts,
-              mainWarehouse: mainWarehouse!.name,
-            };
+            return { poNumber: po.poNumber, ...gr };
           },
           { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
         );

--- a/apps/web/src/pages/PurchaseOrdersPage/components/DirectReceiveModal.tsx
+++ b/apps/web/src/pages/PurchaseOrdersPage/components/DirectReceiveModal.tsx
@@ -1,0 +1,418 @@
+import { useState } from 'react';
+import { UseMutationResult } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { ReceivingUnitForm, DirectReceiveLineForm } from '../types';
+import { defaultChecklist } from '../constants';
+import { ReceivingUnitCard } from './ReceivingUnitCard';
+import { useReceivingDuplicates } from './useReceivingDuplicates';
+import { useIsMobile } from '@/hooks/useIsMobile';
+import { Drawer, DrawerContent, DrawerHeader, DrawerTitle } from '@/components/ui/drawer';
+import { Plus, Trash2, ChevronLeft } from 'lucide-react';
+
+interface SupplierLite {
+  id: string;
+  name: string;
+}
+
+export interface DirectReceiveModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  suppliers: SupplierLite[];
+  supplierId: string;
+  setSupplierId: (v: string) => void;
+  lines: DirectReceiveLineForm[];
+  setLines: React.Dispatch<React.SetStateAction<DirectReceiveLineForm[]>>;
+  notes: string;
+  setNotes: (v: string) => void;
+  directReceiveMutation: UseMutationResult<
+    unknown,
+    unknown,
+    { supplierId: string; orderDate: string; notes?: string; items: ReceivingUnitForm[] },
+    unknown
+  >;
+}
+
+const emptyLine: DirectReceiveLineForm = {
+  category: 'PHONE_NEW',
+  brand: '',
+  model: '',
+  color: '',
+  storage: '',
+  accessoryType: '',
+  accessoryBrand: '',
+  quantity: '1',
+  costPrice: '',
+};
+
+const fieldInput =
+  'w-full min-h-11 px-3 py-2 border border-input rounded-lg text-sm focus-visible:ring-2 focus-visible:ring-ring/30 outline-hidden';
+
+function lineToUnits(line: DirectReceiveLineForm): ReceivingUnitForm[] {
+  const qty = Math.max(1, Number(line.quantity) || 1);
+  const isAccessory = line.category === 'ACCESSORY';
+  const label = (
+    isAccessory
+      ? [line.accessoryType, line.accessoryBrand, line.model]
+      : [line.brand, line.model, line.color, line.storage]
+  )
+    .filter(Boolean)
+    .join(' ');
+  return Array.from({ length: qty }, (_, i) => ({
+    poItemId: '',
+    label: `${label || 'สินค้า'} #${i + 1}`,
+    category: line.category,
+    brand: line.brand,
+    model: line.model,
+    color: line.color,
+    storage: line.storage,
+    accessoryType: line.accessoryType,
+    accessoryBrand: line.accessoryBrand,
+    imeiSerial: '',
+    serialNumber: '',
+    status: 'PASS',
+    rejectReason: '',
+    defectReason: '',
+    batteryHealth: '',
+    warrantyExpired: false,
+    warrantyExpireDate: '',
+    hasBox: true,
+    checklist: defaultChecklist.map((c) => ({ ...c, passed: true, note: '' })),
+    sellingPrice: '',
+    photos: [],
+    costPrice: line.costPrice,
+  }));
+}
+
+export function DirectReceiveModal(props: DirectReceiveModalProps) {
+  const {
+    isOpen,
+    onClose,
+    suppliers,
+    supplierId,
+    setSupplierId,
+    lines,
+    setLines,
+    notes,
+    setNotes,
+    directReceiveMutation,
+  } = props;
+  const isMobile = useIsMobile();
+  const [step, setStep] = useState<'lines' | 'inspect'>('lines');
+  const [units, setUnits] = useState<ReceivingUnitForm[]>([]);
+  const dupIndices = useReceivingDuplicates(units);
+
+  if (!isOpen) return null;
+
+  const updateLine = (idx: number, field: keyof DirectReceiveLineForm, value: string) =>
+    setLines((prev) => prev.map((l, i) => (i === idx ? { ...l, [field]: value } : l)));
+
+  const updateUnit = (idx: number, field: string, value: string) =>
+    setUnits((prev) =>
+      prev.map((u, i) => {
+        if (i !== idx) return u;
+        const boolFields = ['hasBox', 'warrantyExpired'];
+        return { ...u, [field]: boolFields.includes(field) ? value === 'true' : value };
+      }),
+    );
+
+  const updateUnitChecklist = (
+    unitIdx: number,
+    checkIdx: number,
+    field: 'passed' | 'note',
+    value: boolean | string,
+  ) =>
+    setUnits((prev) =>
+      prev.map((u, i) =>
+        i !== unitIdx
+          ? u
+          : {
+              ...u,
+              checklist: u.checklist.map((c, ci) =>
+                ci === checkIdx ? { ...c, [field]: value } : c,
+              ),
+            },
+      ),
+    );
+
+  const onAddPhotos = (idx: number, files: FileList) =>
+    Array.from(files)
+      .slice(0, 6)
+      .forEach((file) => {
+        const reader = new FileReader();
+        reader.onload = () =>
+          setUnits((prev) =>
+            prev.map((u, i) =>
+              i === idx && u.photos.length < 6
+                ? { ...u, photos: [...u.photos, reader.result as string] }
+                : u,
+            ),
+          );
+        reader.readAsDataURL(file);
+      });
+
+  const onRemovePhoto = (idx: number, photoIdx: number) =>
+    setUnits((prev) =>
+      prev.map((u, i) =>
+        i === idx ? { ...u, photos: u.photos.filter((_, p) => p !== photoIdx) } : u,
+      ),
+    );
+
+  const goInspect = () => {
+    if (!supplierId) {
+      toast.error('กรุณาเลือกผู้ขาย (supplier)');
+      return;
+    }
+    const badCost = lines.find((l) => !(Number(l.costPrice) > 0));
+    if (badCost) {
+      toast.error('กรุณาระบุราคาทุนมากกว่า 0 ให้ครบทุกรายการ');
+      return;
+    }
+    setUnits(lines.flatMap(lineToUnits));
+    setStep('inspect');
+  };
+
+  const submit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const passUnits = units.filter((u) => u.status === 'PASS');
+    if (passUnits.some((u) => u.category !== 'ACCESSORY' && !u.imeiSerial.trim())) {
+      toast.error('กรุณาระบุ IMEI ให้ครบทุกเครื่องที่ผ่าน');
+      return;
+    }
+    if (passUnits.some((u) => !u.sellingPrice.trim() || Number(u.sellingPrice) <= 0)) {
+      toast.error('กรุณาระบุราคาขายให้ครบทุกเครื่องที่ผ่าน');
+      return;
+    }
+    if (units.some((u) => u.status === 'REJECT' && !u.defectReason)) {
+      toast.error('กรุณาเลือกสาเหตุที่ไม่ผ่านให้ครบ');
+      return;
+    }
+    if (dupIndices.size > 0) {
+      toast.error('มี IMEI ซ้ำกันในรายการ กรุณาแก้ไขก่อนบันทึก');
+      return;
+    }
+    directReceiveMutation.mutate({
+      supplierId,
+      orderDate: new Date().toISOString().split('T')[0],
+      notes,
+      items: units,
+    });
+  };
+
+  const linesBody = (
+    <div className="flex flex-col flex-1 overflow-hidden">
+      <div className="flex-1 overflow-y-auto p-4 sm:p-6 space-y-3">
+        <div>
+          <label className="block text-xs text-muted-foreground mb-0.5 leading-snug">
+            ผู้ขาย (supplier) <span className="text-destructive">*</span>
+          </label>
+          <select
+            value={supplierId}
+            onChange={(e) => setSupplierId(e.target.value)}
+            className={fieldInput}
+          >
+            <option value="">เลือกผู้ขาย…</option>
+            {suppliers.map((s) => (
+              <option key={s.id} value={s.id}>
+                {s.name}
+              </option>
+            ))}
+          </select>
+        </div>
+        {lines.map((line, idx) => (
+          <div key={idx} className="border border-border rounded-xl p-3 bg-card space-y-2">
+            <div className="flex items-center justify-between">
+              <span className="text-sm font-medium leading-snug">รายการ #{idx + 1}</span>
+              {lines.length > 1 && (
+                <button
+                  type="button"
+                  onClick={() => setLines((p) => p.filter((_, i) => i !== idx))}
+                  className="text-destructive p-2"
+                >
+                  <Trash2 className="size-4" />
+                </button>
+              )}
+            </div>
+            <select
+              value={line.category}
+              onChange={(e) => updateLine(idx, 'category', e.target.value)}
+              className={fieldInput}
+            >
+              <option value="PHONE_NEW">มือถือใหม่</option>
+              <option value="PHONE_USED">มือถือมือสอง</option>
+              <option value="TABLET">แท็บเล็ต</option>
+              <option value="ACCESSORY">อุปกรณ์เสริม</option>
+            </select>
+            <div className="grid grid-cols-2 gap-2">
+              <input
+                value={line.brand}
+                onChange={(e) => updateLine(idx, 'brand', e.target.value)}
+                placeholder="ยี่ห้อ"
+                className={fieldInput}
+              />
+              <input
+                value={line.model}
+                onChange={(e) => updateLine(idx, 'model', e.target.value)}
+                placeholder="รุ่น"
+                className={fieldInput}
+              />
+              <input
+                value={line.color}
+                onChange={(e) => updateLine(idx, 'color', e.target.value)}
+                placeholder="สี"
+                className={fieldInput}
+              />
+              <input
+                value={line.storage}
+                onChange={(e) => updateLine(idx, 'storage', e.target.value)}
+                placeholder="ความจุ"
+                className={fieldInput}
+              />
+            </div>
+            <div className="grid grid-cols-2 gap-2">
+              <div>
+                <label className="block text-xs text-muted-foreground mb-0.5 leading-snug">
+                  จำนวน
+                </label>
+                <input
+                  type="number"
+                  min="1"
+                  value={line.quantity}
+                  onChange={(e) => updateLine(idx, 'quantity', e.target.value)}
+                  className={fieldInput}
+                />
+              </div>
+              <div>
+                <label className="block text-xs text-muted-foreground mb-0.5 leading-snug">
+                  ราคาทุน/ชิ้น <span className="text-destructive">*</span>
+                </label>
+                <input
+                  type="number"
+                  min="0"
+                  value={line.costPrice}
+                  onChange={(e) => updateLine(idx, 'costPrice', e.target.value)}
+                  className={fieldInput}
+                  placeholder="เช่น 30000"
+                />
+              </div>
+            </div>
+          </div>
+        ))}
+        <button
+          type="button"
+          onClick={() => setLines((p) => [...p, { ...emptyLine }])}
+          className="w-full min-h-11 border-2 border-dashed border-input rounded-lg text-sm text-muted-foreground hover:border-primary/60 hover:bg-primary/5 flex items-center justify-center gap-1.5"
+        >
+          <Plus className="size-4" /> เพิ่มรายการ
+        </button>
+        <div>
+          <label className="block text-xs text-muted-foreground mb-1 leading-snug">หมายเหตุ</label>
+          <textarea
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+            rows={2}
+            className="w-full px-3 py-2 border border-input rounded-lg text-sm leading-snug outline-hidden"
+            placeholder="บันทึกเพิ่มเติม…"
+          />
+        </div>
+      </div>
+      <div className="shrink-0 border-t px-4 sm:px-6 py-3 flex gap-3 bg-background/95">
+        <button
+          type="button"
+          onClick={onClose}
+          className="min-h-11 px-4 text-sm text-muted-foreground"
+        >
+          ยกเลิก
+        </button>
+        <button
+          type="button"
+          onClick={goInspect}
+          className="flex-1 min-h-11 bg-primary text-primary-foreground rounded-lg text-sm font-medium hover:bg-primary/90"
+        >
+          ถัดไป: ตรวจรับ
+        </button>
+      </div>
+    </div>
+  );
+
+  const inspectBody = (
+    <form onSubmit={submit} className="flex flex-col flex-1 overflow-hidden">
+      <div className="shrink-0 px-4 sm:px-6 py-2 border-b">
+        <button
+          type="button"
+          onClick={() => setStep('lines')}
+          className="flex items-center gap-1 text-sm text-muted-foreground"
+        >
+          <ChevronLeft className="size-4" /> กลับไปแก้รายการ
+        </button>
+      </div>
+      <div className="flex-1 overflow-y-auto p-4 sm:p-6 space-y-3">
+        {units.map((unit, idx) => (
+          <ReceivingUnitCard
+            key={idx}
+            unit={unit}
+            idx={idx}
+            isDuplicate={dupIndices.has(idx)}
+            showCostPrice
+            updateReceivingUnit={updateUnit}
+            updateChecklist={updateUnitChecklist}
+            onAddPhotos={onAddPhotos}
+            onRemovePhoto={onRemovePhoto}
+          />
+        ))}
+      </div>
+      <div className="shrink-0 border-t px-4 sm:px-6 py-3 flex gap-3 bg-background/95">
+        <button
+          type="submit"
+          disabled={directReceiveMutation.isPending}
+          className="flex-1 min-h-11 bg-primary text-primary-foreground rounded-lg text-sm font-medium hover:bg-primary/90 disabled:opacity-50"
+        >
+          {directReceiveMutation.isPending ? 'กำลังรับเข้า…' : 'ยืนยันรับเข้าตรง'}
+        </button>
+      </div>
+    </form>
+  );
+
+  const body = step === 'lines' ? linesBody : inspectBody;
+  const title = step === 'lines' ? 'รับเข้าตรง — เพิ่มรายการ' : 'รับเข้าตรง — ตรวจรับ';
+
+  if (isMobile) {
+    return (
+      <Drawer
+        open={isOpen}
+        onOpenChange={(o) => {
+          if (!o) onClose();
+        }}
+      >
+        <DrawerContent className="h-[92dvh]">
+          <DrawerHeader className="text-left">
+            <DrawerTitle className="leading-snug">{title}</DrawerTitle>
+          </DrawerHeader>
+          {body}
+        </DrawerContent>
+      </Drawer>
+    );
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 bg-black/50 backdrop-blur-xs flex items-start justify-center pt-8 pb-8"
+      role="dialog"
+      aria-modal="true"
+      aria-label="รับเข้าตรง"
+    >
+      <div className="w-full max-w-3xl bg-background rounded-xl shadow-2xl overflow-hidden flex flex-col max-h-[calc(100vh-4rem)]">
+        <div className="sticky top-0 z-10 bg-background/95 border-b px-6 py-4 flex items-center justify-between shrink-0">
+          <h2 className="text-lg font-semibold text-foreground leading-snug">{title}</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-sm text-muted-foreground hover:text-foreground"
+          >
+            ปิด
+          </button>
+        </div>
+        {body}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/pages/PurchaseOrdersPage/components/GoodsReceivingModal.tsx
+++ b/apps/web/src/pages/PurchaseOrdersPage/components/GoodsReceivingModal.tsx
@@ -168,7 +168,7 @@ export function GoodsReceivingModal(props: GoodsReceivingModalProps) {
               รับสินค้า — {selectedPO?.poNumber || ''}
             </DrawerTitle>
           </DrawerHeader>
-          {body}
+          {selectedPO && body}
         </DrawerContent>
       </Drawer>
     );

--- a/apps/web/src/pages/PurchaseOrdersPage/components/GoodsReceivingModal.tsx
+++ b/apps/web/src/pages/PurchaseOrdersPage/components/GoodsReceivingModal.tsx
@@ -1,7 +1,10 @@
 import { UseMutationResult } from '@tanstack/react-query';
 import { PurchaseOrder, ReceivingUnitForm } from '../types';
-import { checklistCategories } from '../constants';
-import ThaiDateInput from '@/components/ui/ThaiDateInput';
+import { ReceivingUnitCard } from './ReceivingUnitCard';
+import { useReceivingDuplicates } from './useReceivingDuplicates';
+import { useIsMobile } from '@/hooks/useIsMobile';
+import { Drawer, DrawerContent, DrawerHeader, DrawerTitle } from '@/components/ui/drawer';
+import { ChevronLeft } from 'lucide-react';
 
 export interface GoodsReceivingModalProps {
   isOpen: boolean;
@@ -11,332 +14,188 @@ export interface GoodsReceivingModalProps {
   setReceivingUnits: React.Dispatch<React.SetStateAction<ReceivingUnitForm[]>>;
   receivingNotes: string;
   setReceivingNotes: (value: string) => void;
-  goodsReceivingMutation: UseMutationResult<unknown, unknown, { poId: string; items: ReceivingUnitForm[]; notes: string }, unknown>;
+  goodsReceivingMutation: UseMutationResult<
+    unknown,
+    unknown,
+    { poId: string; items: ReceivingUnitForm[]; notes: string },
+    unknown
+  >;
   updateReceivingUnit: (idx: number, field: string, value: string) => void;
-  updateChecklist: (unitIdx: number, checkIdx: number, field: 'passed' | 'note', value: boolean | string) => void;
+  updateChecklist: (
+    unitIdx: number,
+    checkIdx: number,
+    field: 'passed' | 'note',
+    value: boolean | string,
+  ) => void;
   handleGoodsReceiving: (e: React.FormEvent) => void;
 }
 
-export function GoodsReceivingModal({
-  isOpen,
-  onClose,
-  selectedPO,
-  receivingUnits,
-  receivingNotes,
-  setReceivingNotes,
-  goodsReceivingMutation,
-  updateReceivingUnit,
-  updateChecklist,
-  handleGoodsReceiving,
-}: GoodsReceivingModalProps) {
+const MAX_PHOTOS_PER_UNIT = 6;
+
+export function GoodsReceivingModal(props: GoodsReceivingModalProps) {
+  const {
+    isOpen,
+    onClose,
+    selectedPO,
+    receivingUnits,
+    setReceivingUnits,
+    receivingNotes,
+    setReceivingNotes,
+    goodsReceivingMutation,
+    updateReceivingUnit,
+    updateChecklist,
+    handleGoodsReceiving,
+  } = props;
+  const isMobile = useIsMobile();
+  const dupIndices = useReceivingDuplicates(receivingUnits);
+
+  const onAddPhotos = (idx: number, files: FileList) => {
+    Array.from(files)
+      .slice(0, MAX_PHOTOS_PER_UNIT)
+      .forEach((file) => {
+        const reader = new FileReader();
+        reader.onload = () =>
+          setReceivingUnits((prev) => {
+            const next = [...prev];
+            const cur = next[idx];
+            if (cur.photos.length >= MAX_PHOTOS_PER_UNIT) return prev;
+            next[idx] = { ...cur, photos: [...cur.photos, reader.result as string] };
+            return next;
+          });
+        reader.readAsDataURL(file);
+      });
+  };
+  const onRemovePhoto = (idx: number, photoIdx: number) =>
+    setReceivingUnits((prev) => {
+      const next = [...prev];
+      next[idx] = { ...next[idx], photos: next[idx].photos.filter((_, i) => i !== photoIdx) };
+      return next;
+    });
+
+  const passCount = receivingUnits.filter((u) => u.status === 'PASS').length;
+  const rejectCount = receivingUnits.filter((u) => u.status === 'REJECT').length;
+
   if (!isOpen) return null;
 
+  const body = (
+    <form onSubmit={handleGoodsReceiving} className="flex flex-col flex-1 overflow-hidden">
+      {/* Sticky progress strip */}
+      <div className="shrink-0 px-4 sm:px-6 py-3 border-b bg-background/95 backdrop-blur-xs">
+        <div className="flex items-center justify-between text-sm leading-snug">
+          <span className="text-muted-foreground">ตรวจรับ {receivingUnits.length} ชิ้น</span>
+          <span className="flex gap-3">
+            <span className="text-success">ผ่าน {passCount}</span>
+            <span className="text-destructive">ไม่ผ่าน {rejectCount}</span>
+          </span>
+        </div>
+        <div className="mt-2 h-1.5 w-full rounded-full bg-muted overflow-hidden flex">
+          <div
+            className="bg-success h-full"
+            style={{
+              width: `${receivingUnits.length ? (passCount / receivingUnits.length) * 100 : 0}%`,
+            }}
+          />
+          <div
+            className="bg-destructive h-full"
+            style={{
+              width: `${receivingUnits.length ? (rejectCount / receivingUnits.length) * 100 : 0}%`,
+            }}
+          />
+        </div>
+      </div>
+
+      <div className="flex-1 overflow-y-auto p-4 sm:p-6 space-y-3">
+        {receivingUnits.map((unit, idx) => (
+          <ReceivingUnitCard
+            key={idx}
+            unit={unit}
+            idx={idx}
+            isDuplicate={dupIndices.has(idx)}
+            updateReceivingUnit={updateReceivingUnit}
+            updateChecklist={updateChecklist}
+            onAddPhotos={onAddPhotos}
+            onRemovePhoto={onRemovePhoto}
+          />
+        ))}
+        {receivingUnits.length === 0 && (
+          <div className="text-center py-8 text-muted-foreground text-sm leading-snug">
+            ไม่มีรายการที่รอรับสินค้า
+          </div>
+        )}
+        <div>
+          <label className="block text-xs text-muted-foreground mb-1 leading-snug">หมายเหตุ</label>
+          <textarea
+            value={receivingNotes}
+            onChange={(e) => setReceivingNotes(e.target.value)}
+            rows={2}
+            className="w-full px-3 py-2 border border-input rounded-lg text-sm leading-snug focus-visible:ring-2 focus-visible:ring-ring/30 outline-hidden"
+            placeholder="บันทึกเพิ่มเติม…"
+          />
+        </div>
+      </div>
+
+      {/* Sticky footer */}
+      <div className="shrink-0 border-t px-4 sm:px-6 py-3 flex gap-3 bg-background/95 backdrop-blur-xs">
+        <button
+          type="button"
+          onClick={onClose}
+          className="min-h-11 px-4 text-sm text-muted-foreground"
+        >
+          ยกเลิก
+        </button>
+        <button
+          type="submit"
+          disabled={goodsReceivingMutation.isPending || receivingUnits.length === 0}
+          className="flex-1 min-h-11 bg-primary text-primary-foreground rounded-lg text-sm font-medium hover:bg-primary/90 disabled:opacity-50 transition-colors"
+        >
+          {goodsReceivingMutation.isPending ? 'กำลังรับสินค้า…' : 'ยืนยันรับสินค้า'}
+        </button>
+      </div>
+    </form>
+  );
+
+  if (isMobile) {
+    return (
+      <Drawer
+        open={isOpen}
+        onOpenChange={(o) => {
+          if (!o) onClose();
+        }}
+      >
+        <DrawerContent className="h-[92dvh]">
+          <DrawerHeader className="text-left">
+            <DrawerTitle className="leading-snug">
+              รับสินค้า — {selectedPO?.poNumber || ''}
+            </DrawerTitle>
+          </DrawerHeader>
+          {body}
+        </DrawerContent>
+      </Drawer>
+    );
+  }
+
   return (
-    <div className="fixed inset-0 z-50 bg-black/50 backdrop-blur-xs flex items-start justify-center pt-8 pb-8" role="dialog" aria-modal="true" aria-label="รับสินค้า">
+    <div
+      className="fixed inset-0 z-50 bg-black/50 backdrop-blur-xs flex items-start justify-center pt-8 pb-8"
+      role="dialog"
+      aria-modal="true"
+      aria-label="รับสินค้า"
+    >
       <div className="w-full max-w-3xl bg-background rounded-xl shadow-2xl overflow-hidden flex flex-col max-h-[calc(100vh-4rem)]">
-        {/* Sticky Header */}
         <div className="sticky top-0 z-10 bg-background/95 backdrop-blur-xs border-b px-6 py-4 flex items-center justify-between shrink-0">
-          <button type="button" onClick={onClose} className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors">
-            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="m15 18-6-6 6-6"/></svg>
-            กลับ
+          <button
+            type="button"
+            onClick={onClose}
+            className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
+          >
+            <ChevronLeft className="size-4" /> กลับ
           </button>
-          <h2 className="text-lg font-semibold text-foreground">รับสินค้า - {selectedPO?.poNumber || ''}</h2>
+          <h2 className="text-lg font-semibold text-foreground leading-snug">
+            รับสินค้า — {selectedPO?.poNumber || ''}
+          </h2>
           <div className="w-16" />
         </div>
-
-        {selectedPO && (
-          <form onSubmit={handleGoodsReceiving} className="flex flex-col flex-1 overflow-hidden">
-            {/* Scrollable content */}
-            <div className="flex-1 overflow-y-auto p-6 space-y-5">
-              {/* คำแนะนำ */}
-              <div className="rounded-xl border border-border/50 bg-card p-5 shadow-sm">
-                <div className="flex items-center gap-2.5 mb-4">
-                  <div className="flex items-center justify-center size-8 rounded-lg bg-primary/10 text-primary">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><circle cx="12" cy="12" r="10"/><path d="M12 16v-4"/><path d="M12 8h.01"/></svg>
-                  </div>
-                  <div>
-                    <h3 className="text-sm font-semibold text-foreground">คำแนะนำ</h3>
-                    <p className="text-xs text-muted-foreground">ขั้นตอนการตรวจรับสินค้า</p>
-                  </div>
-                </div>
-                <div className="text-sm text-primary-700">
-                  ตรวจรับสินค้าทีละชิ้น ระบุ IMEI/Serial ราคาขาย แล้วเลือกผลตรวจ (ผ่าน/ไม่ผ่าน)
-                  <br />
-                  สินค้าที่ผ่านจะเข้าสถานะ QC_PENDING รอยืนยันก่อนเข้าคลัง
-                </div>
-              </div>
-
-              {/* รายการตรวจรับ */}
-              <div className="rounded-xl border border-border/50 bg-card p-5 shadow-sm">
-                <div className="flex items-center gap-2.5 mb-4">
-                  <div className="flex items-center justify-center size-8 rounded-lg bg-warning/10 text-warning">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="m7.5 4.27 9 5.15"/><path d="M21 8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16Z"/><path d="m3.3 7 8.7 5 8.7-5"/><path d="M12 22V12"/></svg>
-                  </div>
-                  <div>
-                    <h3 className="text-sm font-semibold text-foreground">รายการตรวจรับ</h3>
-                    <p className="text-xs text-muted-foreground">{receivingUnits.length} รายการ</p>
-                  </div>
-                </div>
-
-                <div className="space-y-3">
-                  {receivingUnits.map((unit, idx) => (
-                    <div key={idx} className={`border rounded-lg p-3 ${unit.status === 'REJECT' ? 'border-destructive/30 bg-destructive/5' : 'border-border'}`}>
-                      <div className="flex items-center justify-between mb-2">
-                        <span className="text-sm font-medium">{unit.label}</span>
-                        <div className="flex gap-1">
-                          <button
-                            type="button"
-                            onClick={() => updateReceivingUnit(idx, 'status', 'PASS')}
-                            className={`px-3 py-1 rounded text-xs font-medium transition-colors ${
-                              unit.status === 'PASS'
-                                ? 'bg-success text-success-foreground'
-                                : 'bg-muted text-muted-foreground hover:bg-success/10'
-                            }`}
-                          >
-                            ผ่าน
-                          </button>
-                          <button
-                            type="button"
-                            onClick={() => updateReceivingUnit(idx, 'status', 'REJECT')}
-                            className={`px-3 py-1 rounded text-xs font-medium transition-colors ${
-                              unit.status === 'REJECT'
-                                ? 'bg-destructive text-destructive-foreground'
-                                : 'bg-muted text-muted-foreground hover:bg-destructive/10'
-                            }`}
-                          >
-                            ไม่ผ่าน
-                          </button>
-                        </div>
-                      </div>
-                      {unit.category !== 'ACCESSORY' && unit.status === 'PASS' && (
-                      <div className="grid grid-cols-2 gap-2">
-                        <div>
-                          <label className="block text-xs text-muted-foreground mb-0.5">IMEI <span className="text-destructive">*</span></label>
-                          <input
-                            type="text"
-                            placeholder="IMEI"
-                            value={unit.imeiSerial}
-                            onChange={(e) => updateReceivingUnit(idx, 'imeiSerial', e.target.value)}
-                            required
-                            className="w-full px-2 py-1.5 border border-input rounded text-sm focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:ring-offset-[3px] focus-visible:ring-offset-background outline-hidden font-mono"
-                          />
-                        </div>
-                        <div>
-                          <label className="block text-xs text-muted-foreground mb-0.5">หมายเลขซีเรียล <span className="text-destructive">*</span></label>
-                          <input
-                            type="text"
-                            placeholder="หมายเลขซีเรียล"
-                            value={unit.serialNumber}
-                            onChange={(e) => updateReceivingUnit(idx, 'serialNumber', e.target.value)}
-                            required
-                            className="w-full px-2 py-1.5 border border-input rounded text-sm focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:ring-offset-[3px] focus-visible:ring-offset-background outline-hidden font-mono"
-                          />
-                        </div>
-                      </div>
-                      )}
-                      {unit.category === 'PHONE_USED' && unit.status === 'PASS' && (
-                        <div className="mt-2 border border-warning/20 bg-warning/5 dark:bg-warning/10 rounded-lg p-3 space-y-2">
-                          <div className="text-xs font-medium text-warning mb-1">ข้อมูลมือสอง</div>
-                          <div className="grid grid-cols-2 gap-2">
-                            <div>
-                              <label className="block text-xs text-muted-foreground mb-0.5">% แบตเตอรี่ <span className="text-destructive">*</span></label>
-                              <input
-                                type="number"
-                                placeholder="เช่น 87"
-                                value={unit.batteryHealth}
-                                onChange={(e) => updateReceivingUnit(idx, 'batteryHealth', e.target.value)}
-                                required
-                                className="w-full px-2 py-1.5 border border-input rounded text-sm focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:ring-offset-[3px] focus-visible:ring-offset-background outline-hidden"
-                                min="0"
-                                max="100"
-                              />
-                            </div>
-                            <div>
-                              <label className="block text-xs text-muted-foreground mb-0.5">กล่อง</label>
-                              <div className="flex gap-2 mt-1">
-                                <button
-                                  type="button"
-                                  onClick={() => updateReceivingUnit(idx, 'hasBox', 'true')}
-                                  className={`px-3 py-1 rounded text-xs font-medium transition-colors ${unit.hasBox ? 'bg-success text-success-foreground' : 'bg-muted text-muted-foreground hover:bg-success/10'}`}
-                                >
-                                  มีกล่อง
-                                </button>
-                                <button
-                                  type="button"
-                                  onClick={() => updateReceivingUnit(idx, 'hasBox', 'false')}
-                                  className={`px-3 py-1 rounded text-xs font-medium transition-colors ${!unit.hasBox ? 'bg-destructive text-destructive-foreground' : 'bg-muted text-muted-foreground hover:bg-destructive/10'}`}
-                                >
-                                  ไม่มีกล่อง
-                                </button>
-                              </div>
-                            </div>
-                          </div>
-                          <div>
-                            <label className="block text-xs text-muted-foreground mb-0.5">ประกันศูนย์ <span className="text-destructive">*</span></label>
-                            <div className="flex items-center gap-3">
-                              <label className="flex items-center gap-1.5 cursor-pointer">
-                                <input
-                                  type="checkbox"
-                                  checked={unit.warrantyExpired}
-                                  onChange={(e) => updateReceivingUnit(idx, 'warrantyExpired', e.target.checked ? 'true' : 'false')}
-                                  className="rounded"
-                                />
-                                <span className="text-xs text-muted-foreground">หมดประกันแล้ว</span>
-                              </label>
-                              {!unit.warrantyExpired && (
-                                <ThaiDateInput
-                                  value={unit.warrantyExpireDate}
-                                  onChange={(e) => updateReceivingUnit(idx, 'warrantyExpireDate', e.target.value)}
-                                  required
-                                  className="flex-1 px-2 py-1.5 border border-input rounded text-sm focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:ring-offset-[3px] focus-visible:ring-offset-background outline-hidden"
-                                />
-                              )}
-                            </div>
-                          </div>
-
-                          {/* Checklist */}
-                          <div className="mt-2 border-t border-warning/20 pt-2">
-                            <div className="text-xs font-medium text-warning mb-2">เช็คลิสต์ตรวจเครื่อง</div>
-                            {checklistCategories.map((cat) => (
-                              <div key={cat} className="mb-2">
-                                <div className="text-xs font-medium text-muted-foreground mb-1">{cat}</div>
-                                <div className="space-y-1">
-                                  {unit.checklist.map((c, checkIdx) => c.category !== cat ? null : (
-                                    <div key={checkIdx} className="flex items-center gap-2">
-                                      <button
-                                        type="button"
-                                        onClick={() => updateChecklist(idx, checkIdx, 'passed', !c.passed)}
-                                        className={`w-5 h-5 rounded flex items-center justify-center text-xs font-bold transition-colors ${
-                                          c.passed
-                                            ? 'bg-success text-success-foreground'
-                                            : 'bg-destructive text-destructive-foreground'
-                                        }`}
-                                      >
-                                        {c.passed ? '\u2713' : '\u2717'}
-                                      </button>
-                                      <span className={`text-xs flex-1 ${c.passed ? 'text-foreground' : 'text-destructive font-medium'}`}>
-                                        {c.item}
-                                      </span>
-                                      {!c.passed && (
-                                        <input
-                                          type="text"
-                                          placeholder="หมายเหตุ"
-                                          value={c.note}
-                                          onChange={(e) => updateChecklist(idx, checkIdx, 'note', e.target.value)}
-                                          className="w-32 px-1.5 py-0.5 border border-destructive/30 rounded text-xs focus-visible:ring-1 focus-visible:ring-ring/30 outline-hidden"
-                                        />
-                                      )}
-                                    </div>
-                                  ))}
-                                </div>
-                              </div>
-                            ))}
-                            <div className="text-xs text-muted-foreground mt-1">
-                              ผ่าน {unit.checklist.filter((c) => c.passed).length}/{unit.checklist.length} รายการ
-                            </div>
-                          </div>
-                        </div>
-                      )}
-                      {unit.status === 'PASS' && (
-                        <div className="mt-2 border border-primary/20 bg-primary/5 dark:bg-primary/10 rounded-xl p-3 space-y-2">
-                          <div className="text-xs font-medium text-primary mb-1">ราคาขาย</div>
-                          <div>
-                            <label className="block text-xs text-muted-foreground mb-0.5">ราคาขาย (บาท) <span className="text-destructive">*</span></label>
-                            <input
-                              type="number"
-                              placeholder="เช่น 15000"
-                              value={unit.sellingPrice}
-                              onChange={(e) => updateReceivingUnit(idx, 'sellingPrice', e.target.value)}
-                              required
-                              className="w-full px-2 py-1.5 border border-input rounded text-sm focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:ring-offset-[3px] focus-visible:ring-offset-background outline-hidden"
-                              min="0"
-                            />
-                          </div>
-                        </div>
-                      )}
-                      {unit.status === 'REJECT' && (
-                        <input
-                          type="text"
-                          placeholder="เหตุผลที่ไม่ผ่าน *"
-                          value={unit.rejectReason}
-                          onChange={(e) => updateReceivingUnit(idx, 'rejectReason', e.target.value)}
-                          required
-                          className="mt-2 w-full px-2 py-1.5 border border-destructive/30 rounded text-sm focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:ring-offset-[3px] focus-visible:ring-offset-background outline-hidden"
-                        />
-                      )}
-                    </div>
-                  ))}
-
-                  {receivingUnits.length === 0 && (
-                    <div className="text-center py-4 text-muted-foreground text-sm">
-                      ไม่มีรายการที่รอรับสินค้า
-                    </div>
-                  )}
-                </div>
-              </div>
-
-              {/* สรุปผลตรวจรับ */}
-              {receivingUnits.length > 0 && (
-                <div className="rounded-xl border border-border/50 bg-card p-5 shadow-sm">
-                  <div className="flex items-center gap-2.5 mb-4">
-                    <div className="flex items-center justify-center size-8 rounded-lg bg-success/10 text-success">
-                      <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M22 12h-2.48a2 2 0 0 0-1.93 1.46l-2.35 8.36a.25.25 0 0 1-.48 0L9.24 2.18a.25.25 0 0 0-.48 0l-2.35 8.36A2 2 0 0 1 4.49 12H2"/></svg>
-                    </div>
-                    <div>
-                      <h3 className="text-sm font-semibold text-foreground">สรุปผลตรวจรับ</h3>
-                      <p className="text-xs text-muted-foreground">ภาพรวมการตรวจสอบ</p>
-                    </div>
-                  </div>
-                  <div className="bg-muted rounded-lg p-3 text-sm">
-                    <div className="flex gap-4">
-                      <span>ทั้งหมด: <strong>{receivingUnits.length}</strong></span>
-                      <span className="text-success">ผ่าน: <strong>{receivingUnits.filter((u) => u.status === 'PASS').length}</strong></span>
-                      <span className="text-destructive">ไม่ผ่าน: <strong>{receivingUnits.filter((u) => u.status === 'REJECT').length}</strong></span>
-                    </div>
-                  </div>
-                </div>
-              )}
-
-              {/* หมายเหตุ */}
-              <div className="rounded-xl border border-border/50 bg-card p-5 shadow-sm">
-                <div className="flex items-center gap-2.5 mb-4">
-                  <div className="flex items-center justify-center size-8 rounded-lg bg-primary/10 text-primary">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M12 20h9"/><path d="M16.376 3.622a1 1 0 0 1 3.002 3.002L7.368 18.635a2 2 0 0 1-.855.506l-2.872.838a.5.5 0 0 1-.62-.62l.838-2.872a2 2 0 0 1 .506-.855z"/></svg>
-                  </div>
-                  <div>
-                    <h3 className="text-sm font-semibold text-foreground">หมายเหตุ</h3>
-                    <p className="text-xs text-muted-foreground">บันทึกเพิ่มเติม</p>
-                  </div>
-                </div>
-                <textarea
-                  value={receivingNotes}
-                  onChange={(e) => setReceivingNotes(e.target.value)}
-                  rows={2}
-                  className="w-full px-3 py-2 border border-input rounded-lg text-sm focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:ring-offset-[3px] focus-visible:ring-offset-background outline-hidden"
-                  placeholder="บันทึกเพิ่มเติม..."
-                />
-              </div>
-            </div>
-
-            {/* Sticky Footer */}
-            <div className="sticky bottom-0 bg-background/95 backdrop-blur-xs border-t px-6 py-4 flex justify-end gap-3 shrink-0">
-              <button
-                type="button"
-                onClick={() => onClose()}
-                className="px-4 py-2 text-sm text-muted-foreground"
-              >
-                ยกเลิก
-              </button>
-              <button
-                type="submit"
-                disabled={goodsReceivingMutation.isPending || receivingUnits.length === 0}
-                className="px-4 py-2 bg-primary text-primary-foreground rounded-lg text-sm font-medium hover:bg-primary/90 disabled:opacity-50 transition-colors"
-              >
-                {goodsReceivingMutation.isPending ? 'กำลังรับสินค้า...' : 'ยืนยันรับสินค้า'}
-              </button>
-            </div>
-          </form>
-        )}
+        {selectedPO && body}
       </div>
     </div>
   );

--- a/apps/web/src/pages/PurchaseOrdersPage/components/ReceivingUnitCard.tsx
+++ b/apps/web/src/pages/PurchaseOrdersPage/components/ReceivingUnitCard.tsx
@@ -1,0 +1,322 @@
+import { ReceivingUnitForm, DefectReasonValue } from '../types';
+import { checklistCategories, defectReasonOptions } from '../constants';
+import ThaiDateInput from '@/components/ui/ThaiDateInput';
+import { Camera, X, AlertTriangle } from 'lucide-react';
+
+export interface ReceivingUnitCardProps {
+  unit: ReceivingUnitForm;
+  idx: number;
+  isDuplicate: boolean;
+  showCostPrice?: boolean; // direct-receive only
+  updateReceivingUnit: (idx: number, field: string, value: string) => void;
+  updateChecklist: (
+    unitIdx: number,
+    checkIdx: number,
+    field: 'passed' | 'note',
+    value: boolean | string,
+  ) => void;
+  onAddPhotos: (idx: number, files: FileList) => void;
+  onRemovePhoto: (idx: number, photoIdx: number) => void;
+}
+
+// 44px-min touch targets per .claude/rules (mobile). Tokens only — no gray/hex/bg-white.
+const segBtn = 'min-h-11 px-4 rounded-lg text-sm font-medium transition-colors';
+const fieldInput =
+  'w-full min-h-11 px-3 py-2 border border-input rounded-lg text-sm focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:ring-offset-[3px] focus-visible:ring-offset-background outline-hidden';
+
+export function ReceivingUnitCard({
+  unit,
+  idx,
+  isDuplicate,
+  showCostPrice,
+  updateReceivingUnit,
+  updateChecklist,
+  onAddPhotos,
+  onRemovePhoto,
+}: ReceivingUnitCardProps) {
+  const isUsed = unit.category === 'PHONE_USED';
+  const isAccessory = unit.category === 'ACCESSORY';
+  return (
+    <div
+      className={`border rounded-xl p-3 leading-snug ${unit.status === 'REJECT' ? 'border-destructive/30 bg-destructive/5' : isDuplicate ? 'border-warning/50 bg-warning/5' : 'border-border bg-card'}`}
+    >
+      <div className="flex items-center justify-between gap-2 mb-2">
+        <span className="text-sm font-medium leading-snug">{unit.label}</span>
+        <div className="flex gap-1.5">
+          <button
+            type="button"
+            onClick={() => updateReceivingUnit(idx, 'status', 'PASS')}
+            className={`${segBtn} ${unit.status === 'PASS' ? 'bg-success text-success-foreground' : 'bg-muted text-muted-foreground hover:bg-success/10'}`}
+          >
+            ผ่าน
+          </button>
+          <button
+            type="button"
+            onClick={() => updateReceivingUnit(idx, 'status', 'REJECT')}
+            className={`${segBtn} ${unit.status === 'REJECT' ? 'bg-destructive text-destructive-foreground' : 'bg-muted text-muted-foreground hover:bg-destructive/10'}`}
+          >
+            ไม่ผ่าน
+          </button>
+        </div>
+      </div>
+
+      {showCostPrice && unit.status === 'PASS' && (
+        <div className="mb-2">
+          <label className="block text-xs text-muted-foreground mb-0.5 leading-snug">
+            ราคาทุน (บาท) <span className="text-destructive">*</span>
+          </label>
+          <input
+            type="number"
+            min="0"
+            inputMode="decimal"
+            value={unit.costPrice}
+            onChange={(e) => updateReceivingUnit(idx, 'costPrice', e.target.value)}
+            required
+            className={fieldInput}
+            placeholder="เช่น 30000"
+          />
+        </div>
+      )}
+
+      {!isAccessory && unit.status === 'PASS' && (
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+          <div>
+            <label className="block text-xs text-muted-foreground mb-0.5 leading-snug">
+              IMEI <span className="text-destructive">*</span>
+            </label>
+            <input
+              type="text"
+              inputMode="numeric"
+              value={unit.imeiSerial}
+              onChange={(e) => updateReceivingUnit(idx, 'imeiSerial', e.target.value)}
+              required
+              className={`${fieldInput} font-mono ${isDuplicate ? 'border-warning' : ''}`}
+              placeholder="IMEI"
+            />
+            {isDuplicate && (
+              <p className="mt-1 flex items-center gap-1 text-xs text-warning leading-snug">
+                <AlertTriangle className="size-3.5 shrink-0" /> IMEI ซ้ำกับเครื่องอื่นในรายการนี้
+              </p>
+            )}
+          </div>
+          <div>
+            <label className="block text-xs text-muted-foreground mb-0.5 leading-snug">
+              หมายเลขซีเรียล <span className="text-destructive">*</span>
+            </label>
+            <input
+              type="text"
+              value={unit.serialNumber}
+              onChange={(e) => updateReceivingUnit(idx, 'serialNumber', e.target.value)}
+              required
+              className={`${fieldInput} font-mono`}
+              placeholder="หมายเลขซีเรียล"
+            />
+          </div>
+        </div>
+      )}
+
+      {/* Camera photo capture (mobile rear camera via capture attr) */}
+      {unit.status === 'PASS' && (
+        <div className="mt-2">
+          <label className="block text-xs text-muted-foreground mb-1 leading-snug">
+            รูปถ่ายเครื่อง
+          </label>
+          <div className="flex flex-wrap gap-2">
+            {unit.photos.map((p, pIdx) => (
+              <div key={pIdx} className="relative size-16 rounded-lg overflow-hidden border">
+                <img src={p} alt={`รูป ${pIdx + 1}`} className="size-full object-cover" />
+                <button
+                  type="button"
+                  onClick={() => onRemovePhoto(idx, pIdx)}
+                  className="absolute top-0.5 right-0.5 size-5 bg-destructive text-destructive-foreground rounded-full flex items-center justify-center"
+                >
+                  <X className="size-3" />
+                </button>
+              </div>
+            ))}
+            <label className="size-16 border-2 border-dashed border-input rounded-lg flex flex-col items-center justify-center cursor-pointer hover:border-primary/60 hover:bg-primary/5 transition-colors">
+              <Camera className="size-5 text-muted-foreground" />
+              <span className="text-[10px] text-muted-foreground leading-snug">ถ่ายรูป</span>
+              <input
+                type="file"
+                accept="image/*"
+                capture="environment"
+                multiple
+                className="hidden"
+                onChange={(e) => {
+                  if (e.target.files?.length) onAddPhotos(idx, e.target.files);
+                  e.target.value = '';
+                }}
+              />
+            </label>
+          </div>
+        </div>
+      )}
+
+      {isUsed && unit.status === 'PASS' && (
+        <div className="mt-2 border border-warning/20 bg-warning/5 dark:bg-warning/10 rounded-xl p-3 space-y-2">
+          <div className="text-xs font-medium text-warning mb-1 leading-snug">ข้อมูลมือสอง</div>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+            <div>
+              <label className="block text-xs text-muted-foreground mb-0.5 leading-snug">
+                % แบตเตอรี่ <span className="text-destructive">*</span>
+              </label>
+              <input
+                type="number"
+                inputMode="numeric"
+                min="0"
+                max="100"
+                value={unit.batteryHealth}
+                onChange={(e) => updateReceivingUnit(idx, 'batteryHealth', e.target.value)}
+                required
+                className={fieldInput}
+                placeholder="เช่น 87"
+              />
+            </div>
+            <div>
+              <label className="block text-xs text-muted-foreground mb-0.5 leading-snug">
+                กล่อง
+              </label>
+              <div className="flex gap-2 mt-1">
+                <button
+                  type="button"
+                  onClick={() => updateReceivingUnit(idx, 'hasBox', 'true')}
+                  className={`${segBtn} ${unit.hasBox ? 'bg-success text-success-foreground' : 'bg-muted text-muted-foreground hover:bg-success/10'}`}
+                >
+                  มีกล่อง
+                </button>
+                <button
+                  type="button"
+                  onClick={() => updateReceivingUnit(idx, 'hasBox', 'false')}
+                  className={`${segBtn} ${!unit.hasBox ? 'bg-destructive text-destructive-foreground' : 'bg-muted text-muted-foreground hover:bg-destructive/10'}`}
+                >
+                  ไม่มีกล่อง
+                </button>
+              </div>
+            </div>
+          </div>
+          <div>
+            <label className="block text-xs text-muted-foreground mb-0.5 leading-snug">
+              ประกันศูนย์ <span className="text-destructive">*</span>
+            </label>
+            <div className="flex items-center gap-3">
+              <label className="flex items-center gap-1.5 cursor-pointer min-h-11">
+                <input
+                  type="checkbox"
+                  checked={unit.warrantyExpired}
+                  onChange={(e) =>
+                    updateReceivingUnit(idx, 'warrantyExpired', e.target.checked ? 'true' : 'false')
+                  }
+                  className="rounded size-4"
+                />
+                <span className="text-xs text-muted-foreground leading-snug">หมดประกันแล้ว</span>
+              </label>
+              {!unit.warrantyExpired && (
+                <ThaiDateInput
+                  value={unit.warrantyExpireDate}
+                  onChange={(e) => updateReceivingUnit(idx, 'warrantyExpireDate', e.target.value)}
+                  required
+                  className={`flex-1 ${fieldInput}`}
+                />
+              )}
+            </div>
+          </div>
+          <div className="mt-2 border-t border-warning/20 pt-2">
+            <div className="text-xs font-medium text-warning mb-2 leading-snug">
+              เช็คลิสต์ตรวจเครื่อง
+            </div>
+            {checklistCategories.map((cat) => (
+              <div key={cat} className="mb-2">
+                <div className="text-xs font-medium text-muted-foreground mb-1 leading-snug">
+                  {cat}
+                </div>
+                <div className="space-y-1">
+                  {unit.checklist.map((c, checkIdx) =>
+                    c.category !== cat ? null : (
+                      <div key={checkIdx} className="flex items-center gap-2">
+                        <button
+                          type="button"
+                          onClick={() => updateChecklist(idx, checkIdx, 'passed', !c.passed)}
+                          className={`size-6 rounded flex items-center justify-center text-xs font-bold transition-colors ${c.passed ? 'bg-success text-success-foreground' : 'bg-destructive text-destructive-foreground'}`}
+                        >
+                          {c.passed ? '✓' : '✗'}
+                        </button>
+                        <span
+                          className={`text-xs flex-1 leading-snug ${c.passed ? 'text-foreground' : 'text-destructive font-medium'}`}
+                        >
+                          {c.item}
+                        </span>
+                        {!c.passed && (
+                          <input
+                            type="text"
+                            placeholder="หมายเหตุ"
+                            value={c.note}
+                            onChange={(e) => updateChecklist(idx, checkIdx, 'note', e.target.value)}
+                            className="w-28 px-2 py-1.5 border border-destructive/30 rounded text-xs focus-visible:ring-1 focus-visible:ring-ring/30 outline-hidden"
+                          />
+                        )}
+                      </div>
+                    ),
+                  )}
+                </div>
+              </div>
+            ))}
+            <div className="text-xs text-muted-foreground mt-1 leading-snug">
+              ผ่าน {unit.checklist.filter((c) => c.passed).length}/{unit.checklist.length} รายการ
+            </div>
+          </div>
+        </div>
+      )}
+
+      {unit.status === 'PASS' && (
+        <div className="mt-2 border border-primary/20 bg-primary/5 dark:bg-primary/10 rounded-xl p-3">
+          <label className="block text-xs text-muted-foreground mb-0.5 leading-snug">
+            ราคาขาย (บาท) <span className="text-destructive">*</span>
+          </label>
+          <input
+            type="number"
+            inputMode="decimal"
+            min="0"
+            value={unit.sellingPrice}
+            onChange={(e) => updateReceivingUnit(idx, 'sellingPrice', e.target.value)}
+            required
+            className={fieldInput}
+            placeholder="เช่น 15000"
+          />
+        </div>
+      )}
+
+      {unit.status === 'REJECT' && (
+        <div className="mt-2 space-y-2">
+          <div>
+            <label className="block text-xs text-muted-foreground mb-0.5 leading-snug">
+              สาเหตุที่ไม่ผ่าน <span className="text-destructive">*</span>
+            </label>
+            <select
+              value={unit.defectReason}
+              onChange={(e) =>
+                updateReceivingUnit(idx, 'defectReason', e.target.value as DefectReasonValue)
+              }
+              required
+              className={fieldInput}
+            >
+              <option value="">เลือกสาเหตุ…</option>
+              {defectReasonOptions.map((o) => (
+                <option key={o.value} value={o.value}>
+                  {o.label}
+                </option>
+              ))}
+            </select>
+          </div>
+          <input
+            type="text"
+            placeholder="รายละเอียดเพิ่มเติม (ถ้ามี)"
+            value={unit.rejectReason}
+            onChange={(e) => updateReceivingUnit(idx, 'rejectReason', e.target.value)}
+            className={fieldInput}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/pages/PurchaseOrdersPage/components/useReceivingDuplicates.test.ts
+++ b/apps/web/src/pages/PurchaseOrdersPage/components/useReceivingDuplicates.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { computeDuplicateIndices } from './useReceivingDuplicates';
+import type { ReceivingUnitForm } from '../types';
+
+const u = (over: Partial<ReceivingUnitForm>): ReceivingUnitForm => ({
+  poItemId: '',
+  label: '',
+  category: 'PHONE_NEW',
+  imeiSerial: '',
+  serialNumber: '',
+  status: 'PASS',
+  rejectReason: '',
+  defectReason: '',
+  batteryHealth: '',
+  warrantyExpired: false,
+  warrantyExpireDate: '',
+  hasBox: true,
+  checklist: [],
+  sellingPrice: '',
+  photos: [],
+  costPrice: '',
+  ...over,
+});
+
+describe('computeDuplicateIndices', () => {
+  it('flags both PASS units that share an IMEI', () => {
+    const set = computeDuplicateIndices([
+      u({ imeiSerial: 'A' }),
+      u({ imeiSerial: 'A' }),
+      u({ imeiSerial: 'B' }),
+    ]);
+    expect([...set].sort()).toEqual([0, 1]);
+  });
+
+  it('ignores empty IMEIs and REJECT units', () => {
+    const set = computeDuplicateIndices([
+      u({ imeiSerial: '' }),
+      u({ imeiSerial: '' }),
+      u({ status: 'REJECT', imeiSerial: 'A' }),
+      u({ imeiSerial: 'A' }),
+    ]);
+    expect(set.size).toBe(0);
+  });
+
+  it('is case/space-insensitive', () => {
+    const set = computeDuplicateIndices([u({ imeiSerial: ' a1 ' }), u({ imeiSerial: 'A1' })]);
+    expect([...set].sort()).toEqual([0, 1]);
+  });
+});

--- a/apps/web/src/pages/PurchaseOrdersPage/components/useReceivingDuplicates.ts
+++ b/apps/web/src/pages/PurchaseOrdersPage/components/useReceivingDuplicates.ts
@@ -1,0 +1,24 @@
+import { useMemo } from 'react';
+import type { ReceivingUnitForm } from '../types';
+
+/** Pure: indices of PASS units whose normalized IMEI collides with another PASS unit. */
+export function computeDuplicateIndices(units: ReceivingUnitForm[]): Set<number> {
+  const seen = new Map<string, number[]>();
+  units.forEach((unit, idx) => {
+    if (unit.status !== 'PASS') return;
+    const key = unit.imeiSerial.trim().toLowerCase();
+    if (!key) return;
+    const arr = seen.get(key) ?? [];
+    arr.push(idx);
+    seen.set(key, arr);
+  });
+  const dupes = new Set<number>();
+  for (const arr of seen.values()) {
+    if (arr.length > 1) arr.forEach((i) => dupes.add(i));
+  }
+  return dupes;
+}
+
+export function useReceivingDuplicates(units: ReceivingUnitForm[]): Set<number> {
+  return useMemo(() => computeDuplicateIndices(units), [units]);
+}

--- a/apps/web/src/pages/PurchaseOrdersPage/constants.ts
+++ b/apps/web/src/pages/PurchaseOrdersPage/constants.ts
@@ -1,4 +1,4 @@
-import { ItemForm } from './types';
+import { ItemForm, DefectReasonValue } from './types';
 
 export const statusLabels: Record<string, string> = {
   PENDING: 'รอดำเนินการ',
@@ -66,3 +66,14 @@ export const defaultChecklist = [
 export const checklistCategories = [...new Set(defaultChecklist.map((c) => c.category))];
 
 export const emptyItem: ItemForm = { brand: '', category: '', model: '', color: '', storage: '', quantity: '1', unitPrice: '', accessoryType: '', accessoryBrand: '' };
+
+export const defectReasonOptions: { value: DefectReasonValue; label: string }[] = [
+  { value: 'SCREEN', label: 'จอเสีย/จอแตก' },
+  { value: 'BATTERY', label: 'แบตเตอรี่เสีย' },
+  { value: 'IMEI_BLOCKED', label: 'IMEI ถูกบล็อก' },
+  { value: 'BOX_MISSING', label: 'ไม่มีกล่อง/อุปกรณ์' },
+  { value: 'WRONG_MODEL', label: 'ผิดรุ่น/ผิดสเปก' },
+  { value: 'DOA', label: 'เปิดไม่ติด (DOA)' },
+  { value: 'COSMETIC', label: 'ตำหนิภายนอก' },
+  { value: 'OTHER', label: 'อื่นๆ' },
+];

--- a/apps/web/src/pages/PurchaseOrdersPage/hooks/usePurchaseOrdersData.test.tsx
+++ b/apps/web/src/pages/PurchaseOrdersPage/hooks/usePurchaseOrdersData.test.tsx
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { buildDirectReceiveItem } from './usePurchaseOrdersData';
+import type { ReceivingUnitForm } from '../types';
+
+const baseUnit = (over: Partial<ReceivingUnitForm>): ReceivingUnitForm => ({
+  poItemId: '', label: '', category: 'PHONE_NEW', imeiSerial: '', serialNumber: '',
+  status: 'PASS', rejectReason: '', defectReason: '', batteryHealth: '', warrantyExpired: false,
+  warrantyExpireDate: '', hasBox: true, checklist: [], sellingPrice: '', photos: [], costPrice: '0',
+  ...over,
+});
+
+describe('buildDirectReceiveItem', () => {
+  it('sends costPrice as unitPrice and quantity 1; omits defectReason on PASS', () => {
+    const out = buildDirectReceiveItem(baseUnit({ costPrice: '30000', imeiSerial: 'IMEI-1', sellingPrice: '39900', defectReason: 'SCREEN' }));
+    expect(out.unitPrice).toBe(30000);
+    expect(out.quantity).toBe(1);
+    expect(out.sellingPrice).toBe(39900);
+    expect(out.defectReason).toBeUndefined(); // PASS drops defectReason
+    expect(out.imeiSerial).toBe('IMEI-1');
+  });
+
+  it('includes defectReason + rejectReason only on REJECT, drops sellingPrice', () => {
+    const out = buildDirectReceiveItem(baseUnit({ status: 'REJECT', rejectReason: 'จอแตก', defectReason: 'SCREEN', sellingPrice: '39900', costPrice: '30000' }));
+    expect(out.defectReason).toBe('SCREEN');
+    expect(out.rejectReason).toBe('จอแตก');
+    expect(out.sellingPrice).toBeUndefined();
+  });
+
+  it('attaches used-phone fields + checklistResults only for PHONE_USED PASS', () => {
+    const out = buildDirectReceiveItem(baseUnit({ category: 'PHONE_USED', costPrice: '12000', imeiSerial: 'X', batteryHealth: '88', warrantyExpired: true, checklist: [{ item: 'จอ', category: 'ภายนอก', passed: true, note: '' }] }));
+    expect(out.batteryHealth).toBe(88);
+    expect(out.warrantyExpired).toBe(true);
+    expect(out.checklistResults).toEqual([{ item: 'จอ', category: 'ภายนอก', passed: true }]);
+  });
+
+  it('includes photos only when present', () => {
+    expect(buildDirectReceiveItem(baseUnit({ photos: [] })).photos).toBeUndefined();
+    expect(buildDirectReceiveItem(baseUnit({ photos: ['data:img'] })).photos).toEqual(['data:img']);
+  });
+});

--- a/apps/web/src/pages/PurchaseOrdersPage/hooks/usePurchaseOrdersData.ts
+++ b/apps/web/src/pages/PurchaseOrdersPage/hooks/usePurchaseOrdersData.ts
@@ -2,8 +2,37 @@ import { useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import api, { getErrorMessage } from '@/lib/api';
-import { PurchaseOrder, PODetail, ReceivingUnitForm } from '../types';
+import { PurchaseOrder, PODetail, ReceivingUnitForm, DirectReceiveLineForm } from '../types';
 import { defaultChecklist } from '../constants';
+
+export function buildDirectReceiveItem(i: ReceivingUnitForm) {
+  const isUsed = i.category === 'PHONE_USED';
+  return {
+    category: i.category || undefined,
+    brand: i.brand || undefined,
+    model: i.model || undefined,
+    color: i.color || undefined,
+    storage: i.storage || undefined,
+    accessoryType: i.accessoryType || undefined,
+    accessoryBrand: i.accessoryBrand || undefined,
+    quantity: 1,
+    unitPrice: Number(i.costPrice),
+    imeiSerial: i.imeiSerial || undefined,
+    serialNumber: i.serialNumber || undefined,
+    status: i.status,
+    rejectReason: i.status === 'REJECT' ? i.rejectReason || undefined : undefined,
+    defectReason: i.status === 'REJECT' ? i.defectReason || undefined : undefined,
+    photos: i.photos.length ? i.photos : undefined,
+    ...(isUsed && i.status === 'PASS' ? {
+      batteryHealth: i.batteryHealth ? Number(i.batteryHealth) : undefined,
+      warrantyExpired: i.warrantyExpired,
+      warrantyExpireDate: !i.warrantyExpired && i.warrantyExpireDate ? i.warrantyExpireDate : undefined,
+      hasBox: i.hasBox,
+      checklistResults: i.checklist.map(({ item, category, passed, note }) => ({ item, category, passed, ...(note ? { note } : {}) })),
+    } : {}),
+    ...(i.status === 'PASS' && i.sellingPrice ? { sellingPrice: Number(i.sellingPrice) } : {}),
+  };
+}
 
 export function usePurchaseOrdersData(options?: { onCreateSuccess?: () => void }) {
   const queryClient = useQueryClient();
@@ -14,6 +43,10 @@ export function usePurchaseOrdersData(options?: { onCreateSuccess?: () => void }
   const [showQcPanel, setShowQcPanel] = useState(false);
   const [qcNotes, setQcNotes] = useState<Record<string, string>>({});
   const [isReceiveModalOpen, setIsReceiveModalOpen] = useState(false);
+  const [isDirectReceiveOpen, setIsDirectReceiveOpen] = useState(false);
+  const [directLines, setDirectLines] = useState<DirectReceiveLineForm[]>([]);
+  const [directSupplierId, setDirectSupplierId] = useState('');
+  const [directNotes, setDirectNotes] = useState('');
   const [confirmDialog, setConfirmDialog] = useState<{ open: boolean; message: string; action: () => void }>({ open: false, message: '', action: () => {} });
   const [isPaymentModalOpen, setIsPaymentModalOpen] = useState(false);
   const [selectedPO, setSelectedPO] = useState<PurchaseOrder | null>(null);
@@ -144,6 +177,8 @@ export function usePurchaseOrdersData(options?: { onCreateSuccess?: () => void }
             serialNumber: i.serialNumber || undefined,
             status: i.status,
             rejectReason: i.status === 'REJECT' ? i.rejectReason || undefined : undefined,
+            defectReason: i.status === 'REJECT' ? i.defectReason || undefined : undefined,
+            photos: i.photos.length ? i.photos : undefined,
             ...(isUsed && i.status === 'PASS' ? {
               batteryHealth: i.batteryHealth ? Number(i.batteryHealth) : undefined,
               warrantyExpired: i.warrantyExpired,
@@ -164,6 +199,23 @@ export function usePurchaseOrdersData(options?: { onCreateSuccess?: () => void }
       toast.success(`รับ+ตรวจสำเร็จ: ผ่าน ${data.passed} ชิ้น, ไม่ผ่าน ${data.rejected} ชิ้น → รอ QC ที่คลัง ${data.mainWarehouse}`);
       setIsReceiveModalOpen(false);
       setIsDetailModalOpen(false);
+    },
+    onError: (err: unknown) => toast.error(getErrorMessage(err)),
+  });
+
+  const directReceiveMutation = useMutation({
+    mutationFn: async ({ supplierId, orderDate, notes, items }: { supplierId: string; orderDate: string; notes?: string; items: ReceivingUnitForm[] }) =>
+      api.post('/purchase-orders/direct-receive', {
+        supplierId,
+        orderDate,
+        notes: notes || undefined,
+        items: items.map(buildDirectReceiveItem),
+      }),
+    onSuccess: (res) => {
+      queryClient.invalidateQueries({ queryKey: ['purchase-orders'] });
+      const d = res.data;
+      toast.success(`รับเข้าตรงสำเร็จ (${d.poNumber}): ผ่าน ${d.passed} ชิ้น, ไม่ผ่าน ${d.rejected} ชิ้น → รอ QC ที่คลัง ${d.mainWarehouse}`);
+      setIsDirectReceiveOpen(false);
     },
     onError: (err: unknown) => toast.error(getErrorMessage(err)),
   });
@@ -249,12 +301,15 @@ export function usePurchaseOrdersData(options?: { onCreateSuccess?: () => void }
           serialNumber: '',
           status: 'PASS',
           rejectReason: '',
+          defectReason: '',
           batteryHealth: '',
           warrantyExpired: false,
           warrantyExpireDate: '',
           hasBox: true,
           checklist: defaultChecklist.map((c) => ({ ...c, passed: true, note: '' })),
           sellingPrice: defaultPrice,
+          photos: [],
+          costPrice: '',
         });
       }
     }
@@ -273,6 +328,13 @@ export function usePurchaseOrdersData(options?: { onCreateSuccess?: () => void }
     setPaymentAttachments(po.attachments || []);
     setPaymentAttachmentUrl('');
     setIsPaymentModalOpen(true);
+  };
+
+  const openDirectReceive = () => {
+    setDirectSupplierId('');
+    setDirectNotes('');
+    setDirectLines([{ category: 'PHONE_NEW', brand: '', model: '', color: '', storage: '', accessoryType: '', accessoryBrand: '', quantity: '1', costPrice: '' }]);
+    setIsDirectReceiveOpen(true);
   };
 
   const updateReceivingUnit = (idx: number, field: string, value: string) => {
@@ -379,6 +441,7 @@ export function usePurchaseOrdersData(options?: { onCreateSuccess?: () => void }
     rejectPOMutation,
     cancelMutation,
     goodsReceivingMutation,
+    directReceiveMutation,
     paymentMutation,
     // State
     statusFilter,
@@ -391,6 +454,14 @@ export function usePurchaseOrdersData(options?: { onCreateSuccess?: () => void }
     setIsDetailModalOpen,
     isReceiveModalOpen,
     setIsReceiveModalOpen,
+    isDirectReceiveOpen,
+    setIsDirectReceiveOpen,
+    directLines,
+    setDirectLines,
+    directSupplierId,
+    setDirectSupplierId,
+    directNotes,
+    setDirectNotes,
     isPaymentModalOpen,
     setIsPaymentModalOpen,
     showQcPanel,
@@ -416,6 +487,7 @@ export function usePurchaseOrdersData(options?: { onCreateSuccess?: () => void }
     // Actions
     openDetailModal,
     openReceiveModal,
+    openDirectReceive,
     openPaymentModal,
     updateReceivingUnit,
     updateChecklist,

--- a/apps/web/src/pages/PurchaseOrdersPage/hooks/usePurchaseOrdersData.ts
+++ b/apps/web/src/pages/PurchaseOrdersPage/hooks/usePurchaseOrdersData.ts
@@ -23,13 +23,21 @@ export function buildDirectReceiveItem(i: ReceivingUnitForm) {
     rejectReason: i.status === 'REJECT' ? i.rejectReason || undefined : undefined,
     defectReason: i.status === 'REJECT' ? i.defectReason || undefined : undefined,
     photos: i.photos.length ? i.photos : undefined,
-    ...(isUsed && i.status === 'PASS' ? {
-      batteryHealth: i.batteryHealth ? Number(i.batteryHealth) : undefined,
-      warrantyExpired: i.warrantyExpired,
-      warrantyExpireDate: !i.warrantyExpired && i.warrantyExpireDate ? i.warrantyExpireDate : undefined,
-      hasBox: i.hasBox,
-      checklistResults: i.checklist.map(({ item, category, passed, note }) => ({ item, category, passed, ...(note ? { note } : {}) })),
-    } : {}),
+    ...(isUsed && i.status === 'PASS'
+      ? {
+          batteryHealth: i.batteryHealth ? Number(i.batteryHealth) : undefined,
+          warrantyExpired: i.warrantyExpired,
+          warrantyExpireDate:
+            !i.warrantyExpired && i.warrantyExpireDate ? i.warrantyExpireDate : undefined,
+          hasBox: i.hasBox,
+          checklistResults: i.checklist.map(({ item, category, passed, note }) => ({
+            item,
+            category,
+            passed,
+            ...(note ? { note } : {}),
+          })),
+        }
+      : {}),
     ...(i.status === 'PASS' && i.sellingPrice ? { sellingPrice: Number(i.sellingPrice) } : {}),
   };
 }
@@ -47,17 +55,45 @@ export function usePurchaseOrdersData(options?: { onCreateSuccess?: () => void }
   const [directLines, setDirectLines] = useState<DirectReceiveLineForm[]>([]);
   const [directSupplierId, setDirectSupplierId] = useState('');
   const [directNotes, setDirectNotes] = useState('');
-  const [confirmDialog, setConfirmDialog] = useState<{ open: boolean; message: string; action: () => void }>({ open: false, message: '', action: () => {} });
+  const [confirmDialog, setConfirmDialog] = useState<{
+    open: boolean;
+    message: string;
+    action: () => void;
+  }>({ open: false, message: '', action: () => {} });
   const [isPaymentModalOpen, setIsPaymentModalOpen] = useState(false);
   const [selectedPO, setSelectedPO] = useState<PurchaseOrder | null>(null);
   const [poDetail, setPODetail] = useState<PODetail | null>(null);
   const [receivingUnits, setReceivingUnits] = useState<ReceivingUnitForm[]>([]);
   const [receivingNotes, setReceivingNotes] = useState('');
-  const [paymentForm, setPaymentForm] = useState({ paymentStatus: '', paymentMethod: '', paidAmount: '', paymentNotes: '' });
+  const [paymentForm, setPaymentForm] = useState({
+    paymentStatus: '',
+    paymentMethod: '',
+    paidAmount: '',
+    paymentNotes: '',
+  });
   const [paymentAttachments, setPaymentAttachments] = useState<string[]>([]);
   const [paymentAttachmentUrl, setPaymentAttachmentUrl] = useState('');
 
-  const { data: suppliersRes, isLoading: suppliersLoading, isError: suppliersError } = useQuery<{ data: { id: string; name: string; contactName: string | null; hasVat: boolean; paymentMethods: { paymentMethod: string; bankName?: string; bankAccountName?: string; bankAccountNumber?: string; creditTermDays?: number; isDefault: boolean }[] }[] }>({
+  const {
+    data: suppliersRes,
+    isLoading: suppliersLoading,
+    isError: suppliersError,
+  } = useQuery<{
+    data: {
+      id: string;
+      name: string;
+      contactName: string | null;
+      hasVat: boolean;
+      paymentMethods: {
+        paymentMethod: string;
+        bankName?: string;
+        bankAccountName?: string;
+        bankAccountNumber?: string;
+        creditTermDays?: number;
+        isDefault: boolean;
+      }[];
+    }[];
+  }>({
     queryKey: ['suppliers-for-po'],
     queryFn: async () => (await api.get('/suppliers?limit=200&isActive=true')).data,
     retry: 2,
@@ -72,7 +108,18 @@ export function usePurchaseOrdersData(options?: { onCreateSuccess?: () => void }
       totalPaid: number;
       totalRemaining: number;
       poCount: number;
-      pos: { id: string; poNumber: string; orderDate: string; dueDate: string | null; netAmount: number; paidAmount: number; remaining: number; paymentStatus: string; status: string; itemsSummary: string }[];
+      pos: {
+        id: string;
+        poNumber: string;
+        orderDate: string;
+        dueDate: string | null;
+        netAmount: number;
+        paidAmount: number;
+        remaining: number;
+        paymentStatus: string;
+        status: string;
+        itemsSummary: string;
+      }[];
     }[];
   };
   const { data: payableData } = useQuery<PayableData>({
@@ -81,8 +128,16 @@ export function usePurchaseOrdersData(options?: { onCreateSuccess?: () => void }
       const res = await api.get('/purchase-orders/accounts-payable');
       // Backend returns { grandTotal, data: suppliers[], total, page, limit }
       // Normalize to legacy shape { grandTotal, suppliers: [...] }
-      const raw = res.data as { grandTotal?: number; data?: PayableData['suppliers']; suppliers?: PayableData['suppliers'] };
-      const suppliers = Array.isArray(raw?.suppliers) ? raw.suppliers : Array.isArray(raw?.data) ? raw.data : [];
+      const raw = res.data as {
+        grandTotal?: number;
+        data?: PayableData['suppliers'];
+        suppliers?: PayableData['suppliers'];
+      };
+      const suppliers = Array.isArray(raw?.suppliers)
+        ? raw.suppliers
+        : Array.isArray(raw?.data)
+          ? raw.data
+          : [];
       return { grandTotal: Number(raw?.grandTotal) || 0, suppliers };
     },
     enabled: activeTab === 'payable',
@@ -97,7 +152,9 @@ export function usePurchaseOrdersData(options?: { onCreateSuccess?: () => void }
     },
   });
 
-  const { data: qcPendingItems = [] } = useQuery<{ productId: string; productName: string; imeiSerial?: string }[]>({
+  const { data: qcPendingItems = [] } = useQuery<
+    { productId: string; productName: string; imeiSerial?: string }[]
+  >({
     queryKey: ['qc-pending'],
     queryFn: async () => {
       const res = await api.get('/purchase-orders/qc-pending');
@@ -167,7 +224,15 @@ export function usePurchaseOrdersData(options?: { onCreateSuccess?: () => void }
   });
 
   const goodsReceivingMutation = useMutation({
-    mutationFn: async ({ poId, items, notes }: { poId: string; items: ReceivingUnitForm[]; notes: string }) =>
+    mutationFn: async ({
+      poId,
+      items,
+      notes,
+    }: {
+      poId: string;
+      items: ReceivingUnitForm[];
+      notes: string;
+    }) =>
       api.post(`/purchase-orders/${poId}/goods-receiving`, {
         items: items.map((i) => {
           const isUsed = i.category === 'PHONE_USED';
@@ -179,16 +244,24 @@ export function usePurchaseOrdersData(options?: { onCreateSuccess?: () => void }
             rejectReason: i.status === 'REJECT' ? i.rejectReason || undefined : undefined,
             defectReason: i.status === 'REJECT' ? i.defectReason || undefined : undefined,
             photos: i.photos.length ? i.photos : undefined,
-            ...(isUsed && i.status === 'PASS' ? {
-              batteryHealth: i.batteryHealth ? Number(i.batteryHealth) : undefined,
-              warrantyExpired: i.warrantyExpired,
-              warrantyExpireDate: !i.warrantyExpired && i.warrantyExpireDate ? i.warrantyExpireDate : undefined,
-              hasBox: i.hasBox,
-              checklistResults: i.checklist.map(({ item, category, passed, note }) => ({
-                item, category, passed, ...(note ? { note } : {}),
-              })),
-            } : {}),
-            ...(i.status === 'PASS' && i.sellingPrice ? { sellingPrice: Number(i.sellingPrice) } : {}),
+            ...(isUsed && i.status === 'PASS'
+              ? {
+                  batteryHealth: i.batteryHealth ? Number(i.batteryHealth) : undefined,
+                  warrantyExpired: i.warrantyExpired,
+                  warrantyExpireDate:
+                    !i.warrantyExpired && i.warrantyExpireDate ? i.warrantyExpireDate : undefined,
+                  hasBox: i.hasBox,
+                  checklistResults: i.checklist.map(({ item, category, passed, note }) => ({
+                    item,
+                    category,
+                    passed,
+                    ...(note ? { note } : {}),
+                  })),
+                }
+              : {}),
+            ...(i.status === 'PASS' && i.sellingPrice
+              ? { sellingPrice: Number(i.sellingPrice) }
+              : {}),
           };
         }),
         notes: notes || undefined,
@@ -196,7 +269,9 @@ export function usePurchaseOrdersData(options?: { onCreateSuccess?: () => void }
     onSuccess: (res) => {
       queryClient.invalidateQueries({ queryKey: ['purchase-orders'] });
       const data = res.data;
-      toast.success(`รับ+ตรวจสำเร็จ: ผ่าน ${data.passed} ชิ้น, ไม่ผ่าน ${data.rejected} ชิ้น → รอ QC ที่คลัง ${data.mainWarehouse}`);
+      toast.success(
+        `รับ+ตรวจสำเร็จ: ผ่าน ${data.passed} ชิ้น, ไม่ผ่าน ${data.rejected} ชิ้น → รอ QC ที่คลัง ${data.mainWarehouse}`,
+      );
       setIsReceiveModalOpen(false);
       setIsDetailModalOpen(false);
     },
@@ -204,7 +279,17 @@ export function usePurchaseOrdersData(options?: { onCreateSuccess?: () => void }
   });
 
   const directReceiveMutation = useMutation({
-    mutationFn: async ({ supplierId, orderDate, notes, items }: { supplierId: string; orderDate: string; notes?: string; items: ReceivingUnitForm[] }) =>
+    mutationFn: async ({
+      supplierId,
+      orderDate,
+      notes,
+      items,
+    }: {
+      supplierId: string;
+      orderDate: string;
+      notes?: string;
+      items: ReceivingUnitForm[];
+    }) =>
       api.post('/purchase-orders/direct-receive', {
         supplierId,
         orderDate,
@@ -214,7 +299,9 @@ export function usePurchaseOrdersData(options?: { onCreateSuccess?: () => void }
     onSuccess: (res) => {
       queryClient.invalidateQueries({ queryKey: ['purchase-orders'] });
       const d = res.data;
-      toast.success(`รับเข้าตรงสำเร็จ (${d.poNumber}): ผ่าน ${d.passed} ชิ้น, ไม่ผ่าน ${d.rejected} ชิ้น → รอ QC ที่คลัง ${d.mainWarehouse}`);
+      toast.success(
+        `รับเข้าตรงสำเร็จ (${d.poNumber}): ผ่าน ${d.passed} ชิ้น, ไม่ผ่าน ${d.rejected} ชิ้น → รอ QC ที่คลัง ${d.mainWarehouse}`,
+      );
       setIsDirectReceiveOpen(false);
     },
     onError: (err: unknown) => toast.error(getErrorMessage(err)),
@@ -230,10 +317,15 @@ export function usePurchaseOrdersData(options?: { onCreateSuccess?: () => void }
       setIsPaymentModalOpen(false);
       // Refresh detail if open
       if (selectedPO) {
-        api.get(`/purchase-orders/${selectedPO.id}`).then(({ data }) => {
-          setPODetail(data);
-          setSelectedPO(data);
-        }).catch(() => { /* detail will refresh on next open */ });
+        api
+          .get(`/purchase-orders/${selectedPO.id}`)
+          .then(({ data }) => {
+            setPODetail(data);
+            setSelectedPO(data);
+          })
+          .catch(() => {
+            /* detail will refresh on next open */
+          });
       }
     },
     onError: (err: unknown) => toast.error(getErrorMessage(err)),
@@ -266,7 +358,9 @@ export function usePurchaseOrdersData(options?: { onCreateSuccess?: () => void }
           if (t.cashPrice) pricingCache.set(key, String(Number(t.cashPrice)));
         }
       }
-    } catch { /* failed to fetch pricing templates */ }
+    } catch {
+      /* failed to fetch pricing templates */
+    }
 
     const units: ReceivingUnitForm[] = [];
     for (const item of po.items) {
@@ -274,9 +368,13 @@ export function usePurchaseOrdersData(options?: { onCreateSuccess?: () => void }
       const isAccessory = item.category === 'ACCESSORY';
       const isCharger = isAccessory && item.accessoryType === 'ชุดชาร์จ';
       const nameParts = isAccessory
-        ? (isCharger
-            ? [item.accessoryType, item.accessoryBrand, item.model].filter(Boolean)
-            : [item.accessoryType, item.accessoryBrand, item.model ? `สำหรับ ${item.model}` : ''].filter(Boolean))
+        ? isCharger
+          ? [item.accessoryType, item.accessoryBrand, item.model].filter(Boolean)
+          : [
+              item.accessoryType,
+              item.accessoryBrand,
+              item.model ? `สำหรับ ${item.model}` : '',
+            ].filter(Boolean)
         : [item.brand, item.model, item.color, item.storage].filter(Boolean);
 
       // Try to find matching pricing template (with storage, then without)
@@ -333,7 +431,19 @@ export function usePurchaseOrdersData(options?: { onCreateSuccess?: () => void }
   const openDirectReceive = () => {
     setDirectSupplierId('');
     setDirectNotes('');
-    setDirectLines([{ category: 'PHONE_NEW', brand: '', model: '', color: '', storage: '', accessoryType: '', accessoryBrand: '', quantity: '1', costPrice: '' }]);
+    setDirectLines([
+      {
+        category: 'PHONE_NEW',
+        brand: '',
+        model: '',
+        color: '',
+        storage: '',
+        accessoryType: '',
+        accessoryBrand: '',
+        quantity: '1',
+        costPrice: '',
+      },
+    ]);
     setIsDirectReceiveOpen(true);
   };
 
@@ -345,7 +455,12 @@ export function usePurchaseOrdersData(options?: { onCreateSuccess?: () => void }
     setReceivingUnits(newUnits);
   };
 
-  const updateChecklist = (unitIdx: number, checkIdx: number, field: 'passed' | 'note', value: boolean | string) => {
+  const updateChecklist = (
+    unitIdx: number,
+    checkIdx: number,
+    field: 'passed' | 'note',
+    value: boolean | string,
+  ) => {
     const newUnits = [...receivingUnits];
     const newChecklist = [...newUnits[unitIdx].checklist];
     newChecklist[checkIdx] = { ...newChecklist[checkIdx], [field]: value };
@@ -362,9 +477,9 @@ export function usePurchaseOrdersData(options?: { onCreateSuccess?: () => void }
       return;
     }
 
-    const missingReasons = receivingUnits.filter((u) => u.status === 'REJECT' && !u.rejectReason.trim());
-    if (missingReasons.length > 0) {
-      toast.error('กรุณาระบุเหตุผลสำหรับรายการที่ไม่ผ่าน');
+    const missingDefect = receivingUnits.filter((u) => u.status === 'REJECT' && !u.defectReason);
+    if (missingDefect.length > 0) {
+      toast.error('กรุณาเลือกสาเหตุที่ไม่ผ่าน (defect) สำหรับรายการที่ไม่ผ่าน');
       return;
     }
 
@@ -376,13 +491,17 @@ export function usePurchaseOrdersData(options?: { onCreateSuccess?: () => void }
       return;
     }
 
-    const missingSerial = passUnits.filter((u) => u.category !== 'ACCESSORY' && !u.serialNumber.trim());
+    const missingSerial = passUnits.filter(
+      (u) => u.category !== 'ACCESSORY' && !u.serialNumber.trim(),
+    );
     if (missingSerial.length > 0) {
       toast.error('กรุณาระบุหมายเลขซีเรียลให้ครบทุกรายการที่ผ่าน');
       return;
     }
 
-    const missingSellingPrice = passUnits.filter((u) => !u.sellingPrice.trim() || Number(u.sellingPrice) <= 0);
+    const missingSellingPrice = passUnits.filter(
+      (u) => !u.sellingPrice.trim() || Number(u.sellingPrice) <= 0,
+    );
     if (missingSellingPrice.length > 0) {
       toast.error('กรุณาระบุราคาขายให้ครบทุกรายการที่ผ่าน');
       return;
@@ -396,7 +515,9 @@ export function usePurchaseOrdersData(options?: { onCreateSuccess?: () => void }
       return;
     }
 
-    const missingWarranty = usedPhonePass.filter((u) => !u.warrantyExpired && !u.warrantyExpireDate.trim());
+    const missingWarranty = usedPhonePass.filter(
+      (u) => !u.warrantyExpired && !u.warrantyExpireDate.trim(),
+    );
     if (missingWarranty.length > 0) {
       toast.error('กรุณาระบุวันหมดประกันหรือติ๊กหมดประกันแล้ว');
       return;

--- a/apps/web/src/pages/PurchaseOrdersPage/index.tsx
+++ b/apps/web/src/pages/PurchaseOrdersPage/index.tsx
@@ -18,6 +18,7 @@ import { CreatePOModal } from './components/CreatePOModal';
 import { PODetailModal } from './components/PODetailModal';
 import { PaymentModal } from './components/PaymentModal';
 import { GoodsReceivingModal } from './components/GoodsReceivingModal';
+import { DirectReceiveModal } from './components/DirectReceiveModal';
 
 export default function PurchaseOrdersPage() {
   const resetFormRef = useRef<() => void>(() => {});
@@ -123,6 +124,12 @@ export default function PurchaseOrdersPage() {
                 ส่งออก Excel
               </button>
             )}
+            <button
+              onClick={data.openDirectReceive}
+              className="px-4 py-2 border border-input rounded-lg text-sm font-medium hover:bg-muted transition-colors"
+            >
+              รับเข้าตรง (supplier)
+            </button>
             <button
               onClick={() => data.setIsCreateModalOpen(true)}
               className="px-4 py-2 bg-primary text-primary-foreground rounded-lg text-sm font-medium hover:bg-primary/90 transition-colors"
@@ -267,6 +274,19 @@ export default function PurchaseOrdersPage() {
         updateReceivingUnit={data.updateReceivingUnit}
         updateChecklist={data.updateChecklist}
         handleGoodsReceiving={data.handleGoodsReceiving}
+      />
+
+      <DirectReceiveModal
+        isOpen={data.isDirectReceiveOpen}
+        onClose={() => data.setIsDirectReceiveOpen(false)}
+        suppliers={data.suppliers}
+        supplierId={data.directSupplierId}
+        setSupplierId={data.setDirectSupplierId}
+        lines={data.directLines}
+        setLines={data.setDirectLines}
+        notes={data.directNotes}
+        setNotes={data.setDirectNotes}
+        directReceiveMutation={data.directReceiveMutation}
       />
 
       <ConfirmDialog

--- a/apps/web/src/pages/PurchaseOrdersPage/types.ts
+++ b/apps/web/src/pages/PurchaseOrdersPage/types.ts
@@ -79,6 +79,10 @@ export interface ItemForm {
   accessoryBrand: string;
 }
 
+export type DefectReasonValue =
+  | 'SCREEN' | 'BATTERY' | 'IMEI_BLOCKED' | 'BOX_MISSING'
+  | 'WRONG_MODEL' | 'DOA' | 'COSMETIC' | 'OTHER';
+
 export interface ReceivingUnitForm {
   poItemId: string;
   label: string;
@@ -87,10 +91,35 @@ export interface ReceivingUnitForm {
   serialNumber: string;
   status: 'PASS' | 'REJECT';
   rejectReason: string;
+  defectReason: DefectReasonValue | '';
   batteryHealth: string;
   warrantyExpired: boolean;
   warrantyExpireDate: string;
   hasBox: boolean;
   checklist: { item: string; category: string; passed: boolean; note: string }[];
   sellingPrice: string;
+  photos: string[];
+  costPrice: string; // direct-receive only (empty for PO-based receive)
+  // Direct-receive-only product attrs (PO-based seeds leave these undefined —
+  // the PO unit derives its name from the PO line; direct-receive seeds set them).
+  // Required by buildDirectReceiveItem (Task 2 Step 6) + lineToUnits (Task 4 Step 2).
+  brand?: string;
+  model?: string;
+  color?: string;
+  storage?: string;
+  accessoryType?: string;
+  accessoryBrand?: string;
+}
+
+// One ad-hoc supplier-direct line (expands into `quantity` ReceivingUnitForm units)
+export interface DirectReceiveLineForm {
+  category: string;
+  brand: string;
+  model: string;
+  color: string;
+  storage: string;
+  accessoryType: string;
+  accessoryBrand: string;
+  quantity: string;
+  costPrice: string;
 }


### PR DESCRIPTION
## Purchasing & Receiving v2 — Batch B3 (mobile-first receiving + supplier-direct receive)

> ⚠️ **Stacked on B2 (#1304) → B1 (#1303) → B0 (#1302).** Base is `feat/purchasing-v2-b2`, so this PR's diff shows ONLY B3's changes. **Merge order: #1302 → #1303 → #1304 → this.** GitHub auto-retargets each PR's base when its parent merges.

Backend + frontend. Makes รับเข้าหน้างาน mobile-first and adds **supplier-direct receive ("รับเข้าตรง")** for urgent buys with no pre-made PO — implemented as an **auto-PO**. **No JournalEntry. No accounting touch.**

Spec: `docs/superpowers/specs/2026-06-29-purchasing-receiving-ux-v2-design.md`
Plan: `docs/superpowers/plans/2026-06-29-purchasing-b3-receive-mobile-direct.md`

### What's in it
| # | Change |
|---|---|
| 1 | **Backend** `POST /purchase-orders/direct-receive` — in ONE Serializable `$transaction`: create a real `PurchaseOrder` (`isDirectReceive=true`, `unitPrice=costPrice`, supplier required) → advance `APPROVED → ORDERED` bypassing the OWNER approval gate (audited: `PO_DIRECT_RECEIVE_APPROVAL_BYPASS`) → run the existing receiving pipeline. The `goodsReceiving()` body was extracted into a shared `private runReceiveInTx(tx,...)` (DRY — both flows reuse the battle-tested ceiling/IMEI/dup defenses); both keep their own P2002/P2034 retry; the receive guard gained `'ORDERED'`. |
| 2 | Frontend data: `directReceiveMutation`, `ReceivingUnitForm` gains `defectReason`/`photos`/`costPrice`, an exported `buildDirectReceiveItem` payload-builder (tested), `defectReasonOptions`. |
| 3 | Mobile-first `GoodsReceivingModal` rebuild: one shared body in a `Drawer` (`h-[92dvh]`) on mobile + the desktop modal; per-unit `ReceivingUnitCard` with **camera capture** (`capture="environment"`), **live in-batch IMEI duplicate feedback**, structured defect `<select>`, a passed/rejected progress strip, 44px touch targets. |
| 4 | `DirectReceiveModal` (two-phase: line-builder → unit-inspect) + a "รับเข้าตรง (supplier)" header entry; the REJECT gate now requires a structured `defectReason`. |

### Red line (verified holistically by an Opus reviewer)
- ✅ Direct-receive posts **ZERO** JournalEntry/GeneralLedger/ExpenseDocument; **no** accounting/finance/journal/expense/tax import; the `purchase-orders` module stays `imports: []` (sealed).
- ✅ The approval-bypass AuditLog is written via `tx.auditLog.create` (a PrismaService delegate) — no audit-service import.
- ✅ `costPrice` is **mandatory + validated** (`@Min(0.01)` + an up-front guard) because COGS reads `Product.costPrice` at sale time.
- ✅ `trade-in` / `Product.ownedByCompanyId` untouched. No migration (B0 shipped the columns).
- ✅ IMEI duplicate **defense-in-depth**: frontend UX block + backend in-batch AND system-wide (incl. soft-deleted) enforcement — both preserved.

### Atomicity & extraction integrity
- The `runReceiveInTx` extraction is behavior-identical to the prior `goodsReceiving()` body (only the `tx` param + the additive `'ORDERED'` guard differ) — proven by the B0 race (T5-C16) + IMEI-dup + grnumber-retry specs all staying green. Both `goodsReceiving()` and `directReceive()` keep independent bounded retries.
- Closes a gap: B1's frontend already offered "รับสินค้า" on `ORDERED` POs; the backend guard now accepts `ORDERED`.

### Verification
- `./tools/check-types.sh all` → **0 errors** (API + Web)
- Backend purchase-orders jest → **22/22** (incl. B0 race + IMEI-dup + grnumber-retry)
- Full web `vitest run` → **808/808** (incl. direct-receive payload-builder + dup-logic tests)
- Each task: TDD for the pure units + two-stage subagent review; final whole-branch review on Opus = **READY TO MERGE** (no Critical/Important; all Minors triaged acceptable).

### Notes
- Adds the new endpoint `/purchase-orders/direct-receive` (no schema/migration). Prod is throwaway test data.
- The local DB/app was unreachable, so verification is type-check + jest + vitest + review. A **manual mobile pass on a real device** is recommended (camera capture, bottom-sheet, 44px targets, the direct-receive flow + the `PO_DIRECT_RECEIVE_APPROVAL_BYPASS` audit row).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
