### PR TITLE
Purchasing v2 — B5: dashboard summary strip + overdue filter + AP polish (FINAL batch)

### DIFF
--- a/apps/web/src/pages/PurchaseOrdersPage/components/AccountsPayableTab.tsx
+++ b/apps/web/src/pages/PurchaseOrdersPage/components/AccountsPayableTab.tsx
@@ -33,6 +33,10 @@ export function AccountsPayableTab({ payableData, onOpenDetail }: AccountsPayabl
         </div>
       </div>
 
+      {!payableData && (
+        <div className="text-center py-12 text-muted-foreground">กำลังโหลดยอดค้างจ่าย…</div>
+      )}
+
       {/* Per-supplier Breakdown */}
       {payableData?.suppliers.map((entry) => (
         <div key={entry.supplier.id} className="border border-border/50 rounded-xl overflow-hidden bg-card shadow-sm">
@@ -44,9 +48,19 @@ export function AccountsPayableTab({ payableData, onOpenDetail }: AccountsPayabl
                 {[entry.supplier.contactName, entry.supplier.phone].filter(Boolean).join(' | ')}
               </div>
             </div>
-            <div className="text-right">
+            <div className="text-right min-w-[180px]">
               <div className="text-lg font-bold text-destructive tabular-nums font-mono">{(Number(entry.totalRemaining) || 0).toLocaleString()} บาท</div>
-              <div className="text-xs text-muted-foreground tabular-nums">จาก {(Number(entry.totalNet) || 0).toLocaleString()} (จ่ายแล้ว {(Number(entry.totalPaid) || 0).toLocaleString()})</div>
+              <div className="text-xs text-muted-foreground tabular-nums">
+                จ่ายแล้ว {(Number(entry.totalPaid) || 0).toLocaleString()} / {(Number(entry.totalNet) || 0).toLocaleString()}
+              </div>
+              {Number(entry.totalNet) > 0 && (
+                <div className="mt-1.5 w-full bg-secondary rounded-full h-1.5">
+                  <div
+                    className="bg-success h-1.5 rounded-full"
+                    style={{ width: `${Math.min((Number(entry.totalPaid) / Number(entry.totalNet)) * 100, 100)}%` }}
+                  />
+                </div>
+              )}
             </div>
           </div>
           {/* PO List */}
@@ -59,26 +73,41 @@ export function AccountsPayableTab({ payableData, onOpenDetail }: AccountsPayabl
                 <th className="px-4 py-2.5 text-left font-semibold">รายการ</th>
                 <th className="px-4 py-2.5 text-right font-semibold">ยอดสุทธิ</th>
                 <th className="px-4 py-2.5 text-right font-semibold">จ่ายแล้ว</th>
-                <th className="px-4 py-2.5 text-right font-semibold">คงค้าง</th>
+                <th className="px-4 py-2.5 text-right font-semibold text-destructive">คงค้าง</th>
                 <th className="px-4 py-2.5 text-center font-semibold">สถานะจ่าย</th>
               </tr>
             </thead>
             <tbody className="divide-y divide-border/50">
               {entry.pos.map((po) => (
-                <tr key={po.id} className="hover:bg-muted/30">
+                <tr
+                  key={po.id}
+                  className="hover:bg-muted/30 cursor-pointer"
+                  onClick={async () => { try { const { data } = await api.get(`/purchase-orders/${po.id}`); onOpenDetail(data, data); } catch {} }}
+                >
                   <td className="px-4 py-2">
-                    <button onClick={async () => { try { const { data } = await api.get(`/purchase-orders/${po.id}`); onOpenDetail(data, data); } catch {} }} className="text-primary hover:underline font-medium">
+                    <button
+                      onClick={async (e) => { e.stopPropagation(); try { const { data } = await api.get(`/purchase-orders/${po.id}`); onOpenDetail(data, data); } catch {} }}
+                      className="text-primary hover:underline font-medium"
+                    >
                       {po.poNumber}
                     </button>
                   </td>
                   <td className="px-4 py-2 text-muted-foreground">{formatDateShort(po.orderDate)}</td>
                   <td className="px-4 py-2">
-                    {po.dueDate ? (
-                      <span className={`text-sm ${new Date(po.dueDate) < new Date() ? 'text-destructive font-semibold' : 'text-muted-foreground'}`}>
-                        {formatDateShort(po.dueDate)}
-                        {new Date(po.dueDate) < new Date() && <span className="ml-1 text-xs bg-destructive/10 text-destructive dark:bg-destructive/15 px-1.5 py-0.5 rounded-full">เลยกำหนด</span>}
-                      </span>
-                    ) : (
+                    {po.dueDate ? (() => {
+                      const due = new Date(po.dueDate);
+                      const now = new Date();
+                      const isLate = due < now;
+                      const inSevenDays = new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000);
+                      const dueSoon = !isLate && due <= inSevenDays;
+                      return (
+                        <span className={`text-sm ${isLate ? 'text-destructive font-semibold' : dueSoon ? 'text-warning font-medium' : 'text-muted-foreground'}`}>
+                          {formatDateShort(po.dueDate)}
+                          {isLate && <span className="ml-1 text-2xs bg-destructive/10 text-destructive dark:bg-destructive/15 px-1.5 py-0.5 rounded-full leading-snug">เลยกำหนด</span>}
+                          {dueSoon && <span className="ml-1 text-2xs bg-warning/10 text-warning dark:bg-warning/15 px-1.5 py-0.5 rounded-full leading-snug">ใกล้ครบกำหนด</span>}
+                        </span>
+                      );
+                    })() : (
                       <span className="text-muted-foreground text-xs">-</span>
                     )}
                   </td>

--- a/apps/web/src/pages/PurchaseOrdersPage/components/POListTab.tsx
+++ b/apps/web/src/pages/PurchaseOrdersPage/components/POListTab.tsx
@@ -35,6 +35,8 @@ export interface POListTabProps {
   cancelMutation: UseMutationResult<unknown, unknown, string, unknown>;
   setConfirmDialog: (value: { open: boolean; message: string; action: () => void }) => void;
   suppliers: { id: string; name: string }[];
+  overdueOnly: boolean;
+  setOverdueOnly: (value: boolean) => void;
 }
 
 const periodOptions: { value: PeriodFilter; label: string }[] = [
@@ -80,6 +82,8 @@ export function POListTab({
   cancelMutation,
   setConfirmDialog,
   suppliers,
+  overdueOnly,
+  setOverdueOnly,
 }: POListTabProps) {
   const [search, setSearch] = useState('');
   const debouncedSearch = useDebounce(search, 250);
@@ -95,6 +99,7 @@ export function POListTab({
     const q = debouncedSearch.trim().toLowerCase();
     const range = periodRange(periodFilter);
     return pos.filter((po) => {
+      if (overdueOnly && !isOverdue(po)) return false;
       if (supplierFilter && po.supplier.id !== supplierFilter) return false;
       if (range) {
         const d = new Date(po.orderDate);
@@ -109,13 +114,14 @@ export function POListTab({
       }
       return true;
     });
-  }, [pos, debouncedSearch, supplierFilter, periodFilter]);
+  }, [pos, debouncedSearch, supplierFilter, periodFilter, overdueOnly]);
 
   const clearAll = () => {
     setSearch('');
     setStatusFilter('');
     setSupplierFilter('');
     setPeriodFilter('');
+    setOverdueOnly(false);
   };
 
   const selectedSupplierName = suppliers.find((s) => s.id === supplierFilter)?.name || supplierFilter;
@@ -345,7 +351,7 @@ export function POListTab({
     },
   ];
 
-  const hasFilter = Boolean(search || statusFilter || supplierFilter || periodFilter);
+  const hasFilter = Boolean(search || statusFilter || supplierFilter || periodFilter || overdueOnly);
 
   return (
     <>
@@ -421,6 +427,9 @@ export function POListTab({
           )}
           {periodFilter && (
             <FilterChip label={`ช่วงเวลา: ${selectedPeriodLabel}`} onRemove={() => setPeriodFilter('')} />
+          )}
+          {overdueOnly && (
+            <FilterChip label="เฉพาะที่เลยกำหนดส่ง" onRemove={() => setOverdueOnly(false)} />
           )}
           <button
             onClick={clearAll}

--- a/apps/web/src/pages/PurchaseOrdersPage/components/PurchasingSummaryStrip.tsx
+++ b/apps/web/src/pages/PurchaseOrdersPage/components/PurchasingSummaryStrip.tsx
@@ -1,0 +1,58 @@
+import { Card, CardContent } from '@/components/ui/card';
+import AnimatedCounter from '@/components/ui/animated-counter';
+import { cn } from '@/lib/utils';
+import { SUMMARY_CARDS, TONE_STYLES, type PurchasingSummary, type SummaryFilterAction } from '../summaryStrip';
+
+interface PurchasingSummaryStripProps {
+  summary: PurchasingSummary | undefined;
+  onCardClick: (action: SummaryFilterAction) => void;
+}
+
+export function PurchasingSummaryStrip({ summary, onCardClick }: PurchasingSummaryStripProps) {
+  // No data yet (loading) or the B0 endpoint is unavailable → render nothing rather than crash.
+  if (!summary) return null;
+
+  return (
+    <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-7 gap-3 lg:gap-4 mb-5">
+      {SUMMARY_CARDS.map((card) => {
+        const Icon = card.icon;
+        const styles = TONE_STYLES[card.tone];
+        const count = summary[card.key] ?? 0;
+        return (
+          <button
+            key={card.key}
+            type="button"
+            onClick={() => onCardClick(card.action)}
+            aria-label={`${card.label}: ${count} รายการ — คลิกเพื่อกรอง`}
+            className="text-left focus:outline-hidden focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 rounded-xl"
+          >
+            <Card className="cursor-pointer group hover:shadow-md hover:-translate-y-0.5 transition-all duration-200 overflow-hidden h-full">
+              <CardContent className="p-4 relative">
+                <div className={cn('absolute inset-y-0 left-0 w-1 rounded-l-xl', styles.border)} />
+                <div className="pl-2">
+                  <div className="flex items-center justify-between mb-3">
+                    <div
+                      className={cn(
+                        'size-10 rounded-xl flex items-center justify-center transition-colors',
+                        styles.iconBox,
+                      )}
+                    >
+                      <Icon className={cn('size-5', styles.icon)} />
+                    </div>
+                    {count > 0 && (
+                      <span className={cn('text-2xs font-semibold px-2 py-0.5 rounded-full', styles.pill)}>
+                        {count}
+                      </span>
+                    )}
+                  </div>
+                  <AnimatedCounter value={count} className="text-2xl font-bold text-foreground" />
+                  <div className="text-xs font-medium text-muted-foreground mt-1 leading-snug">{card.label}</div>
+                </div>
+              </CardContent>
+            </Card>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/pages/PurchaseOrdersPage/hooks/usePurchaseOrdersData.ts
+++ b/apps/web/src/pages/PurchaseOrdersPage/hooks/usePurchaseOrdersData.ts
@@ -4,6 +4,7 @@ import { toast } from 'sonner';
 import api, { getErrorMessage } from '@/lib/api';
 import { PurchaseOrder, PODetail, ReceivingUnitForm, DirectReceiveLineForm } from '../types';
 import { defaultChecklist } from '../constants';
+import { PurchasingSummary } from '../summaryStrip';
 
 export function buildDirectReceiveItem(i: ReceivingUnitForm) {
   const isUsed = i.category === 'PHONE_USED';
@@ -45,6 +46,7 @@ export function buildDirectReceiveItem(i: ReceivingUnitForm) {
 export function usePurchaseOrdersData(options?: { onCreateSuccess?: () => void }) {
   const queryClient = useQueryClient();
   const [statusFilter, setStatusFilter] = useState('');
+  const [overdueOnly, setOverdueOnly] = useState(false);
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
   const [isDetailModalOpen, setIsDetailModalOpen] = useState(false);
   const [activeTab, setActiveTab] = useState<'list' | 'payable'>('list');
@@ -97,6 +99,18 @@ export function usePurchaseOrdersData(options?: { onCreateSuccess?: () => void }
     retry: 2,
   });
   const suppliers = suppliersRes?.data || [];
+
+  const { data: summaryRes } = useQuery<{ data?: PurchasingSummary } | PurchasingSummary>({
+    queryKey: ['purchase-orders-summary'],
+    queryFn: async () => (await api.get('/purchase-orders/summary')).data,
+    // Stale-while-refresh so the strip stays snappy; counts are compute-on-read and cheap.
+    staleTime: 30_000,
+    retry: 1,
+  });
+  // Backend returns the bare object; tolerate a { data } envelope defensively.
+  const summary: PurchasingSummary | undefined = summaryRes
+    ? ('pendingApproval' in summaryRes ? summaryRes : (summaryRes as { data?: PurchasingSummary }).data)
+    : undefined;
 
   type PayableData = {
     grandTotal: number;
@@ -154,6 +168,7 @@ export function usePurchaseOrdersData(options?: { onCreateSuccess?: () => void }
     mutationFn: async (data: Record<string, unknown>) => api.post('/purchase-orders', data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['purchase-orders'] });
+      queryClient.invalidateQueries({ queryKey: ['purchase-orders-summary'] });
       toast.success('สร้างใบสั่งซื้อสำเร็จ (สถานะ: รออนุมัติ)');
       setIsCreateModalOpen(false);
       options?.onCreateSuccess?.();
@@ -165,6 +180,7 @@ export function usePurchaseOrdersData(options?: { onCreateSuccess?: () => void }
     mutationFn: async (id: string) => api.post(`/purchase-orders/${id}/approve`),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['purchase-orders'] });
+      queryClient.invalidateQueries({ queryKey: ['purchase-orders-summary'] });
       toast.success('อนุมัติ PO สำเร็จ');
     },
     onError: (err: unknown) => toast.error(getErrorMessage(err)),
@@ -174,6 +190,7 @@ export function usePurchaseOrdersData(options?: { onCreateSuccess?: () => void }
     mutationFn: async (id: string) => api.post(`/purchase-orders/${id}/order`),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['purchase-orders'] });
+      queryClient.invalidateQueries({ queryKey: ['purchase-orders-summary'] });
       toast.success('สั่งซื้อ PO สำเร็จ (สถานะ: สั่งซื้อแล้ว)');
     },
     onError: (err: unknown) => toast.error(getErrorMessage(err)),
@@ -184,6 +201,7 @@ export function usePurchaseOrdersData(options?: { onCreateSuccess?: () => void }
       api.post(`/purchase-orders/${id}/reject`, { reason }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['purchase-orders'] });
+      queryClient.invalidateQueries({ queryKey: ['purchase-orders-summary'] });
       toast.success('ปฏิเสธ PO สำเร็จ');
     },
     onError: (err: unknown) => toast.error(getErrorMessage(err)),
@@ -193,6 +211,7 @@ export function usePurchaseOrdersData(options?: { onCreateSuccess?: () => void }
     mutationFn: async (id: string) => api.post(`/purchase-orders/${id}/cancel`),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['purchase-orders'] });
+      queryClient.invalidateQueries({ queryKey: ['purchase-orders-summary'] });
       toast.success('ยกเลิก PO สำเร็จ');
     },
     onError: (err: unknown) => toast.error(getErrorMessage(err)),
@@ -243,6 +262,7 @@ export function usePurchaseOrdersData(options?: { onCreateSuccess?: () => void }
       }),
     onSuccess: (res) => {
       queryClient.invalidateQueries({ queryKey: ['purchase-orders'] });
+      queryClient.invalidateQueries({ queryKey: ['purchase-orders-summary'] });
       const data = res.data;
       toast.success(
         `รับ+ตรวจสำเร็จ: ผ่าน ${data.passed} ชิ้น, ไม่ผ่าน ${data.rejected} ชิ้น → รอ QC ที่คลัง ${data.mainWarehouse}`,
@@ -273,6 +293,7 @@ export function usePurchaseOrdersData(options?: { onCreateSuccess?: () => void }
       }),
     onSuccess: (res) => {
       queryClient.invalidateQueries({ queryKey: ['purchase-orders'] });
+      queryClient.invalidateQueries({ queryKey: ['purchase-orders-summary'] });
       const d = res.data;
       toast.success(
         `รับเข้าตรงสำเร็จ (${d.poNumber}): ผ่าน ${d.passed} ชิ้น, ไม่ผ่าน ${d.rejected} ชิ้น → รอ QC ที่คลัง ${d.mainWarehouse}`,
@@ -287,6 +308,7 @@ export function usePurchaseOrdersData(options?: { onCreateSuccess?: () => void }
       api.patch(`/purchase-orders/${poId}/payment`, data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['purchase-orders'] });
+      queryClient.invalidateQueries({ queryKey: ['purchase-orders-summary'] });
       queryClient.invalidateQueries({ queryKey: ['accounts-payable'] });
       toast.success('อัปเดตสถานะการจ่ายเงินสำเร็จ');
       setIsPaymentModalOpen(false);
@@ -305,6 +327,11 @@ export function usePurchaseOrdersData(options?: { onCreateSuccess?: () => void }
     },
     onError: (err: unknown) => toast.error(getErrorMessage(err)),
   });
+
+  const setStatusFilterAndResetOverdue = (value: string) => {
+    setStatusFilter(value);
+    setOverdueOnly(false);
+  };
 
   const openDetailModal = async (po: PurchaseOrder) => {
     setSelectedPO(po);
@@ -528,6 +555,7 @@ export function usePurchaseOrdersData(options?: { onCreateSuccess?: () => void }
     payableData,
     pos,
     isLoading,
+    summary,
     // Mutations
     createMutation,
     approveMutation,
@@ -540,6 +568,9 @@ export function usePurchaseOrdersData(options?: { onCreateSuccess?: () => void }
     // State
     statusFilter,
     setStatusFilter,
+    overdueOnly,
+    setOverdueOnly,
+    setStatusFilterAndResetOverdue,
     activeTab,
     setActiveTab,
     isCreateModalOpen,

--- a/apps/web/src/pages/PurchaseOrdersPage/index.tsx
+++ b/apps/web/src/pages/PurchaseOrdersPage/index.tsx
@@ -5,7 +5,7 @@ import PageHeader from '@/components/ui/PageHeader';
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
 import { exportToExcel } from '@/utils/excel.util';
 import { Download, ClipboardCheck } from 'lucide-react';
-import { Link } from 'react-router';
+import { Link, useNavigate } from 'react-router';
 import { formatDateShort } from '@/utils/formatters';
 import { usePurchaseOrdersData } from './hooks/usePurchaseOrdersData';
 import { usePOForm } from './hooks/usePOForm';
@@ -19,10 +19,13 @@ import { PODetailModal } from './components/PODetailModal';
 import { PaymentModal } from './components/PaymentModal';
 import { GoodsReceivingModal } from './components/GoodsReceivingModal';
 import { DirectReceiveModal } from './components/DirectReceiveModal';
+import { PurchasingSummaryStrip } from './components/PurchasingSummaryStrip';
+import type { SummaryFilterAction } from './summaryStrip';
 
 export default function PurchaseOrdersPage() {
   const resetFormRef = useRef<() => void>(() => {});
   const queryClient = useQueryClient();
+  const navigate = useNavigate();
 
   const wizardClearRef = useRef<() => void>(() => {});
   const onCreateSuccess = useCallback(() => {
@@ -80,6 +83,23 @@ export default function PurchaseOrdersPage() {
       }));
     },
     [queryClient, data.suppliers, poForm],
+  );
+
+  const onSummaryCardClick = useCallback(
+    (action: SummaryFilterAction) => {
+      if ('panel' in action) {
+        navigate('/purchase-orders/qc'); // รอ QC → the dedicated QC center page (B4)
+        return;
+      }
+      if (action.tab === 'payable') {
+        data.setActiveTab('payable');
+        return;
+      }
+      data.setActiveTab('list');
+      data.setStatusFilter(action.status);
+      data.setOverdueOnly(action.overdueOnly);
+    },
+    [data, navigate],
   );
 
   return (
@@ -147,6 +167,8 @@ export default function PurchaseOrdersPage() {
         }
       />
 
+      <PurchasingSummaryStrip summary={data.summary} onCardClick={onSummaryCardClick} />
+
       {/* Tabs */}
       <div className="flex gap-1 mb-5 border-b border-border/60">
         <button
@@ -171,7 +193,7 @@ export default function PurchaseOrdersPage() {
       {data.activeTab === 'list' ? (
         <POListTab
           statusFilter={data.statusFilter}
-          setStatusFilter={data.setStatusFilter}
+          setStatusFilter={data.setStatusFilterAndResetOverdue}
           pos={data.pos}
           isLoading={data.isLoading}
           openDetailModal={data.openDetailModal}
@@ -183,6 +205,8 @@ export default function PurchaseOrdersPage() {
           cancelMutation={data.cancelMutation}
           setConfirmDialog={data.setConfirmDialog}
           suppliers={data.suppliers}
+          overdueOnly={data.overdueOnly}
+          setOverdueOnly={data.setOverdueOnly}
         />
       ) : (
         <AccountsPayableTab

--- a/apps/web/src/pages/PurchaseOrdersPage/summaryStrip.test.ts
+++ b/apps/web/src/pages/PurchaseOrdersPage/summaryStrip.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { SUMMARY_CARDS, TONE_STYLES, type PurchasingSummary } from './summaryStrip';
+
+describe('SUMMARY_CARDS', () => {
+  it('defines exactly the 7 B0 summary keys, in order, with no duplicates', () => {
+    const keys = SUMMARY_CARDS.map((c) => c.key);
+    expect(keys).toEqual([
+      'pendingApproval',
+      'toOrder',
+      'incoming',
+      'overdue',
+      'receiving',
+      'waitingQc',
+      'unpaid',
+    ]);
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+
+  it('covers every key of the PurchasingSummary type (compile-time + runtime parity)', () => {
+    const sample: PurchasingSummary = {
+      pendingApproval: 1, toOrder: 2, incoming: 3, overdue: 4, receiving: 5, waitingQc: 6, unpaid: 7,
+    };
+    for (const card of SUMMARY_CARDS) {
+      expect(typeof sample[card.key]).toBe('number');
+    }
+  });
+
+  it('every card has a Thai label and a defined lucide icon', () => {
+    for (const card of SUMMARY_CARDS) {
+      expect(card.label.length).toBeGreaterThan(0);
+      // lucide icons are forwardRef components → function (object in some builds)
+      expect(['function', 'object']).toContain(typeof card.icon);
+    }
+  });
+
+  it('overdue card routes to list+overdueOnly; toOrder→APPROVED; incoming→ORDERED; receiving→PARTIALLY_RECEIVED; pendingApproval→DRAFT', () => {
+    const byKey = Object.fromEntries(SUMMARY_CARDS.map((c) => [c.key, c.action]));
+    expect(byKey.overdue).toEqual({ tab: 'list', status: 'ORDERED', overdueOnly: true });
+    expect(byKey.toOrder).toEqual({ tab: 'list', status: 'APPROVED', overdueOnly: false });
+    expect(byKey.incoming).toEqual({ tab: 'list', status: 'ORDERED', overdueOnly: false });
+    expect(byKey.receiving).toEqual({ tab: 'list', status: 'PARTIALLY_RECEIVED', overdueOnly: false });
+    expect(byKey.pendingApproval).toEqual({ tab: 'list', status: 'DRAFT', overdueOnly: false });
+  });
+
+  it('unpaid card routes to the payable tab; waitingQc opens the qc panel', () => {
+    const byKey = Object.fromEntries(SUMMARY_CARDS.map((c) => [c.key, c.action]));
+    expect(byKey.unpaid).toEqual({ tab: 'payable' });
+    expect(byKey.waitingQc).toEqual({ panel: 'qc' });
+  });
+
+  it('TONE_STYLES uses only design-token classes (no hardcoded gray/hex/white)', () => {
+    const blob = JSON.stringify(TONE_STYLES);
+    expect(blob).not.toMatch(/#[0-9a-fA-F]{3,6}/); // no hex
+    expect(blob).not.toMatch(/\bbg-white\b/);
+    expect(blob).not.toMatch(/-gray-/);
+    // every tone present
+    expect(Object.keys(TONE_STYLES).sort()).toEqual(
+      ['destructive', 'info', 'primary', 'success', 'warning'].sort(),
+    );
+  });
+});

--- a/apps/web/src/pages/PurchaseOrdersPage/summaryStrip.ts
+++ b/apps/web/src/pages/PurchaseOrdersPage/summaryStrip.ts
@@ -1,0 +1,130 @@
+import type { LucideIcon } from 'lucide-react';
+import {
+  FileClock,
+  ShoppingCart,
+  Truck,
+  AlertTriangle,
+  PackageCheck,
+  ClipboardCheck,
+  Wallet,
+} from 'lucide-react';
+
+/**
+ * Compute-on-read purchasing counts from GET /purchase-orders/summary (B0).
+ * Keys MUST stay identical to po-query.service.ts getSummary() return shape.
+ */
+export interface PurchasingSummary {
+  pendingApproval: number;
+  toOrder: number;
+  incoming: number;
+  overdue: number;
+  receiving: number;
+  waitingQc: number;
+  unpaid: number;
+}
+
+/** What clicking a card does to the page. */
+export type SummaryFilterAction =
+  | { tab: 'list'; status: string; overdueOnly: boolean }
+  | { tab: 'payable' }
+  | { panel: 'qc' };
+
+export type SummaryTone = 'primary' | 'warning' | 'destructive' | 'success' | 'info';
+
+export interface SummaryCardDef {
+  key: keyof PurchasingSummary;
+  label: string;
+  icon: LucideIcon;
+  tone: SummaryTone;
+  action: SummaryFilterAction;
+}
+
+/** Display order matches the spec's summary-strip zone. */
+export const SUMMARY_CARDS: SummaryCardDef[] = [
+  {
+    key: 'pendingApproval',
+    label: 'รออนุมัติ',
+    icon: FileClock,
+    tone: 'warning',
+    action: { tab: 'list', status: 'DRAFT', overdueOnly: false },
+  },
+  {
+    key: 'toOrder',
+    label: 'รอสั่งซื้อ',
+    icon: ShoppingCart,
+    tone: 'primary',
+    action: { tab: 'list', status: 'APPROVED', overdueOnly: false },
+  },
+  {
+    key: 'incoming',
+    label: 'กำลังมา',
+    icon: Truck,
+    tone: 'info',
+    action: { tab: 'list', status: 'ORDERED', overdueOnly: false },
+  },
+  {
+    key: 'overdue',
+    label: 'เลยกำหนดส่ง',
+    icon: AlertTriangle,
+    tone: 'destructive',
+    action: { tab: 'list', status: 'ORDERED', overdueOnly: true },
+  },
+  {
+    key: 'receiving',
+    label: 'รับบางส่วน',
+    icon: PackageCheck,
+    tone: 'warning',
+    action: { tab: 'list', status: 'PARTIALLY_RECEIVED', overdueOnly: false },
+  },
+  {
+    key: 'waitingQc',
+    label: 'รอตรวจ QC',
+    icon: ClipboardCheck,
+    tone: 'warning',
+    action: { panel: 'qc' },
+  },
+  {
+    key: 'unpaid',
+    label: 'ค้างจ่าย',
+    icon: Wallet,
+    tone: 'destructive',
+    action: { tab: 'payable' },
+  },
+];
+
+/**
+ * Token-only Tailwind classes per tone — mirrors the DashboardKPIs card anatomy
+ * (left border-strip, size-10 rounded icon box, count pill). No hex, no gray, no bg-white.
+ */
+export const TONE_STYLES: Record<SummaryTone, { border: string; iconBox: string; icon: string; pill: string }> = {
+  primary: {
+    border: 'bg-primary',
+    iconBox: 'bg-primary/10 group-hover:bg-primary/20',
+    icon: 'text-primary',
+    pill: 'text-primary bg-primary/10',
+  },
+  warning: {
+    border: 'bg-warning',
+    iconBox: 'bg-warning/10 group-hover:bg-warning/20',
+    icon: 'text-warning',
+    pill: 'text-warning bg-warning/10',
+  },
+  destructive: {
+    border: 'bg-destructive',
+    iconBox: 'bg-destructive/10 group-hover:bg-destructive/20',
+    icon: 'text-destructive',
+    pill: 'text-destructive bg-destructive/10',
+  },
+  success: {
+    border: 'bg-success',
+    iconBox: 'bg-success/10 group-hover:bg-success/20',
+    icon: 'text-success',
+    pill: 'text-success bg-success/10',
+  },
+  info: {
+    border: 'bg-info',
+    iconBox: 'bg-info/10 group-hover:bg-info/20',
+    icon: 'text-info',
+    pill: 'text-info bg-info/10',
+  },
+};


### PR DESCRIPTION
## Purchasing & Receiving v2 — Batch B5 (dashboard strip + overdue filter + AP polish) — FINAL batch

> ⚠️ **Stacked on B4 (#1306) → B3 (#1305) → B2 (#1304) → B1 (#1303) → B0 (#1302).** Base is `feat/purchasing-v2-b4`, so this PR's diff shows ONLY B5's changes. **Merge order: #1302 → #1303 → #1304 → #1305 → #1306 → this.** GitHub auto-retargets each PR's base when its parent merges. **This PR closes the 6-batch overhaul.**

Pure-frontend batch (**zero `apps/api` change**). Gives `/purchase-orders` a glanceable **ภาพรวมจัดซื้อ** summary strip + an overdue filter, and polishes the AP tab.

Spec: `docs/superpowers/specs/2026-06-29-purchasing-receiving-ux-v2-design.md`
Plan: `docs/superpowers/plans/2026-06-29-purchasing-b5-dashboard-overdue-ap.md`

### What's in it
| # | Change |
|---|---|
| 1 | `summaryStrip.ts` — 7-card config (`SUMMARY_CARDS`) + `TONE_STYLES` (token-only) + `SummaryFilterAction` mapping, unit-tested. |
| 2 | `usePurchaseOrdersData` — summary `useQuery` (`GET /purchase-orders/summary`, B0), `overdueOnly` state, summary-cache invalidation on all 8 PO mutations, `setStatusFilterAndResetOverdue`. |
| 3 | `PurchasingSummaryStrip` — 7 KPI/alert cards on the `DashboardKPIs` pattern (colored left border, `size-10` icon box, `AnimatedCounter`, hover-lift). Renders nothing if `/summary` is unavailable (no crash). |
| 4+5 | Wire the strip into the page + `onSummaryCardClick` (each card filters the list / switches tab / navigates to QC) + an `overdueOnly` client filter in `POListTab` (reuses B1's `isOverdue` + per-row badge) with a clear chip. |
| 6 | `AccountsPayableTab` polish — per-supplier paid-progress bar, "ใกล้ครบกำหนด" (≤7d) amber hint, red "คงค้าง" header, whole-row deep-link into PO detail, loading state. |

The 7 cards: **รออนุมัติ · รอสั่งซื้อ · กำลังมา · เลยกำหนดส่ง · รับบางส่วน · รอตรวจ QC · ค้างจ่าย** — each a one-click filter shortcut.

### B4 adaptation (the one integration subtlety)
B4 retired the inline `QcPendingPanel` and promoted QC to a dedicated page. So the **รอตรวจ QC** card `navigate('/purchase-orders/qc')` (B4's page) instead of opening the old panel — no reference to any removed symbol (`setShowQcPanel`/`QcPendingPanel`/`qcConfirmMutation`). `useNavigate` is from `'react-router'` (this repo's import).

### Red line & correctness (verified holistically by an Opus reviewer)
- ✅ **Frontend-only** — zero `apps/api` change; no accounting/finance/journal/expense/tax import; `trade-in`/`ownedByCompanyId` untouched.
- ✅ **Strip ↔ list consistency proven**: the backend `getSummary()` overdue predicate (`status='ORDERED' && expectedDate<now`) is byte-for-byte the same as the frontend `isOverdue` helper, so the **เลยกำหนดส่ง** card count equals its filtered-list size. All 7 summary keys match B0's `getSummary()` return 1:1 (locked by a test).
- ✅ **Graceful degradation** — if `/summary` errors, the strip renders nothing; the page still works.
- ✅ **No stuck double-filter** — the overdue card sets `ORDERED`+`overdueOnly`; a manual status-dropdown change clears `overdueOnly` via `setStatusFilterAndResetOverdue`.
- ✅ **AP polish** — progress bar can't divide-by-zero (`totalNet>0`) or exceed 100% (`Math.min`); whole-row + PO# button can't double-open (`stopPropagation`); due-soon vs overdue pills are mutually exclusive.

### Verification
- `./tools/check-types.sh all` → **0 errors**
- Full web `vitest run` → **820/820** (incl. `summaryStrip.test` ×6)
- No backend change → no jest needed.
- Each task: TDD for the pure config + two-stage subagent review; final whole-branch review on Opus = **READY TO MERGE** (no Critical/Important; all Minors triaged acceptable).

### Notes
- Consumes B0's `GET /purchase-orders/summary` and reuses B1's `isOverdue` — depends on B0+B1 having landed (they're earlier in this stack).
- `waitingQc` is counted company-wide (not PO-scoped) — consistent with B4's QC badge (owner decision: keep).
- Minor freshness: the strip's `waitingQc` self-corrects via 30s staleTime + refetch-on-navigation (QC confirm/reject happens on a different page); a B4 cross-invalidate is a possible nice-to-have, out of B5's scope.
- The local DB/app was unreachable, so verification is type-check + vitest + review. A **manual pass** (desktop + mobile) of the strip — card filters, the overdue filter + chip, the QC card navigating, the AP row deep-link — is recommended before sign-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
