### PR TITLE
fix(web): unbreak 'Lint & Test' — replace 3 ternary-as-statement (no-unused-expressions)

### DIFF
--- a/apps/web/src/pages/QcCenterPage/index.tsx
+++ b/apps/web/src/pages/QcCenterPage/index.tsx
@@ -55,7 +55,8 @@ export default function QcCenterPage() {
   const toggle = (id: string) =>
     setSelected((prev) => {
       const next = new Set(prev);
-      next.has(id) ? next.delete(id) : next.add(id);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
       return next;
     });
   const toggleAll = () =>

--- a/apps/web/src/pages/UnifiedInboxPage/components/MessageBubble.tsx
+++ b/apps/web/src/pages/UnifiedInboxPage/components/MessageBubble.tsx
@@ -92,7 +92,8 @@ function MessageBubble({ message, customerAvatar, customerInitial }: MessageBubb
   const copyText = async () => {
     if (!message.text) return;
     const ok = await copy(message.text);
-    ok ? toast.success('คัดลอกแล้ว') : toast.error('คัดลอกไม่สำเร็จ');
+    if (ok) toast.success('คัดลอกแล้ว');
+    else toast.error('คัดลอกไม่สำเร็จ');
   };
   const canCopy = !!message.text && !/^\[(sticker|gif|flex):/.test(message.text);
 

--- a/apps/web/src/pages/UnifiedInboxPage/hooks/useNotificationPrefs.ts
+++ b/apps/web/src/pages/UnifiedInboxPage/hooks/useNotificationPrefs.ts
@@ -46,7 +46,8 @@ export function useNotificationPrefs() {
   const toggleRoomMute = useCallback((roomId: string) => {
     setMutedRooms((prev) => {
       const next = new Set(prev);
-      next.has(roomId) ? next.delete(roomId) : next.add(roomId);
+      if (next.has(roomId)) next.delete(roomId);
+      else next.add(roomId);
       return next;
     });
   }, []);


### PR DESCRIPTION
Unbreaks the required **Lint & Test** gate on `main` (it was failing repo-wide on `@typescript-eslint/no-unused-expressions`).

3 Set-toggle/branch ternaries used as bare statements, converted to behavior-identical `if/else`:
| File | Origin |
|---|---|
| `UnifiedInboxPage/hooks/useNotificationPrefs.ts:49` | pre-existing (inbox) |
| `UnifiedInboxPage/components/MessageBubble.tsx:95` | pre-existing (inbox) |
| `QcCenterPage/index.tsx:58` | introduced in Purchasing v2 B4 (eslint wasn't run that batch) |

### Verification
- `eslint .` (apps/web) → **exit 0** (was 1 error → now 0)
- `./tools/check-types.sh all` → 0 errors
- `vitest run` QcCenterPage + UnifiedInboxPage → **38/38** (behavior preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)