### PR TITLE
fix(purchasing): mobile PO card list, true AP scope, real company on print (QA fixes)

### DIFF
--- a/apps/api/prisma/seed-production.ts
+++ b/apps/api/prisma/seed-production.ts
@@ -39,14 +39,24 @@ async function main() {
   console.log('\n[1/6] CompanyInfo...');
 
   await prisma.companyInfo.upsert({
-    where: { id: 'company-shop' },
-    update: {},
+    // Key on companyCode (unique) so this also REPAIRS the migration stub row
+    // (which has a random id, not 'company-shop'). Updates only the legal
+    // identity — owner-set address/director/bank are preserved.
+    where: { companyCode: 'SHOP' },
+    update: {
+      nameTh: 'บริษัท เบสท์ช้อยส์โฟน จำกัด',
+      nameEn: 'BESTCHOICE PHONE Co., Ltd.',
+      taxId: '0165568000050',
+    },
     create: {
       id: 'company-shop',
-      nameTh: 'เบสท์ชอยส์ ช็อป',
-      nameEn: 'BESTCHOICE Shop',
+      // Real registered นิติบุคคล (1 entity, 2 business halves today). Address /
+      // director / bank below are placeholders — owner sets the real values via
+      // Company settings (PATCH /companies/:id) after first deploy.
+      nameTh: 'บริษัท เบสท์ช้อยส์โฟน จำกัด',
+      nameEn: 'BESTCHOICE PHONE Co., Ltd.',
       companyCode: 'SHOP',
-      taxId: '0105566012345',
+      taxId: '0165568000050',
       address: '99 ถ.วิภาวดีรังสิต แขวงจตุจักร เขตจตุจักร กรุงเทพฯ 10900',
       phone: '02-100-0000',
       directorName: 'สุรชัย เจ้าของร้าน',
@@ -61,14 +71,20 @@ async function main() {
   });
 
   await prisma.companyInfo.upsert({
-    where: { id: 'company-finance' },
-    update: {},
+    // Key on companyCode (unique) so this also REPAIRS the migration stub row.
+    where: { companyCode: 'FINANCE' },
+    update: {
+      nameTh: 'บริษัท เบสท์ช้อยส์โฟน จำกัด',
+      nameEn: 'BESTCHOICE PHONE Co., Ltd.',
+      taxId: '0165568000050',
+    },
     create: {
       id: 'company-finance',
-      nameTh: 'เบสท์ชอยส์ ไฟแนนซ์',
-      nameEn: 'BESTCHOICE Finance',
+      // Same registered นิติบุคคล as SHOP (single legal entity today).
+      nameTh: 'บริษัท เบสท์ช้อยส์โฟน จำกัด',
+      nameEn: 'BESTCHOICE PHONE Co., Ltd.',
       companyCode: 'FINANCE',
-      taxId: '0105566012346',
+      taxId: '0165568000050',
       address: '99 ถ.วิภาวดีรังสิต แขวงจตุจักร เขตจตุจักร กรุงเทพฯ 10900',
       phone: '02-100-0001',
       directorName: 'สุรชัย เจ้าของร้าน',

--- a/apps/api/prisma/seed.ts
+++ b/apps/api/prisma/seed.ts
@@ -111,10 +111,13 @@ async function main() {
   const companyShop = await prisma.companyInfo.create({
     data: {
       id: 'company-shop',
-      nameTh: 'เบสท์ชอยส์ ช็อป',
-      nameEn: 'BESTCHOICE Shop',
+      // Real registered นิติบุคคล (1 entity, 2 business halves today). Address /
+      // director / bank below are placeholders — owner sets the real values via
+      // Company settings (PATCH /companies/:id).
+      nameTh: 'บริษัท เบสท์ช้อยส์โฟน จำกัด',
+      nameEn: 'BESTCHOICE PHONE Co., Ltd.',
       companyCode: 'SHOP',
-      taxId: '0105566012345',
+      taxId: '0165568000050',
       address: '99 ถ.วิภาวดีรังสิต แขวงจตุจักร เขตจตุจักร กรุงเทพฯ 10900',
       phone: '02-100-0000',
       directorName: 'สุรชัย เจ้าของร้าน',
@@ -131,10 +134,11 @@ async function main() {
   const companyFinance = await prisma.companyInfo.create({
     data: {
       id: 'company-finance',
-      nameTh: 'เบสท์ชอยส์ ไฟแนนซ์',
-      nameEn: 'BESTCHOICE Finance',
+      // Same registered นิติบุคคล as SHOP (single legal entity today).
+      nameTh: 'บริษัท เบสท์ช้อยส์โฟน จำกัด',
+      nameEn: 'BESTCHOICE PHONE Co., Ltd.',
       companyCode: 'FINANCE',
-      taxId: '0105566012346',
+      taxId: '0165568000050',
       address: '99 ถ.วิภาวดีรังสิต แขวงจตุจักร เขตจตุจักร กรุงเทพฯ 10900',
       phone: '02-100-0001',
       directorName: 'สุรชัย เจ้าของร้าน',

--- a/apps/api/src/modules/purchase-orders/purchase-orders.summary.spec.ts
+++ b/apps/api/src/modules/purchase-orders/purchase-orders.summary.spec.ts
@@ -31,5 +31,46 @@ describe('PurchaseOrdersService.getSummary', () => {
     expect(poCount).toHaveBeenCalledWith(
       expect.objectContaining({ where: expect.objectContaining({ status: 'ORDERED', expectedDate: { lt: expect.any(Date) } }) }),
     );
+    // unpaid/AP count = owed money: received OR already-paid-something, not fully paid.
+    // Pure DRAFT/APPROVED/ORDERED commitments (nothing received, nothing paid) are excluded.
+    expect(poCount).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          status: { notIn: ['CANCELLED', 'DRAFT'] },
+          paymentStatus: { not: 'FULLY_PAID' },
+          OR: [
+            { status: { in: ['PARTIALLY_RECEIVED', 'FULLY_RECEIVED'] } },
+            { paidAmount: { gt: 0 } },
+          ],
+        }),
+      }),
+    );
+  });
+});
+
+describe('PurchaseOrdersService.getAccountsPayable', () => {
+  it('includes owed POs (received OR already-paid) but excludes pure DRAFT/APPROVED/ORDERED commitments', async () => {
+    const findMany = jest.fn().mockResolvedValue([]);
+    const prisma: any = { purchaseOrder: { findMany } };
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [PurchaseOrdersService, { provide: PrismaService, useValue: prisma }],
+    }).compile();
+    const service = module.get<PurchaseOrdersService>(PurchaseOrdersService);
+
+    await service.getAccountsPayable();
+
+    expect(findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          deletedAt: null,
+          status: { notIn: ['CANCELLED', 'DRAFT'] },
+          paymentStatus: { not: 'FULLY_PAID' },
+          OR: [
+            { status: { in: ['PARTIALLY_RECEIVED', 'FULLY_RECEIVED'] } },
+            { paidAmount: { gt: 0 } },
+          ],
+        }),
+      }),
+    );
   });
 });

--- a/apps/api/src/modules/purchase-orders/services/po-query.service.ts
+++ b/apps/api/src/modules/purchase-orders/services/po-query.service.ts
@@ -1,6 +1,23 @@
 import { NotFoundException } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
 import { PrismaService } from '../../../prisma/prisma.service';
 import { d, dAdd, dSub, dSum } from '../../../utils/decimal.util';
+
+// Accounts-payable ("ค้างจ่าย") = money actually owed to a supplier: either the
+// goods have been RECEIVED (a payable), OR a deposit/partial payment has already
+// been made (cash is in-flight and the remainder is still owed). A pure,
+// untouched commitment — DRAFT/APPROVED/ORDERED with nothing received and nothing
+// paid — is NOT a payable and must be excluded. The AP-tab query and the
+// dashboard "ค้างจ่าย" badge MUST share this exact predicate so the count always
+// matches the tab.
+const AP_OWED_WHERE: Prisma.PurchaseOrderWhereInput = {
+  status: { notIn: ['CANCELLED', 'DRAFT'] },
+  paymentStatus: { not: 'FULLY_PAID' },
+  OR: [
+    { status: { in: ['PARTIALLY_RECEIVED', 'FULLY_RECEIVED'] } },
+    { paidAmount: { gt: 0 } },
+  ],
+};
 
 /**
  * Read-side of purchase orders: list/detail reads, accounts-payable
@@ -79,12 +96,11 @@ export class PoQueryService {
   async getAccountsPayable(page = 1, limit = 50) {
     const safeLimit = Math.min(limit, 100);
 
-    // Get all non-cancelled POs that are not fully paid
+    // True accounts payable: received OR already-paid-something, not fully paid (see AP_OWED_WHERE)
     const pos = await this.prisma.purchaseOrder.findMany({
       where: {
         deletedAt: null,
-        status: { notIn: ['CANCELLED', 'DRAFT'] },
-        paymentStatus: { not: 'FULLY_PAID' },
+        ...AP_OWED_WHERE,
       },
       include: {
         supplier: { select: { id: true, name: true, contactName: true, phone: true } },
@@ -303,7 +319,7 @@ export class PoQueryService {
       this.prisma.purchaseOrder.count({ where: { ...base, status: 'ORDERED', expectedDate: { lt: now } } }),
       this.prisma.purchaseOrder.count({ where: { ...base, status: 'PARTIALLY_RECEIVED' } }),
       this.prisma.product.count({ where: { deletedAt: null, status: { in: ['QC_PENDING', 'PHOTO_PENDING'] } } }),
-      this.prisma.purchaseOrder.count({ where: { ...base, status: { notIn: ['CANCELLED', 'DRAFT'] }, paymentStatus: { not: 'FULLY_PAID' } } }),
+      this.prisma.purchaseOrder.count({ where: { ...base, ...AP_OWED_WHERE } }),
     ]);
     return { pendingApproval, toOrder, incoming, overdue, receiving, waitingQc, unpaid };
   }

--- a/apps/web/src/pages/PurchaseOrdersPage/components/POCard.tsx
+++ b/apps/web/src/pages/PurchaseOrdersPage/components/POCard.tsx
@@ -1,0 +1,197 @@
+import { memo } from 'react';
+import { Badge } from '@/components/ui/badge';
+import { getStatusBadgeProps, poStatusMap, poPaymentStatusMap } from '@/lib/status-badges';
+import { formatDateShort } from '@/utils/formatters';
+import { receiveProgress, isOverdue, supplierContactIsRedundant } from '../po-list.util';
+import type { PurchaseOrder } from '../types';
+import { PackageCheck, Check, X, Ban, ShoppingCart, AlertTriangle } from 'lucide-react';
+
+// Mobile-only card for the PO list. The desktop view keeps the DataTable; on
+// phones (<lg) the table side-scrolls and its row actions land off-screen, so we
+// reflow each PO into a tappable card whose status-specific actions are reachable
+// 44px touch targets. Mirrors the project card pattern (rounded-xl border bg-card)
+// and reuses the same badge maps + receiveProgress/isOverdue helpers as the table
+// so the two views never drift. Tokens only — no gray/hex/bg-white.
+
+// 44px touch-target convention (matches ReceivingUnitCard / ConversationItem)
+const actionBtn =
+  'min-h-11 flex-1 inline-flex items-center justify-center gap-1.5 rounded-lg border text-sm font-medium transition-colors disabled:opacity-50';
+
+export interface POCardProps {
+  po: PurchaseOrder;
+  openDetailModal: (po: PurchaseOrder) => void;
+  openReceiveModal: (po: PurchaseOrder) => void;
+  openPaymentModal: (po: PurchaseOrder) => void;
+  onApprove: (po: PurchaseOrder) => void;
+  onOrder: (po: PurchaseOrder) => void;
+  onReject: (po: PurchaseOrder) => void;
+  onCancel: (po: PurchaseOrder) => void;
+  approvePending: boolean;
+  orderPending: boolean;
+  rejectPending: boolean;
+}
+
+function POCardImpl({
+  po,
+  openDetailModal,
+  openReceiveModal,
+  openPaymentModal,
+  onApprove,
+  onOrder,
+  onReject,
+  onCancel,
+  approvePending,
+  orderPending,
+  rejectPending,
+}: POCardProps) {
+  const statusCfg = getStatusBadgeProps(po.status, poStatusMap);
+  const payCfg = getStatusBadgeProps(po.paymentStatus || 'UNPAID', poPaymentStatusMap);
+  const { received, ordered, pct } = receiveProgress(po);
+  const receiveDone = ordered > 0 && received >= ordered;
+  const overdue = isOverdue(po);
+  const canReceive = ['APPROVED', 'ORDERED', 'PARTIALLY_RECEIVED'].includes(po.status);
+  const sameName = supplierContactIsRedundant(po.supplier);
+
+  const stop = (fn: () => void) => (e: React.MouseEvent) => {
+    e.stopPropagation();
+    fn();
+  };
+
+  return (
+    <div
+      onClick={() => openDetailModal(po)}
+      className="rounded-xl border border-border/50 bg-card shadow-sm p-4 leading-snug cursor-pointer hover:bg-accent/40 transition-colors"
+    >
+      {/* Header: PO number + net amount */}
+      <div className="flex items-start justify-between gap-2">
+        <button
+          onClick={stop(() => openDetailModal(po))}
+          className="font-medium text-primary hover:underline text-left"
+        >
+          {po.poNumber}
+        </button>
+        <div className="text-right shrink-0">
+          <div className="text-lg font-bold tabular-nums leading-none">
+            {Number(po.netAmount ?? po.totalAmount).toLocaleString()}
+            <span className="text-xs font-normal text-muted-foreground"> บาท</span>
+          </div>
+          {Number(po.vatAmount) > 0 && (
+            <div className="text-2xs text-primary mt-0.5">รวม VAT {Number(po.vatAmount).toLocaleString()}</div>
+          )}
+        </div>
+      </div>
+
+      {/* Supplier */}
+      <div className="mt-1.5">
+        <div className="font-medium text-foreground">{po.supplier.name}</div>
+        {po.supplier.contactName && !sameName && (
+          <div className="text-xs text-muted-foreground">{po.supplier.contactName}</div>
+        )}
+      </div>
+
+      {/* Meta: order date + item count */}
+      <div className="mt-1 text-xs text-muted-foreground">
+        {formatDateShort(po.orderDate)} · {po.items.length} รายการ
+      </div>
+
+      {/* Status + payment chips */}
+      <div className="mt-2 flex flex-wrap items-center gap-1.5">
+        <Badge variant={statusCfg.variant} appearance={statusCfg.appearance}>
+          {statusCfg.label}
+        </Badge>
+        {overdue && (
+          <Badge variant="destructive" appearance="light" className="gap-1 leading-snug">
+            <AlertTriangle className="size-3" />
+            เลยกำหนด
+          </Badge>
+        )}
+        <button
+          onClick={stop(() => openPaymentModal(po))}
+          title="แก้ไขสถานะการจ่ายเงิน"
+          aria-label={`แก้ไขสถานะการจ่ายเงิน ${po.poNumber}`}
+          className="hover:opacity-80"
+        >
+          <Badge variant={payCfg.variant} appearance={payCfg.appearance}>
+            {payCfg.label}
+          </Badge>
+        </button>
+      </div>
+
+      {/* Receive progress — label always shown (mirrors desktop column); bar gated on ordered>0 */}
+      <div className="mt-2 flex items-center gap-2">
+        <span className="text-xs whitespace-nowrap tabular-nums">
+          <span className="text-muted-foreground">รับแล้ว </span>
+          <span className={receiveDone ? 'text-success font-semibold' : 'font-medium'}>{received}</span>
+          <span className="text-muted-foreground">/{ordered}</span>
+        </span>
+        {ordered > 0 && (
+          <div className="flex-1 bg-secondary rounded-full h-1.5">
+            <div
+              className={`h-1.5 rounded-full ${receiveDone ? 'bg-success' : 'bg-primary'}`}
+              style={{ width: `${pct}%` }}
+            />
+          </div>
+        )}
+      </div>
+
+      {/* Status-specific actions (detail is the whole-card tap + PO# button) */}
+      {(canReceive || po.status === 'DRAFT') && (
+        <div className="mt-3 flex flex-wrap gap-2" onClick={(e) => e.stopPropagation()}>
+          {po.status === 'APPROVED' && (
+            <button
+              onClick={stop(() => onOrder(po))}
+              disabled={orderPending}
+              className={`${actionBtn} border-info/30 text-info hover:bg-info/10`}
+              aria-label={`สั่งซื้อ ${po.poNumber}`}
+            >
+              <ShoppingCart className="size-4" />
+              สั่งซื้อ
+            </button>
+          )}
+          {canReceive && (
+            <button
+              onClick={stop(() => openReceiveModal(po))}
+              className={`${actionBtn} border-primary/30 text-primary hover:bg-primary/10`}
+              aria-label={`รับสินค้า ${po.poNumber}`}
+            >
+              <PackageCheck className="size-4" />
+              รับสินค้า
+            </button>
+          )}
+          {po.status === 'DRAFT' && (
+            <>
+              <button
+                onClick={stop(() => onApprove(po))}
+                disabled={approvePending}
+                className={`${actionBtn} border-success/30 text-success hover:bg-success/10`}
+                aria-label={`อนุมัติ ${po.poNumber}`}
+              >
+                <Check className="size-4" />
+                อนุมัติ
+              </button>
+              <button
+                onClick={stop(() => onReject(po))}
+                disabled={rejectPending}
+                className={`${actionBtn} border-warning/30 text-warning hover:bg-warning/10`}
+                aria-label={`ปฏิเสธ ${po.poNumber}`}
+              >
+                <X className="size-4" />
+                ปฏิเสธ
+              </button>
+              <button
+                onClick={stop(() => onCancel(po))}
+                className={`${actionBtn} border-destructive/30 text-destructive hover:bg-destructive/10`}
+                aria-label={`ยกเลิก ${po.poNumber}`}
+              >
+                <Ban className="size-4" />
+                ยกเลิก
+              </button>
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export const POCard = memo(POCardImpl);

--- a/apps/web/src/pages/PurchaseOrdersPage/components/POListTab.tsx
+++ b/apps/web/src/pages/PurchaseOrdersPage/components/POListTab.tsx
@@ -3,10 +3,12 @@ import { UseMutationResult } from '@tanstack/react-query';
 import DataTable, { Column } from '@/components/ui/DataTable';
 import { formatDateShort } from '@/utils/formatters';
 import { useDebounce } from '@/hooks/useDebounce';
+import { useIsMobile } from '@/hooks/useIsMobile';
 import { PurchaseOrder } from '../types';
-import { receiveProgress, isOverdue } from '../po-list.util';
+import { receiveProgress, isOverdue, supplierContactIsRedundant } from '../po-list.util';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent } from '@/components/ui/card';
+import { POCard } from './POCard';
 import { getStatusBadgeProps, poStatusMap, poPaymentStatusMap } from '@/lib/status-badges';
 import { PackageCheck, Check, X, Ban, FileText, Search, ShoppingCart, AlertTriangle } from 'lucide-react';
 import {
@@ -127,6 +129,30 @@ export function POListTab({
   const selectedSupplierName = suppliers.find((s) => s.id === supplierFilter)?.name || supplierFilter;
   const selectedPeriodLabel = periodOptions.find((p) => p.value === periodFilter)?.label || periodFilter;
 
+  const isMobile = useIsMobile();
+
+  // Shared action handlers — used by both the desktop table action column and
+  // the mobile POCard so the two views can never drift in behavior.
+  const onApprove = (po: PurchaseOrder) =>
+    setConfirmDialog({
+      open: true,
+      message: `อนุมัติ PO ${po.poNumber}?`,
+      action: () => approveMutation.mutate(po.id),
+    });
+  const onOrder = (po: PurchaseOrder) =>
+    setConfirmDialog({
+      open: true,
+      message: `ยืนยันสั่งซื้อ PO ${po.poNumber}? (สถานะจะเปลี่ยนเป็น "สั่งซื้อแล้ว")`,
+      action: () => orderMutation.mutate(po.id),
+    });
+  const onReject = (po: PurchaseOrder) => setRejectDialog({ open: true, po, reason: '' });
+  const onCancel = (po: PurchaseOrder) =>
+    setConfirmDialog({
+      open: true,
+      message: `ต้องการยกเลิก PO ${po.poNumber}?`,
+      action: () => cancelMutation.mutate(po.id),
+    });
+
   const columns: Column<PurchaseOrder>[] = [
     {
       key: 'poNumber',
@@ -149,9 +175,7 @@ export function POListTab({
       label: 'ผู้จัดจำหน่าย',
       sortable: true,
       render: (po) => {
-        const sameName =
-          po.supplier.contactName &&
-          po.supplier.contactName.trim().toLowerCase() === po.supplier.name.trim().toLowerCase();
+        const sameName = supplierContactIsRedundant(po.supplier);
         return (
           <div>
             <div className="font-medium">{po.supplier.name}</div>
@@ -279,13 +303,7 @@ export function POListTab({
           </button>
           {po.status === 'APPROVED' && (
             <button
-              onClick={() => {
-                setConfirmDialog({
-                  open: true,
-                  message: `ยืนยันสั่งซื้อ PO ${po.poNumber}? (สถานะจะเปลี่ยนเป็น "สั่งซื้อแล้ว")`,
-                  action: () => orderMutation.mutate(po.id),
-                });
-              }}
+              onClick={() => onOrder(po)}
               disabled={orderMutation.isPending}
               className="p-1.5 rounded-md text-info hover:bg-info/10 transition-colors disabled:opacity-50"
               title="สั่งซื้อ"
@@ -307,13 +325,7 @@ export function POListTab({
           {po.status === 'DRAFT' && (
             <>
               <button
-                onClick={() => {
-                  setConfirmDialog({
-                    open: true,
-                    message: `อนุมัติ PO ${po.poNumber}?`,
-                    action: () => approveMutation.mutate(po.id),
-                  });
-                }}
+                onClick={() => onApprove(po)}
                 disabled={approveMutation.isPending}
                 className="p-1.5 rounded-md text-success hover:bg-success/10 transition-colors disabled:opacity-50"
                 title="อนุมัติ"
@@ -322,7 +334,7 @@ export function POListTab({
                 <Check className="size-4" />
               </button>
               <button
-                onClick={() => setRejectDialog({ open: true, po, reason: '' })}
+                onClick={() => onReject(po)}
                 disabled={rejectPOMutation.isPending}
                 className="p-1.5 rounded-md text-warning hover:bg-warning/10 transition-colors disabled:opacity-50"
                 title="ปฏิเสธ"
@@ -331,13 +343,7 @@ export function POListTab({
                 <X className="size-4" />
               </button>
               <button
-                onClick={() => {
-                  setConfirmDialog({
-                    open: true,
-                    message: `ต้องการยกเลิก PO ${po.poNumber}?`,
-                    action: () => cancelMutation.mutate(po.id),
-                  });
-                }}
+                onClick={() => onCancel(po)}
                 className="p-1.5 rounded-md text-destructive hover:bg-destructive/10 transition-colors"
                 title="ยกเลิก"
                 aria-label={`ยกเลิก ${po.poNumber}`}
@@ -352,6 +358,11 @@ export function POListTab({
   ];
 
   const hasFilter = Boolean(search || statusFilter || supplierFilter || periodFilter || overdueOnly);
+  const EmptyIcon = hasFilter ? Search : ShoppingCart;
+  const emptyTitle = hasFilter ? 'ไม่พบใบสั่งซื้อที่ตรงกับตัวกรอง' : 'ยังไม่มีใบสั่งซื้อ';
+  const emptyDesc = hasFilter
+    ? 'ลองล้างตัวกรองหรือเปลี่ยนคำค้นหา'
+    : 'กด "+ สร้าง PO" ที่มุมขวาบนเพื่อเริ่มสั่งซื้อสินค้าจากผู้จัดจำหน่าย';
 
   return (
     <>
@@ -440,24 +451,58 @@ export function POListTab({
         </div>
       )}
 
-      <Card>
-        <CardContent className="p-0">
-          <DataTable
-            columns={columns}
-            data={filteredPos}
-            isLoading={isLoading}
-            emptyMessage={hasFilter ? 'ไม่พบใบสั่งซื้อที่ตรงกับตัวกรอง' : 'ยังไม่มีใบสั่งซื้อ'}
-            emptyIcon={hasFilter ? Search : ShoppingCart}
-            emptyDescription={
-              hasFilter
-                ? 'ลองล้างตัวกรองหรือเปลี่ยนคำค้นหา'
-                : 'กด "+ สร้าง PO" ที่มุมขวาบนเพื่อเริ่มสั่งซื้อสินค้าจากผู้จัดจำหน่าย'
-            }
-            columnToggle
-            onRowClick={openDetailModal}
-          />
-        </CardContent>
-      </Card>
+      {isMobile ? (
+        /* Mobile: reflow into tappable cards so row actions are reachable (44px) */
+        isLoading ? (
+          <div className="space-y-3">
+            {[0, 1, 2].map((i) => (
+              <div key={i} className="h-32 rounded-xl border border-border/50 bg-card animate-pulse" />
+            ))}
+          </div>
+        ) : filteredPos.length === 0 ? (
+          <Card>
+            <CardContent className="py-12 flex flex-col items-center text-center gap-2">
+              <EmptyIcon className="size-10 text-muted-foreground/50" />
+              <p className="font-medium text-foreground leading-snug">{emptyTitle}</p>
+              <p className="text-sm text-muted-foreground leading-snug">{emptyDesc}</p>
+            </CardContent>
+          </Card>
+        ) : (
+          <div className="space-y-3">
+            {filteredPos.map((po) => (
+              <POCard
+                key={po.id}
+                po={po}
+                openDetailModal={openDetailModal}
+                openReceiveModal={openReceiveModal}
+                openPaymentModal={openPaymentModal}
+                onApprove={onApprove}
+                onOrder={onOrder}
+                onReject={onReject}
+                onCancel={onCancel}
+                approvePending={approveMutation.isPending}
+                orderPending={orderMutation.isPending}
+                rejectPending={rejectPOMutation.isPending}
+              />
+            ))}
+          </div>
+        )
+      ) : (
+        <Card>
+          <CardContent className="p-0">
+            <DataTable
+              columns={columns}
+              data={filteredPos}
+              isLoading={isLoading}
+              emptyMessage={emptyTitle}
+              emptyIcon={EmptyIcon}
+              emptyDescription={emptyDesc}
+              columnToggle
+              onRowClick={openDetailModal}
+            />
+          </CardContent>
+        </Card>
+      )}
 
       {/* Reject reason dialog */}
       <Dialog

--- a/apps/web/src/pages/PurchaseOrdersPage/po-list.util.test.ts
+++ b/apps/web/src/pages/PurchaseOrdersPage/po-list.util.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { receiveProgress, isOverdue } from './po-list.util';
+import { receiveProgress, isOverdue, supplierContactIsRedundant } from './po-list.util';
 
 describe('receiveProgress', () => {
   it('sums received/ordered across items and computes pct', () => {
@@ -35,5 +35,18 @@ describe('isOverdue', () => {
 
   it('is false when expectedDate is null', () => {
     expect(isOverdue({ status: 'ORDERED', expectedDate: null }, now)).toBe(false);
+  });
+});
+
+describe('supplierContactIsRedundant', () => {
+  it('is true when contactName equals name (case/space-insensitive)', () => {
+    expect(supplierContactIsRedundant({ name: 'ACME', contactName: ' acme ' })).toBe(true);
+  });
+  it('is false when contactName differs', () => {
+    expect(supplierContactIsRedundant({ name: 'ACME Co.', contactName: 'คุณสมชาย' })).toBe(false);
+  });
+  it('is false when contactName is null/empty', () => {
+    expect(supplierContactIsRedundant({ name: 'ACME', contactName: null })).toBe(false);
+    expect(supplierContactIsRedundant({ name: 'ACME', contactName: '' })).toBe(false);
   });
 });

--- a/apps/web/src/pages/PurchaseOrdersPage/po-list.util.ts
+++ b/apps/web/src/pages/PurchaseOrdersPage/po-list.util.ts
@@ -20,3 +20,18 @@ export function isOverdue(
   if (po.status !== 'ORDERED' || !po.expectedDate) return false;
   return new Date(po.expectedDate) < now;
 }
+
+/**
+ * True when the supplier's contactName just repeats its name, so the UI should
+ * hide the redundant second line. Shared by the desktop table column and the
+ * mobile POCard so the two views can't drift.
+ */
+export function supplierContactIsRedundant(supplier: {
+  name: string;
+  contactName: string | null;
+}): boolean {
+  return (
+    !!supplier.contactName &&
+    supplier.contactName.trim().toLowerCase() === supplier.name.trim().toLowerCase()
+  );
+}


### PR DESCRIPTION
## What
End-to-end QA of the purchasing→receiving v2 overhaul (all 8 areas + RBAC + red lines passed) surfaced 3 issues — all fixed here.

### #1 [Medium] Mobile PO list — row actions off-screen
- New `POCard.tsx`; `POListTab` branches on `useIsMobile()` (<1024px) → tappable cards (44px actions reachable; was off-screen on a 390px viewport). Desktop `DataTable` unchanged.
- Reuses `getStatusBadgeProps`/`poStatusMap`/`poPaymentStatusMap` + `receiveProgress`/`isOverdue`; the table's action buttons were refactored to call the **same** shared `onApprove/onOrder/onReject/onCancel` handlers so the two views can't drift.

### #2 [Low→Major on review] "ค้างจ่าย"/AP counted not-yet-received POs
- AP tab + dashboard badge now share `AP_OWED_WHERE` = **received OR already-paid-something**, not fully paid. Pure DRAFT/APPROVED/ORDERED commitments (nothing received, nothing paid) are excluded; a deposit-paid in-transit PO still shows (adversarial review caught that received-only would hide it).

### #3 [Low] ใบรับของ printed a stub company
- Root: the inter-company migration inserts stub `company_info` rows + `seed-production.ts` shipped placeholder identity that deploy never runs (prod could show the stub too). Set the real registered entity (บริษัท เบสท์ช้อยส์โฟน จำกัด / 0165568000050) for SHOP+FINANCE in both seeds, and keyed the prod upsert on `companyCode` so it **repairs** the stub on re-run while preserving owner-set address/director/bank.

## Verification
- `tsc --noEmit` 0 errors (web + api)
- **29 api + 39 web** PO tests pass (added: AP `getAccountsPayable` + summary `unpaid` predicate specs, `supplierContactIsRedundant` helper spec)
- eslint clean on changed files
- Browser re-QA: mobile cards (ORDERED / DRAFT 3-action / received), AP excludes ORDERED-unpaid + includes deposit-paid, print header shows real entity

## Follow-up (owner)
- Real registered **address / director / bank** → set via Company settings (`PATCH /companies/:id`); seed carries real name + taxId only.
- Red line held: **no accounting/JE touched** — purchasing stays JE-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)