### PR TITLE
feat(settings): ค่าปรับ settings card (+PER_DAY) & fix(payments): partial-pay tolerance gate

### DIFF
--- a/apps/api/src/modules/settings/services/settings-write.service.ts
+++ b/apps/api/src/modules/settings/services/settings-write.service.ts
@@ -11,6 +11,18 @@ import {
 } from '../settings.constants';
 
 /**
+ * Late-fee amount keys that must be a finite number >= 0 (rejecting '' so
+ * loadLateFeeConfig never reads a blank as 0). cap_pct and tier2_min_days have
+ * tighter bounds handled inline in validateKeyValue.
+ */
+const LATE_FEE_NONNEG_KEYS = new Set<string>([
+  'late_fee_per_day_rate',
+  'late_fee_max_amount',
+  'late_fee_tier1_amount',
+  'late_fee_tier2_amount',
+]);
+
+/**
  * Write/mutation slice of the decomposed SettingsService (Wave-4). Owns the
  * SOLE `$transaction` in the module (the bulkUpdate upsert-array). All method
  * bodies are byte-identical to the original; only `this.prisma`/`this.audit`
@@ -77,6 +89,36 @@ export class SettingsWriteService {
         throw new BadRequestException(
           `doc_number_reset_cycle ต้องเป็นหนึ่งใน: ${VALID_DOC_NUMBER_RESET_CYCLES.join(', ')}`,
         );
+      }
+    }
+    // Late-fee dispatch mode — mirror of resolveLateFee (apps/api/src/utils/
+    // late-fee.util.ts). Only these two values select a real branch; anything
+    // else would silently fall back to the code default and confuse the owner.
+    if (key === 'late_fee_mode') {
+      if (value !== 'BRACKET' && value !== 'PER_DAY') {
+        throw new BadRequestException('late_fee_mode ต้องเป็น BRACKET หรือ PER_DAY');
+      }
+    }
+    // Late-fee amounts flow through loadLateFeeConfig, which does
+    // `row ? Number(row.value) : default`. A stored '' is a present row, so
+    // Number('')=0 silently DISABLES the fee (default never applies). Reject
+    // blank/non-numeric here so no client (UI, LIFF, script) can zero it out.
+    if (LATE_FEE_NONNEG_KEYS.has(key)) {
+      const n = Number(value);
+      if (value.trim() === '' || !Number.isFinite(n) || n < 0) {
+        throw new BadRequestException(`${key} ต้องเป็นตัวเลข ≥ 0`);
+      }
+    }
+    if (key === 'late_fee_cap_pct') {
+      const n = Number(value);
+      if (value.trim() === '' || !Number.isFinite(n) || n < 0 || n > 100) {
+        throw new BadRequestException('late_fee_cap_pct ต้องเป็นตัวเลข 0–100');
+      }
+    }
+    if (key === 'late_fee_tier2_min_days') {
+      const n = Number(value);
+      if (value.trim() === '' || !Number.isInteger(n) || n < 1) {
+        throw new BadRequestException('late_fee_tier2_min_days ต้องเป็นจำนวนเต็ม ≥ 1');
       }
     }
   }

--- a/apps/api/src/modules/settings/settings.service.spec.ts
+++ b/apps/api/src/modules/settings/settings.service.spec.ts
@@ -146,6 +146,68 @@ describe('SettingsService audit trail', () => {
     });
   });
 
+  // late_fee_mode whitelist — mirrors resolveLateFee (apps/api/src/utils/late-fee.util.ts).
+  describe('late_fee_mode whitelist', () => {
+    it('accepts PER_DAY', async () => {
+      prisma.systemConfig.findUnique.mockResolvedValue(null);
+      await expect(service.update('late_fee_mode', 'PER_DAY', 'u-1')).resolves.toBeDefined();
+    });
+
+    it('accepts BRACKET', async () => {
+      prisma.systemConfig.findUnique.mockResolvedValue(null);
+      await expect(service.update('late_fee_mode', 'BRACKET', 'u-1')).resolves.toBeDefined();
+    });
+
+    it('rejects an unknown mode with a Thai message', async () => {
+      await expect(service.update('late_fee_mode', 'WEEKLY', 'u-1')).rejects.toThrow(
+        /BRACKET หรือ PER_DAY/,
+      );
+    });
+
+    it('rejects the whole bulk batch when one late_fee_mode value is invalid', async () => {
+      await expect(
+        service.bulkUpdate(
+          [
+            { key: 'late_fee_mode', value: 'bogus' },
+            { key: 'late_fee_per_day_rate', value: '20' },
+          ],
+          'u-1',
+        ),
+      ).rejects.toThrow(/BRACKET หรือ PER_DAY/);
+      // Nothing persisted — validation runs before the transaction.
+      expect(prisma.$transaction).not.toHaveBeenCalled();
+    });
+
+    it('bulkUpdate accepts a valid late_fee_mode + numeric key and upserts both', async () => {
+      prisma.systemConfig.findMany.mockResolvedValue([]);
+      await service.bulkUpdate(
+        [
+          { key: 'late_fee_mode', value: 'BRACKET' },
+          { key: 'late_fee_per_day_rate', value: '20' },
+        ],
+        'u-1',
+      );
+      expect(prisma.$transaction).toHaveBeenCalled();
+      const keys = prisma.systemConfig.upsert.mock.calls.map(
+        (c: [{ where: { key: string } }]) => c[0].where.key,
+      );
+      expect(keys).toContain('late_fee_mode');
+      expect(keys).toContain('late_fee_per_day_rate');
+    });
+
+    it('rejects a blank late-fee amount (would resolve to 0 downstream)', async () => {
+      await expect(service.update('late_fee_per_day_rate', '', 'u-1')).rejects.toThrow(
+        /ตัวเลข/,
+      );
+    });
+
+    it('rejects late_fee_cap_pct above 100', async () => {
+      await expect(service.update('late_fee_cap_pct', '150', 'u-1')).rejects.toThrow(
+        /0–100/,
+      );
+    });
+  });
+
   it('audit failure does NOT block config update (audit.log is fire-and-forget-style)', async () => {
     prisma.systemConfig.findUnique.mockResolvedValue({ value: 'old' });
     audit.log.mockRejectedValue(new Error('audit DB down'));

--- a/apps/web/src/config/settings-registry.tsx
+++ b/apps/web/src/config/settings-registry.tsx
@@ -37,6 +37,7 @@ import { ReversePermissionCard } from '@/pages/SettingsPage/components/ReversePe
 import { ReverseReasonsManagementCard } from '@/pages/SettingsPage/components/ReverseReasonsManagementCard';
 import { PettyCashCustodianCard } from '@/pages/SettingsPage/components/PettyCashCustodianCard';
 import { TestModeToggle } from '@/pages/SettingsPage/components/TestModeToggle';
+import { LateFeeSettingsCard } from '@/pages/SettingsPage/components/LateFeeSettingsCard';
 
 export type SettingsRole = 'OWNER' | 'FINANCE_MANAGER' | 'ACCOUNTANT';
 export type SettingsItemKind = 'inline' | 'route' | 'external';
@@ -98,6 +99,7 @@ export const settingsRegistry: SettingsCategory[] = [
     id: 'finance', label: 'การเงิน & สินเชื่อ', icon: Wallet, roles: ['OWNER', 'FINANCE_MANAGER'],
     items: [
       { id: 'interest', label: 'ดอกเบี้ย', roles: ['OWNER'], kind: 'route', component: InterestConfigPage, path: '/settings/finance/interest' },
+      { id: 'late-fee', label: 'ค่าปรับ & เงื่อนไขผ่อน', roles: ['OWNER'], kind: 'inline', component: LateFeeSettingsCard, keywords: ['ค่าปรับ', 'late fee', 'เบี้ยปรับ', 'ปรับล่าช้า', 'per day', 'ต่อวัน', 'งวด', 'overdue', 'ติดตามหนี้', 'ปิดก่อนกำหนด'] },
       { id: 'gfin', label: 'GFIN', roles: ['OWNER'], kind: 'route', component: GfinConfigPage, path: '/settings/finance/gfin' },
       { id: 'payment-methods', label: 'ช่องทางชำระเงิน', roles: ['OWNER', 'FINANCE_MANAGER'], kind: 'route', component: PaymentMethodSettingsPage, path: '/settings/finance/payment-methods' },
     ],

--- a/apps/web/src/pages/PaymentsPage/__tests__/invalidatePaymentQueries.test.ts
+++ b/apps/web/src/pages/PaymentsPage/__tests__/invalidatePaymentQueries.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { QueryClient } from '@tanstack/react-query';
+import { invalidatePaymentQueries } from '../invalidatePaymentQueries';
+
+describe('invalidatePaymentQueries', () => {
+  it('invalidates the per-contract history caches (regression: stale ประวัติ after a payment)', () => {
+    const invalidateQueries = vi.fn();
+    invalidatePaymentQueries({ invalidateQueries } as unknown as QueryClient);
+
+    const keys = invalidateQueries.mock.calls.map((c) => c[0].queryKey[0]);
+    // The two that were previously missing — their absence let the 3-min
+    // staleTime serve a stale 0/N history behind a fresh daily summary.
+    expect(keys).toContain('contract-payments');
+    expect(keys).toContain('contract-receipts');
+    // Existing invalidations preserved.
+    expect(keys).toContain('pending-payments');
+    expect(keys).toContain('daily-summary');
+  });
+});

--- a/apps/web/src/pages/PaymentsPage/__tests__/paymentToleranceGate.test.ts
+++ b/apps/web/src/pages/PaymentsPage/__tests__/paymentToleranceGate.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { paymentToleranceGate } from '../paymentToleranceGate';
+
+describe('paymentToleranceGate', () => {
+  // Regression: แบ่งชำระ (PARTIAL) an overdue installment short by 2,000฿ must NOT
+  // be blocked by the ±1฿ tolerance gate.
+  it('PARTIAL bypasses the gate even with a large shortfall', () => {
+    expect(paymentToleranceGate('PARTIAL', 1854.55, 3854.55)).toEqual({ action: 'proceed', absDiff: 0 });
+  });
+
+  it('OVERPAY_ADVANCE bypasses the gate even with a large excess', () => {
+    expect(paymentToleranceGate('OVERPAY_ADVANCE', 6000, 3854.55)).toEqual({ action: 'proceed', absDiff: 0 });
+  });
+
+  it('NORMAL exact payment proceeds', () => {
+    expect(paymentToleranceGate('NORMAL', 3854.55, 3854.55)).toEqual({ action: 'proceed', absDiff: 0 });
+  });
+
+  it('NORMAL within ±1฿ needs approval (confirm)', () => {
+    const r = paymentToleranceGate('NORMAL', 3854.05, 3854.55); // 0.50 short
+    expect(r.action).toBe('confirm');
+    expect(r.absDiff).toBe(0.5);
+  });
+
+  it('NORMAL over 1฿ off is blocked', () => {
+    const r = paymentToleranceGate('NORMAL', 1854.55, 3854.55); // 2000 short in full-pay intent
+    expect(r.action).toBe('block');
+    expect(r.absDiff).toBe(2000);
+  });
+
+  it('UNDERPAY within tolerance still requires confirm (not bypassed)', () => {
+    expect(paymentToleranceGate('UNDERPAY', 3853.55, 3854.55).action).toBe('confirm'); // 1.00 off
+  });
+
+  it('boundary: exactly 1฿ off is confirm, just over is block', () => {
+    expect(paymentToleranceGate('NORMAL', 3853.55, 3854.55).action).toBe('confirm'); // 1.00
+    expect(paymentToleranceGate('NORMAL', 3853.54, 3854.55).action).toBe('block'); // 1.01
+  });
+});

--- a/apps/web/src/pages/PaymentsPage/index.tsx
+++ b/apps/web/src/pages/PaymentsPage/index.tsx
@@ -1,6 +1,7 @@
 import { useState, useMemo, useCallback, useRef, useEffect } from 'react';
 import Decimal from 'decimal.js';
 import { paymentToleranceGate } from './paymentToleranceGate';
+import { invalidatePaymentQueries } from './invalidatePaymentQueries';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
 import { useSearchParams } from 'react-router';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
@@ -179,8 +180,7 @@ export default function PaymentsPage() {
     },
     onSuccess: () => {
       toast.success('บันทึกการชำระสำเร็จ');
-      queryClient.invalidateQueries({ queryKey: ['pending-payments'] });
-      queryClient.invalidateQueries({ queryKey: ['daily-summary'] });
+      invalidatePaymentQueries(queryClient);
       setShowPayModal(false);
       setSelectedPayment(null);
       setSlipResult(null);
@@ -204,8 +204,7 @@ export default function PaymentsPage() {
     mutationFn: async (paymentId: string) => (await api.post(`/payments/${paymentId}/post-draft`, {})).data,
     onSuccess: () => {
       toast.success('ลงบัญชีฉบับร่างสำเร็จ');
-      queryClient.invalidateQueries({ queryKey: ['pending-payments'] });
-      queryClient.invalidateQueries({ queryKey: ['daily-summary'] });
+      invalidatePaymentQueries(queryClient);
       queryClient.invalidateQueries({ queryKey: ['payment-draft'] });
       setShowPayWizard(false);
       setSelectedPayment(null);

--- a/apps/web/src/pages/PaymentsPage/index.tsx
+++ b/apps/web/src/pages/PaymentsPage/index.tsx
@@ -1,5 +1,6 @@
 import { useState, useMemo, useCallback, useRef, useEffect } from 'react';
 import Decimal from 'decimal.js';
+import { paymentToleranceGate } from './paymentToleranceGate';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
 import { useSearchParams } from 'react-router';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
@@ -653,10 +654,11 @@ export default function PaymentsPage() {
             const remaining = Decimal.max(new Decimal(0), grossRemaining.sub(consumed))
               .toDecimalPlaces(2)
               .toNumber();
-            const diff = new Decimal(payload.amount).sub(remaining).toDecimalPlaces(2).toNumber();
-            const absDiff = Math.abs(diff);
-            if (absDiff > 1.0) {
-              toast.error(`ส่วนต่างเกิน 1 ฿ (${absDiff.toFixed(2)} ฿) ไม่สามารถอนุมัติได้ กรุณาแก้ไขจำนวนเงิน`);
+            // แบ่งชำระ (PARTIAL) และ ล่วงหน้า (OVERPAY_ADVANCE) ตั้งใจให้ส่วนต่าง > 1฿ —
+            // จึง bypass tolerance gate (backend บันทึกเป็น PARTIALLY_PAID / เงินรับล่วงหน้า).
+            const gate = paymentToleranceGate(payload.case, payload.amount, remaining);
+            if (gate.action === 'block') {
+              toast.error(`ส่วนต่างเกิน 1 ฿ (${gate.absDiff.toFixed(2)} ฿) ไม่สามารถอนุมัติได้ กรุณาแก้ไขจำนวนเงิน`);
               return;
             }
             const mutationPayload: Record<string, unknown> = {
@@ -684,7 +686,7 @@ export default function PaymentsPage() {
               // form state + makes the user intent traceable in request logs.
               lateFee: payload.lateFee,
             };
-            if (absDiff >= 0.01) {
+            if (gate.action === 'confirm') {
               setPendingPayload(mutationPayload);
               setShowToleranceDialog(true);
               return;

--- a/apps/web/src/pages/PaymentsPage/invalidatePaymentQueries.ts
+++ b/apps/web/src/pages/PaymentsPage/invalidatePaymentQueries.ts
@@ -1,0 +1,18 @@
+import type { QueryClient } from '@tanstack/react-query';
+
+/**
+ * Invalidate every cache a recorded/posted payment can change.
+ *
+ * Crucially this includes the per-contract history queries
+ * (`contract-payments` / `contract-receipts`, keyed by contractId — matched
+ * here by key prefix). They were previously left out, so with the global
+ * 3-minute `staleTime` (main.tsx) a warm history cache was served STALE after a
+ * payment: "ประวัติการชำระ" showed 0/N + "ไม่พบใบเสร็จ" even though the daily
+ * summary (which WAS invalidated) already showed the PAID payment.
+ */
+export function invalidatePaymentQueries(qc: QueryClient): void {
+  const keys = ['pending-payments', 'daily-summary', 'contract-payments', 'contract-receipts'];
+  for (const key of keys) {
+    qc.invalidateQueries({ queryKey: [key] });
+  }
+}

--- a/apps/web/src/pages/PaymentsPage/paymentToleranceGate.ts
+++ b/apps/web/src/pages/PaymentsPage/paymentToleranceGate.ts
@@ -1,0 +1,38 @@
+import Decimal from 'decimal.js';
+
+export type ToleranceAction = 'block' | 'confirm' | 'proceed';
+
+export interface ToleranceGateResult {
+  action: ToleranceAction;
+  /** |amount − remaining| rounded to 2dp (0 for the intentional-diff bypass). */
+  absDiff: number;
+}
+
+/**
+ * Tolerance gate for recording a payment against a single installment.
+ *
+ * The ±1฿ rounding tolerance only applies to payments that INTEND to settle the
+ * installment in full (NORMAL / OVERPAY / UNDERPAY). แบ่งชำระ (PARTIAL) and
+ * ล่วงหน้า (OVERPAY_ADVANCE) intentionally differ from the exact remaining by
+ * more than 1฿ — the backend books them as PARTIALLY_PAID / advance — so they
+ * must bypass the gate entirely. Before this exemption, the gate blocked every
+ * partial/advance payment with "ส่วนต่างเกิน 1 ฿ ... ไม่สามารถอนุมัติได้".
+ *
+ * For full-settlement cases:
+ *   |diff| > 1฿   → 'block'   (cashier must fix the amount)
+ *   0.01–1฿       → 'confirm' (≤1฿ tolerance; needs an approver — 52-1104/53-1503)
+ *   < 0.01฿       → 'proceed' (exact)
+ */
+export function paymentToleranceGate(
+  paymentCase: string,
+  amount: number,
+  remaining: number,
+): ToleranceGateResult {
+  if (paymentCase === 'PARTIAL' || paymentCase === 'OVERPAY_ADVANCE') {
+    return { action: 'proceed', absDiff: 0 };
+  }
+  const absDiff = new Decimal(amount).sub(remaining).abs().toDecimalPlaces(2).toNumber();
+  if (absDiff > 1.0) return { action: 'block', absDiff };
+  if (absDiff >= 0.01) return { action: 'confirm', absDiff };
+  return { action: 'proceed', absDiff };
+}

--- a/apps/web/src/pages/SettingsPage/GeneralSettingsPage.tsx
+++ b/apps/web/src/pages/SettingsPage/GeneralSettingsPage.tsx
@@ -43,9 +43,9 @@ export default function GeneralSettingsPage() {
     <div className="flex flex-col gap-4">
       <PageHeader
         title="ตั้งค่าทั่วไป"
-        subtitle="บัญชีธนาคาร, ค่าปรับ, PDPA และ payment gateway"
+        subtitle="บัญชีธนาคาร, PDPA และ payment gateway"
       />
-      {/* penalty + pdpa */}
+      {/* pdpa */}
       <GeneralSettings
         values={values}
         editingSection={editingSection}

--- a/apps/web/src/pages/SettingsPage/components/GeneralSettings.tsx
+++ b/apps/web/src/pages/SettingsPage/components/GeneralSettings.tsx
@@ -1,7 +1,10 @@
 import { configGroups, SettingsCard } from './shared';
 
-// Groups rendered before the company card
-const PRE_COMPANY_KEYS = ['penalty', 'pdpa'];
+// Groups rendered before the company card.
+// NOTE: 'penalty' moved to the dedicated LateFeeSettingsCard (registry: finance ›
+// late-fee) which adds late_fee_mode + PER_DAY fields. Keep it OUT of here so
+// there's a single editor for those keys.
+const PRE_COMPANY_KEYS = ['pdpa'];
 // Groups rendered after the company card
 const POST_COMPANY_KEYS = ['banking', 'payment_link'];
 
@@ -12,11 +15,12 @@ interface GeneralSettingsProps {
   onSave: (items: { key: string; value: string }[]) => void;
   onCancel: () => void;
   isSaving: boolean;
-  /** 'pre' renders penalty+pdpa; 'post' renders banking+payment_link */
+  /** 'pre' renders pdpa; 'post' renders banking+payment_link */
   slot: 'pre' | 'post';
 }
 
-// ── GeneralSettings: penalty, PDPA, banking, payment gateway configs ──
+// ── GeneralSettings: PDPA, banking, payment gateway configs ──
+// (late-fee / installment-terms moved to LateFeeSettingsCard — finance › late-fee)
 
 export default function GeneralSettings({
   values,

--- a/apps/web/src/pages/SettingsPage/components/LateFeeSettingsCard.tsx
+++ b/apps/web/src/pages/SettingsPage/components/LateFeeSettingsCard.tsx
@@ -1,0 +1,419 @@
+import { useMemo, useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { useAuth } from '@/contexts/AuthContext';
+import api, { getErrorMessage } from '@/lib/api';
+import { EditField, StatCard, type ConfigItem, type ConfigGroupItem } from './shared';
+
+/**
+ * ค่าปรับ & เงื่อนไขผ่อน — self-contained settings card (registry `inline` item,
+ * rendered as `<C />` with no props by CategoryPage). Owns its own GET/PATCH
+ * `/settings` round-trip, mirroring TestModeToggle.
+ *
+ * Backing keys map 1:1 onto the SystemConfig keys consumed by the API
+ * `resolveLateFee` / `loadLateFeeConfig` (apps/api/src/utils/late-fee.util.ts).
+ * `late_fee_mode` switches which branch is live:
+ *   PER_DAY → min(days × per_day_rate, max_amount, cap_pct% × installmentGross)
+ *   BRACKET → flat tier1 (1..min-1 days) / tier2 (>= min days)
+ * Defaults below mirror BUSINESS_RULES in apps/api/src/utils/config.util.ts so
+ * the form reflects what the backend actually uses when a key is not yet stored
+ * (e.g. a fresh DB with no per-day rows).
+ */
+
+type Mode = 'BRACKET' | 'PER_DAY';
+
+// Mirrors BUSINESS_RULES.* in apps/api/src/utils/config.util.ts (keep in sync)
+// so the form reflects what the backend actually uses when a key is not yet stored.
+const DEFAULTS: Record<string, string> = {
+  late_fee_mode: 'PER_DAY',
+  late_fee_tier1_amount: '50',
+  late_fee_tier2_amount: '100',
+  late_fee_tier2_min_days: '3',
+  late_fee_per_day_rate: '20',
+  late_fee_max_amount: '500',
+  late_fee_cap_pct: '5',
+  min_installment_months: '6',
+  max_installment_months: '12',
+  overdue_days_threshold: '7',
+};
+
+// These flow through loadLateFeeConfig, which reads a stored '' as Number('')=0
+// (NOT the default) — so a blank must never be persisted for them. Guarded both
+// in validate() below and server-side in settings-write.service.ts.
+const LATE_FEE_NUMERIC = new Set([
+  'late_fee_per_day_rate',
+  'late_fee_max_amount',
+  'late_fee_cap_pct',
+  'late_fee_tier1_amount',
+  'late_fee_tier2_amount',
+  'late_fee_tier2_min_days',
+]);
+
+const PER_DAY_FIELDS: ConfigGroupItem[] = [
+  { key: 'late_fee_per_day_rate', label: 'ค่าปรับต่อวัน (บาท/วัน)', shortLabel: 'ค่าปรับ/วัน', suffix: ' บาท/วัน', type: 'number', step: '1', desc: 'คิดค่าปรับ = ฿/วัน × จำนวนวันที่ค้าง (ก่อนเพดาน)' },
+  { key: 'late_fee_max_amount', label: 'เพดานค่าปรับสูงสุด (บาท)', shortLabel: 'เพดาน (บาท)', suffix: ' บาท', type: 'number', step: '1', desc: 'ค่าปรับต่องวดไม่เกินจำนวนนี้' },
+  { key: 'late_fee_cap_pct', label: 'เพดาน % ของค่างวด', shortLabel: 'เพดาน %', suffix: ' %', type: 'number', step: '0.1', desc: 'ค่าปรับต่องวดไม่เกิน x% ของค่างวด (รวม VAT)' },
+];
+
+const BRACKET_FIELDS: ConfigGroupItem[] = [
+  { key: 'late_fee_tier1_amount', label: 'ค่าปรับ tier1 (บาท) — ช้า 1 ถึง (วันเริ่ม tier2 − 1) วัน', shortLabel: 'ค่าปรับ tier1', suffix: ' บาท', type: 'number', step: '1', desc: 'ค่าปรับคงที่เมื่อช้าไม่ถึงขั้นที่ 2' },
+  { key: 'late_fee_tier2_amount', label: 'ค่าปรับ tier2 (บาท) — ตั้งแต่วันเริ่ม tier2 ขึ้นไป', shortLabel: 'ค่าปรับ tier2', suffix: ' บาท', type: 'number', step: '1', desc: 'ค่าปรับคงที่ (ไม่สะสมต่อวัน)' },
+  { key: 'late_fee_tier2_min_days', label: 'วันเริ่มต้น tier2', shortLabel: 'tier2 เริ่มวันที่', suffix: ' วัน', type: 'number', step: '1', desc: 'ช้ากี่วันถึงเริ่มคิดค่าปรับขั้นที่ 2' },
+];
+
+// NOTE: `early_payoff_discount` is intentionally NOT here — it is a dead
+// SystemConfig key (no backend reader; early-payoff math uses its own input),
+// so surfacing it as an editable control would mislead the owner into thinking
+// it changes behavior. Kept out until it is actually wired.
+const TERMS_FIELDS: ConfigGroupItem[] = [
+  { key: 'min_installment_months', label: 'จำนวนงวดขั้นต่ำ (เดือน)', shortLabel: 'งวดขั้นต่ำ', suffix: ' เดือน', type: 'number', step: '1', desc: 'จำนวนงวดต่ำสุดที่เลือกได้' },
+  { key: 'max_installment_months', label: 'จำนวนงวดสูงสุด (เดือน)', shortLabel: 'งวดสูงสุด', suffix: ' เดือน', type: 'number', step: '1', desc: 'จำนวนงวดสูงสุดที่เลือกได้' },
+];
+
+const COLLECTIONS_FIELDS: ConfigGroupItem[] = [
+  { key: 'overdue_days_threshold', label: 'จำนวนวันก่อนเปลี่ยนสถานะ OVERDUE', shortLabel: 'เกณฑ์ OVERDUE', suffix: ' วัน', type: 'number', step: '1', desc: 'ค้างกี่วันถึงเปลี่ยนสถานะเป็น OVERDUE' },
+];
+
+const ALL_KEYS = [
+  'late_fee_mode',
+  ...PER_DAY_FIELDS.map((f) => f.key),
+  ...BRACKET_FIELDS.map((f) => f.key),
+  ...TERMS_FIELDS.map((f) => f.key),
+  ...COLLECTIONS_FIELDS.map((f) => f.key),
+];
+
+const round2 = (n: number) => Math.round(n * 100) / 100;
+
+/** Client-side mirror of resolveLateFee — estimate only (display), not authoritative. */
+function estimateLateFee(mode: Mode, v: Record<string, string>, days: number, gross: number): number {
+  const d = Math.max(0, Math.floor(days));
+  if (mode === 'PER_DAY') {
+    if (d < 1) return 0;
+    const byDay = Number(v.late_fee_per_day_rate || 0) * d;
+    const byMax = Number(v.late_fee_max_amount || 0);
+    const byPct = round2((Number(v.late_fee_cap_pct || 0) / 100) * gross);
+    return Math.min(byDay, byMax, byPct);
+  }
+  if (d <= 0) return 0;
+  return d >= Number(v.late_fee_tier2_min_days || 0)
+    ? Number(v.late_fee_tier2_amount || 0)
+    : Number(v.late_fee_tier1_amount || 0);
+}
+
+// The ACTIVE mode's fee fields must carry a concrete number — an empty value
+// would persist as '' and resolve to 0 downstream (see LATE_FEE_NUMERIC note).
+// Months go through config.util getValue which falls back safely on '', so they
+// may stay blank; we only guard NaN + the min<max relationship.
+function validate(v: Record<string, string>): string | null {
+  const mode = v.late_fee_mode;
+  if (mode !== 'BRACKET' && mode !== 'PER_DAY') return 'โหมดค่าปรับต้องเป็น BRACKET หรือ PER_DAY';
+  const num = (k: string) => Number(v[k]);
+  const reqNonNeg = (k: string) => v[k] !== '' && Number.isFinite(num(k)) && num(k) >= 0;
+  if (mode === 'PER_DAY') {
+    if (!reqNonNeg('late_fee_per_day_rate')) return 'ค่าปรับต่อวันต้องเป็นตัวเลข ≥ 0';
+    if (!reqNonNeg('late_fee_max_amount')) return 'เพดานค่าปรับต้องเป็นตัวเลข ≥ 0';
+    if (!reqNonNeg('late_fee_cap_pct') || num('late_fee_cap_pct') > 100)
+      return 'เพดาน % ของค่างวดต้องเป็นตัวเลข 0–100';
+  } else {
+    if (!reqNonNeg('late_fee_tier1_amount')) return 'ค่าปรับ tier1 ต้องเป็นตัวเลข ≥ 0';
+    if (!reqNonNeg('late_fee_tier2_amount')) return 'ค่าปรับ tier2 ต้องเป็นตัวเลข ≥ 0';
+    if (!Number.isFinite(num('late_fee_tier2_min_days')) || num('late_fee_tier2_min_days') < 1)
+      return 'วันเริ่ม tier2 ต้องเป็นจำนวน ≥ 1';
+  }
+  if (v.min_installment_months !== '' && v.max_installment_months !== '') {
+    const minM = num('min_installment_months');
+    const maxM = num('max_installment_months');
+    if (!Number.isFinite(minM) || !Number.isFinite(maxM)) return 'จำนวนงวดต้องเป็นตัวเลข';
+    if (minM >= maxM) return 'งวดขั้นต่ำต้องน้อยกว่างวดสูงสุด';
+  }
+  return null;
+}
+
+export function LateFeeSettingsCard() {
+  const { user } = useAuth();
+  const isOwner = user?.role === 'OWNER';
+  const queryClient = useQueryClient();
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState<Record<string, string>>({});
+  const [previewDays, setPreviewDays] = useState('10');
+  const [previewGross, setPreviewGross] = useState('1515.83');
+
+  const { data: configs = [], isLoading, isError, refetch } = useQuery<ConfigItem[]>({
+    queryKey: ['settings'],
+    queryFn: async () => (await api.get('/settings')).data,
+  });
+
+  const serverValues = useMemo(() => {
+    const map: Record<string, string> = {};
+    for (const k of ALL_KEYS) map[k] = DEFAULTS[k] ?? '';
+    for (const c of configs) if (ALL_KEYS.includes(c.key)) map[c.key] = c.value;
+    return map;
+  }, [configs]);
+
+  const saveMutation = useMutation({
+    mutationFn: (items: { key: string; value: string }[]) => api.patch('/settings', { items }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['settings'] });
+      toast.success('บันทึกสำเร็จ');
+      setEditing(false);
+    },
+    onError: (err) => toast.error(getErrorMessage(err)),
+  });
+
+  const current = editing ? draft : serverValues;
+  const mode = (current.late_fee_mode === 'BRACKET' ? 'BRACKET' : 'PER_DAY') as Mode;
+  const activeFeeFields = mode === 'PER_DAY' ? PER_DAY_FIELDS : BRACKET_FIELDS;
+
+  const startEdit = () => {
+    if (!isOwner) return;
+    // Normalise a legacy/corrupt stored mode so the draft matches what the
+    // <select> displays — otherwise save would block on a value the UI can't show.
+    setDraft({
+      ...serverValues,
+      late_fee_mode: serverValues.late_fee_mode === 'BRACKET' ? 'BRACKET' : 'PER_DAY',
+    });
+    setEditing(true);
+  };
+
+  const setField = (key: string, val: string) =>
+    setDraft((prev) => ({ ...prev, [key]: val }));
+
+  const handleSave = () => {
+    const err = validate(draft);
+    if (err) {
+      toast.error(err);
+      return;
+    }
+    const items = ALL_KEYS.filter((k) => draft[k] !== serverValues[k])
+      // Defense-in-depth: never persist a blank late-fee number (would resolve
+      // to 0). validate() already blocks this, but guard the payload too.
+      .filter((k) => !(LATE_FEE_NUMERIC.has(k) && (draft[k] ?? '').trim() === ''))
+      .map((k) => ({ key: k, value: draft[k] ?? '' }));
+    if (items.length === 0) {
+      setEditing(false);
+      return;
+    }
+    saveMutation.mutate(items);
+  };
+
+  const previewResult = estimateLateFee(
+    mode,
+    current,
+    Number(previewDays) || 0,
+    Number(previewGross) || 0,
+  );
+
+  return (
+    <div className="rounded-xl border border-border/50 bg-card shadow-sm overflow-hidden">
+      <div className="flex">
+        <div className="w-1 shrink-0 bg-primary" />
+        <div className="p-5 flex-1">
+          <div className="flex items-start justify-between">
+            <div>
+              <h3 className="text-lg font-bold text-foreground leading-snug">ค่าปรับ &amp; เงื่อนไขผ่อน</h3>
+              <p className="text-xs text-muted-foreground mt-0.5 leading-snug">
+                กำหนดค่าปรับล่าช้า จำนวนงวด และเกณฑ์ติดตามหนี้สำหรับสัญญาผ่อนชำระ
+              </p>
+            </div>
+            {!editing && isOwner && !isLoading && !isError && (
+              <button onClick={startEdit} className="text-xs text-primary hover:underline px-2 py-1 shrink-0">
+                แก้ไข
+              </button>
+            )}
+          </div>
+
+          {!isOwner && (
+            <p className="text-xs text-muted-foreground mt-3 leading-snug">เฉพาะ OWNER เท่านั้นที่แก้ไขได้</p>
+          )}
+
+          {isLoading ? (
+            <p className="text-sm text-muted-foreground mt-4">กำลังโหลด...</p>
+          ) : isError ? (
+            <div className="mt-4 flex items-center gap-3">
+              <p className="text-sm text-destructive">โหลดการตั้งค่าไม่สำเร็จ</p>
+              <button onClick={() => refetch()} className="text-xs text-primary hover:underline">
+                ลองใหม่
+              </button>
+            </div>
+          ) : !editing ? (
+            <ViewMode values={serverValues} mode={mode} activeFeeFields={activeFeeFields} />
+          ) : (
+            <div className="mt-4 flex flex-col gap-5">
+              {/* Section 1 — late fee mode + fields */}
+              <section className="flex flex-col gap-4">
+                <SectionTitle>ค่าปรับล่าช้า</SectionTitle>
+                <div>
+                  <div className="flex items-center gap-4">
+                    <label htmlFor="late_fee_mode" className="flex-1 text-sm text-foreground">
+                      โหมดคิดค่าปรับ
+                    </label>
+                    <div className="w-48">
+                      <select
+                        id="late_fee_mode"
+                        value={mode}
+                        onChange={(e) => setField('late_fee_mode', e.target.value)}
+                        className="w-full px-3 py-2 border border-input rounded-lg text-sm bg-background text-foreground focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:ring-offset-[3px] focus-visible:ring-offset-background outline-hidden"
+                      >
+                        <option value="PER_DAY">ต่อวัน (PER_DAY)</option>
+                        <option value="BRACKET">ขั้นบันได (BRACKET)</option>
+                      </select>
+                    </div>
+                  </div>
+                  <p className="text-xs text-muted-foreground/70 mt-1 ml-0.5 leading-snug">
+                    {mode === 'PER_DAY'
+                      ? 'คิด ฿/วัน × จำนวนวันที่ค้าง แล้วจำกัดด้วยเพดานบาท และเพดาน % ของค่างวด (อันที่น้อยสุดชนะ)'
+                      : 'คิดค่าปรับคงที่เป็นขั้น: tier1 เมื่อช้าไม่ถึงเกณฑ์, tier2 เมื่อช้าตั้งแต่วันที่กำหนด'}
+                  </p>
+                </div>
+                {activeFeeFields.map((item) => (
+                  <EditField key={item.key} item={item} value={draft[item.key] ?? ''} onChange={(val) => setField(item.key, val)} />
+                ))}
+                <FeePreview
+                  days={previewDays}
+                  gross={previewGross}
+                  onDays={setPreviewDays}
+                  onGross={setPreviewGross}
+                  result={previewResult}
+                  mode={mode}
+                />
+              </section>
+
+              {/* Section 2 — installment terms */}
+              <section className="flex flex-col gap-4 border-t border-border/50 pt-4">
+                <SectionTitle>เงื่อนไขผ่อน</SectionTitle>
+                {TERMS_FIELDS.map((item) => (
+                  <EditField key={item.key} item={item} value={draft[item.key] ?? ''} onChange={(val) => setField(item.key, val)} />
+                ))}
+              </section>
+
+              {/* Section 3 — collections */}
+              <section className="flex flex-col gap-4 border-t border-border/50 pt-4">
+                <SectionTitle>ติดตามหนี้</SectionTitle>
+                {COLLECTIONS_FIELDS.map((item) => (
+                  <EditField key={item.key} item={item} value={draft[item.key] ?? ''} onChange={(val) => setField(item.key, val)} />
+                ))}
+              </section>
+
+              <div className="flex gap-2 pt-1">
+                <button
+                  onClick={handleSave}
+                  disabled={saveMutation.isPending}
+                  className="px-4 py-2 text-sm bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 disabled:opacity-50"
+                >
+                  {saveMutation.isPending ? 'กำลังบันทึก...' : 'บันทึก'}
+                </button>
+                <button
+                  onClick={() => setEditing(false)}
+                  className="px-3 py-2 text-sm text-muted-foreground hover:text-foreground"
+                >
+                  ยกเลิก
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function SectionTitle({ children }: { children: React.ReactNode }) {
+  return <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground leading-snug">{children}</h4>;
+}
+
+function ViewMode({
+  values,
+  mode,
+  activeFeeFields,
+}: {
+  values: Record<string, string>;
+  mode: Mode;
+  activeFeeFields: ConfigGroupItem[];
+}) {
+  return (
+    <div className="mt-4 flex flex-col gap-4">
+      <section className="flex flex-col gap-2">
+        <div className="flex items-center gap-2">
+          <SectionTitle>ค่าปรับล่าช้า</SectionTitle>
+          <span className="text-xs font-medium rounded-md bg-primary/10 text-primary px-2 py-0.5">
+            {mode === 'PER_DAY' ? 'โหมด: ต่อวัน' : 'โหมด: ขั้นบันได'}
+          </span>
+        </div>
+        <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
+          {activeFeeFields.map((item) => (
+            <StatCard key={item.key} label={item.shortLabel} value={values[item.key] || ''} suffix={item.suffix} desc={item.desc} />
+          ))}
+        </div>
+      </section>
+      <section className="flex flex-col gap-2 border-t border-border/50 pt-4">
+        <SectionTitle>เงื่อนไขผ่อน</SectionTitle>
+        <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
+          {TERMS_FIELDS.map((item) => (
+            <StatCard key={item.key} label={item.shortLabel} value={values[item.key] || ''} suffix={item.suffix} desc={item.desc} />
+          ))}
+        </div>
+      </section>
+      <section className="flex flex-col gap-2 border-t border-border/50 pt-4">
+        <SectionTitle>ติดตามหนี้</SectionTitle>
+        <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
+          {COLLECTIONS_FIELDS.map((item) => (
+            <StatCard key={item.key} label={item.shortLabel} value={values[item.key] || ''} suffix={item.suffix} desc={item.desc} />
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function FeePreview({
+  days,
+  gross,
+  onDays,
+  onGross,
+  result,
+  mode,
+}: {
+  days: string;
+  gross: string;
+  onDays: (v: string) => void;
+  onGross: (v: string) => void;
+  result: number;
+  mode: Mode;
+}) {
+  return (
+    <div className="rounded-lg bg-muted p-3">
+      <div className="text-xs font-semibold text-foreground leading-snug">ทดลองคำนวณ (ประมาณการ)</div>
+      <div className="flex flex-wrap items-end gap-3 mt-2">
+        <label className="text-xs text-muted-foreground">
+          วันที่ค้าง
+          <input
+            type="number"
+            step="1"
+            value={days}
+            onChange={(e) => onDays(e.target.value)}
+            className="mt-1 block w-24 px-2 py-1 border border-input rounded-md text-sm text-right bg-background text-foreground focus-visible:ring-2 focus-visible:ring-ring/30 outline-hidden"
+          />
+        </label>
+        {mode === 'PER_DAY' && (
+          <label className="text-xs text-muted-foreground">
+            ค่างวด (รวม VAT)
+            <input
+              type="number"
+              step="0.01"
+              value={gross}
+              onChange={(e) => onGross(e.target.value)}
+              className="mt-1 block w-32 px-2 py-1 border border-input rounded-md text-sm text-right bg-background text-foreground focus-visible:ring-2 focus-visible:ring-ring/30 outline-hidden"
+            />
+          </label>
+        )}
+        <div className="text-sm">
+          <span className="text-muted-foreground">ค่าปรับ ≈ </span>
+          <span className="font-bold text-foreground">{result.toLocaleString('th-TH', { minimumFractionDigits: 2, maximumFractionDigits: 2 })} บาท</span>
+        </div>
+      </div>
+      <p className="text-xs text-muted-foreground/70 mt-2 leading-snug">
+        ประมาณการฝั่งหน้าจอ — ยอดจริงคิดจากระบบหลังบ้าน (resolveLateFee)
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/pages/SettingsPage/components/__tests__/LateFeeSettingsCard.test.tsx
+++ b/apps/web/src/pages/SettingsPage/components/__tests__/LateFeeSettingsCard.test.tsx
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+import React from 'react';
+
+// Mutable auth role (vi.mock factory is hoisted — reference via vi.hoisted holder).
+const authState = vi.hoisted(() => ({ role: 'OWNER' as string }));
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => ({ user: { role: authState.role } }),
+}));
+
+const apiGet = vi.fn();
+const apiPatch = vi.fn();
+vi.mock('@/lib/api', () => ({
+  __esModule: true,
+  default: {
+    get: (...args: unknown[]) => apiGet(...args),
+    patch: (...args: unknown[]) => apiPatch(...args),
+  },
+  getErrorMessage: (e: unknown) => (e instanceof Error ? e.message : String(e)),
+}));
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn(), warning: vi.fn(), info: vi.fn() },
+}));
+
+import { toast } from 'sonner';
+import { LateFeeSettingsCard } from '../LateFeeSettingsCard';
+
+function wrap(ui: ReactNode) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(React.createElement(QueryClientProvider, { client: qc }, ui));
+}
+
+// Minimal /settings payload — the card fills the rest from BUSINESS_RULES defaults.
+function settingsResponse(overrides: Record<string, string> = {}) {
+  const base: Record<string, string> = { late_fee_mode: 'PER_DAY', late_fee_per_day_rate: '25', ...overrides };
+  return {
+    data: Object.entries(base).map(([key, value], i) => ({ id: `sc-${i}`, key, value, label: null })),
+  };
+}
+
+async function enterEditMode() {
+  await waitFor(() => expect(screen.getByRole('button', { name: 'แก้ไข' })).toBeInTheDocument());
+  fireEvent.click(screen.getByRole('button', { name: 'แก้ไข' }));
+}
+
+describe('LateFeeSettingsCard', () => {
+  beforeEach(() => {
+    authState.role = 'OWNER';
+    apiGet.mockReset();
+    apiPatch.mockReset();
+    apiPatch.mockResolvedValue({ data: {} });
+    (toast.error as ReturnType<typeof vi.fn>).mockClear();
+    (toast.success as ReturnType<typeof vi.fn>).mockClear();
+  });
+
+  it('view mode shows the active PER_DAY mode badge + stored value', async () => {
+    apiGet.mockResolvedValue(settingsResponse());
+    wrap(<LateFeeSettingsCard />);
+    await waitFor(() => expect(screen.getByText('โหมด: ต่อวัน')).toBeInTheDocument());
+    expect(screen.getByText(/25\s*บาท\/วัน/)).toBeInTheDocument();
+  });
+
+  it('switching mode to BRACKET swaps the per-day fields for tier fields', async () => {
+    apiGet.mockResolvedValue(settingsResponse());
+    wrap(<LateFeeSettingsCard />);
+    await enterEditMode();
+
+    expect(screen.getByDisplayValue('25')).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText('โหมดคิดค่าปรับ'), { target: { value: 'BRACKET' } });
+
+    expect(screen.getByDisplayValue('50')).toBeInTheDocument(); // tier1 default
+    expect(screen.queryByDisplayValue('25')).toBeNull(); // per-day rate gone
+  });
+
+  it('PER_DAY save PATCHes only the changed keys', async () => {
+    apiGet.mockResolvedValue(settingsResponse());
+    wrap(<LateFeeSettingsCard />);
+    await enterEditMode();
+
+    fireEvent.change(screen.getByDisplayValue('25'), { target: { value: '30' } });
+    fireEvent.click(screen.getByRole('button', { name: 'บันทึก' }));
+
+    await waitFor(() => expect(apiPatch).toHaveBeenCalledTimes(1));
+    const [url, body] = apiPatch.mock.calls[0];
+    expect(url).toBe('/settings');
+    expect(body.items).toEqual([{ key: 'late_fee_per_day_rate', value: '30' }]);
+  });
+
+  it('BRACKET save sends late_fee_mode + edited tier field, and NOT the hidden per-day keys', async () => {
+    apiGet.mockResolvedValue(settingsResponse());
+    wrap(<LateFeeSettingsCard />);
+    await enterEditMode();
+
+    fireEvent.change(screen.getByLabelText('โหมดคิดค่าปรับ'), { target: { value: 'BRACKET' } });
+    fireEvent.change(screen.getByDisplayValue('50'), { target: { value: '60' } }); // tier1 50 -> 60
+    fireEvent.click(screen.getByRole('button', { name: 'บันทึก' }));
+
+    await waitFor(() => expect(apiPatch).toHaveBeenCalledTimes(1));
+    const [, body] = apiPatch.mock.calls[0];
+    const keys = body.items.map((i: { key: string }) => i.key);
+    expect(body.items).toEqual(
+      expect.arrayContaining([
+        { key: 'late_fee_mode', value: 'BRACKET' },
+        { key: 'late_fee_tier1_amount', value: '60' },
+      ]),
+    );
+    // hidden per-day keys must NOT be resent
+    expect(keys).not.toContain('late_fee_per_day_rate');
+    expect(keys).not.toContain('late_fee_max_amount');
+    expect(keys).not.toContain('late_fee_cap_pct');
+  });
+
+  it('blocks save with a toast when cap_pct is out of range (no PATCH)', async () => {
+    apiGet.mockResolvedValue(settingsResponse());
+    wrap(<LateFeeSettingsCard />);
+    await enterEditMode();
+
+    fireEvent.change(screen.getByDisplayValue('5'), { target: { value: '150' } }); // cap_pct default 5 -> 150
+    fireEvent.click(screen.getByRole('button', { name: 'บันทึก' }));
+
+    expect(toast.error).toHaveBeenCalled();
+    expect(apiPatch).not.toHaveBeenCalled();
+  });
+
+  it('blocks save when a late-fee field is cleared to empty (would zero the fee)', async () => {
+    apiGet.mockResolvedValue(settingsResponse());
+    wrap(<LateFeeSettingsCard />);
+    await enterEditMode();
+
+    fireEvent.change(screen.getByDisplayValue('25'), { target: { value: '' } }); // clear per-day rate
+    fireEvent.click(screen.getByRole('button', { name: 'บันทึก' }));
+
+    expect(toast.error).toHaveBeenCalled();
+    expect(apiPatch).not.toHaveBeenCalled();
+  });
+
+  it('preview estimates the PER_DAY fee with the 5% cap binding', async () => {
+    apiGet.mockResolvedValue(settingsResponse());
+    wrap(<LateFeeSettingsCard />);
+    await enterEditMode();
+    // defaults: rate=25, max=500, cap=5, days=10, gross=1515.83
+    // byDay=250, byMax=500, byPct=round2(0.05*1515.83)=75.79 → min=75.79
+    expect(screen.getByText(/75\.79/)).toBeInTheDocument();
+  });
+
+  it('non-OWNER sees a read-only notice and no edit button', async () => {
+    authState.role = 'SALES';
+    apiGet.mockResolvedValue(settingsResponse());
+    wrap(<LateFeeSettingsCard />);
+    await waitFor(() => expect(screen.getByText('โหมด: ต่อวัน')).toBeInTheDocument());
+    expect(screen.getByText('เฉพาะ OWNER เท่านั้นที่แก้ไขได้')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'แก้ไข' })).toBeNull();
+  });
+});

--- a/apps/web/src/pages/SettingsPage/components/shared.tsx
+++ b/apps/web/src/pages/SettingsPage/components/shared.tsx
@@ -28,21 +28,11 @@ export interface ConfigGroup {
 
 // ── Shared config data ──
 
+// NOTE: the 'penalty' group (late fee + installment months + overdue threshold)
+// moved to the dedicated LateFeeSettingsCard (registry: finance › late-fee),
+// which adds late_fee_mode + the PER_DAY fields. It is intentionally no longer
+// declared here — that card owns those SystemConfig keys now.
 export const configGroups: ConfigGroup[] = [
-  {
-    key: 'penalty',
-    title: 'ค่าปรับ จำนวนงวด และการติดตามหนี้',
-    subtitle: 'กำหนดค่าปรับ จำนวนงวด และเกณฑ์ติดตามหนี้สำหรับสัญญาผ่อนชำระ',
-    items: [
-      { key: 'late_fee_tier1_amount', label: 'ค่าปรับล่าช้า tier1 (บาท) — 1 ถึง tier2MinDays-1 วัน', shortLabel: 'ค่าปรับ tier1', suffix: ' บาท', type: 'number', step: '1', desc: 'ค่าปรับเมื่อจ่ายช้า 1–2 วัน (ก่อนถึงขั้นที่ 2)' },
-      { key: 'late_fee_tier2_amount', label: 'ค่าปรับล่าช้า tier2 (บาท) — ตั้งแต่ tier2MinDays วันขึ้นไป', shortLabel: 'ค่าปรับ tier2', suffix: ' บาท', type: 'number', step: '1', desc: 'ค่าปรับเมื่อจ่ายช้าตั้งแต่วันที่กำหนดขึ้นไป' },
-      { key: 'late_fee_tier2_min_days', label: 'วันเริ่มต้น tier2 ค่าปรับล่าช้า', shortLabel: 'tier2 เริ่มวันที่', suffix: ' วัน', type: 'number', step: '1', desc: 'จำนวนวันที่เริ่มคิดค่าปรับขั้นที่ 2 (tier2)' },
-      { key: 'early_payoff_discount', label: 'ส่วนลดปิดบัญชีก่อนกำหนด (%)', shortLabel: 'ส่วนลดปิดก่อน', suffix: '', type: 'number', step: '0.1', desc: 'ลดให้ลูกค้าที่ปิดบัญชีก่อนกำหนด' },
-      { key: 'min_installment_months', label: 'จำนวนงวดขั้นต่ำ (เดือน)', shortLabel: 'งวดขั้นต่ำ', suffix: ' เดือน', type: 'number', step: '1', desc: 'จำนวนงวดต่ำสุดที่เลือกได้' },
-      { key: 'max_installment_months', label: 'จำนวนงวดสูงสุด (เดือน)', shortLabel: 'งวดสูงสุด', suffix: ' เดือน', type: 'number', step: '1', desc: 'จำนวนงวดสูงสุดที่เลือกได้' },
-      { key: 'overdue_days_threshold', label: 'จำนวนวันก่อนเปลี่ยนสถานะ OVERDUE', shortLabel: 'เกณฑ์ OVERDUE', suffix: ' วัน', type: 'number', step: '1', desc: 'ค้างกี่วันถึงเปลี่ยนสถานะเป็น OVERDUE' },
-    ],
-  },
   {
     key: 'pdpa',
     title: 'PDPA และความปลอดภัย',


### PR DESCRIPTION
รวม 2 เรื่องที่ทำในรอบเดียว แยกเป็น 2 commit อิสระ

## 1) feat(settings) — หน้าตั้งค่าปรับที่เห็นชัด + โหมด PER_DAY  (`a8596620`)

**ปัญหา:** config ค่าปรับ/เงื่อนไขผ่อนถูกฝังอยู่ในหน้า `/settings/general` ที่หลุดจาก registry — ไม่มีในเมนู/Command Palette เข้าได้ทางเดียวคือพิมพ์ URL ตรงๆ

- **`LateFeeSettingsCard`** ใหม่ (registry: การเงิน › "ค่าปรับ & เงื่อนไขผ่อน", OWNER) — สลับโหมด BRACKET/PER_DAY, ช่องตามโหมด, preview คำนวณสด, งวด min/max + เกณฑ์ OVERDUE → เข้าถึงจากเมนู + palette
- ย้าย penalty group ออกจาก `GeneralSettings` (single editor) + ลบ dead `early_payoff_discount` control + อัปเดตคอมเมนต์ค้าง
- **Backend guard:** whitelist `late_fee_mode` (BRACKET|PER_DAY) + numeric guards สำหรับ late-fee amount keys — กันค่าว่างที่จะถูกอ่านเป็น 0 downstream (`loadLateFeeConfig` ใช้ `row ? Number(row.value) : default`, `Number('')=0`)
- **Tests:** LateFeeSettingsCard (8) + settings whitelist/guard (+6)

## 2) fix(payments) — แบ่งชำระ/ล่วงหน้า ผ่าน tolerance gate ได้  (`83b6e633`)

**ปัญหา:** บันทึกแบ่งชำระ (แบ่งชำระ) งวดที่เกินดิว เด้ง _"ส่วนต่างเกิน 1 ฿ … ไม่สามารถอนุมัติได้"_ ทั้งที่ wizard + backend รองรับ `case='PARTIAL'` (บันทึก PARTIALLY_PAID) แล้ว — สาเหตุคือ tolerance gate เก่าใน `onSubmit` บล็อกทุก payment ที่ `|amount − remaining| > 1฿` → PARTIAL และ OVERPAY_ADVANCE (ที่ตั้งใจให้ต่าง >1฿) เลยโดนบล็อก

- แยก decision เป็น pure `paymentToleranceGate(case, amount, remaining)` → block | confirm | proceed — ยกเว้น PARTIAL + OVERPAY_ADVANCE; NORMAL/OVERPAY/UNDERPAY คงกฎเดิม
- wire เข้า `RecordPaymentWizard` onSubmit
- **Tests:** paymentToleranceGate (7) รวม regression เคสขาด 2,000฿ เป๊ะ

## Verification
- Web tsc ✅ · API tsc ✅
- Web: LateFeeSettingsCard 8/8 · paymentToleranceGate 7/7 · settings+palette regression 94/94
- API: settings.service 175/175

🤖 Generated with [Claude Code](https://claude.com/claude-code)
