### PR TITLE
fix(payments): retarget stale overpay tests for D1 auto-advance (unblock CI)

### DIFF
--- a/apps/api/src/modules/payments/payments-financial.spec.ts
+++ b/apps/api/src/modules/payments/payments-financial.spec.ts
@@ -127,9 +127,12 @@ describe('PaymentsService — Financial Integration', () => {
       expect(Number(payments[0].amountPaid)).toBe(500);
     });
 
-    it('should reject overpayment', async () => {
+    it('should reject overpayment beyond the auto-advance ceiling', async () => {
+      // D1 (owner 2026-06-25): overpay within 2×amountDue (=2000) auto-routes to
+      // advance; only overage above the ceiling is rejected. amountDue=1000 →
+      // ceiling=2000, so 3500 (overage 2500) must throw. (Was 1500 → now auto-advances.)
       await expect(
-        service.recordPayment('c1', 1, 1500, 'CASH', 'u1', 'https://s3.example.com/slip.jpg', undefined, 'TXN-3'),
+        service.recordPayment('c1', 1, 3500, 'CASH', 'u1', 'https://s3.example.com/slip.jpg', undefined, 'TXN-3'),
       ).rejects.toThrow(BadRequestException);
     });
 

--- a/apps/api/src/modules/payments/payments.preview-journal-money.spec.ts
+++ b/apps/api/src/modules/payments/payments.preview-journal-money.spec.ts
@@ -652,15 +652,20 @@ describe('PaymentsService.recordPayment — tolerance gating (characterization)'
     expect(result.status).toBe('PAID');
   });
 
-  it('overage == 1.01 throws BadRequest mentioning OVERPAY_ADVANCE', async () => {
+  it('overage above the auto-advance ceiling throws BadRequest mentioning OVERPAY_ADVANCE', async () => {
+    // D1 (owner 2026-06-25): overpay within multiplier×amountDue (default 2 →
+    // ceiling 2000) auto-routes to advance (Cr 21-1103) WITHOUT throwing. Only
+    // overage ABOVE the ceiling still requires an explicit OVERPAY_ADVANCE case.
+    // amountDue=1000 → ceiling=2000, so overage 2000.01 must throw. (Was overage
+    // 1.01, which now legitimately auto-advances → no throw.)
     await expect(
       service.recordPayment(
         'tol-contract-1',
         1,
-        REMAINING + 1.01, // 1001.01 → overage 1.01
+        REMAINING + 2000.01, // 3000.01 → overage 2000.01 > ceiling 2000
         'CASH',
         'user-1',
-        'https://slip.test/over-101',
+        'https://slip.test/over-ceiling',
       ),
     ).rejects.toThrow(BadRequestException);
 
@@ -668,10 +673,10 @@ describe('PaymentsService.recordPayment — tolerance gating (characterization)'
       service.recordPayment(
         'tol-contract-1',
         1,
-        REMAINING + 1.01,
+        REMAINING + 2000.01,
         'CASH',
         'user-1',
-        'https://slip.test/over-101b',
+        'https://slip.test/over-ceiling-b',
       ),
     ).rejects.toThrow(/OVERPAY_ADVANCE/);
   });

--- a/apps/api/src/modules/payments/payments.service.spec.ts
+++ b/apps/api/src/modules/payments/payments.service.spec.ts
@@ -243,9 +243,15 @@ describe('PaymentsService', () => {
       ).rejects.toThrow(BadRequestException);
     });
 
-    it('should throw if amount exceeds remaining', async () => {
+    it('should throw if amount exceeds remaining beyond the auto-advance ceiling', async () => {
+      // D1 (owner 2026-06-25): overpay within multiplier×amountDue auto-routes to
+      // advance (Cr 21-1103) WITHOUT throwing. Only overpay ABOVE that ceiling
+      // still requires an explicit OVERPAY_ADVANCE case — that's the guard here.
+      // amountDue=3000, default multiplier=2 → ceiling=6000, so 10000 (overage
+      // 7000 > 6000) must be rejected. (The old assertion used 5000, whose 2000
+      // overage now legitimately auto-advances → no throw.)
       await expect(
-        service.recordPayment('contract-1', 1, 5000, 'CASH', 'user-1', 'http://slip.jpg'),
+        service.recordPayment('contract-1', 1, 10000, 'CASH', 'user-1', 'http://slip.jpg'),
       ).rejects.toThrow(BadRequestException);
     });
 


### PR DESCRIPTION
## Problem
CI "Test API" on `main` is **red** — 3 payment unit suites fail, blocking every PR (this is why #1310 needed an admin-merge).

Root cause: these tests assert the **pre-D1** rule where any overpay beyond `remaining` threw. Since **D1 (owner 2026-06-25)**, overpay within `multiplier × amountDue` (default 2× → ceiling) **auto-routes to advance** (Cr 21-1103); only overage **above** the ceiling throws (requires `OVERPAY_ADVANCE`). The hardcoded amounts fell *inside* the ceiling, so they now auto-advance → tests fail ("resolved instead of rejected" / crash on the undefined `payment.update` mock).

## Fix (test-only — no product behavior changed)
Retarget each to an amount **above** the ceiling so it exercises the real guard:

| Suite | before | after | amountDue → ceiling |
|---|---|---|---|
| `payments.service.spec` | 5000 | 10000 | 3000 → 6000 |
| `payments.preview-journal-money.spec` | overage 1.01 | overage 2000.01 | 1000 → 2000 |
| `payments-financial.spec` | 1500 | 3500 | 1000 → 2000 |

## Verification
`jest payments.service.spec payments.preview-journal-money.spec payments-financial.spec` → **3 suites / 93 tests pass** (were the exact 3 suites CI reported: `3 failed, 456 passed`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
