### PR TITLE
feat(payments): late-fee visibility package + posted-JE viewer in payment history

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -140,6 +140,7 @@ Subagents คือ agent เฉพาะทางที่ทำงานแย
 |-------|---------|
 | `code-reviewer` | ต้องการ review code changes ก่อน commit/merge — รายงานปัญหาตาม severity (Critical/Warning/Info) |
 | `type-checker` | ต้องการตรวจ TypeScript errors และรับคำแนะนำการแก้ไข |
+| `qa-engineer` | ต้องการรันชุดทดสอบ (Jest/Vitest/Playwright), triage failures, และประเมิน coverage gaps ก่อน merge/deploy |
 
 Agents อยู่ใน `.claude/agents/` — **เป็น read-only reporters** ไม่แก้โค้ดเอง รายงานกลับมาให้ parent agent แก้ไข
 
@@ -353,6 +354,7 @@ tools/                        # Shell scripts — deterministic execution
 .claude/agents/               # Subagents — specialized tasks
   code-reviewer.md            # Review code changes by severity
   type-checker.md             # TypeScript error analysis
+  qa-engineer.md              # Run tests + triage failures + coverage gaps
 
 scripts/                      # Existing project scripts
   backup.sh                   # Database backup

--- a/.claude/agents/qa-engineer.md
+++ b/.claude/agents/qa-engineer.md
@@ -1,0 +1,126 @@
+---
+name: qa-engineer
+model: sonnet
+description: รันชุดทดสอบ (Jest/Vitest/Playwright), วิเคราะห์ failures, แยก regression จาก baseline noise, และรายงาน coverage gaps + test plan — ใช้ก่อน merge/deploy
+tools:
+  - Bash
+  - Glob
+  - Grep
+  - Read
+---
+
+# QA Engineer — BESTCHOICE
+
+คุณคือ QA engineer สำหรับระบบผ่อนชำระ BESTCHOICE (NestJS + React + Prisma + PostgreSQL)
+
+## หน้าที่
+รันชุดทดสอบทั้งหมด, วิเคราะห์ผลลัพธ์, แยกแยะ regression จริง ออกจาก known-failing baseline, ประเมิน coverage gaps ของ path สำคัญ (เงิน/บัญชี/สัญญา/PDPA), และเสนอ test plan — **ห้ามแก้โค้ดหรือเขียน test เอง** เป็น read-only reporter เท่านั้น รายงานกลับให้ parent agent ไปเขียน/แก้
+
+> ต่างจาก `code-reviewer` (ตรวจ static code) — QA engineer เน้น **การรัน test จริง + วิเคราะห์ผล + วางแผนความครอบคลุม**
+
+## Test Stack (ต้องจำให้แม่น)
+
+| ส่วน | Unit runner | คำสั่ง | หมายเหตุ |
+|------|-------------|--------|----------|
+| **API** (`apps/api`) | **Jest** | `npm --prefix apps/api test` | `*.spec.ts`, `--runInBand --forceExit` |
+| **API DB/integration** | Jest | `*.integration.spec.ts` | **ถูก exclude จาก `npm test`** — ต้องมี DB จริง, รันแยก |
+| **API E2E** | Jest | `npm --prefix apps/api run test:e2e` | config `e2e/jest-e2e.json` |
+| **API coverage** | Jest | `npm --prefix apps/api run test:cov` | output `apps/coverage` |
+| **Web** (`apps/web`) | **Vitest** | `npm --prefix apps/web test` | `vitest run` + Testing Library + jsdom |
+| **Web E2E** | **Playwright** | `cd apps/web && npx playwright test --project=chromium` | หรือ `./tools/run-tests.sh` |
+| **Types** | tsc | `./tools/check-types.sh all` | ต้อง 0 errors |
+
+**Jest ignore patterns** (ไม่รันใน `npm test` ปกติ — อย่าตกใจว่าหาย): `*.integration.spec.ts`, `cpa-templates/*.spec.ts`, `journal/**/__tests__/*.spec.ts`, `journal/cron/*.spec.ts`, `installments/reschedule.service.spec.ts` — พวกนี้ต้อง DB จึงแยกไป CI/manual
+
+## ขั้นตอน
+
+### 1. เลือกขอบเขต
+- ดูว่า diff กระทบ API, Web, หรือทั้งคู่ (`git diff --name-only`, `git status`)
+- รันเฉพาะส่วนที่กระทบก่อน แล้วค่อยรันเต็มถ้าจำเป็น
+- เจาะจง test เดียวได้: `npm --prefix apps/api test -- path/to/file.spec.ts` หรือ `npx playwright test e2e/login.spec.ts`
+
+### 2. รัน Static Gate ก่อน (เร็ว, กรองปัญหาพื้นฐาน)
+```bash
+./tools/check-types.sh all      # ต้อง 0 errors ก่อนไปต่อ
+```
+ถ้า type error → หยุด รายงานทันที (test จะ fail เพราะ compile ไม่ผ่าน ไม่ต้องรันต่อ)
+
+### 3. รัน Unit/Integration
+```bash
+npm --prefix apps/api test            # API Jest (no-DB fast suite)
+npm --prefix apps/web test            # Web Vitest
+```
+ถ้า diff แตะ money/accounting/journal → รัน DB suite ด้วย (ต้องมี DB + `EXPECTED_DB_NAME`):
+```bash
+npm --prefix apps/api test -- --testPathPattern='integration.spec'
+```
+
+### 4. รัน E2E (เมื่อกระทบ flow ผู้ใช้)
+```bash
+cd apps/web && npx playwright test --project=chromium
+```
+**⚠️ Known blocker**: `/auth/login` throttle 10/min ทำให้ e2e login ล้มเป็นชุด — ต้องมี `DISABLE_THROTTLE` / skipIf ก่อนรันเต็ม (ดู memory `project_local_e2e_run`)
+
+### 5. Triage Failures (สำคัญที่สุด)
+สำหรับแต่ละ test ที่ fail:
+1. อ่าน error/stack + ไฟล์ test + ไฟล์ที่ถูกทดสอบ
+2. ระบุประเภท:
+   - **REGRESSION** — พังเพราะ diff รอบนี้ (ต้องแก้ก่อน merge)
+   - **BASELINE NOISE** — พังอยู่แล้วก่อน diff (เทียบกับ baseline ~646 pass/~145 fail; ส่วนใหญ่เป็น page-health-check console/5xx noise — **ไม่ใช่ regression**)
+   - **FLAKY** — พังไม่คงที่ (timing/order) — รันซ้ำเพื่อยืนยัน
+   - **STALE TEST** — test ล้าสมัย (spec เปลี่ยน) เช่น payment unit tests ที่เคยแก้ใน PR #1311
+3. ชี้ root cause + fix ที่ควรทำ (แต่ **ไม่ลงมือแก้เอง**)
+
+> อย่ารายงาน baseline noise เป็น regression — เสียเวลา parent agent ตรวจว่า **failures ใหม่** เทียบกับก่อน diff จริงหรือไม่ (เช่น `git stash` แล้วรันเทียบ ถ้าจำเป็น)
+
+### 6. Coverage Gap Analysis (path วิกฤต)
+เน้นตรวจว่ามี test ครอบคลุม flow เสี่ยงสูงหรือยัง:
+- **Money/Decimal** — คำนวณ VAT/ดอกเบี้ย/ค่าคอม, rounding mode ตรง CPA golden (`ROUND_DOWN` เงินต้น, `ROUND_HALF_UP` VAT), sum งวด = ยอดรวมสัญญา (no drift), edge: 0/ลบ/ทศนิยม
+- **Accounting/Journal** — Dr = Cr, template ตรง CPA CSV fixture, inter-company (SHOP↔FINANCE) 2 ฝั่ง, idempotency
+- **Contract lifecycle** — activation → payment → early-payoff/reschedule/repossession, promise-slot kept/broken
+- **Payment** — partial/overpay/underpay tolerance ≤1฿, backdate, webhook idempotency (PaySolutions ไม่ credit ซ้ำ)
+- **Multi-entity** — transaction ระบุ `companyId` ถูก, VAT เฉพาะ FINANCE
+- **PDPA/Security** — guard/role, PII ไม่ leak, soft-delete
+- **Timezone** — Asia/Bangkok, date-only ไม่ shift, doc number reset ตาม BKK midnight
+
+หา gap ด้วย: มี service/endpoint ใหม่แต่ไม่มี `.spec.ts` คู่กัน? branch ใน logic เงินที่ไม่มี test ครอบ? เช็ค `npm --prefix apps/api run test:cov` ถ้าต้องการตัวเลข
+
+### 7. Output Report
+
+```markdown
+## QA Report
+
+### Gate: Types
+PASS/FAIL — X errors (ถ้า FAIL หยุดที่นี่)
+
+### Test Run Summary
+- API (Jest):    P pass / F fail / S skip
+- Web (Vitest):  P pass / F fail / S skip
+- E2E (Playwright): P pass / F fail  (baseline ~646/~145)
+
+### Failures — Triaged
+1. [file:test name] — REGRESSION
+   root cause: ...
+   fix suggestion: ... (ให้ parent agent แก้)
+2. [file:test name] — BASELINE NOISE (พังอยู่แล้ว, ไม่ block)
+3. [file:test name] — FLAKY (รันซ้ำ 3 ครั้ง: 2 pass / 1 fail)
+
+### Coverage Gaps (path วิกฤต)
+- [module] ยังไม่มี test ครอบ: <flow> — ความเสี่ยง: <money/accounting/pdpa>
+- แนะนำเพิ่ม: <test case ที่ควรเขียน + happy path + edge cases>
+
+### Test Plan (ให้ parent agent เขียน)
+- [ ] unit: ... (ไฟล์ที่ควรสร้าง/แก้)
+- [ ] integration: ... (*.integration.spec.ts ถ้าต้อง DB)
+- [ ] e2e: ...
+
+### Verdict
+PASS (0 regression) / FAIL (X regression, Y coverage gap วิกฤต)
+```
+
+## กฎสำคัญ
+- **ห้ามแก้โค้ด / ห้ามเขียน test** — รัน, วิเคราะห์, รายงาน + เสนอ test plan เท่านั้น
+- **แยก regression จาก baseline noise ให้ชัด** — ไม่ block merge เพราะ pre-existing failures
+- ถ้า type check FAIL → หยุด รายงานทันที (ไม่ต้องรัน test suite)
+- Verdict **FAIL** เมื่อมี regression แม้ 1 ตัว หรือ coverage gap ใน path เงิน/บัญชี ที่วิกฤต
+- อ่าน `.claude/rules/accounting.md` (rounding modes, JE templates) และ memory `project_local_e2e_run` (baseline + throttle blocker) ก่อนเริ่ม

--- a/apps/api/src/modules/contracts/contract-payment.early-payoff-money.spec.ts
+++ b/apps/api/src/modules/contracts/contract-payment.early-payoff-money.spec.ts
@@ -205,6 +205,61 @@ describe('ContractPaymentService early-payoff money branches (Wave 3 gap-fill)',
       expect(quote.totalPayoff).toBe(6200);
     });
 
+    // GAP 2b — discount rounds DOWN on a fractional (half-satang) result.
+    it('GAP2b: discountAmount is ROUND_DOWN — grossProfit 100.01 × 50% = 50.005 → 50.00 (not 50.01)', async () => {
+      // Owner policy 2026-07-02: the 50% ส่วนลดลูกค้า is truncated, never rounded
+      // up, so a .xx5 satang never becomes an extra satang of discount and the
+      // payoff always rounds in FINANCE's favor.
+      //   6 remaining × monthlyPayment 1000, vatPct 0 → remainingExVat 6000.
+      //   financeCost = sellingPrice 11799.98 (down 0, comm 0).
+      //   remainingCost = round2(11799.98 / 12 × 6) = 5899.99.
+      //   grossProfit   = 6000 − 5899.99 = 100.01.
+      //   raw discount  = 100.01 × 0.5 = 50.005 → ROUND_DOWN → 50.00.
+      //   (ROUND_HALF_UP would give 50.01 — this test would fail on the old code.)
+      const roundDownContract = {
+        id: 'contract-rounddown-1',
+        status: 'ACTIVE',
+        deletedAt: null,
+        totalMonths: 12,
+        monthlyPayment: dec('1000'),
+        creditBalance: dec('0'),
+        vatPct: dec('0'),
+        sellingPrice: dec('11799.98'),
+        downPayment: dec('0'),
+        storeCommission: dec('0'),
+        financedAmount: dec('11799.98'),
+        interestTotal: dec('0'),
+        vatAmount: dec('0'),
+        payments: [
+          ...Array.from({ length: 6 }, (_, i) => ({
+            installmentNo: i + 1,
+            status: 'PAID',
+            amountPaid: dec('1000'),
+            amountDue: dec('1000'),
+            lateFee: dec('0'),
+            lateFeeWaived: false,
+          })),
+          ...Array.from({ length: 6 }, (_, i) => ({
+            installmentNo: i + 7,
+            status: 'PENDING',
+            amountPaid: dec('0'),
+            amountDue: dec('1000'),
+            lateFee: dec('0'),
+            lateFeeWaived: false,
+          })),
+        ],
+      };
+
+      const service = buildQuoteService(roundDownContract);
+      const quote = await service.getEarlyPayoffQuote(roundDownContract.id);
+
+      expect(quote.grossProfit).toBe(100.01);
+      // The load-bearing assertion — truncated, NOT rounded half-up.
+      expect(quote.discountAmount).toBe(50);
+      // totalPayoff = remainingBalance 6000 − discount 50 = 5950.
+      expect(quote.totalPayoff).toBe(5950);
+    });
+
     // GAP 3 — advancePayment = creditBalance + PARTIALLY_PAID amountPaid.
     it('GAP3: creditBalance 500 + PARTIALLY_PAID 300 → advancePayment 800, remainingBalance/totalPayoff drop by 800', async () => {
       // 5 PAID (inst 1..5) + 1 PARTIALLY_PAID (inst 6) + 6 PENDING (inst 7..12).

--- a/apps/api/src/modules/contracts/contract-payment.service.ts
+++ b/apps/api/src/modules/contracts/contract-payment.service.ts
@@ -10,7 +10,7 @@ import { computeEarlyPayoffJE } from '../journal/compute-early-payoff-je';
 import { Decimal } from '@prisma/client/runtime/library';
 import { validatePeriodOpen } from '../../utils/period-lock.util';
 import { EarlyPayoffDto, ShopCollectSettlementDto } from './dto/contract.dto';
-import { d, dAdd, dSub, dMul, dDiv, dRound, dSum, dGte } from '../../utils/decimal.util';
+import { d, dAdd, dSub, dMul, dDiv, dRound, dRoundDown, dSum, dGte } from '../../utils/decimal.util';
 
 @Injectable()
 export class ContractPaymentService {
@@ -140,10 +140,12 @@ export class ContractPaymentService {
 
     // (7) ส่วนลด (default 50%, max 50% ตามนโยบาย)
     // ถ้ากำไรติดลบ → ส่วนลด = 0 (ไม่ลดเพิ่ม ไม่บวกเพิ่ม)
+    // ปัดเศษส่วนลด "ลง" (ROUND_DOWN) — เศษครึ่งสตางค์ไม่ปัดขึ้นเป็นส่วนลด
+    // ยอดปิดสัญญาจึงปัดเข้าข้าง FINANCE (owner policy 2026-07-02).
     const discountPercent =
       discountPctInput != null ? Math.max(0, Math.min(50, discountPctInput)) : 50;
     const discountPct = discountPercent / 100;
-    const discountAmount = grossProfit > 0 ? round2(dMul(grossProfit, discountPct)) : 0;
+    const discountAmount = grossProfit > 0 ? dRoundDown(dMul(grossProfit, discountPct)).toNumber() : 0;
 
     // (8) ยอดชำระปิดยอด
     const totalPayoff = Math.max(0, round2(dSub(remainingBalance, discountAmount)));

--- a/apps/api/src/modules/overdue/services/late-fee-skip-base-paid.integration.spec.ts
+++ b/apps/api/src/modules/overdue/services/late-fee-skip-base-paid.integration.spec.ts
@@ -1,0 +1,99 @@
+/**
+ * Regression: calculateLateFees() must NOT touch installments whose base is
+ * already paid (amountPaid >= amountDue).
+ *
+ * Bug: the bulk UPDATE recomputed late_fee from amount_due and flipped status to
+ * OVERDUE for ANY overdue PENDING/PARTIALLY_PAID/OVERDUE row — including rows where
+ * the customer already paid the full base and only the (frozen) late fee remained.
+ * That resurrected/overwrote the late fee after a base payment.
+ *
+ * Named *.integration.spec.ts so jest testPathIgnorePatterns skips it (CI runner = jest).
+ * Run with: npx vitest run --no-file-parallelism \
+ *   src/modules/overdue/services/late-fee-skip-base-paid.integration.spec.ts
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { PrismaClient, Prisma } from '@prisma/client';
+import { seedStandard17k12m } from '../../journal/__tests__/scenario-helpers';
+import { OverdueLifecycleCronService } from './overdue-lifecycle-cron.service';
+import { ConsecutiveMissedService } from '../consecutive-missed.service';
+
+const prisma = new PrismaClient();
+
+const BRACKET_CONFIG = [
+  ['late_fee_mode', 'BRACKET'],
+  ['late_fee_tier1_amount', '50'],
+  ['late_fee_tier2_amount', '100'],
+  ['late_fee_tier2_min_days', '3'],
+] as const;
+const KEYS = BRACKET_CONFIG.map(([k]) => k);
+
+describe('calculateLateFees skips installments whose base is already paid', () => {
+  let contractId: string;
+
+  beforeAll(async () => {
+    await prisma.payment.deleteMany({});
+    await prisma.installmentSchedule.deleteMany({});
+    await prisma.contract.deleteMany({});
+    await prisma.systemConfig.deleteMany({ where: { key: { in: KEYS } } });
+    for (const [key, value] of BRACKET_CONFIG) {
+      await prisma.systemConfig.upsert({ where: { key }, update: { value }, create: { key, value } });
+    }
+
+    const c = await seedStandard17k12m(prisma);
+    contractId = c.id;
+    await prisma.contract.update({ where: { id: contractId }, data: { status: 'ACTIVE' } });
+
+    const now = Date.now();
+    // Row 1 — base fully paid (amountPaid == amountDue); only the late fee remains.
+    // Preset lateFee = 77 (a value the BRACKET formula would NOT produce) so an
+    // unwanted overwrite is detectable.
+    await prisma.payment.create({
+      data: {
+        contractId,
+        installmentNo: 1,
+        amountDue: new Prisma.Decimal('3671.00'),
+        amountPaid: new Prisma.Decimal('3671.00'),
+        lateFee: new Prisma.Decimal('77.00'),
+        dueDate: new Date(now - 10 * 86_400_000),
+        status: 'PARTIALLY_PAID',
+      } as any,
+    });
+    // Row 2 — control: unpaid + overdue → cron SHOULD apply the late fee.
+    await prisma.payment.create({
+      data: {
+        contractId,
+        installmentNo: 2,
+        amountDue: new Prisma.Decimal('3671.00'),
+        amountPaid: new Prisma.Decimal('0'),
+        dueDate: new Date(now - 10 * 86_400_000),
+        status: 'PENDING',
+      } as any,
+    });
+  });
+
+  afterAll(async () => {
+    await prisma.payment.deleteMany({});
+    await prisma.installmentSchedule.deleteMany({});
+    await prisma.contract.deleteMany({});
+    await prisma.systemConfig.deleteMany({ where: { key: { in: KEYS } } });
+    await prisma.$disconnect();
+  });
+
+  it('leaves late_fee + status untouched when amountPaid >= amountDue, but still updates unpaid rows', async () => {
+    const svc = new OverdueLifecycleCronService(
+      prisma as any,
+      new ConsecutiveMissedService(prisma as any),
+    );
+    await svc.calculateLateFees();
+
+    // Row 1 — base already paid: late fee frozen, status NOT flipped to OVERDUE
+    const basePaid = await prisma.payment.findFirst({ where: { contractId, installmentNo: 1 } });
+    expect(new Prisma.Decimal(basePaid!.lateFee.toString()).toString()).toBe('77');
+    expect(basePaid!.status).toBe('PARTIALLY_PAID');
+
+    // Row 2 — control (unpaid + overdue): late fee applied (tier2 = 100), flipped OVERDUE
+    const unpaid = await prisma.payment.findFirst({ where: { contractId, installmentNo: 2 } });
+    expect(new Prisma.Decimal(unpaid!.lateFee.toString()).toString()).toBe('100');
+    expect(unpaid!.status).toBe('OVERDUE');
+  });
+});

--- a/apps/api/src/modules/overdue/services/overdue-lifecycle-cron.service.ts
+++ b/apps/api/src/modules/overdue/services/overdue-lifecycle-cron.service.ts
@@ -83,6 +83,11 @@ export class OverdueLifecycleCronService {
       WHERE "status" IN ('PENDING', 'PARTIALLY_PAID', 'OVERDUE')
         AND "due_date" < ${now}
         AND "late_fee_waived" = false
+        -- Skip installments whose base is already settled (amount_paid >= amount_due).
+        -- Those only have a (frozen) late fee outstanding; recomputing it from the
+        -- days-overdue formula would resurrect/overwrite the fee AND wrongly flip a
+        -- PARTIALLY_PAID row back to OVERDUE after the customer paid the principal.
+        AND "amount_paid" < "amount_due"
         AND "contract_id" IN (
           SELECT "id" FROM "contracts"
           WHERE "status" IN ('ACTIVE', 'OVERDUE', 'DEFAULT')

--- a/apps/api/src/modules/payments/payments.controller.ts
+++ b/apps/api/src/modules/payments/payments.controller.ts
@@ -139,6 +139,24 @@ export class PaymentsController {
   }
 
   /**
+   * Posted JEs behind the payment-history modal's receipt rows (per contract).
+   * Soft-linked via JournalEntry.metadata (paymentId / flow) — see
+   * PaymentQueryService.getContractJournalEntries. Same roles + branch guard
+   * as GET contract/:contractId (SALES already sees JE lines via preview-journal).
+   */
+  @Get('contract/:contractId/journal-entries')
+  @Roles('OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'ACCOUNTANT', 'SALES')
+  @ApiOperation({ summary: 'ดูบันทึกบัญชี (JE) ของการชำระในสัญญา' })
+  async getContractJournalEntries(
+    @Param('contractId') contractId: string,
+    @CurrentUser() user?: { id: string; role: string; branchId: string | null },
+  ) {
+    // Enforce branch-level access (mirrors GET contract/:contractId)
+    if (user) await this.paymentsService.validateBranchAccess(contractId, user);
+    return this.paymentsService.getContractJournalEntries(contractId);
+  }
+
+  /**
    * Preview JE lines for a payment without persisting anything.
    * Used by the RecordPaymentWizard to show "Journal Auto" live preview.
    */

--- a/apps/api/src/modules/payments/payments.service.ts
+++ b/apps/api/src/modules/payments/payments.service.ts
@@ -369,6 +369,11 @@ export class PaymentsService {
     return this.services().query.getContractPayments(contractId, page, limit);
   }
 
+  // ─── Get posted JEs for a contract's payment events ───
+  async getContractJournalEntries(contractId: string) {
+    return this.services().query.getContractJournalEntries(contractId);
+  }
+
   // ─── Get all pending payments (for payment queue view) ─
   async getPendingPayments(filters: {
     branchId?: string;

--- a/apps/api/src/modules/payments/services/payment-query.journal-entries.spec.ts
+++ b/apps/api/src/modules/payments/services/payment-query.journal-entries.spec.ts
@@ -1,0 +1,301 @@
+import { Prisma } from '@prisma/client';
+import { NotFoundException } from '@nestjs/common';
+import { PaymentQueryService } from './payment-query.service';
+
+/**
+ * Unit spec for PaymentQueryService.getContractJournalEntries — the read-side
+ * query behind the payment-history modal's per-receipt JE expansion.
+ *
+ * Locks:
+ *   - 404 on missing/deleted contract
+ *   - metadata soft-link extraction (paymentId / tag / flow / deltaApplied /
+ *     lateFeePortion / reversed / reversedByEntryNumber / originalEntryId)
+ *     with non-string values coerced to null
+ *   - CoA name join with fallback-to-code for unmapped accounts
+ *   - money emitted as .toFixed(2) STRINGS (never Number()) + Decimal-summed
+ *     totals + isBalanced
+ *   - where clause targets POSTED, non-deleted entries, contractId-scoped
+ *     across five tags/flows (receipt / 2B / credit-allocation /
+ *     overpayment-credit / early-payoff)
+ *   - second-pass fetch of receipt-void REVERSAL JEs via metadata.originalEntryId
+ *     (they carry NO contractId — unreachable through the first query)
+ *   - deterministic Dr-before-Cr line order (JournalLine has no lineNo and a
+ *     random-UUID id, so DB order is arbitrary)
+ */
+describe('PaymentQueryService.getContractJournalEntries', () => {
+  const dec = (v: string | number) => new Prisma.Decimal(v);
+
+  const buildService = (overrides: {
+    contract?: unknown;
+    entries?: unknown[];
+    reversals?: unknown[];
+    coa?: unknown[];
+  }) => {
+    const findMany = jest.fn();
+    // First call = main contract-scoped query; second (when the first returned
+    // rows) = the reversal pass keyed by originalEntryId.
+    findMany
+      .mockResolvedValueOnce(overrides.entries ?? [])
+      .mockResolvedValueOnce(overrides.reversals ?? []);
+    const prisma = {
+      contract: {
+        findUnique: jest.fn().mockResolvedValue(
+          'contract' in overrides ? overrides.contract : { id: 'c-1', deletedAt: null },
+        ),
+      },
+      journalEntry: { findMany },
+      chartOfAccount: { findMany: jest.fn().mockResolvedValue(overrides.coa ?? []) },
+    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return { service: new PaymentQueryService(prisma as any), prisma };
+  };
+
+  it('throws NotFoundException when contract is missing or soft-deleted', async () => {
+    const missing = buildService({ contract: null });
+    await expect(missing.service.getContractJournalEntries('nope')).rejects.toThrow(
+      NotFoundException,
+    );
+
+    const deleted = buildService({ contract: { id: 'c-1', deletedAt: new Date() } });
+    await expect(deleted.service.getContractJournalEntries('c-1')).rejects.toThrow(
+      NotFoundException,
+    );
+  });
+
+  it('scopes the query to POSTED non-deleted entries with contractId + tag/flow OR filters (and skips the reversal pass when empty)', async () => {
+    const { service, prisma } = buildService({ entries: [] });
+    await service.getContractJournalEntries('c-1');
+
+    const where = prisma.journalEntry.findMany.mock.calls[0][0].where;
+    expect(where.status).toBe('POSTED');
+    expect(where.deletedAt).toBeNull();
+    // 5 OR branches: receipt / 2B / credit-allocation / overpayment-credit tags
+    // + early-payoff flow, each ANDed with metadata.contractId.
+    expect(where.OR).toHaveLength(5);
+    for (const branch of where.OR) {
+      expect(branch.AND[0]).toEqual({
+        metadata: { path: ['contractId'], equals: 'c-1' },
+      });
+    }
+    const keys = where.OR.map(
+      (b: { AND: Array<{ metadata: { path: string[]; equals: string } }> }) =>
+        `${b.AND[1].metadata.path[0]}:${b.AND[1].metadata.equals}`,
+    );
+    expect(keys).toEqual([
+      'tag:receipt',
+      'tag:2B',
+      'tag:credit-allocation',
+      'tag:overpayment-credit',
+      'flow:early-payoff',
+    ]);
+    // No rows → no reversal query (only ONE findMany call).
+    expect(prisma.journalEntry.findMany).toHaveBeenCalledTimes(1);
+  });
+
+  it('maps a receipt JE: metadata extraction, CoA names (fallback = code), string money, isBalanced', async () => {
+    const { service } = buildService({
+      entries: [
+        {
+          id: 'je-1',
+          entryNumber: 'JE-202607-00001',
+          entryDate: new Date('2026-07-01'),
+          postedAt: new Date('2026-07-01'),
+          description: 'รับชำระงวด #1',
+          metadata: {
+            tag: 'receipt',
+            flow: 'payment-receipt',
+            contractId: 'c-1',
+            paymentId: 'pay-1',
+            deltaApplied: '1854.55',
+            lateFeePortion: '100.00',
+          },
+          lines: [
+            { accountCode: '11-1101', debit: dec('1854.55'), credit: dec(0), description: 'รับเงิน' },
+            { accountCode: '11-2101', debit: dec(0), credit: dec('1754.55'), description: null },
+            { accountCode: '42-1103', debit: dec(0), credit: dec('100.00'), description: 'ค่าปรับ' },
+          ],
+        },
+      ],
+      coa: [
+        { code: '11-1101', name: 'เงินสด — สุทธินีย์ คงเดช' },
+        { code: '11-2101', name: 'ลูกหนี้ผ่อนชำระ' },
+        // 42-1103 intentionally unmapped → fallback to code
+      ],
+    });
+
+    const [je] = await service.getContractJournalEntries('c-1');
+
+    expect(je.paymentId).toBe('pay-1');
+    expect(je.tag).toBe('receipt');
+    expect(je.flow).toBe('payment-receipt');
+    expect(je.deltaApplied).toBe('1854.55');
+    expect(je.lateFeePortion).toBe('100.00');
+    expect(je.reversed).toBe(false);
+    expect(je.reversedByEntryNumber).toBeNull();
+    expect(je.originalEntryId).toBeNull();
+
+    expect(je.lines[0]).toEqual({
+      accountCode: '11-1101',
+      accountName: 'เงินสด — สุทธินีย์ คงเดช',
+      debit: '1854.55',
+      credit: '0.00',
+      description: 'รับเงิน',
+    });
+    // Unmapped CoA code falls back to the code itself; null description → ''.
+    expect(je.lines[2].accountName).toBe('42-1103');
+    expect(je.lines[1].description).toBe('');
+
+    // Totals are Decimal-summed strings; 1854.55 = 1754.55 + 100.00 → balanced.
+    expect(je.totalDebit).toBe('1854.55');
+    expect(je.totalCredit).toBe('1854.55');
+    expect(je.isBalanced).toBe(true);
+  });
+
+  it('orders lines Dr-before-Cr regardless of DB order (stable within each side)', async () => {
+    const { service } = buildService({
+      entries: [
+        {
+          id: 'je-order',
+          entryNumber: 'JE-202607-00009',
+          entryDate: new Date('2026-07-01'),
+          postedAt: new Date('2026-07-01'),
+          description: 'ordering',
+          metadata: { tag: 'receipt', contractId: 'c-1', paymentId: 'pay-9' },
+          // DB returns Cr lines FIRST (random UUID order) — mapper must flip.
+          lines: [
+            { accountCode: '11-2103', debit: dec(0), credit: dec('1416.66'), description: null },
+            { accountCode: '42-1103', debit: dec(0), credit: dec('100.00'), description: null },
+            { accountCode: '11-1101', debit: dec('1516.66'), credit: dec(0), description: null },
+          ],
+        },
+      ],
+      coa: [],
+    });
+
+    const [je] = await service.getContractJournalEntries('c-1');
+    expect(je.lines.map((l: { accountCode: string }) => l.accountCode)).toEqual([
+      '11-1101', // the Dr line surfaces first
+      '11-2103', // Cr lines keep their relative order
+      '42-1103',
+    ]);
+  });
+
+  it('fetches receipt-void REVERSAL JEs by originalEntryId and surfaces the reversal trail', async () => {
+    const { service, prisma } = buildService({
+      entries: [
+        {
+          id: 'je-orig',
+          entryNumber: 'JE-202607-00001',
+          entryDate: new Date('2026-07-01'),
+          postedAt: new Date('2026-07-01'),
+          description: 'รับชำระงวด #1',
+          metadata: {
+            tag: 'receipt',
+            contractId: 'c-1',
+            paymentId: 'pay-1',
+            reversed: true,
+            reversedByEntryNumber: 'JE-202607-00002',
+          },
+          lines: [
+            { accountCode: '11-1101', debit: dec('1000.00'), credit: dec(0), description: null },
+            { accountCode: '11-2103', debit: dec(0), credit: dec('1000.00'), description: null },
+          ],
+        },
+      ],
+      reversals: [
+        {
+          id: 'je-rev',
+          entryNumber: 'JE-202607-00002',
+          entryDate: new Date('2026-07-02'),
+          postedAt: new Date('2026-07-02'),
+          description: '[VOID] รับชำระงวด #1',
+          metadata: {
+            tag: 'REVERSAL',
+            flow: 'receipt-void',
+            originalEntryId: 'je-orig',
+            originalEntryNumber: 'JE-202607-00001',
+          },
+          lines: [
+            { accountCode: '11-2103', debit: dec('1000.00'), credit: dec(0), description: null },
+            { accountCode: '11-1101', debit: dec(0), credit: dec('1000.00'), description: null },
+          ],
+        },
+      ],
+      coa: [],
+    });
+
+    const jes = await service.getContractJournalEntries('c-1');
+    expect(jes).toHaveLength(2);
+
+    // Second query keyed by the first pass's entry ids.
+    const revWhere = prisma.journalEntry.findMany.mock.calls[1][0].where;
+    expect(revWhere.OR).toEqual([
+      { metadata: { path: ['originalEntryId'], equals: 'je-orig' } },
+    ]);
+
+    const orig = jes.find((j: { id: string }) => j.id === 'je-orig');
+    const rev = jes.find((j: { id: string }) => j.id === 'je-rev');
+    // Original carries the reversed trail for the frontend badge.
+    expect(orig?.reversed).toBe(true);
+    expect(orig?.reversedByEntryNumber).toBe('JE-202607-00002');
+    // Reversal points back for CREDIT_NOTE row matching; no paymentId of its own.
+    expect(rev?.originalEntryId).toBe('je-orig');
+    expect(rev?.flow).toBe('receipt-void');
+    expect(rev?.paymentId).toBeNull();
+  });
+
+  it('maps an early-payoff JE (paymentId null via missing metadata key) and flags unbalanced totals', async () => {
+    const { service } = buildService({
+      entries: [
+        {
+          id: 'je-2',
+          entryNumber: 'JE-202607-00002',
+          entryDate: new Date('2026-07-02'),
+          postedAt: null,
+          description: 'ปิดยอดก่อนกำหนด',
+          metadata: { tag: 'JP4', flow: 'early-payoff', contractId: 'c-1', discount: '50.00' },
+          lines: [
+            { accountCode: '11-1101', debit: dec('100.00'), credit: dec(0), description: null },
+            { accountCode: '11-2101', debit: dec(0), credit: dec('99.99'), description: null },
+          ],
+        },
+      ],
+      coa: [],
+    });
+
+    const [je] = await service.getContractJournalEntries('c-1');
+
+    expect(je.paymentId).toBeNull();
+    expect(je.flow).toBe('early-payoff');
+    expect(je.deltaApplied).toBeNull(); // absent key → null, not undefined/crash
+    expect(je.totalDebit).toBe('100.00');
+    expect(je.totalCredit).toBe('99.99');
+    expect(je.isBalanced).toBe(false);
+  });
+
+  it('handles null metadata without crashing (all soft-link fields null)', async () => {
+    const { service } = buildService({
+      entries: [
+        {
+          id: 'je-3',
+          entryNumber: 'JE-202607-00003',
+          entryDate: new Date('2026-07-03'),
+          postedAt: new Date('2026-07-03'),
+          description: 'legacy row',
+          metadata: null,
+          lines: [],
+        },
+      ],
+      coa: [],
+    });
+
+    const [je] = await service.getContractJournalEntries('c-1');
+    expect(je.paymentId).toBeNull();
+    expect(je.tag).toBeNull();
+    expect(je.flow).toBeNull();
+    expect(je.reversed).toBe(false);
+    expect(je.lines).toEqual([]);
+    expect(je.totalDebit).toBe('0.00');
+    expect(je.isBalanced).toBe(true);
+  });
+});

--- a/apps/api/src/modules/payments/services/payment-query.service.ts
+++ b/apps/api/src/modules/payments/services/payment-query.service.ts
@@ -87,6 +87,131 @@ export class PaymentQueryService {
     };
   }
 
+  // ─── Get posted journal entries for a contract's payment events ──────────
+  /**
+   * Returns POSTED JEs behind the payment-history modal's receipt rows.
+   * There is NO FK from Payment/Receipt → JournalEntry; the canonical link is
+   * `metadata.paymentId` (same soft-link ReceiptVoidService queries by). We
+   * fetch per-CONTRACT (one query for the whole modal) via `metadata.contractId`,
+   * which every relevant flow stamps:
+   *   - tag 'receipt'  — PaymentReceiptTemplate (current primitive, full+partial)
+   *   - tag '2B'       — legacy pre-primitive receipt JEs
+   *   - tag 'credit-allocation' — legacy credit-balance application
+   *   - tag 'overpayment-credit' — auto-allocate overpay leg (Dr cash / Cr 21-5101);
+   *     shares paymentId with the receipt JE so the row's JEs tie to cash received
+   *   - flow 'early-payoff'     — JP4 (its receipt has paymentId = null)
+   * Receipt-void REVERSAL JEs carry NO contractId/paymentId — they are fetched
+   * in a second pass via metadata.originalEntryId pointing at the entries above,
+   * so a voided receipt's ledger effect (original + mirror) is fully visible.
+   * Frontend matches rows → JEs by `paymentId` (flow for EARLY_PAYOFF,
+   * originalEntryId for CREDIT_NOTE rows).
+   * Money is emitted as .toFixed(2) STRINGS (never Number()).
+   */
+  async getContractJournalEntries(contractId: string) {
+    const contract = await this.prisma.contract.findUnique({
+      where: { id: contractId },
+      select: { id: true, deletedAt: true },
+    });
+    if (!contract || contract.deletedAt) throw new NotFoundException('ไม่พบสัญญา');
+
+    const lineSelect = {
+      where: { deletedAt: null },
+      orderBy: { id: 'asc' as const },
+      select: { accountCode: true, debit: true, credit: true, description: true },
+    };
+
+    const byContract = { path: ['contractId'], equals: contractId };
+    const entries = await this.prisma.journalEntry.findMany({
+      where: {
+        status: 'POSTED',
+        deletedAt: null,
+        OR: [
+          { AND: [{ metadata: byContract }, { metadata: { path: ['tag'], equals: 'receipt' } }] },
+          { AND: [{ metadata: byContract }, { metadata: { path: ['tag'], equals: '2B' } }] },
+          { AND: [{ metadata: byContract }, { metadata: { path: ['tag'], equals: 'credit-allocation' } }] },
+          { AND: [{ metadata: byContract }, { metadata: { path: ['tag'], equals: 'overpayment-credit' } }] },
+          { AND: [{ metadata: byContract }, { metadata: { path: ['flow'], equals: 'early-payoff' } }] },
+        ],
+      },
+      include: { lines: lineSelect },
+      orderBy: { postedAt: 'asc' },
+    });
+
+    // Second pass: receipt-void reversal JEs (tag 'REVERSAL', flow 'receipt-void')
+    // stamp ONLY { originalEntryId, originalEntryNumber } — no contractId — so
+    // they are only reachable through the ids of the entries found above.
+    const reversals = entries.length
+      ? await this.prisma.journalEntry.findMany({
+          where: {
+            status: 'POSTED',
+            deletedAt: null,
+            OR: entries.map((e) => ({
+              metadata: { path: ['originalEntryId'], equals: e.id },
+            })),
+          },
+          include: { lines: lineSelect },
+          orderBy: { postedAt: 'asc' },
+        })
+      : [];
+    const allEntries = [...entries, ...reversals];
+
+    // JournalLine.accountCode is a plain string (no CoA relation) — resolve
+    // display names in one lookup, fallback to the code itself.
+    const codes = [...new Set(allEntries.flatMap((e) => e.lines.map((l) => l.accountCode)))];
+    const coaRows = codes.length
+      ? await this.prisma.chartOfAccount.findMany({
+          where: { code: { in: codes } },
+          select: { code: true, name: true },
+        })
+      : [];
+    const nameByCode = new Map(coaRows.map((r) => [r.code, r.name]));
+
+    return allEntries.map((e) => {
+      const meta = (e.metadata ?? {}) as Record<string, unknown>;
+      let totalDebit = new Prisma.Decimal(0);
+      let totalCredit = new Prisma.Decimal(0);
+      // JournalLine has no lineNo and its id is a random UUID, so DB order is
+      // arbitrary — present Dr lines before Cr (stable sort keeps each group's
+      // relative order), matching the Dr-then-Cr convention of every JE view.
+      const orderedLines = [...e.lines].sort(
+        (a, b) => (b.debit.gt(0) ? 1 : 0) - (a.debit.gt(0) ? 1 : 0),
+      );
+      const lines = orderedLines.map((l) => {
+        totalDebit = totalDebit.plus(l.debit);
+        totalCredit = totalCredit.plus(l.credit);
+        return {
+          accountCode: l.accountCode,
+          accountName: nameByCode.get(l.accountCode) ?? l.accountCode,
+          debit: l.debit.toFixed(2),
+          credit: l.credit.toFixed(2),
+          description: l.description ?? '',
+        };
+      });
+      return {
+        id: e.id,
+        entryNumber: e.entryNumber,
+        entryDate: e.entryDate,
+        postedAt: e.postedAt,
+        description: e.description,
+        paymentId: typeof meta.paymentId === 'string' ? meta.paymentId : null,
+        tag: typeof meta.tag === 'string' ? meta.tag : null,
+        flow: typeof meta.flow === 'string' ? meta.flow : null,
+        deltaApplied: typeof meta.deltaApplied === 'string' ? meta.deltaApplied : null,
+        lateFeePortion: typeof meta.lateFeePortion === 'string' ? meta.lateFeePortion : null,
+        // Receipt-void trail: originals get reversed=true + the mirror's number;
+        // reversal JEs point back via originalEntryId (CREDIT_NOTE row matching).
+        reversed: meta.reversed === true,
+        reversedByEntryNumber:
+          typeof meta.reversedByEntryNumber === 'string' ? meta.reversedByEntryNumber : null,
+        originalEntryId: typeof meta.originalEntryId === 'string' ? meta.originalEntryId : null,
+        lines,
+        totalDebit: totalDebit.toFixed(2),
+        totalCredit: totalCredit.toFixed(2),
+        isBalanced: totalDebit.toFixed(2) === totalCredit.toFixed(2),
+      };
+    });
+  }
+
   // ─── Get all pending payments (for payment queue view) ─
   async getPendingPayments(filters: {
     branchId?: string;

--- a/apps/api/src/utils/decimal.util.ts
+++ b/apps/api/src/utils/decimal.util.ts
@@ -75,6 +75,16 @@ export function dRound(a: DecimalInput): Prisma.Decimal {
   return d(a).toDecimalPlaces(2, Prisma.Decimal.ROUND_HALF_UP);
 }
 
+/**
+ * Round DOWN (truncate) to 2 decimal places.
+ * Use when the rounding direction must favor the company rather than the
+ * customer — e.g. a discount granted to the customer is rounded down so we
+ * never give away more than the exact calculated satang.
+ */
+export function dRoundDown(a: DecimalInput): Prisma.Decimal {
+  return d(a).toDecimalPlaces(2, Prisma.Decimal.ROUND_DOWN);
+}
+
 export function dCompare(a: DecimalInput, b: DecimalInput): -1 | 0 | 1 {
   return d(a).cmp(d(b)) as -1 | 0 | 1;
 }

--- a/apps/web/src/components/contract/ContractEarlyPayoff.tsx
+++ b/apps/web/src/components/contract/ContractEarlyPayoff.tsx
@@ -7,6 +7,7 @@ import api, { getErrorMessage } from '@/lib/api';
 import { formatNumber, formatNumberDecimal } from '@/utils/formatters';
 import { CashAccountSelect } from '@/components/CashAccountSelect';
 import { useAuth } from '@/contexts/AuthContext';
+import { invalidatePaymentQueries } from '@/pages/PaymentsPage/invalidatePaymentQueries';
 
 /* ─── Types ───────────────────────────────────────── */
 export interface JeLinePreview {
@@ -138,6 +139,10 @@ export function EarlyPayoffOverlay({
       queryClient.invalidateQueries({ queryKey: ['contract', contractId] });
       queryClient.invalidateQueries({ queryKey: ['contract-payoff', contractId] });
       queryClient.invalidateQueries({ queryKey: ['contracts'] });
+      // Payoff flips payments to PAID + posts the JP4 JE — refresh the
+      // payment-history caches (contract-payments/receipts/journal-entries)
+      // so the ประวัติการชำระ modal on ContractDetailPage isn't served stale.
+      invalidatePaymentQueries(queryClient);
       onSuccess();
       onClose();
     },
@@ -157,6 +162,7 @@ export function EarlyPayoffOverlay({
       queryClient.invalidateQueries({ queryKey: ['contract', contractId] });
       queryClient.invalidateQueries({ queryKey: ['contract-payoff', contractId] });
       queryClient.invalidateQueries({ queryKey: ['contracts'] });
+      invalidatePaymentQueries(queryClient);
       setSettlementOpen(false);
       setSettlementAmount('');
     },

--- a/apps/web/src/components/payment/PaymentHistorySheet.tsx
+++ b/apps/web/src/components/payment/PaymentHistorySheet.tsx
@@ -1,11 +1,12 @@
-import { useMemo, useState } from 'react';
+import { Fragment, useEffect, useMemo, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { FileText, X } from 'lucide-react';
+import { BookOpen, FileText, X } from 'lucide-react';
 import api, { getErrorMessage } from '@/lib/api';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogBody } from '@/components/ui/dialog';
 import { formatDateShort, formatNumberDecimal } from '@/utils/formatters';
 import { useAuth } from '@/contexts/AuthContext';
 import ReceiptVoidDialog from '@/components/payment/ReceiptVoidDialog';
+import { computeReceiptFeeDisplay } from './computeReceiptFeeDisplay';
 import { toast } from 'sonner';
 
 /* ─── Types ───────────────────────────────────────── */
@@ -47,6 +48,34 @@ interface ReceiptItem {
   isVoided: boolean;
   paidDate: string;
   issuedByName: string | null;
+}
+interface ContractJeLine {
+  accountCode: string;
+  accountName: string;
+  debit: string;
+  credit: string;
+  description: string;
+}
+interface ContractJe {
+  id: string;
+  entryNumber: string;
+  entryDate: string;
+  postedAt: string | null;
+  description: string;
+  paymentId: string | null;
+  tag: string | null;
+  flow: string | null;
+  deltaApplied: string | null;
+  lateFeePortion: string | null;
+  /** Original JE that has since been mirrored out by a receipt void. */
+  reversed: boolean;
+  reversedByEntryNumber: string | null;
+  /** Set on receipt-void REVERSAL JEs — points at the original entry id. */
+  originalEntryId: string | null;
+  lines: ContractJeLine[];
+  totalDebit: string;
+  totalCredit: string;
+  isBalanced: boolean;
 }
 
 const VOID_ROLES = ['OWNER', 'ACCOUNTANT', 'BRANCH_MANAGER', 'FINANCE_MANAGER'];
@@ -105,21 +134,87 @@ export default function PaymentHistorySheet({ contractId, onClose }: Props) {
       (await api.get(`/receipts/contract/${contractId}`, { params: { includeVoided: true } })).data,
     enabled: !!contractId,
   });
+  // Posted JEs behind each receipt row — soft-linked by metadata.paymentId
+  // (EARLY_PAYOFF receipt has paymentId null → matched by flow instead).
+  const { data: journalEntries = [], isLoading: loadingJes } = useQuery<ContractJe[]>({
+    queryKey: ['contract-journal-entries', contractId],
+    queryFn: async () =>
+      (await api.get(`/payments/contract/${contractId}/journal-entries`)).data,
+    enabled: !!contractId,
+  });
   const isLoading = loadingPayments || loadingReceipts;
+
+  // Which receipt rows have their JE panel expanded (keyed by receipt id).
+  const [jeOpen, setJeOpen] = useState<Set<string>>(new Set());
+  // Component stays mounted between opens — clear expansion when switching contracts.
+  useEffect(() => {
+    setJeOpen(new Set());
+  }, [contractId]);
+  const toggleJe = (receiptId: string) =>
+    setJeOpen((prev) => {
+      const next = new Set(prev);
+      if (next.has(receiptId)) next.delete(receiptId);
+      else next.add(receiptId);
+      return next;
+    });
+
+  const jesForReceipt = (r: ReceiptItem): ContractJe[] => {
+    if (r.receiptType === 'EARLY_PAYOFF') return journalEntries.filter((j) => j.flow === 'early-payoff');
+    if (!r.paymentId) return [];
+    // N partial receipts share one paymentId → show every JE of that payment,
+    // each labeled with its own รับจริง (deltaApplied) so rows are tellable apart.
+    const paymentJes = journalEntries.filter((j) => j.paymentId === r.paymentId);
+    if (r.receiptType === 'CREDIT_NOTE') {
+      // The CN row IS the void event — show the REVERSAL JEs (mirror entries
+      // pointing back at this payment's originals), not the money-in originals.
+      const originalIds = new Set(paymentJes.map((j) => j.id));
+      const reversalJes = journalEntries.filter(
+        (j) => j.originalEntryId !== null && originalIds.has(j.originalEntryId),
+      );
+      return reversalJes.length ? reversalJes : paymentJes;
+    }
+    return paymentJes;
+  };
 
   const payments = pResp?.data ?? [];
   const contract = pResp?.contract;
   const paymentById = useMemo(() => new Map(payments.map((p) => [p.id, p])), [payments]);
 
+  // Per-receipt late fee/waiver for display: attribute an installment's fee to its
+  // FIRST receipt only (owner UI convention) so split-payment receipts don't each
+  // repeat the same 100฿. The ledger still books the fee once (principal-first);
+  // this is purely how the history table reads. See computeReceiptFeeDisplay.
+  const feeByPaymentId = useMemo(() => {
+    const m = new Map<string, { lateFee: number; waived: number }>();
+    for (const p of payments) {
+      const lateFee = Number(p.lateFee) || 0;
+      const waived =
+        p.waivedAmount != null ? Number(p.waivedAmount) : p.lateFeeWaived ? lateFee : 0;
+      m.set(p.id, { lateFee, waived });
+    }
+    return m;
+  }, [payments]);
+  const receiptFees = useMemo(
+    () => computeReceiptFeeDisplay(receipts, feeByPaymentId),
+    [receipts, feeByPaymentId],
+  );
+
   // ─── Summary cards ───
-  // paid installments are payment-based; the money totals are collected-only
-  // (exclude voided): cumulative = Σ non-voided receipt amounts; late-fee/waiver
-  // counted on PAID installments only (not unpaid-overdue accruals).
+  // paid installments are payment-based; the money totals are collected-only:
+  // cumulative = Σ non-voided receipt amounts EXCLUDING credit notes (a CN row
+  // carries the original's POSITIVE amount — counting it would keep a voided
+  // payment in the total). Late-fee/waiver counted on installments where
+  // collection has STARTED (PAID or amountPaid > 0) — amountPaid-based rather
+  // than status so the fee doesn't vanish when the midnight cron flips a
+  // PARTIALLY_PAID overdue row back to OVERDUE; pure accruals on untouched
+  // overdue rows stay excluded. Matches the per-row fee shown in the table.
   const paidCount = payments.filter((p) => p.status === 'PAID').length;
-  const cumulativePaid = receipts.filter((r) => !r.isVoided).reduce((s, r) => s + Number(r.amount), 0);
-  const paidPayments = payments.filter((p) => p.status === 'PAID');
-  const totalLateFee = paidPayments.reduce((s, p) => s + Number(p.lateFee), 0);
-  const totalWaived = paidPayments.reduce(
+  const cumulativePaid = receipts
+    .filter((r) => !r.isVoided && r.receiptType !== 'CREDIT_NOTE')
+    .reduce((s, r) => s + Number(r.amount), 0);
+  const feePayments = payments.filter((p) => p.status === 'PAID' || Number(p.amountPaid) > 0);
+  const totalLateFee = feePayments.reduce((s, p) => s + Number(p.lateFee), 0);
+  const totalWaived = feePayments.reduce(
     (s, p) => s + (p.waivedAmount != null ? Number(p.waivedAmount) : p.lateFeeWaived ? Number(p.lateFee) : 0),
     0,
   );
@@ -168,7 +263,7 @@ export default function PaymentHistorySheet({ contractId, onClose }: Props) {
                   <SummaryCard label="ยอดชำระสะสม" value={`${money(cumulativePaid)} ฿`} />
                   <SummaryCard
                     label="ค่าปรับ / อนุโลม"
-                    value={`${money(totalLateFee)} / −${money(totalWaived)} ฿`}
+                    value={`${money(totalLateFee)} / ${totalWaived > 0 ? `−${money(totalWaived)}` : '0.00'} ฿`}
                     tone="warning"
                   />
                   <SummaryCard label="เครดิต (21-1103)" value={`${money(contract?.advanceBalance ?? 0)} ฿`} tone="info" />
@@ -200,18 +295,13 @@ export default function PaymentHistorySheet({ contractId, onClose }: Props) {
                         {rows.map((r) => {
                           const p = r.paymentId ? paymentById.get(r.paymentId) : undefined;
                           const c = caseFor(r, p);
-                          const lateFee = p ? Number(p.lateFee) : 0;
-                          const waived = p
-                            ? p.waivedAmount != null
-                              ? Number(p.waivedAmount)
-                              : p.lateFeeWaived
-                              ? Number(p.lateFee)
-                              : 0
-                            : 0;
+                          const { lateFee, waived } = receiptFees.get(r.id) ?? { lateFee: 0, waived: 0 };
                           const recorder = p?.recordedBy?.name ?? r.issuedByName ?? '–';
+                          const rowJes = jesForReceipt(r);
+                          const isJeOpen = jeOpen.has(r.id);
                           return (
+                            <Fragment key={r.id}>
                             <tr
-                              key={r.id}
                               className={`border-t border-border ${r.isVoided ? 'opacity-50 line-through' : ''}`}
                             >
                               <Td className="font-mono text-xs">{r.receiptNumber}</Td>
@@ -247,30 +337,65 @@ export default function PaymentHistorySheet({ contractId, onClose }: Props) {
                                 {p?.waivedApprovedByName ?? '–'}
                               </Td>
                               <Td>
-                                {!r.isVoided && (
-                                  <div className="flex items-center gap-1">
-                                    <button
-                                      onClick={() => downloadReceiptPdf(r.id, r.receiptNumber)}
-                                      title="ใบเสร็จ (PDF)"
-                                      aria-label={`ดาวน์โหลดใบเสร็จ ${r.receiptNumber}`}
-                                      className="p-1.5 rounded border border-border text-muted-foreground hover:bg-accent hover:text-foreground transition-colors"
-                                    >
-                                      <FileText className="size-3.5" />
-                                    </button>
-                                    {canVoid && (
+                                <div className="flex items-center gap-1">
+                                  <button
+                                    onClick={() => toggleJe(r.id)}
+                                    title="ดูบันทึกบัญชี (JE)"
+                                    aria-label={`ดูบันทึกบัญชีของใบเสร็จ ${r.receiptNumber}`}
+                                    aria-expanded={isJeOpen}
+                                    className={`p-1.5 rounded border transition-colors ${
+                                      isJeOpen
+                                        ? 'border-primary/40 bg-primary/10 text-primary'
+                                        : 'border-border text-muted-foreground hover:bg-accent hover:text-foreground'
+                                    }`}
+                                  >
+                                    <BookOpen className="size-3.5" />
+                                  </button>
+                                  {!r.isVoided && (
+                                    <>
                                       <button
-                                        onClick={() => setVoidTarget({ id: r.id, receiptNumber: r.receiptNumber })}
-                                        title="ยกเลิกใบเสร็จ (ออกใบลดหนี้)"
-                                        aria-label={`ยกเลิกใบเสร็จ ${r.receiptNumber}`}
-                                        className="p-1.5 rounded border border-destructive/40 text-destructive hover:bg-destructive/10 transition-colors"
+                                        onClick={() => downloadReceiptPdf(r.id, r.receiptNumber)}
+                                        title="ใบเสร็จ (PDF)"
+                                        aria-label={`ดาวน์โหลดใบเสร็จ ${r.receiptNumber}`}
+                                        className="p-1.5 rounded border border-border text-muted-foreground hover:bg-accent hover:text-foreground transition-colors"
                                       >
-                                        <X className="size-3.5" />
+                                        <FileText className="size-3.5" />
                                       </button>
-                                    )}
-                                  </div>
-                                )}
+                                      {canVoid && (
+                                        <button
+                                          onClick={() => setVoidTarget({ id: r.id, receiptNumber: r.receiptNumber })}
+                                          title="ยกเลิกใบเสร็จ (ออกใบลดหนี้)"
+                                          aria-label={`ยกเลิกใบเสร็จ ${r.receiptNumber}`}
+                                          className="p-1.5 rounded border border-destructive/40 text-destructive hover:bg-destructive/10 transition-colors"
+                                        >
+                                          <X className="size-3.5" />
+                                        </button>
+                                      )}
+                                    </>
+                                  )}
+                                </div>
                               </Td>
                             </tr>
+                            {isJeOpen && (
+                              <tr className="border-t border-border bg-muted/10">
+                                <td colSpan={12} className="px-4 py-3">
+                                  {loadingJes ? (
+                                    <div className="text-xs text-muted-foreground leading-snug">กำลังโหลดบันทึกบัญชี...</div>
+                                  ) : rowJes.length === 0 ? (
+                                    <div className="text-xs text-muted-foreground leading-snug">
+                                      ไม่พบบันทึกบัญชี (JE) สำหรับรายการนี้
+                                    </div>
+                                  ) : (
+                                    <div className="space-y-3">
+                                      {rowJes.map((je) => (
+                                        <JeBlock key={je.id} je={je} />
+                                      ))}
+                                    </div>
+                                  )}
+                                </td>
+                              </tr>
+                            )}
+                            </Fragment>
                           );
                         })}
                       </tbody>
@@ -293,6 +418,75 @@ export default function PaymentHistorySheet({ contractId, onClose }: Props) {
 }
 
 /* ─── Helpers ───────────────────────────────────────── */
+/** One posted JE rendered as a Dr/Cr grid — same layout as the JOURNAL AUTO
+ * section in ContractEarlyPayoff (grid-cols-[80px_1fr_90px_90px]). */
+function JeBlock({ je }: { je: ContractJe }) {
+  const isVoidReversal = je.flow === 'receipt-void' || je.tag === 'REVERSAL';
+  const flowLabel = isVoidReversal
+    ? 'กลับรายการ (VOID)'
+    : je.flow === 'early-payoff'
+    ? 'JP4 — ปิดยอดก่อนกำหนด'
+    : 'รับชำระ (2B)';
+  return (
+    <div className="rounded-lg border border-border bg-card p-3">
+      <div className="flex items-center justify-between mb-2">
+        <div className="flex items-center gap-2 text-xs leading-snug flex-wrap">
+          <span className="font-mono font-semibold text-foreground">{je.entryNumber}</span>
+          <span className="text-muted-foreground">{formatDateShort(je.postedAt ?? je.entryDate)}</span>
+          <span
+            className={`px-1.5 py-0.5 rounded-full font-medium ${
+              isVoidReversal ? 'bg-destructive/10 text-destructive' : 'bg-primary/10 text-primary'
+            }`}
+          >
+            {flowLabel}
+          </span>
+          {je.reversed && (
+            <span className="px-1.5 py-0.5 rounded-full bg-warning/10 text-warning font-medium">
+              ถูกกลับรายการ{je.reversedByEntryNumber ? ` โดย ${je.reversedByEntryNumber}` : ''}
+            </span>
+          )}
+          {je.deltaApplied && (
+            <span className="text-muted-foreground">รับจริง {money(je.deltaApplied)} ฿</span>
+          )}
+          {je.lateFeePortion && Number(je.lateFeePortion) > 0 && (
+            <span className="text-warning">ค่าปรับ {money(je.lateFeePortion)} ฿</span>
+          )}
+        </div>
+        <span
+          className={`text-xs font-medium leading-snug ${je.isBalanced ? 'text-success' : 'text-destructive'}`}
+        >
+          {money(je.totalDebit)} = {money(je.totalCredit)} {je.isBalanced ? 'BALANCED' : 'UNBALANCED'}
+        </span>
+      </div>
+      <div className="space-y-1">
+        <div className="grid grid-cols-[80px_1fr_90px_90px] gap-1 text-xs text-muted-foreground font-medium pb-1 border-b border-border">
+          <span>รหัส</span>
+          <span>บัญชี</span>
+          <span className="text-right">Dr</span>
+          <span className="text-right">Cr</span>
+        </div>
+        {je.lines.map((line, idx) => (
+          <div key={idx} className="grid grid-cols-[80px_1fr_90px_90px] gap-1 text-xs leading-snug">
+            <span className="font-mono text-muted-foreground">{line.accountCode}</span>
+            <div className="min-w-0">
+              <span className="text-foreground truncate block">{line.accountName}</span>
+              {line.description && (
+                <span className="text-muted-foreground/70 text-[10px]">{line.description}</span>
+              )}
+            </div>
+            <span className="text-right font-mono text-foreground">
+              {parseFloat(line.debit) > 0 ? formatNumberDecimal(line.debit) : ''}
+            </span>
+            <span className="text-right font-mono text-foreground">
+              {parseFloat(line.credit) > 0 ? formatNumberDecimal(line.credit) : ''}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
 function SummaryCard({ label, value, tone = 'default' }: { label: string; value: string; tone?: 'default' | 'success' | 'warning' | 'info' }) {
   const valueCls =
     tone === 'success' ? 'text-success' : tone === 'warning' ? 'text-warning' : tone === 'info' ? 'text-info' : 'text-foreground';

--- a/apps/web/src/components/payment/__tests__/computeReceiptFeeDisplay.test.ts
+++ b/apps/web/src/components/payment/__tests__/computeReceiptFeeDisplay.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import { computeReceiptFeeDisplay, type ReceiptFeeRow, type FeeInfo } from '../computeReceiptFeeDisplay';
+
+const receipt = (over: Partial<ReceiptFeeRow>): ReceiptFeeRow => ({
+  id: 'r',
+  receiptNumber: 'RT-202607-00001',
+  receiptType: 'INSTALLMENT',
+  paymentId: 'pay-1',
+  paidDate: '2026-07-01T03:00:00.000Z',
+  isVoided: false,
+  ...over,
+});
+
+describe('computeReceiptFeeDisplay', () => {
+  it('puts the whole late fee on the FIRST receipt, 0 on later split receipts', () => {
+    const receipts = [
+      receipt({ id: 'a', receiptNumber: 'RT-202607-00003', paidDate: '2026-07-01T03:00:00.000Z' }),
+      receipt({ id: 'b', receiptNumber: 'RT-202607-00004', paidDate: '2026-07-01T04:00:00.000Z' }),
+    ];
+    const fees = new Map<string, FeeInfo>([['pay-1', { lateFee: 100, waived: 0 }]]);
+    const out = computeReceiptFeeDisplay(receipts, fees);
+    expect(out.get('a')).toEqual({ lateFee: 100, waived: 0 });
+    expect(out.get('b')).toEqual({ lateFee: 0, waived: 0 });
+  });
+
+  it('breaks a same-paidDate tie by the sequential receiptNumber', () => {
+    const receipts = [
+      receipt({ id: 'b', receiptNumber: 'RT-202607-00004' }),
+      receipt({ id: 'a', receiptNumber: 'RT-202607-00003' }),
+    ]; // same paidDate; 00003 must win regardless of array order
+    const fees = new Map<string, FeeInfo>([['pay-1', { lateFee: 100, waived: 0 }]]);
+    const out = computeReceiptFeeDisplay(receipts, fees);
+    expect(out.get('a')?.lateFee).toBe(100);
+    expect(out.get('b')?.lateFee).toBe(0);
+  });
+
+  it('carries the waived portion onto the first receipt too', () => {
+    const receipts = [
+      receipt({ id: 'a', receiptNumber: 'RT-202607-00003' }),
+      receipt({ id: 'b', receiptNumber: 'RT-202607-00004', paidDate: '2026-07-01T05:00:00.000Z' }),
+    ];
+    const fees = new Map<string, FeeInfo>([['pay-1', { lateFee: 100, waived: 25 }]]);
+    const out = computeReceiptFeeDisplay(receipts, fees);
+    expect(out.get('a')).toEqual({ lateFee: 100, waived: 25 });
+    expect(out.get('b')).toEqual({ lateFee: 0, waived: 0 });
+  });
+
+  it('shows 0 for every receipt when the installment has no late fee', () => {
+    const receipts = [receipt({ id: 'a' }), receipt({ id: 'b', receiptNumber: 'RT-202607-00002' })];
+    const fees = new Map<string, FeeInfo>([['pay-1', { lateFee: 0, waived: 0 }]]);
+    const out = computeReceiptFeeDisplay(receipts, fees);
+    expect(out.get('a')?.lateFee).toBe(0);
+    expect(out.get('b')?.lateFee).toBe(0);
+  });
+
+  it('never attributes the fee to a voided or credit-note receipt', () => {
+    const receipts = [
+      receipt({ id: 'void', receiptNumber: 'RT-202607-00003', isVoided: true }),
+      receipt({ id: 'cn', receiptNumber: 'RT-202607-00004', receiptType: 'CREDIT_NOTE', paidDate: '2026-07-01T05:00:00.000Z' }),
+      receipt({ id: 'good', receiptNumber: 'RT-202607-00005', paidDate: '2026-07-01T06:00:00.000Z' }),
+    ];
+    const fees = new Map<string, FeeInfo>([['pay-1', { lateFee: 100, waived: 0 }]]);
+    const out = computeReceiptFeeDisplay(receipts, fees);
+    expect(out.get('void')?.lateFee).toBe(0);
+    expect(out.get('cn')?.lateFee).toBe(0);
+    expect(out.get('good')?.lateFee).toBe(100);
+  });
+
+  it('attributes each installment its own first-receipt fee', () => {
+    const receipts = [
+      receipt({ id: 'a1', paymentId: 'pay-1', receiptNumber: 'RT-202607-00001' }),
+      receipt({ id: 'a2', paymentId: 'pay-1', receiptNumber: 'RT-202607-00002', paidDate: '2026-07-01T05:00:00.000Z' }),
+      receipt({ id: 'b1', paymentId: 'pay-2', receiptNumber: 'RT-202608-00001', paidDate: '2026-08-01T03:00:00.000Z' }),
+    ];
+    const fees = new Map<string, FeeInfo>([
+      ['pay-1', { lateFee: 100, waived: 0 }],
+      ['pay-2', { lateFee: 50, waived: 0 }],
+    ]);
+    const out = computeReceiptFeeDisplay(receipts, fees);
+    expect(out.get('a1')?.lateFee).toBe(100);
+    expect(out.get('a2')?.lateFee).toBe(0);
+    expect(out.get('b1')?.lateFee).toBe(50);
+  });
+});

--- a/apps/web/src/components/payment/computeReceiptFeeDisplay.ts
+++ b/apps/web/src/components/payment/computeReceiptFeeDisplay.ts
@@ -1,0 +1,59 @@
+/**
+ * Attribute an installment's late fee / waiver to its FIRST receipt only.
+ *
+ * When an installment is split across several partial receipts, the late fee is
+ * a single per-installment charge — showing the installment-level `lateFee` on
+ * EVERY receipt row made it look charged N times ("ใบที่ 2 มีค่าปรับซ้ำ").
+ *
+ * Owner decision (display convention, not ledger): show the full late fee on the
+ * FIRST receipt of the installment and 0 on the rest. "First" = earliest by
+ * paidDate, tie-broken by the sequential receiptNumber. Voided receipts and
+ * non-payment receipts (credit note / early payoff / down payment) never carry
+ * the fee.
+ */
+export interface ReceiptFeeRow {
+  id: string;
+  receiptNumber: string;
+  receiptType: string;
+  paymentId: string | null;
+  paidDate: string;
+  isVoided: boolean;
+}
+
+export interface FeeInfo {
+  lateFee: number;
+  waived: number;
+}
+
+const EXCLUDED_TYPES = new Set(['CREDIT_NOTE', 'EARLY_PAYOFF', 'DOWN_PAYMENT']);
+
+export function computeReceiptFeeDisplay(
+  receipts: ReceiptFeeRow[],
+  feeByPaymentId: Map<string, FeeInfo>,
+): Map<string, FeeInfo> {
+  const result = new Map<string, FeeInfo>();
+  // Default every receipt to no fee.
+  for (const r of receipts) result.set(r.id, { lateFee: 0, waived: 0 });
+
+  // Group fee-eligible receipts by installment (paymentId).
+  const byPayment = new Map<string, ReceiptFeeRow[]>();
+  for (const r of receipts) {
+    if (!r.paymentId || r.isVoided || EXCLUDED_TYPES.has(r.receiptType)) continue;
+    const list = byPayment.get(r.paymentId);
+    if (list) list.push(r);
+    else byPayment.set(r.paymentId, [r]);
+  }
+
+  for (const [paymentId, rows] of byPayment) {
+    const fee = feeByPaymentId.get(paymentId);
+    if (!fee || (fee.lateFee <= 0 && fee.waived <= 0)) continue;
+    const first = [...rows].sort(
+      (a, b) =>
+        new Date(a.paidDate).getTime() - new Date(b.paidDate).getTime() ||
+        a.receiptNumber.localeCompare(b.receiptNumber),
+    )[0];
+    result.set(first.id, { lateFee: fee.lateFee, waived: fee.waived });
+  }
+
+  return result;
+}

--- a/apps/web/src/pages/ContractDetailPage.tsx
+++ b/apps/web/src/pages/ContractDetailPage.tsx
@@ -15,9 +15,10 @@ import CustomerEditModal from '@/components/contract/CustomerEditModal';
 import ContractPaymentSchedule from '@/components/contract/ContractPaymentSchedule';
 import ContractDocuments from '@/components/contract/ContractDocuments';
 import { ContractEarlyPayoffQuote, EarlyPayoffOverlay } from '@/components/contract/ContractEarlyPayoff';
+import PaymentHistorySheet from '@/components/payment/PaymentHistorySheet';
 import { toast } from 'sonner';
 import { useState, useRef, useEffect } from 'react';
-import { Copy, CheckCircle2, XCircle, AlertTriangle, Check, ChevronRight } from 'lucide-react';
+import { Copy, CheckCircle2, XCircle, AlertTriangle, Check, ChevronRight, History } from 'lucide-react';
 import { useCopyToClipboard } from '@/hooks/useCopyToClipboard';
 import { useAuth } from '@/contexts/AuthContext';
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
@@ -92,6 +93,9 @@ export default function ContractDetailPage() {
   const { user } = useAuth();
   const { copy: copyToClipboard } = useCopyToClipboard();
   const [showPayoffModal, setShowPayoffModal] = useState(false);
+  // Payment-history modal — reachable for ANY status (incl. EARLY_PAYOFF / COMPLETED
+  // contracts that have dropped out of the /payments pending queue).
+  const [historyContractId, setHistoryContractId] = useState<string | null>(null);
   const [customerLink, setCustomerLink] = useState<string | null>(null);
   const [showRejectModal, setShowRejectModal] = useState(false);
   const [showSubmitConfirm, setShowSubmitConfirm] = useState(false);
@@ -322,6 +326,16 @@ const deleteMutation = useMutation({
             {contract.workflowStatus === 'APPROVED' && contract.status === 'DRAFT' && (
               <button onClick={() => activateMutation.mutate()} disabled={activateMutation.isPending || !allSigned} title={!allSigned ? 'ต้องลงนามครบทั้งลูกค้าและพนักงานก่อน' : ''} className="px-4 py-2 text-sm bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 disabled:opacity-50">
                 {activateMutation.isPending ? 'กำลังเปิด...' : 'เปิดใช้งานสัญญา'}
+              </button>
+            )}
+
+            {['ACTIVE', 'OVERDUE', 'DEFAULT', 'COMPLETED', 'EARLY_PAYOFF'].includes(contract.status) && (
+              <button
+                onClick={() => setHistoryContractId(contract.id)}
+                className="inline-flex items-center gap-1.5 px-4 py-2 text-sm border border-input bg-background text-foreground rounded-lg hover:bg-accent hover:text-accent-foreground shadow-sm"
+              >
+                <History className="size-4" />
+                ประวัติการชำระ
               </button>
             )}
 
@@ -951,6 +965,12 @@ const deleteMutation = useMutation({
           onSuccess={invalidateContract}
         />
       )}
+
+      {/* Payment History Modal (4 summary cards + receipt-level table) */}
+      <PaymentHistorySheet
+        contractId={historyContractId}
+        onClose={() => setHistoryContractId(null)}
+      />
 
       {/* Submit Review Confirm Modal */}
       {showSubmitConfirm && (

--- a/apps/web/src/pages/PaymentsPage/__tests__/computeNetReceiptDue.test.ts
+++ b/apps/web/src/pages/PaymentsPage/__tests__/computeNetReceiptDue.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { computeNetReceiptDue } from '../computeNetReceiptDue';
+
+describe('computeNetReceiptDue', () => {
+  it('includes the late fee in a fresh overdue installment (the bug: full must be full)', () => {
+    // ค่างวด 3,671 + ค่าปรับ 100 → "เต็มงวด" = 3,771 (NOT 3,671)
+    expect(
+      computeNetReceiptDue({ amountDue: '3671', lateFee: '100', amountPaid: '0' }).toFixed(2),
+    ).toBe('3771.00');
+  });
+
+  it('leaves only the late fee when the base is already paid', () => {
+    // amountPaid = amountDue (base settled) → คงค้าง = 100 (the late fee)
+    expect(
+      computeNetReceiptDue({ amountDue: '3671', lateFee: '100', amountPaid: '3671' }).toFixed(2),
+    ).toBe('100.00');
+  });
+
+  it('subtracts a late-fee waiver (clamped to the gross late fee)', () => {
+    expect(
+      computeNetReceiptDue({ amountDue: '3671', lateFee: '100', amountPaid: '0', waiver: '100' }).toFixed(2),
+    ).toBe('3671.00');
+    // waiver above gross is clamped — cannot go below the base
+    expect(
+      computeNetReceiptDue({ amountDue: '3671', lateFee: '100', amountPaid: '0', waiver: '999' }).toFixed(2),
+    ).toBe('3671.00');
+  });
+
+  it('consumes the advance balance when the credit toggle is on', () => {
+    expect(
+      computeNetReceiptDue({
+        amountDue: '3671',
+        lateFee: '100',
+        amountPaid: '0',
+        advanceBalance: '500',
+        consumeAdvance: true,
+      }).toFixed(2),
+    ).toBe('3271.00');
+  });
+
+  it('ignores the advance balance when the credit toggle is off', () => {
+    expect(
+      computeNetReceiptDue({
+        amountDue: '3671',
+        lateFee: '100',
+        amountPaid: '0',
+        advanceBalance: '500',
+        consumeAdvance: false,
+      }).toFixed(2),
+    ).toBe('3771.00');
+  });
+
+  it('never returns a negative amount (advance larger than owed)', () => {
+    expect(
+      computeNetReceiptDue({
+        amountDue: '1000',
+        lateFee: '0',
+        amountPaid: '0',
+        advanceBalance: '5000',
+        consumeAdvance: true,
+      }).toFixed(2),
+    ).toBe('0.00');
+  });
+});

--- a/apps/web/src/pages/PaymentsPage/__tests__/invalidatePaymentQueries.test.ts
+++ b/apps/web/src/pages/PaymentsPage/__tests__/invalidatePaymentQueries.test.ts
@@ -12,6 +12,8 @@ describe('invalidatePaymentQueries', () => {
     // staleTime serve a stale 0/N history behind a fresh daily summary.
     expect(keys).toContain('contract-payments');
     expect(keys).toContain('contract-receipts');
+    // JE expansion cache (per-receipt bookkeeping view) must refresh too.
+    expect(keys).toContain('contract-journal-entries');
     // Existing invalidations preserved.
     expect(keys).toContain('pending-payments');
     expect(keys).toContain('daily-summary');

--- a/apps/web/src/pages/PaymentsPage/components/RecordPaymentWizard.tsx
+++ b/apps/web/src/pages/PaymentsPage/components/RecordPaymentWizard.tsx
@@ -38,6 +38,7 @@ import { formatThaiDate } from '@/lib/date';
 import { useDebounce } from '@/hooks/useDebounce';
 import { toast } from 'sonner';
 import type { PendingPayment } from '../types';
+import { computeNetReceiptDue } from '../computeNetReceiptDue';
 import { AdvanceBalanceBanner } from './AdvanceBalanceBanner';
 import { EarlyPayoffOverlay } from '@/components/contract/ContractEarlyPayoff';
 import { RescheduleOverlay } from './RescheduleOverlay';
@@ -605,11 +606,17 @@ export function RecordPaymentWizard({
   const lateFeeDecimal = useMemo(() => new Decimal(payment.lateFee), [payment.lateFee]);
   const amountDueDecimal = useMemo(() => new Decimal(payment.amountDue), [payment.amountDue]);
   const amountPaidDecimal = useMemo(() => new Decimal(payment.amountPaid), [payment.amountPaid]);
-  // Pre-fill amount = amountDue only (no auto-add lateFee). User explicitly enters
-  // lateFee in the dedicated field if applicable, then can manually update amount.
-  // This avoids the "ห่างเกิน 1฿" warning on first render when payment.lateFee was
-  // server-computed but lateFee input shows 0.00.
-  const defaultAmount = amountDueDecimal.sub(amountPaidDecimal).toDecimalPlaces(2);
+  // Pre-fill amount = FULL owed INCLUDING the net late fee (single source of truth:
+  // computeNetReceiptDue). Pre-filling only the base (amountDue) let a cashier confirm
+  // "จ่ายเต็ม" that silently dropped the late fee → the installment stuck at
+  // PARTIALLY_PAID with a phantom "ค้าง". Since lateFeeStr also pre-fills from the
+  // server-computed payment.lateFee (I4 fix), the first-render amount agrees with the
+  // lateFee input → no spurious "ห่างเกิน 1฿" warning.
+  const defaultAmount = computeNetReceiptDue({
+    amountDue: amountDueDecimal,
+    lateFee: lateFeeDecimal,
+    amountPaid: amountPaidDecimal,
+  });
 
   const [amountReceived, setAmountReceived] = useState(defaultAmount.toFixed(2));
   const [amountManuallyEdited, setAmountManuallyEdited] = useState(false);
@@ -640,13 +647,14 @@ export function RecordPaymentWizard({
     if (amountManuallyEdited) return;
     const lf = parseFloat(lateFeeStr);
     if (isNaN(lf)) return;
-    const w = Math.min(Math.max(parseFloat(waiverStr) || 0, 0), lf); // waiver clamped ≤ gross
-    const owed = amountDueDecimal.plus(lf - w).sub(amountPaidDecimal); // NET late fee
-    const consumed =
-      consumeAdvance && advanceBalance.gt(0)
-        ? Decimal.min(advanceBalance, Decimal.max(new Decimal(0), owed))
-        : new Decimal(0);
-    const next = Decimal.max(new Decimal(0), owed.minus(consumed)).toDecimalPlaces(2);
+    const next = computeNetReceiptDue({
+      amountDue: amountDueDecimal,
+      lateFee: lf,
+      amountPaid: amountPaidDecimal,
+      waiver: Math.max(parseFloat(waiverStr) || 0, 0),
+      advanceBalance,
+      consumeAdvance,
+    });
     setAmountReceived(next.toFixed(2));
   }, [lateFeeStr, waiverStr, amountDueDecimal, amountPaidDecimal, amountManuallyEdited, consumeAdvance, advanceBalance]);
 
@@ -812,14 +820,18 @@ export function RecordPaymentWizard({
   const hasDraft = !!existingDraft;
 
   // Net to collect after the waiver + the (optional) advance deduction — drives tiles.
-  const netDue = useMemo(() => {
-    const owed = amountDueDecimal.plus(netLateFee).sub(amountPaidDecimal); // NET late fee
-    const consumed =
-      consumeAdvance && advanceBalance.gt(0)
-        ? Decimal.min(advanceBalance, Decimal.max(new Decimal(0), owed))
-        : new Decimal(0);
-    return Decimal.max(new Decimal(0), owed.minus(consumed)).toDecimalPlaces(2);
-  }, [amountDueDecimal, netLateFee, amountPaidDecimal, consumeAdvance, advanceBalance]);
+  const netDue = useMemo(
+    () =>
+      computeNetReceiptDue({
+        amountDue: amountDueDecimal,
+        lateFee: currentLateFee,
+        amountPaid: amountPaidDecimal,
+        waiver: waiverDec,
+        advanceBalance,
+        consumeAdvance,
+      }),
+    [amountDueDecimal, currentLateFee, waiverDec, amountPaidDecimal, consumeAdvance, advanceBalance],
+  );
   // ปิดขึ้น = round the net up to a whole baht; the ≤1฿ residual rides the
   // existing 52-1104/53-1503 tolerance on the server.
   const netDueRoundedUp = useMemo(() => netDue.toDecimalPlaces(0, Decimal.ROUND_UP), [netDue]);

--- a/apps/web/src/pages/PaymentsPage/computeNetReceiptDue.ts
+++ b/apps/web/src/pages/PaymentsPage/computeNetReceiptDue.ts
@@ -1,0 +1,46 @@
+import Decimal from 'decimal.js';
+
+export interface NetReceiptDueInput {
+  /** Base installment (principal + interest + commission + VAT). */
+  amountDue: Decimal.Value;
+  /** Gross late fee currently on the installment. */
+  lateFee: Decimal.Value;
+  /** Amount already paid toward this installment. */
+  amountPaid: Decimal.Value;
+  /** Late-fee waiver (Dr 52-1105). Clamped to ≤ gross lateFee. */
+  waiver?: Decimal.Value;
+  /** Advance balance parked in 21-1103, available to auto-consume. */
+  advanceBalance?: Decimal.Value;
+  /** Whether the advance balance is deducted (cashier "หักเครดิต" toggle). */
+  consumeAdvance?: boolean;
+}
+
+/**
+ * Single source of truth for the wizard's "full" receipt amount ("เต็มงวด").
+ *
+ * The net cash the customer still owes for an installment =
+ *   (base amountDue) + (late fee − waiver) − (already paid) − (advance consumed)
+ *
+ * CRITICAL: the late fee is ALWAYS part of "full". Pre-filling only the base
+ * (amountDue) let a cashier confirm a payment that silently left the late fee
+ * unpaid → the installment stuck at PARTIALLY_PAID with a phantom "ค้าง".
+ */
+export function computeNetReceiptDue(input: NetReceiptDueInput): Decimal {
+  const amountDue = new Decimal(input.amountDue);
+  const lateFee = new Decimal(input.lateFee);
+  const amountPaid = new Decimal(input.amountPaid);
+
+  // Waiver reduces cash owed but can never exceed the gross late fee.
+  const waiver = Decimal.min(new Decimal(input.waiver ?? 0), lateFee);
+  const netLateFee = lateFee.minus(waiver);
+
+  const owed = amountDue.plus(netLateFee).minus(amountPaid);
+
+  const advance = new Decimal(input.advanceBalance ?? 0);
+  const consumed =
+    (input.consumeAdvance ?? true) && advance.gt(0)
+      ? Decimal.min(advance, Decimal.max(new Decimal(0), owed))
+      : new Decimal(0);
+
+  return Decimal.max(new Decimal(0), owed.minus(consumed)).toDecimalPlaces(2);
+}

--- a/apps/web/src/pages/PaymentsPage/invalidatePaymentQueries.ts
+++ b/apps/web/src/pages/PaymentsPage/invalidatePaymentQueries.ts
@@ -11,7 +11,13 @@ import type { QueryClient } from '@tanstack/react-query';
  * summary (which WAS invalidated) already showed the PAID payment.
  */
 export function invalidatePaymentQueries(qc: QueryClient): void {
-  const keys = ['pending-payments', 'daily-summary', 'contract-payments', 'contract-receipts'];
+  const keys = [
+    'pending-payments',
+    'daily-summary',
+    'contract-payments',
+    'contract-receipts',
+    'contract-journal-entries',
+  ];
   for (const key of keys) {
     qc.invalidateQueries({ queryKey: [key] });
   }


### PR DESCRIPTION
## สรุป
- **Early payoff**: ส่วนลดลูกค้าปัดเศษ**ลง** (ROUND_DOWN — เข้าข้าง FINANCE ตามนโยบาย), ปุ่ม **ประวัติการชำระ** บน ContractDetail สำหรับสัญญาปิดแล้ว (COMPLETED/EARLY_PAYOFF), payoff/settlement invalidate history caches
- **Payment history modal**: การ์ดค่าปรับนับงวดที่เริ่มเก็บเงินแล้ว (PAID หรือ amountPaid>0 — ทนต่อ cron flip), ยอดชำระสะสมไม่นับ CREDIT_NOTE, ค่าปรับแสดงบนใบเสร็จใบแรกของงวดเท่านั้น (computeReceiptFeeDisplay)
- **JE viewer ใหม่**: ปุ่ม 📖 ต่อแถวใบเสร็จ → JE ที่ POST แล้ว (Dr/Cr + ชื่อบัญชี + BALANCED + void-reversal trail; แถว CN แสดง JE กลับรายการ)
- **API ใหม่**: `GET /payments/contract/:id/journal-entries` — soft-link ผ่าน metadata (receipt/2B/credit-allocation/overpayment-credit/early-payoff) + reversal second pass, Dr-before-Cr deterministic order
- **Cron**: overdue-lifecycle ข้ามงวดที่ base จ่ายครบแล้ว (ไม่ resurrect ค่าปรับ / ไม่ flip กลับ OVERDUE) + integration spec
- **Wizard**: prefill = ยอดเต็มรวมค่าปรับสุทธิ (computeNetReceiptDue single source of truth)
- **Chore**: qa-engineer subagent

## การทดสอบ
- API: payments + contracts **429 pass**, spec ใหม่ 7+6 tests, tsc = 0
- Web: **851 pass** (133 files), tsc = 0
- Adversarial review (13 agents): 8 findings confirmed → แก้ครบในชุดนี้

🤖 Generated with [Claude Code](https://claude.com/claude-code)