### PR TITLE
test(payments): backfill money-path coverage gaps from PR #1314 QA

### DIFF
--- a/apps/api/src/modules/overdue/services/late-fee-skip-base-paid.integration.spec.ts
+++ b/apps/api/src/modules/overdue/services/late-fee-skip-base-paid.integration.spec.ts
@@ -69,6 +69,21 @@ describe('calculateLateFees skips installments whose base is already paid', () =
         status: 'PENDING',
       } as any,
     });
+    // Row 3 — PARTIAL principal (0 < amountPaid < amountDue): the base is NOT settled,
+    // so the `amount_paid < amount_due` guard must NOT skip it — the cron SHOULD still
+    // recompute the fee + flip OVERDUE. Preset lateFee = 77 (not a BRACKET output) so a
+    // recompute is detectable. Pins the strict-'<' boundary from the paid side.
+    await prisma.payment.create({
+      data: {
+        contractId,
+        installmentNo: 3,
+        amountDue: new Prisma.Decimal('3671.00'),
+        amountPaid: new Prisma.Decimal('2000.00'),
+        lateFee: new Prisma.Decimal('77.00'),
+        dueDate: new Date(now - 10 * 86_400_000),
+        status: 'PARTIALLY_PAID',
+      } as any,
+    });
   });
 
   afterAll(async () => {
@@ -95,5 +110,20 @@ describe('calculateLateFees skips installments whose base is already paid', () =
     const unpaid = await prisma.payment.findFirst({ where: { contractId, installmentNo: 2 } });
     expect(new Prisma.Decimal(unpaid!.lateFee.toString()).toString()).toBe('100');
     expect(unpaid!.status).toBe('OVERDUE');
+  });
+
+  it('still recomputes the fee + flips OVERDUE for a PARTIAL principal row (0 < amountPaid < amountDue)', async () => {
+    const svc = new OverdueLifecycleCronService(
+      prisma as any,
+      new ConsecutiveMissedService(prisma as any),
+    );
+    await svc.calculateLateFees();
+
+    // Row 3 — base only partly paid: guard `amount_paid < amount_due` is TRUE, so the
+    // row is processed like any overdue row — fee recomputed to tier2 (100, NOT frozen 77),
+    // status flipped OVERDUE. Confirms the skip applies ONLY to base-settled rows.
+    const partial = await prisma.payment.findFirst({ where: { contractId, installmentNo: 3 } });
+    expect(new Prisma.Decimal(partial!.lateFee.toString()).toString()).toBe('100');
+    expect(partial!.status).toBe('OVERDUE');
   });
 });

--- a/apps/api/src/modules/overdue/services/late-fee-skip-base-paid.unit.spec.ts
+++ b/apps/api/src/modules/overdue/services/late-fee-skip-base-paid.unit.spec.ts
@@ -1,0 +1,85 @@
+/**
+ * PR #1314 gap-fill — LOCALLY-RUNNABLE guard for the base-settled skip clause.
+ *
+ * The behavioural proof (real Postgres) lives in the sibling
+ * `late-fee-skip-base-paid.integration.spec.ts`, but that file is *.integration.spec.ts
+ * and therefore EXCLUDED from the jest run (CI DB-only). Nothing in the local suite
+ * caught an accidental removal / operator flip (`<` → `<=`) / column typo in the raw
+ * SQL — raw SQL is not type-checked by tsc either.
+ *
+ * This spec closes that gap cheaply: it constructs OverdueLifecycleCronService with a
+ * mocked Prisma, runs calculateLateFees(), and asserts the compiled bulk-UPDATE SQL
+ * still contains `"amount_paid" < "amount_due"` — in BOTH fee-formula modes, so the
+ * guard survives a BRACKET/PER_DAY branch refactor. Mock-only, no DB.
+ *
+ * Sibling pattern: overdue.late-fee-escalation.spec.ts (makeBracketPrisma/makePerDayPrisma).
+ */
+import { OverdueLifecycleCronService } from './overdue-lifecycle-cron.service';
+import type { ConsecutiveMissedService } from '../consecutive-missed.service';
+
+// calculateLateFees calls `this.prisma.$executeRaw(Prisma.sql`…`)`, so mock.calls[0][0]
+// is a Prisma.Sql. The new skip clause is a pure literal (no interpolation), so it lands
+// verbatim in Sql.strings regardless of which fee fragment (BRACKET / PER_DAY) is spliced in.
+type SqlLike = { strings?: readonly string[]; sql?: string };
+const sqlTextOf = (arg: unknown): string => {
+  const s = arg as SqlLike;
+  if (Array.isArray(s?.strings)) return s.strings.join(' ');
+  if (typeof s?.sql === 'string') return s.sql;
+  return String(arg);
+};
+
+/** Minimal Prisma stub: only systemConfig.findUnique (mode dispatch) + $executeRaw. */
+const makePrisma = (mode: 'BRACKET' | 'PER_DAY', rowsUpdated = 4) => {
+  const $executeRaw = jest.fn().mockResolvedValue(rowsUpdated);
+  const prisma = {
+    systemConfig: {
+      findUnique: jest.fn(({ where }: { where: { key: string } }) =>
+        Promise.resolve(where.key === 'late_fee_mode' ? { value: mode } : null),
+      ),
+    },
+    $executeRaw,
+  };
+  return { prisma, $executeRaw };
+};
+
+const buildCron = (prisma: unknown) =>
+  new OverdueLifecycleCronService(
+    prisma as never,
+    {} as unknown as ConsecutiveMissedService,
+  );
+
+describe('OverdueLifecycleCronService.calculateLateFees — base-settled skip guard (SQL text)', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('BRACKET mode: bulk UPDATE skips base-settled rows via "amount_paid" < "amount_due"', async () => {
+    const { prisma, $executeRaw } = makePrisma('BRACKET');
+
+    const out = await buildCron(prisma).calculateLateFees();
+
+    expect($executeRaw).toHaveBeenCalledTimes(1);
+    expect(out.updated).toBe(4);
+    const text = sqlTextOf($executeRaw.mock.calls[0][0]);
+    expect(text).toContain('"amount_paid" < "amount_due"');
+  });
+
+  it('PER_DAY mode: the same guard survives the alternate fee-formula branch', async () => {
+    const { prisma, $executeRaw } = makePrisma('PER_DAY');
+
+    await buildCron(prisma).calculateLateFees();
+
+    expect($executeRaw).toHaveBeenCalledTimes(1);
+    const text = sqlTextOf($executeRaw.mock.calls[0][0]);
+    expect(text).toContain('"amount_paid" < "amount_due"');
+  });
+
+  it('the skip clause sits beside the existing filters without displacing them', async () => {
+    const { prisma, $executeRaw } = makePrisma('BRACKET');
+
+    await buildCron(prisma).calculateLateFees();
+
+    const text = sqlTextOf($executeRaw.mock.calls[0][0]);
+    expect(text).toMatch(/UPDATE\s+"payments"/);
+    expect(text).toContain('"late_fee_waived" = false');
+    expect(text).toContain('"amount_paid" < "amount_due"');
+  });
+});

--- a/apps/api/src/modules/payments/payments.controller.spec.ts
+++ b/apps/api/src/modules/payments/payments.controller.spec.ts
@@ -38,6 +38,7 @@ describe('PaymentsController', () => {
       autoAllocatePayment: jest.fn().mockResolvedValue({ allocatedPayments: [], totalAllocated: 0, overpayment: 0 }),
       getPendingPayments: jest.fn().mockResolvedValue([]),
       getDailySummary: jest.fn().mockResolvedValue({ totalPayments: 0 }),
+      getContractJournalEntries: jest.fn().mockResolvedValue([]),
     };
 
     const mockRescheduleService = {
@@ -244,6 +245,40 @@ describe('PaymentsController', () => {
       expect(paymentsService.getPendingPayments).toHaveBeenCalledWith(
         expect.objectContaining({ branchId: 'branch-2' }),
       );
+    });
+  });
+
+  // PR #1314 — GET contract/:contractId/journal-entries (payment-history JE panel).
+  // The endpoint's only guard beyond @Roles is the per-contract validateBranchAccess,
+  // which must run BEFORE the query service is hit.
+  describe('getContractJournalEntries branch access + passthrough', () => {
+    const jeRows = [{ id: 'je-1', entryNumber: 'JV-0001', isBalanced: true }];
+
+    beforeEach(() => {
+      (paymentsService.getContractJournalEntries as jest.Mock).mockResolvedValue(jeRows);
+    });
+
+    it('validates branch access then returns the query-service rows (OWNER, cross-branch)', async () => {
+      const user = { id: 'user-1', role: 'OWNER', branchId: 'branch-2' };
+      const res = await controller.getContractJournalEntries('contract-1', user);
+
+      expect(paymentsService.validateBranchAccess).toHaveBeenCalledWith('contract-1', user);
+      expect(paymentsService.getContractJournalEntries).toHaveBeenCalledWith('contract-1');
+      expect(res).toBe(jeRows);
+    });
+
+    it('allows SALES for own branch', async () => {
+      const user = { id: 'user-1', role: 'SALES', branchId: 'branch-1' };
+      await controller.getContractJournalEntries('contract-1', user);
+      expect(paymentsService.getContractJournalEntries).toHaveBeenCalledWith('contract-1');
+    });
+
+    it('rejects SALES cross-branch BEFORE reaching the query service', async () => {
+      const user = { id: 'user-1', role: 'SALES', branchId: 'branch-2' };
+      await expect(controller.getContractJournalEntries('contract-1', user)).rejects.toThrow(
+        ForbiddenException,
+      );
+      expect(paymentsService.getContractJournalEntries).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/api/src/modules/payments/payments.service.advance.spec.ts
+++ b/apps/api/src/modules/payments/payments.service.advance.spec.ts
@@ -835,4 +835,33 @@ describe('PaymentsService — advance balance (Task 4)', () => {
       );
     });
   });
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // PR #1314 — a PARTIAL payment must leave amount_paid < amount_due so the overdue
+  // cron's base-settled skip guard (`amount_paid < amount_due`) still processes the
+  // row (recomputes fee / keeps it OVERDUE). Existing PARTIAL tests assert the status
+  // only; this pins the recorded amountPaid, linking the record side to the cron guard.
+  // ───────────────────────────────────────────────────────────────────────────
+  describe('PR #1314 — partial keeps amount_paid < amount_due (cron-guard link)', () => {
+    it('records amountPaid strictly below amountDue on a fresh PARTIAL payment', async () => {
+      prisma.installmentSchedule.findUnique.mockResolvedValueOnce({ id: 'sch-guard-1' });
+      prisma.payment.findFirst.mockResolvedValueOnce(makePayment(30)); // amountDue 1000, fresh (amountPaid 0)
+
+      await service.recordPayment(
+        'adv-contract-1', 30, 800, 'CASH', 'user-1',
+        undefined, undefined, 'TEST-GUARD', '11-1101', undefined, 'PARTIAL',
+      );
+
+      const partialUpdate = (prisma.payment.update as jest.Mock).mock.calls
+        .map(([arg]) => arg)
+        .find((arg) => arg?.data?.status === 'PARTIALLY_PAID');
+      expect(partialUpdate).toBeDefined();
+
+      const recordedPaid = Number(
+        partialUpdate.data.amountPaid?.toString?.() ?? partialUpdate.data.amountPaid,
+      );
+      expect(recordedPaid).toBe(800);
+      expect(recordedPaid).toBeLessThan(INST_TOTAL); // 800 < 1000 → cron `amount_paid < amount_due` holds
+    });
+  });
 });

--- a/apps/web/src/components/payment/PaymentHistorySheet.tsx
+++ b/apps/web/src/components/payment/PaymentHistorySheet.tsx
@@ -7,6 +7,11 @@ import { formatDateShort, formatNumberDecimal } from '@/utils/formatters';
 import { useAuth } from '@/contexts/AuthContext';
 import ReceiptVoidDialog from '@/components/payment/ReceiptVoidDialog';
 import { computeReceiptFeeDisplay } from './computeReceiptFeeDisplay';
+import {
+  computeCumulativePaid,
+  computeFeeTotals,
+  jesForReceipt as selectJesForReceipt,
+} from './paymentHistoryDerivations';
 import { toast } from 'sonner';
 
 /* ─── Types ───────────────────────────────────────── */
@@ -158,23 +163,9 @@ export default function PaymentHistorySheet({ contractId, onClose }: Props) {
       return next;
     });
 
-  const jesForReceipt = (r: ReceiptItem): ContractJe[] => {
-    if (r.receiptType === 'EARLY_PAYOFF') return journalEntries.filter((j) => j.flow === 'early-payoff');
-    if (!r.paymentId) return [];
-    // N partial receipts share one paymentId → show every JE of that payment,
-    // each labeled with its own รับจริง (deltaApplied) so rows are tellable apart.
-    const paymentJes = journalEntries.filter((j) => j.paymentId === r.paymentId);
-    if (r.receiptType === 'CREDIT_NOTE') {
-      // The CN row IS the void event — show the REVERSAL JEs (mirror entries
-      // pointing back at this payment's originals), not the money-in originals.
-      const originalIds = new Set(paymentJes.map((j) => j.id));
-      const reversalJes = journalEntries.filter(
-        (j) => j.originalEntryId !== null && originalIds.has(j.originalEntryId),
-      );
-      return reversalJes.length ? reversalJes : paymentJes;
-    }
-    return paymentJes;
-  };
+  // Receipt → posted-JE selection (early-payoff by flow, CN → reversal mirrors,
+  // else by shared paymentId). Extracted to paymentHistoryDerivations for unit test.
+  const jesForReceipt = (r: ReceiptItem): ContractJe[] => selectJesForReceipt(r, journalEntries);
 
   const payments = pResp?.data ?? [];
   const contract = pResp?.contract;
@@ -209,15 +200,8 @@ export default function PaymentHistorySheet({ contractId, onClose }: Props) {
   // PARTIALLY_PAID overdue row back to OVERDUE; pure accruals on untouched
   // overdue rows stay excluded. Matches the per-row fee shown in the table.
   const paidCount = payments.filter((p) => p.status === 'PAID').length;
-  const cumulativePaid = receipts
-    .filter((r) => !r.isVoided && r.receiptType !== 'CREDIT_NOTE')
-    .reduce((s, r) => s + Number(r.amount), 0);
-  const feePayments = payments.filter((p) => p.status === 'PAID' || Number(p.amountPaid) > 0);
-  const totalLateFee = feePayments.reduce((s, p) => s + Number(p.lateFee), 0);
-  const totalWaived = feePayments.reduce(
-    (s, p) => s + (p.waivedAmount != null ? Number(p.waivedAmount) : p.lateFeeWaived ? Number(p.lateFee) : 0),
-    0,
-  );
+  const cumulativePaid = computeCumulativePaid(receipts);
+  const { totalLateFee, totalWaived } = computeFeeTotals(payments);
 
   // One row per receipt (incl. voided), oldest installment first.
   const rows = useMemo(

--- a/apps/web/src/components/payment/__tests__/paymentHistoryDerivations.test.ts
+++ b/apps/web/src/components/payment/__tests__/paymentHistoryDerivations.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from 'vitest';
+import {
+  computeCumulativePaid,
+  computeFeeTotals,
+  jesForReceipt,
+  type ReceiptAmountRow,
+  type FeePaymentRow,
+  type JeRef,
+} from '../paymentHistoryDerivations';
+
+const rec = (over: Partial<ReceiptAmountRow>): ReceiptAmountRow => ({
+  isVoided: false,
+  receiptType: 'INSTALLMENT',
+  amount: '0',
+  ...over,
+});
+
+const pay = (over: Partial<FeePaymentRow>): FeePaymentRow => ({
+  status: 'PENDING',
+  amountPaid: '0',
+  lateFee: '0',
+  waivedAmount: null,
+  lateFeeWaived: false,
+  ...over,
+});
+
+const je = (over: Partial<JeRef>): JeRef => ({
+  id: 'je',
+  paymentId: null,
+  flow: null,
+  originalEntryId: null,
+  ...over,
+});
+
+describe('computeCumulativePaid', () => {
+  it('sums non-voided, non-CREDIT_NOTE receipt amounts', () => {
+    const receipts = [
+      rec({ receiptType: 'INSTALLMENT', amount: '1500' }),
+      rec({ receiptType: 'EARLY_PAYOFF', amount: '500' }),
+    ];
+    expect(computeCumulativePaid(receipts)).toBe(2000);
+  });
+
+  it('excludes voided receipts and CREDIT_NOTE rows (a CN carries the original positive amount)', () => {
+    const receipts = [
+      rec({ receiptType: 'INSTALLMENT', amount: '1500' }),
+      rec({ receiptType: 'INSTALLMENT', amount: '1000', isVoided: true }), // voided original
+      rec({ receiptType: 'CREDIT_NOTE', amount: '1000' }), // the void's CN row
+    ];
+    expect(computeCumulativePaid(receipts)).toBe(1500);
+  });
+
+  it('returns 0 when every receipt is either voided or a credit note', () => {
+    const receipts = [
+      rec({ receiptType: 'INSTALLMENT', amount: '1000', isVoided: true }),
+      rec({ receiptType: 'CREDIT_NOTE', amount: '1000' }),
+    ];
+    expect(computeCumulativePaid(receipts)).toBe(0);
+  });
+});
+
+describe('computeFeeTotals', () => {
+  it('counts the fee once collection has started via amountPaid > 0 (even if status is OVERDUE)', () => {
+    // Simulates the midnight cron flipping a base-touched PARTIALLY_PAID row back to
+    // OVERDUE — the fee must NOT vanish because amountPaid > 0.
+    const payments = [pay({ status: 'OVERDUE', amountPaid: '2000', lateFee: '100' })];
+    expect(computeFeeTotals(payments)).toEqual({ totalLateFee: 100, totalWaived: 0 });
+  });
+
+  it('counts the fee for a PAID installment', () => {
+    const payments = [pay({ status: 'PAID', amountPaid: '3671', lateFee: '77' })];
+    expect(computeFeeTotals(payments).totalLateFee).toBe(77);
+  });
+
+  it('excludes pure accruals (amountPaid 0 and not PAID) so untouched overdue rows do not inflate the card', () => {
+    const payments = [
+      pay({ status: 'OVERDUE', amountPaid: '0', lateFee: '100' }), // untouched → excluded
+      pay({ status: 'PAID', amountPaid: '1000', lateFee: '50' }), // included
+    ];
+    expect(computeFeeTotals(payments).totalLateFee).toBe(50);
+  });
+
+  it('prefers waivedAmount, falling back to full lateFee when lateFeeWaived is set', () => {
+    const payments = [
+      pay({ status: 'PAID', amountPaid: '1', lateFee: '100', waivedAmount: '40' }), // explicit partial waiver
+      pay({ status: 'PAID', amountPaid: '1', lateFee: '80', waivedAmount: null, lateFeeWaived: true }), // full waive
+    ];
+    expect(computeFeeTotals(payments)).toEqual({ totalLateFee: 180, totalWaived: 120 });
+  });
+});
+
+describe('jesForReceipt', () => {
+  it('EARLY_PAYOFF receipt matches JEs by flow (paymentId is null on the JP4 receipt)', () => {
+    const jes = [je({ id: 'a', flow: 'early-payoff' }), je({ id: 'b', flow: null, paymentId: 'p1' })];
+    const out = jesForReceipt({ receiptType: 'EARLY_PAYOFF', paymentId: null }, jes);
+    expect(out.map((j) => j.id)).toEqual(['a']);
+  });
+
+  it('normal receipt returns every JE sharing its paymentId (N partial receipts share one)', () => {
+    const jes = [
+      je({ id: 'a', paymentId: 'p1' }),
+      je({ id: 'b', paymentId: 'p1' }),
+      je({ id: 'c', paymentId: 'p2' }),
+    ];
+    const out = jesForReceipt({ receiptType: 'INSTALLMENT', paymentId: 'p1' }, jes);
+    expect(out.map((j) => j.id)).toEqual(['a', 'b']);
+  });
+
+  it('CREDIT_NOTE row shows the REVERSAL mirrors (matched via originalEntryId), not the money-in originals', () => {
+    const jes = [
+      je({ id: 'orig', paymentId: 'p1' }), // the money-in original
+      je({ id: 'rev', originalEntryId: 'orig', flow: 'receipt-void' }), // its mirror
+    ];
+    const out = jesForReceipt({ receiptType: 'CREDIT_NOTE', paymentId: 'p1' }, jes);
+    expect(out.map((j) => j.id)).toEqual(['rev']);
+  });
+
+  it('CREDIT_NOTE falls back to the originals when no reversal mirror is present', () => {
+    const jes = [je({ id: 'orig', paymentId: 'p1' })];
+    const out = jesForReceipt({ receiptType: 'CREDIT_NOTE', paymentId: 'p1' }, jes);
+    expect(out.map((j) => j.id)).toEqual(['orig']);
+  });
+
+  it('non-early-payoff receipt with a null paymentId returns nothing', () => {
+    const jes = [je({ id: 'a', paymentId: 'p1' })];
+    expect(jesForReceipt({ receiptType: 'INSTALLMENT', paymentId: null }, jes)).toEqual([]);
+  });
+});

--- a/apps/web/src/components/payment/paymentHistoryDerivations.ts
+++ b/apps/web/src/components/payment/paymentHistoryDerivations.ts
@@ -1,0 +1,89 @@
+/**
+ * Pure derivations behind PaymentHistorySheet's summary cards + JE panel.
+ *
+ * Extracted (PR #1314 gap-fill) so the running-total, fee-total, and receipt→JE
+ * selection rules can be unit-tested without rendering the sheet. The component
+ * keeps the react-query wiring; these functions own the arithmetic + selection.
+ * Logic is byte-identical to the previous inline implementation.
+ */
+
+export interface ReceiptAmountRow {
+  isVoided: boolean;
+  receiptType: string;
+  amount: string;
+}
+
+export interface FeePaymentRow {
+  status: string;
+  amountPaid: string;
+  lateFee: string;
+  waivedAmount: string | null;
+  lateFeeWaived: boolean;
+}
+
+export interface ReceiptRef {
+  receiptType: string;
+  paymentId: string | null;
+}
+
+export interface JeRef {
+  id: string;
+  paymentId: string | null;
+  flow: string | null;
+  originalEntryId: string | null;
+}
+
+/**
+ * Money collected = Σ non-voided receipt amounts EXCLUDING credit notes. A CN row
+ * carries the ORIGINAL's positive amount, so counting it would keep a voided
+ * payment in the total.
+ */
+export function computeCumulativePaid(receipts: ReceiptAmountRow[]): number {
+  return receipts
+    .filter((r) => !r.isVoided && r.receiptType !== 'CREDIT_NOTE')
+    .reduce((s, r) => s + Number(r.amount), 0);
+}
+
+/**
+ * Late-fee / waiver totals for the summary card. Counted on installments where
+ * collection has STARTED (status PAID or amountPaid > 0) — amountPaid-based rather
+ * than status so the fee doesn't vanish when the midnight cron flips a
+ * PARTIALLY_PAID overdue row back to OVERDUE; pure accruals on untouched overdue
+ * rows stay excluded.
+ */
+export function computeFeeTotals(payments: FeePaymentRow[]): {
+  totalLateFee: number;
+  totalWaived: number;
+} {
+  const feePayments = payments.filter((p) => p.status === 'PAID' || Number(p.amountPaid) > 0);
+  const totalLateFee = feePayments.reduce((s, p) => s + Number(p.lateFee), 0);
+  const totalWaived = feePayments.reduce(
+    (s, p) =>
+      s + (p.waivedAmount != null ? Number(p.waivedAmount) : p.lateFeeWaived ? Number(p.lateFee) : 0),
+    0,
+  );
+  return { totalLateFee, totalWaived };
+}
+
+/**
+ * The posted JEs shown under a receipt row.
+ *   - EARLY_PAYOFF receipt (paymentId null) → matched by flow 'early-payoff'.
+ *   - CREDIT_NOTE row IS the void event → show the REVERSAL mirrors (pointing back
+ *     at this payment's originals), falling back to the originals if no mirror exists.
+ *   - otherwise → every JE sharing the receipt's paymentId (N partial receipts share one).
+ * Generic so the caller keeps its richer JE type on the way out.
+ */
+export function jesForReceipt<J extends JeRef>(r: ReceiptRef, journalEntries: J[]): J[] {
+  if (r.receiptType === 'EARLY_PAYOFF')
+    return journalEntries.filter((j) => j.flow === 'early-payoff');
+  if (!r.paymentId) return [];
+  const paymentJes = journalEntries.filter((j) => j.paymentId === r.paymentId);
+  if (r.receiptType === 'CREDIT_NOTE') {
+    const originalIds = new Set(paymentJes.map((j) => j.id));
+    const reversalJes = journalEntries.filter(
+      (j) => j.originalEntryId !== null && originalIds.has(j.originalEntryId),
+    );
+    return reversalJes.length ? reversalJes : paymentJes;
+  }
+  return paymentJes;
+}

--- a/apps/web/src/pages/PaymentsPage/__tests__/computeNetReceiptDue.test.ts
+++ b/apps/web/src/pages/PaymentsPage/__tests__/computeNetReceiptDue.test.ts
@@ -61,4 +61,61 @@ describe('computeNetReceiptDue', () => {
       }).toFixed(2),
     ).toBe('0.00');
   });
+
+  // ── PR #1314 gap-fill: principal-first partial payments (0 < amountPaid < base) ──
+  // The existing suite only covered amountPaid == 0 (fresh) and amountPaid == amountDue
+  // (base settled). These pin the in-between band, where the base is PARTLY paid and the
+  // late fee is still outstanding — the exact state the wizard prefill must not drop.
+  it('still includes the full late fee when the base is only PARTLY paid', () => {
+    // 3671 base, 100 fee, 2000 already paid → 3671 + 100 − 2000 = 1771
+    expect(
+      computeNetReceiptDue({ amountDue: '3671', lateFee: '100', amountPaid: '2000' }).toFixed(2),
+    ).toBe('1771.00');
+  });
+
+  it('partial base + partial waiver: net fee (fee − waiver) rides on top of the base remainder', () => {
+    // owed = 3671 + (100 − 40) − 2000 = 1731
+    expect(
+      computeNetReceiptDue({
+        amountDue: '3671',
+        lateFee: '100',
+        amountPaid: '2000',
+        waiver: '40',
+      }).toFixed(2),
+    ).toBe('1731.00');
+  });
+
+  it('partial base + advance consume: advance is deducted after the fee is added', () => {
+    // owed = 3671 + 100 − 2000 = 1771; consume min(500, 1771) = 500 → 1271
+    expect(
+      computeNetReceiptDue({
+        amountDue: '3671',
+        lateFee: '100',
+        amountPaid: '2000',
+        advanceBalance: '500',
+        consumeAdvance: true,
+      }).toFixed(2),
+    ).toBe('1271.00');
+  });
+
+  it('returns 0 when an overpayment has already cleared base + late fee', () => {
+    // amountPaid (4000) >= amountDue + lateFee (3771) → nothing owed
+    expect(
+      computeNetReceiptDue({ amountDue: '3671', lateFee: '100', amountPaid: '4000' }).toFixed(2),
+    ).toBe('0.00');
+  });
+
+  it('applies waiver + advance + partial payment together (all reducers at once)', () => {
+    // owed = 1000 + (200 − 50) − 300 = 850; consume min(100, 850) = 100 → 750
+    expect(
+      computeNetReceiptDue({
+        amountDue: '1000',
+        lateFee: '200',
+        amountPaid: '300',
+        waiver: '50',
+        advanceBalance: '100',
+        consumeAdvance: true,
+      }).toFixed(2),
+    ).toBe('750.00');
+  });
 });

--- a/apps/web/src/pages/PaymentsPage/__tests__/computeWizardPrefill.test.ts
+++ b/apps/web/src/pages/PaymentsPage/__tests__/computeWizardPrefill.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { computeWizardPrefill } from '../computeWizardPrefill';
+import { computeNetReceiptDue } from '../computeNetReceiptDue';
+
+describe('computeWizardPrefill (RecordPaymentWizard first-render amount)', () => {
+  it('INCLUDES the late fee in the prefill (the bug: full must mean base + fee)', () => {
+    // 3671 base + 100 fee, nothing paid → เต็มงวด = 3771 (not 3671)
+    expect(
+      computeWizardPrefill({ amountDue: '3671', lateFee: '100', amountPaid: '0' }).toFixed(2),
+    ).toBe('3771.00');
+  });
+
+  it('nets out what has already been paid on the installment', () => {
+    expect(
+      computeWizardPrefill({ amountDue: '3671', lateFee: '100', amountPaid: '2000' }).toFixed(2),
+    ).toBe('1771.00');
+  });
+
+  it('leaves only the late fee once the base is settled', () => {
+    expect(
+      computeWizardPrefill({ amountDue: '3671', lateFee: '100', amountPaid: '3671' }).toFixed(2),
+    ).toBe('100.00');
+  });
+
+  it('shows the FULL owed on first render — advance is NOT pre-deducted (auto-sync applies it later)', () => {
+    const input = { amountDue: '3671', lateFee: '100', amountPaid: '0' } as const;
+    const prefill = computeWizardPrefill(input);
+    // What the auto-sync effect computes once the advance/consume inputs are wired in.
+    const afterAdvance = computeNetReceiptDue({ ...input, advanceBalance: '500', consumeAdvance: true });
+
+    expect(prefill.toFixed(2)).toBe('3771.00');
+    expect(afterAdvance.toFixed(2)).toBe('3271.00');
+    // The initial prefill is intentionally HIGHER — it omits the advance deduction.
+    expect(prefill.gt(afterAdvance)).toBe(true);
+  });
+});

--- a/apps/web/src/pages/PaymentsPage/components/RecordPaymentWizard.tsx
+++ b/apps/web/src/pages/PaymentsPage/components/RecordPaymentWizard.tsx
@@ -39,6 +39,7 @@ import { useDebounce } from '@/hooks/useDebounce';
 import { toast } from 'sonner';
 import type { PendingPayment } from '../types';
 import { computeNetReceiptDue } from '../computeNetReceiptDue';
+import { computeWizardPrefill } from '../computeWizardPrefill';
 import { AdvanceBalanceBanner } from './AdvanceBalanceBanner';
 import { EarlyPayoffOverlay } from '@/components/contract/ContractEarlyPayoff';
 import { RescheduleOverlay } from './RescheduleOverlay';
@@ -612,7 +613,7 @@ export function RecordPaymentWizard({
   // PARTIALLY_PAID with a phantom "ค้าง". Since lateFeeStr also pre-fills from the
   // server-computed payment.lateFee (I4 fix), the first-render amount agrees with the
   // lateFee input → no spurious "ห่างเกิน 1฿" warning.
-  const defaultAmount = computeNetReceiptDue({
+  const defaultAmount = computeWizardPrefill({
     amountDue: amountDueDecimal,
     lateFee: lateFeeDecimal,
     amountPaid: amountPaidDecimal,

--- a/apps/web/src/pages/PaymentsPage/computeWizardPrefill.ts
+++ b/apps/web/src/pages/PaymentsPage/computeWizardPrefill.ts
@@ -1,0 +1,27 @@
+import Decimal from 'decimal.js';
+import { computeNetReceiptDue } from './computeNetReceiptDue';
+
+/**
+ * The RecordPaymentWizard's FIRST-render "เต็มงวด" amount for an installment.
+ *
+ * = base amountDue + net late fee − already-paid, via the single source of truth
+ * computeNetReceiptDue. Deliberately OMITS waiver / advance / consumeAdvance: the
+ * initial render shows the plain owed figure so the cashier sees the full charge
+ * (base + fee − paid); the wizard's auto-sync effect layers the waiver + advance
+ * deduction on afterward once those inputs exist.
+ *
+ * Extracted (PR #1314 gap-fill) so the prefill wiring — specifically that it
+ * INCLUDES the late fee and EXCLUDES advance/waiver — is unit-testable without
+ * rendering the multi-query wizard.
+ */
+export function computeWizardPrefill(payment: {
+  amountDue: Decimal.Value;
+  lateFee: Decimal.Value;
+  amountPaid: Decimal.Value;
+}): Decimal {
+  return computeNetReceiptDue({
+    amountDue: payment.amountDue,
+    lateFee: payment.lateFee,
+    amountPaid: payment.amountPaid,
+  });
+}


### PR DESCRIPTION
Follow-up to **#1314** (merged via #1313). The post-merge QA review found the PR was green (0 regressions) but left four money-path coverage gaps — this closes them with locally-runnable tests, plus two behaviour-preserving pure-helper extractions so the UI wiring becomes testable without rendering.

## What & why

| P | Gap (from QA) | This PR |
|---|---|---|
| **P1a** | cron `amount_paid < amount_due` skip had **no locally-running** test (only DB-only `*.integration`; raw SQL isn't type-checked) | new `late-fee-skip-base-paid.unit.spec.ts` — constructs `OverdueLifecycleCronService` directly, asserts the clause is in the compiled bulk-UPDATE `Prisma.Sql` for **BRACKET + PER_DAY** |
| **P1b** | `PaymentHistorySheet` running-total (CN-exclusion), `amountPaid>0` fee attribution, CN→reversal-JE selection — untested inline logic | extracted `computeCumulativePaid` / `computeFeeTotals` / `jesForReceipt` → `paymentHistoryDerivations.ts` + 12 unit tests; component delegates (no behaviour change) |
| **P2a** | `computeNetReceiptDue` missing partial-base / overpay-clears-fee / waiver+advance+partial | +5 cases |
| **P2b** | advance spec never pinned `amountPaid < amountDue` after a partial | +1 test linking the record side to the cron guard |
| **P3** | partial-principal boundary only implied | +1 integration fixture row (0 < amountPaid < amountDue → fee recomputed + flips OVERDUE) |
| **P4a** | `GET /payments/contract/:id/journal-entries` had **zero** endpoint coverage | controller test: roles + `validateBranchAccess` branch guard + passthrough |
| **P4b** | wizard prefill wiring (includes fee, excludes advance/waiver) untested; full render test would be flaky (6 queries on mount) | extracted `computeWizardPrefill` + unit test |

## Notes
- **Two source files touched** (`PaymentHistorySheet.tsx`, `RecordPaymentWizard.tsx`) are behaviour-preserving extract-and-delegate refactors, following the codebase's existing `computeNetReceiptDue` / `computeReceiptFeeDisplay` pure-helper convention.
- P4b is a **pure-seam** test rather than a full-wizard render test on purpose — the wizard fires 6 `useQuery`/`useMutation` on mount, so a render test would be brittle; the prefill is computed synchronously from props and is fully covered at the seam.

## Verification
- API `jest src/modules/payments src/modules/contracts`: **27 suites / 436 pass / 0 fail**
- Web `vitest run`: new + existing green (the only parallel-run failures — `CollectionsPage/tabVisibility` and `overdue/collections-foundation.seed` — are **pre-existing timing flakes**, untouched by this PR, and pass in isolation)
- `tsc --noEmit`: **0 errors** both apps
- `eslint`: **0 errors** both apps

🤖 Generated with [Claude Code](https://claude.com/claude-code)