### PR TITLE
fix(payments): fee-first late-fee split + reschedule collect-first (ปรับดิว)

### DIFF
--- a/apps/api/prisma/migrations/20260979000000_partial_link_purpose_metadata/migration.sql
+++ b/apps/api/prisma/migrations/20260979000000_partial_link_purpose_metadata/migration.sql
@@ -1,0 +1,7 @@
+-- ปรับดิว (reschedule) collect-first flow: PartialPaymentLink gains a purpose
+-- discriminator + a metadata payload so a RESCHEDULE QR can carry its frozen
+-- quote (daysToShift/splitMode/fee/lateFee) until the PaySolutions webhook
+-- confirms payment — reschedule executes only after money arrives.
+ALTER TABLE "partial_payment_links"
+  ADD COLUMN IF NOT EXISTS "purpose" TEXT NOT NULL DEFAULT 'INSTALLMENT',
+  ADD COLUMN IF NOT EXISTS "metadata" JSONB;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -6704,6 +6704,14 @@ model PartialPaymentLink {
   /// 'ACTIVE' | 'PAID' | 'EXPIRED' | 'CANCELLED'
   status String @default("ACTIVE")
 
+  /// 'INSTALLMENT' (default — partial installment QR) | 'RESCHEDULE' (ปรับดิว collect QR:
+  /// reschedule executes ONLY after this link is PAID — เงินไม่เข้า ดิวไม่เลื่อน)
+  purpose String @default("INSTALLMENT")
+
+  /// RESCHEDULE purpose: { daysToShift, splitMode, rescheduleFee, lateFee, requestedById }
+  /// — the server-computed quote frozen at QR creation; the webhook books these amounts.
+  metadata Json?
+
   expiresAt   DateTime  @map("expires_at")
   paidAt      DateTime? @map("paid_at")
   cancelledAt DateTime? @map("cancelled_at")

--- a/apps/api/src/modules/installments/reschedule.service.spec.ts
+++ b/apps/api/src/modules/installments/reschedule.service.spec.ts
@@ -38,7 +38,7 @@ describe('RescheduleService', () => {
     await seedFinanceCoa(prisma);
   });
 
-  it('shifts due_date for installments >= fromInstallmentNo + reduces last installment by fee', async () => {
+  it('shifts due_date for installments >= fromInstallmentNo (amountDue untouched — fee is an advance)', async () => {
     const c = await seedStandard17k12m(prisma);
     const svc = new RescheduleService(prisma as any);
     const result = await svc.execute({
@@ -67,10 +67,13 @@ describe('RescheduleService', () => {
     const inst12 = await prisma.installmentSchedule.findFirstOrThrow({
       where: { contractId: c.id, installmentNo: 12 },
     });
-    // monthlyPayment is 1515.84 (1416.67 + 99.17) - 809 (fee rounded up) = 706.84
-    // Note: CSV uses 1515.83 but seeder rounds differently; actual DB value is 1515.84
+    // (2026-07-02, review C1) The last installment's amountDue is NO LONGER reduced —
+    // the old write was to a field no billing path reads, so the fee's 21-1103 credit
+    // was never relieved. The CPA case-6a prepayment now flows through
+    // Contract.advanceBalance (RescheduleCollectService) instead; the schedule row
+    // stays at the full per-installment amount.
     const inst12AmountDue = new Decimal((inst12.amountDue as any).toString());
-    expect(inst12AmountDue.toFixed(2)).toBe('706.84');
+    expect(inst12AmountDue.toFixed(2)).toBe('1515.84');
 
     // Installments 5-12 should all be shifted
     const allShifted = await prisma.installmentSchedule.findMany({

--- a/apps/api/src/modules/installments/reschedule.service.ts
+++ b/apps/api/src/modules/installments/reschedule.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { Decimal } from '@prisma/client/runtime/library';
+import { Prisma } from '@prisma/client';
 import { PrismaService } from '../../prisma/prisma.service';
 
 export type RescheduleVariant = '6a' | '6b';
@@ -37,9 +38,18 @@ export class RescheduleService {
    * outside this transaction — per CSV golden case-6a/6b: "Step 1 — UPDATE DB
    * (ไม่มี Journal)" comes before any JE. The JE is posted later when the
    * customer actually pays (Step 2/3 of the CSV).
+   *
+   * `outerTx` (ปรับดิว collect-first, 2026-07-02): when provided, ALL writes run on
+   * the caller's transaction so the collect JE + lateFee reset + date shift commit
+   * as ONE atom (RescheduleCollectService). Without it, behaviour is unchanged —
+   * the service opens its own $transaction.
    */
-  async execute(input: RescheduleInput): Promise<RescheduleResult> {
-    const installments = await this.prisma.installmentSchedule.findMany({
+  async execute(
+    input: RescheduleInput,
+    outerTx?: Prisma.TransactionClient,
+  ): Promise<RescheduleResult> {
+    const readClient: Prisma.TransactionClient | PrismaService = outerTx ?? this.prisma;
+    const installments = await readClient.installmentSchedule.findMany({
       where: {
         contractId: input.contractId,
         installmentNo: { gte: input.fromInstallmentNo },
@@ -54,7 +64,7 @@ export class RescheduleService {
     // Use contract.monthlyPayment as the installment total (includes commission + VAT).
     // installment.amountDue only carries principal+interest+vat and does not include commission,
     // so it would undercount the reschedule fee.
-    const contract = await this.prisma.contract.findUniqueOrThrow({
+    const contract = await readClient.contract.findUniqueOrThrow({
       where: { id: input.contractId },
       select: { monthlyPayment: true },
     });
@@ -62,12 +72,14 @@ export class RescheduleService {
 
     // Reschedule fee = monthlyPayment / 30 × daysToShift, rounded UP to a whole baht
     // (owner policy 2026-06 — ปัดเศษขึ้นเต็มบาท). e.g. 1515.83/30×22 = 1111.6086 → 1112.
+    // Must stay identical to computeRescheduleQuote (reschedule-quote.util.ts) — the
+    // collect service asserts the two agree before posting money.
     const fee = firstInstTotal
       .div(30)
       .times(input.daysToShift)
       .toDecimalPlaces(0, Decimal.ROUND_UP);
 
-    return this.prisma.$transaction(async (tx) => {
+    const body = async (tx: Prisma.TransactionClient) => {
       const oldDueDates: Record<string, Date> = {};
       const newDueDates: Record<string, Date> = {};
       const shiftedIds: string[] = [];
@@ -110,12 +122,13 @@ export class RescheduleService {
         shiftedIds.push(inst.id);
       }
 
-      // Reduce last installment amountDue by fee
-      const last = installments[installments.length - 1];
-      await tx.installmentSchedule.update({
-        where: { id: last.id },
-        data: { amountDue: firstInstTotal.minus(fee) } as any,
-      });
+      // (Removed 2026-07-02, review C1) The old "reduce last installment
+      // amountDue by fee" wrote InstallmentSchedule.amountDue — a field NO
+      // billing path reads (Payment.amountDue + computeInstallmentBreakdown
+      // drive billing/accrual), so the reduction was write-only and the fee's
+      // 21-1103 credit was never relieved. The CPA case-6a prepayment is now
+      // realised through Contract.advanceBalance (RescheduleCollectService),
+      // which the existing advance machinery consumes against real installments.
 
       // AuditLog (only when caller provides a real userId — keeps the
       // existing test signature backward-compatible until callers are wired)
@@ -135,7 +148,6 @@ export class RescheduleService {
               firstShiftedInstallmentNo: installments[0].installmentNo,
               firstShiftedOldDue: installments[0].dueDate.toISOString(),
               firstShiftedNewDue: newDueDates[installments[0].id].toISOString(),
-              lastInstallmentNewAmountDue: firstInstTotal.minus(fee).toFixed(2),
             },
           },
         });
@@ -147,6 +159,8 @@ export class RescheduleService {
         oldDueDates,
         newDueDates,
       };
-    });
+    };
+
+    return outerTx ? body(outerTx) : this.prisma.$transaction(body);
   }
 }

--- a/apps/api/src/modules/journal/cpa-templates/payment-receipt.template.ts
+++ b/apps/api/src/modules/journal/cpa-templates/payment-receipt.template.ts
@@ -8,6 +8,7 @@ import { AccountRoleService } from '../account-role.service';
 import { computeInstallmentBreakdown } from '../compute-installment-breakdown';
 import { splitReceipt, SplitReceiptResult } from '../split-receipt';
 import { buildReceiptLines } from '../build-receipt-lines';
+import { reconstructPriorCleared } from '../reconstruct-prior';
 
 const TOLERANCE = new Decimal('1.00');
 
@@ -110,89 +111,6 @@ export class PaymentReceiptTemplate {
     }
   }
 
-  /**
-   * Reconstruct prior cleared amounts for this installment from its own prior JE lines.
-   *
-   * Phase 2: matched only `tag:'receipt'` entries.
-   * Phase 3 (PR-843/I2 Option A — widen reconstruction): also matches `tag:'2B'` entries
-   * so that a legacy partial posted by the OLD non-split PaymentReceipt2BTemplate is not
-   * invisible to the primitive.  A legacy 2B JE carries:
-   *   metadata: { tag:'2B', contractId, installmentScheduleId, paymentId }  (NO partial/final flag)
-   *
-   * Discriminator (guards against over-inclusion):
-   *   - tag:'receipt' → always include (primitive's own JEs).
-   *   - tag:'2B' with flow:'advance-consume-on-accrual' → ALWAYS include. The 2A
-   *                    accrual cron posts `Dr 21-1103 / Cr 11-2103 = consume` to clear
-   *                    the receivable from a parked advance. Its Cr 11-2103 is a REAL
-   *                    prior-clearing and MUST be counted — even when consume ==
-   *                    installmentTotal (a full consume). Excluding a full consume here
-   *                    let a subsequent receipt double-credit 11-2103 (FINAL-REVIEW
-   *                    BLOCKER 1): the receipt would clear the full installmentTotal
-   *                    AGAIN → Σ(Cr 11-2103) = 2×installmentTotal.
-   *   - tag:'2B' (legacy full-payment receipt, flow != advance-consume-on-accrual)
-   *                  → include ONLY when Cr 11-2103 on that entry is STRICTLY LESS THAN
-   *                    installmentTotal.  A full-clear legacy 2B credits exactly
-   *                    installmentTotal; including it would set priorPrincipalCleared =
-   *                    installmentTotal and silently make principalRemaining = 0,
-   *                    rejecting any subsequent receipt. Using strict-less-than (no float
-   *                    equality) is safe: installmentTotal is a Decimal from
-   *                    computeInstallmentBreakdown, and the historical JE credit is also a
-   *                    Decimal stored in Postgres — comparison is exact.
-   *
-   * Historical JEs are never mutated (Option A = read-side only).
-   */
-  private async reconstructPrior(
-    readClient: Prisma.TransactionClient | PrismaService,
-    installmentScheduleId: string,
-    installmentTotal: Decimal,
-  ): Promise<{ priorPrincipalCleared: Decimal; priorLateFeeBooked: Decimal }> {
-    const entries = await readClient.journalEntry.findMany({
-      where: {
-        AND: [
-          {
-            OR: [
-              { metadata: { path: ['tag'], equals: 'receipt' } } as any,
-              { metadata: { path: ['tag'], equals: '2B' } } as any,
-            ],
-          },
-          {
-            metadata: { path: ['installmentScheduleId'], equals: installmentScheduleId },
-          } as any,
-        ],
-      },
-      include: { lines: true },
-    });
-    let priorPrincipalCleared = new Decimal(0);
-    let priorLateFeeBooked = new Decimal(0);
-    for (const e of entries) {
-      const meta = e.metadata as any;
-      const tag: string = meta?.tag ?? '';
-      if (tag === '2B') {
-        const flowMeta: string = (meta?.flow as string) ?? '';
-        if (flowMeta !== 'advance-consume-on-accrual') {
-          // Legacy PaymentReceipt2B full-payment JE: keep the full-clear discriminator
-          // (a one-shot full clear == installmentTotal must NOT be counted as a prior
-          // partial — including it would set priorPrincipalCleared = installmentTotal and
-          // silently make principalRemaining = 0, rejecting any subsequent receipt).
-          const entryCr11 = e.lines
-            .filter((l) => l.accountCode === '11-2103')
-            .reduce((s, l) => s.plus(new Decimal(l.credit.toString())), new Decimal(0));
-          // Only partial-clear legacy 2B JEs are included; full-clear JEs (cr == installmentTotal) are excluded.
-          if (!entryCr11.lt(installmentTotal)) continue;
-        }
-        // advance-consume-on-accrual JEs: ALWAYS included — their Cr 11-2103 IS prior-cleared
-        // (Dr 21-1103 advance / Cr 11-2103). Excluding a full consume == installmentTotal here
-        // would let a subsequent receipt double-credit 11-2103 (FINAL-REVIEW BLOCKER 1).
-      }
-      for (const l of e.lines) {
-        const cr = new Decimal(l.credit.toString());
-        if (l.accountCode === '11-2103') priorPrincipalCleared = priorPrincipalCleared.plus(cr);
-        else if (l.accountCode === '42-1103') priorLateFeeBooked = priorLateFeeBooked.plus(cr);
-      }
-    }
-    return { priorPrincipalCleared, priorLateFeeBooked };
-  }
-
   async execute(
     input: PaymentReceiptPrimitiveInput,
     outerTx?: Prisma.TransactionClient,
@@ -213,7 +131,9 @@ export class PaymentReceiptTemplate {
       totalMonths: c.totalMonths,
     });
 
-    const { priorPrincipalCleared, priorLateFeeBooked } = await this.reconstructPrior(
+    // Shared with the wizard's PARTIAL preview (reconstruct-prior.ts) so the
+    // preview's allocation can't drift from what this template posts.
+    const { priorPrincipalCleared, priorLateFeeBooked } = await reconstructPriorCleared(
       readClient,
       inst.id,
       installmentTotal,

--- a/apps/api/src/modules/journal/reconstruct-prior.ts
+++ b/apps/api/src/modules/journal/reconstruct-prior.ts
@@ -1,0 +1,88 @@
+import { Decimal } from '@prisma/client/runtime/library';
+import { Prisma } from '@prisma/client';
+import { PrismaService } from '../../prisma/prisma.service';
+
+/**
+ * Reconstruct prior cleared amounts for an installment from its own prior JE lines.
+ * Shared by PaymentReceiptTemplate (posting) and PaymentJournalPreviewService
+ * (PARTIAL preview) so preview == posted allocation for any receipt sequence.
+ *
+ * Phase 2: matched only `tag:'receipt'` entries.
+ * Phase 3 (PR-843/I2 Option A — widen reconstruction): also matches `tag:'2B'` entries
+ * so that a legacy partial posted by the OLD non-split PaymentReceipt2BTemplate is not
+ * invisible to the primitive.  A legacy 2B JE carries:
+ *   metadata: { tag:'2B', contractId, installmentScheduleId, paymentId }  (NO partial/final flag)
+ *
+ * Discriminator (guards against over-inclusion):
+ *   - tag:'receipt' → always include (primitive's own JEs).
+ *   - tag:'2B' with flow:'advance-consume-on-accrual' → ALWAYS include. The 2A
+ *                    accrual cron posts `Dr 21-1103 / Cr 11-2103 = consume` to clear
+ *                    the receivable from a parked advance. Its Cr 11-2103 is a REAL
+ *                    prior-clearing and MUST be counted — even when consume ==
+ *                    installmentTotal (a full consume). Excluding a full consume here
+ *                    let a subsequent receipt double-credit 11-2103 (FINAL-REVIEW
+ *                    BLOCKER 1): the receipt would clear the full installmentTotal
+ *                    AGAIN → Σ(Cr 11-2103) = 2×installmentTotal.
+ *   - tag:'2B' (legacy full-payment receipt, flow != advance-consume-on-accrual)
+ *                  → include ONLY when Cr 11-2103 on that entry is STRICTLY LESS THAN
+ *                    installmentTotal.  A full-clear legacy 2B credits exactly
+ *                    installmentTotal; including it would set priorPrincipalCleared =
+ *                    installmentTotal and silently make principalRemaining = 0,
+ *                    rejecting any subsequent receipt. Using strict-less-than (no float
+ *                    equality) is safe: installmentTotal is a Decimal from
+ *                    computeInstallmentBreakdown, and the historical JE credit is also a
+ *                    Decimal stored in Postgres — comparison is exact.
+ *
+ * Historical JEs are never mutated (Option A = read-side only).
+ */
+export async function reconstructPriorCleared(
+  readClient: Prisma.TransactionClient | PrismaService,
+  installmentScheduleId: string,
+  installmentTotal: Decimal,
+): Promise<{ priorPrincipalCleared: Decimal; priorLateFeeBooked: Decimal }> {
+  const entries = await readClient.journalEntry.findMany({
+    where: {
+      AND: [
+        {
+          OR: [
+            { metadata: { path: ['tag'], equals: 'receipt' } } as any,
+            { metadata: { path: ['tag'], equals: '2B' } } as any,
+          ],
+        },
+        {
+          metadata: { path: ['installmentScheduleId'], equals: installmentScheduleId },
+        } as any,
+      ],
+    },
+    include: { lines: true },
+  });
+  let priorPrincipalCleared = new Decimal(0);
+  let priorLateFeeBooked = new Decimal(0);
+  for (const e of entries) {
+    const meta = e.metadata as any;
+    const tag: string = meta?.tag ?? '';
+    if (tag === '2B') {
+      const flowMeta: string = (meta?.flow as string) ?? '';
+      if (flowMeta !== 'advance-consume-on-accrual') {
+        // Legacy PaymentReceipt2B full-payment JE: keep the full-clear discriminator
+        // (a one-shot full clear == installmentTotal must NOT be counted as a prior
+        // partial — including it would set priorPrincipalCleared = installmentTotal and
+        // silently make principalRemaining = 0, rejecting any subsequent receipt).
+        const entryCr11 = e.lines
+          .filter((l) => l.accountCode === '11-2103')
+          .reduce((s, l) => s.plus(new Decimal(l.credit.toString())), new Decimal(0));
+        // Only partial-clear legacy 2B JEs are included; full-clear JEs (cr == installmentTotal) are excluded.
+        if (!entryCr11.lt(installmentTotal)) continue;
+      }
+      // advance-consume-on-accrual JEs: ALWAYS included — their Cr 11-2103 IS prior-cleared
+      // (Dr 21-1103 advance / Cr 11-2103). Excluding a full consume == installmentTotal here
+      // would let a subsequent receipt double-credit 11-2103 (FINAL-REVIEW BLOCKER 1).
+    }
+    for (const l of e.lines) {
+      const cr = new Decimal(l.credit.toString());
+      if (l.accountCode === '11-2103') priorPrincipalCleared = priorPrincipalCleared.plus(cr);
+      else if (l.accountCode === '42-1103') priorLateFeeBooked = priorLateFeeBooked.plus(cr);
+    }
+  }
+  return { priorPrincipalCleared, priorLateFeeBooked };
+}

--- a/apps/api/src/modules/journal/split-receipt.spec.ts
+++ b/apps/api/src/modules/journal/split-receipt.spec.ts
@@ -40,6 +40,56 @@ describe('splitReceipt — per-receipt allocation (Σ-invariant primitive)', () 
     expect(r.principalRemainingAfter.toFixed(2)).toBe('0.00');
   });
 
+  // Owner directive 2026-07-02: late fee books FIRST — the receipt that collects
+  // cash books Cr 42-1103 before clearing 11-2103, so the ledger matches the
+  // receipt document (fee displays on the first receipt).
+  describe('fee-first allocation on partial receipts (owner 2026-07-02)', () => {
+    // Mockup case TEST-20260630-003: installment 4,472 + late fee 100, partial 2,572.
+    const partialBase = {
+      ...base,
+      installmentTotal: D('4472.00'),
+      lateFee: D('100'),
+    };
+
+    it('first partial receipt books the fee first: 2,572 → Cr 42-1103 = 100 + Cr 11-2103 = 2,472', () => {
+      const r = splitReceipt({ ...partialBase, delta: D('2572') });
+      expect(r.lateFeePortion.toFixed(2)).toBe('100.00');
+      expect(r.principalCleared.toFixed(2)).toBe('2472.00');
+      expect(r.overpayRounding.toFixed(2)).toBe('0.00');
+      expect(r.underpayRounding.toFixed(2)).toBe('0.00');
+      expect(r.principalRemainingAfter.toFixed(2)).toBe('2000.00');
+    });
+
+    it('follow-up receipt with fee already booked: 2,000 → principal only, no double 42-1103', () => {
+      const r = splitReceipt({
+        ...partialBase,
+        delta: D('2000'),
+        priorPrincipalCleared: D('2472'),
+        priorLateFeeBooked: D('100'),
+        isFinalReceipt: true,
+      });
+      expect(r.lateFeePortion.toFixed(2)).toBe('0.00');
+      expect(r.principalCleared.toFixed(2)).toBe('2000.00');
+      expect(r.principalRemainingAfter.toFixed(2)).toBe('0.00');
+    });
+
+    it('tiny partial smaller than the fee: 50 → all to 42-1103, nothing to principal', () => {
+      const r = splitReceipt({ ...partialBase, delta: D('50') });
+      expect(r.lateFeePortion.toFixed(2)).toBe('50.00');
+      expect(r.principalCleared.toFixed(2)).toBe('0.00');
+      expect(r.principalRemainingAfter.toFixed(2)).toBe('4472.00');
+    });
+
+    it('final receipt short ≤1฿ lands on PRINCIPAL (52-1104 close) — fee income stays gross', () => {
+      // Full obligation 4,572; pays 4,571.50 in one final receipt.
+      const r = splitReceipt({ ...partialBase, delta: D('4571.50'), isFinalReceipt: true });
+      expect(r.lateFeePortion.toFixed(2)).toBe('100.00'); // fee never shorted
+      expect(r.underpayRounding.toFixed(2)).toBe('0.50');
+      expect(r.principalCleared.toFixed(2)).toBe('4472.00'); // full clear incl. absorbed 0.50
+      expect(r.principalRemainingAfter.toFixed(2)).toBe('0.00');
+    });
+  });
+
   it('overpay rounding (monthlyPayment > installmentTotal by 0.01) → 53-1503 gain', () => {
     const r = splitReceipt({ ...base, delta: D('1515.84') });
     expect(r.principalCleared.toFixed(2)).toBe('1515.83');

--- a/apps/api/src/modules/journal/split-receipt.ts
+++ b/apps/api/src/modules/journal/split-receipt.ts
@@ -65,10 +65,15 @@ export function splitReceipt(input: SplitReceiptInput): SplitReceiptResult {
   // PaymentReceiptTemplate enforces before calling.
   const available = input.delta.plus(input.advanceConsume).minus(input.advanceCredit);
 
-  let principalCleared = Decimal.max(Decimal.min(available, principalRemaining), zero);
-  const afterPrincipal = available.minus(principalCleared);
-  const lateFeePortion = Decimal.min(Decimal.max(afterPrincipal, zero), lateFeeRemaining);
-  const leftover = afterPrincipal.minus(lateFeePortion); // ≥ 0 when available ≥ 0 (precondition)
+  // Fee-first allocation (owner 2026-07-02): the receipt that collects cash books
+  // Cr 42-1103 BEFORE clearing 11-2103, so the ledger matches the receipt document
+  // (the fee displays on the first receipt — computeReceiptFeeDisplay). Also keeps
+  // fee income gross on a final ≤1฿-short receipt: the shortfall lands on principal
+  // where the 52-1104 underpay-close can absorb it.
+  const lateFeePortion = Decimal.min(Decimal.max(available, zero), lateFeeRemaining);
+  const afterLateFee = available.minus(lateFeePortion);
+  let principalCleared = Decimal.max(Decimal.min(afterLateFee, principalRemaining), zero);
+  const leftover = afterLateFee.minus(principalCleared); // ≥ 0 when available ≥ 0 (precondition)
 
   let overpayRounding = leftover;
   let underpayRounding = zero;

--- a/apps/api/src/modules/line-oa/flex-messages/reschedule-qr.flex.ts
+++ b/apps/api/src/modules/line-oa/flex-messages/reschedule-qr.flex.ts
@@ -1,0 +1,75 @@
+import { FlexMessagePayload, wrapFlexMessage, formatBaht } from './base-template';
+import {
+  buildPremiumBubble,
+  createHeroAmount,
+  createRow,
+  createRowsBlock,
+  createQRSection,
+  createFooter,
+} from './style-d';
+
+export interface RescheduleQRFlexData {
+  customerName: string;
+  contractNumber: string;
+  installmentNo: number;
+  daysToShift: number;
+  /** วันครบกำหนดใหม่ (หลังเลื่อน) — pre-formatted Thai date string. */
+  newDueDateText: string;
+  /** ค่าธรรมเนียมเลื่อนดิว (0 เมื่อ 6b — รวมกับงวดถัดไป). */
+  rescheduleFee: number;
+  /** ค่าปรับค้างของช่วงที่เกินกำหนดมาแล้ว (0 ถ้าไม่มี). */
+  lateFee: number;
+  /** ยอดรวมที่ต้องชำระผ่าน QR นี้. */
+  collectAmount: number;
+  paymentUrl: string;
+  orderRef: string;
+}
+
+/**
+ * "ใบแจ้งชำระปรับดิว" — pushed to the customer's LINE OA when the cashier
+ * triggers `POST /payments/:id/reschedule-qr`. Style D Premium Thai — warning
+ * role (amber): the due date shifts ONLY after this QR is paid
+ * (เงินไม่เข้า ดิวไม่เลื่อน — owner directive 2026-07-02).
+ */
+export function buildRescheduleQRFlex(data: RescheduleQRFlexData): FlexMessagePayload {
+  const qrImageUrl = `https://api.qrserver.com/v1/create-qr-code/?size=400x400&margin=10&data=${encodeURIComponent(data.paymentUrl)}`;
+
+  const rows = [
+    createRow('สัญญา', data.contractNumber),
+    createRow('เลื่อนงวดที่', `${data.installmentNo} (+${data.daysToShift} วัน)`),
+    createRow('ครบกำหนดใหม่', data.newDueDateText),
+  ];
+  if (data.rescheduleFee > 0) {
+    rows.push(createRow('ค่าธรรมเนียมปรับดิว', formatBaht(data.rescheduleFee)));
+  }
+  if (data.lateFee > 0) {
+    rows.push(createRow('ค่าปรับล่าช้า', formatBaht(data.lateFee), { valueColor: '#b45309' }));
+  }
+
+  const bubble = buildPremiumBubble({
+    role: 'warn',
+    tag: 'Reschedule',
+    section: {
+      label: `ปรับดิว · งวดที่ ${data.installmentNo}`,
+      headline: 'ใบแจ้งชำระปรับดิว',
+      subtle: `คุณ${data.customerName}`,
+    },
+    body: [
+      createHeroAmount('warn', formatBaht(data.collectAmount), {
+        cap: 'ยอดที่ต้องชำระ',
+        pill: {
+          text: `ชำระแล้วดิวเลื่อนเป็น ${data.newDueDateText}`,
+          role: 'warn',
+        },
+      }),
+      createRowsBlock(rows),
+      createQRSection(qrImageUrl, 'สแกนด้วยแอปธนาคาร · วันครบกำหนดจะเลื่อนเมื่อชำระสำเร็จ'),
+      createFooter('หมดอายุ 24 ชั่วโมง', `REF ${data.orderRef}`),
+    ],
+  });
+
+  return wrapFlexMessage(
+    `ใบแจ้งชำระปรับดิว ${data.contractNumber} งวด ${data.installmentNo} ยอด ${formatBaht(data.collectAmount)}`,
+    bubble,
+  );
+}

--- a/apps/api/src/modules/payments/payments.controller.spec.ts
+++ b/apps/api/src/modules/payments/payments.controller.spec.ts
@@ -6,6 +6,7 @@ import { PaymentsService } from './payments.service';
 import { PaySolutionsService } from '../paysolutions/paysolutions.service';
 import { PrismaService } from '../../prisma/prisma.service';
 import { RescheduleService } from '../installments/reschedule.service';
+import { RescheduleCollectService } from './services/reschedule-collect.service';
 import { UserThrottlerGuard } from '../../guards/user-throttler.guard';
 import { RecordPaymentDto, BulkRecordPaymentDto } from './dto/payment.dto';
 
@@ -14,6 +15,7 @@ describe('PaymentsController', () => {
   let _prisma: unknown;
   let paymentsService: PaymentsService;
   let rescheduleService: RescheduleService;
+  let rescheduleCollectService: RescheduleCollectService;
 
   const mockContract = {
     id: 'contract-1',
@@ -49,13 +51,39 @@ describe('PaymentsController', () => {
       }),
     };
 
+    // ปรับดิว collect-first (2026-07-02): the RESCHEDULE branch now routes to
+    // RescheduleCollectService.executeWithCollect (collect JE + lateFee reset +
+    // shift in one atom) instead of the bare RescheduleService.execute.
+    const mockRescheduleCollectService = {
+      quote: jest.fn().mockResolvedValue({
+        rescheduleFee: '809.00',
+        lateFee: '0.00',
+        collectAmount: '809.00',
+        variant: '6a',
+        newDueDate: new Date('2026-08-01').toISOString(),
+        currentDueDate: new Date('2026-07-01').toISOString(),
+      }),
+      executeWithCollect: jest.fn().mockImplementation(async (input: { splitMode: string; daysToShift: number }) => ({
+        success: true,
+        case: 'RESCHEDULE',
+        variant: input.splitMode === 'SPLIT' ? '6a' : '6b',
+        rescheduleFee: '809.00',
+        lateFeeCollected: '0.00',
+        collectAmount: input.splitMode === 'SPLIT' ? '809.00' : '0.00',
+        journalEntryNo: 'JE-RESCH-1',
+        shiftedInstallmentCount: 3,
+        shiftedInstallmentIds: ['inst-5', 'inst-6', 'inst-7'],
+      })),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       controllers: [PaymentsController],
       providers: [
         { provide: PaymentsService, useValue: mockPaymentsService },
         { provide: PrismaService, useValue: mockPrisma },
-        { provide: PaySolutionsService, useValue: { createPartialPaymentQR: jest.fn() } },
+        { provide: PaySolutionsService, useValue: { createPartialPaymentQR: jest.fn(), createRescheduleQR: jest.fn() } },
         { provide: RescheduleService, useValue: mockRescheduleService },
+        { provide: RescheduleCollectService, useValue: mockRescheduleCollectService },
       ],
     })
       .overrideGuard(UserThrottlerGuard)
@@ -66,6 +94,7 @@ describe('PaymentsController', () => {
     _prisma = module.get<PrismaService>(PrismaService);
     paymentsService = module.get<PaymentsService>(PaymentsService);
     rescheduleService = module.get<RescheduleService>(RescheduleService);
+    rescheduleCollectService = module.get<RescheduleCollectService>(RescheduleCollectService);
   });
 
   describe('branch access control', () => {
@@ -133,13 +162,13 @@ describe('PaymentsController', () => {
     });
   });
 
-  describe('case=RESCHEDULE wiring (Wave 3 / T3)', () => {
-    it('routes to RescheduleService.execute() with variant=6b for splitMode=SINGLE', async () => {
+  describe('case=RESCHEDULE wiring (ปรับดิว collect-first, 2026-07-02)', () => {
+    it('routes to RescheduleCollectService.executeWithCollect with splitMode=SINGLE (6b)', async () => {
       const user = { id: 'user-1', role: 'OWNER', branchId: 'branch-1' };
       const dto = {
         contractId: 'contract-1',
         installmentNo: 5,
-        amount: 1, // wizard sends amount placeholder; service uses daysToShift
+        amount: 1, // 6b zero-collect placeholder (@Min(0.01)); server ignores when quote = 0
         paymentMethod: 'CASH',
         evidenceUrl: 'https://slip.jpg',
         case: 'RESCHEDULE',
@@ -149,15 +178,21 @@ describe('PaymentsController', () => {
 
       const result = await controller.recordPayment(dto, user);
 
-      expect(rescheduleService.execute).toHaveBeenCalledWith({
-        contractId: 'contract-1',
-        fromInstallmentNo: 5,
-        daysToShift: 16,
-        userId: 'user-1',
-        variant: '6b',
-      });
+      expect(rescheduleCollectService.executeWithCollect).toHaveBeenCalledWith(
+        expect.objectContaining({
+          contractId: 'contract-1',
+          installmentNo: 5,
+          daysToShift: 16,
+          splitMode: 'SINGLE',
+          amount: 1,
+          paymentMethod: 'CASH',
+          recordedById: 'user-1',
+        }),
+      );
       // Should NOT have called recordPayment (the normal-payment service path)
+      // nor the bare RescheduleService (the collect service owns that now).
       expect(paymentsService.recordPayment).not.toHaveBeenCalled();
+      expect(rescheduleService.execute).not.toHaveBeenCalled();
       expect(result).toMatchObject({
         success: true,
         case: 'RESCHEDULE',
@@ -167,23 +202,45 @@ describe('PaymentsController', () => {
       });
     });
 
-    it('routes to RescheduleService.execute() with variant=6a for splitMode=SPLIT', async () => {
+    it('routes splitMode=SPLIT (6a) with the collected amount + deposit account', async () => {
       const user = { id: 'user-1', role: 'OWNER', branchId: 'branch-1' };
       const dto = {
         contractId: 'contract-1',
         installmentNo: 5,
-        amount: 1,
+        amount: 809,
         paymentMethod: 'CASH',
         evidenceUrl: 'https://slip.jpg',
         case: 'RESCHEDULE',
         daysToShift: 10,
         splitMode: 'SPLIT',
+        depositAccountCode: '11-1201',
       } as unknown as RecordPaymentDto;
 
       await controller.recordPayment(dto, user);
-      expect(rescheduleService.execute).toHaveBeenCalledWith(
-        expect.objectContaining({ variant: '6a', daysToShift: 10 }),
+      expect(rescheduleCollectService.executeWithCollect).toHaveBeenCalledWith(
+        expect.objectContaining({
+          splitMode: 'SPLIT',
+          daysToShift: 10,
+          amount: 809,
+          depositAccountCode: '11-1201',
+        }),
       );
+    });
+
+    it('rejects QR method on the synchronous path (must use /payments/:id/reschedule-qr)', async () => {
+      const user = { id: 'user-1', role: 'OWNER', branchId: 'branch-1' };
+      const dto = {
+        contractId: 'contract-1',
+        installmentNo: 5,
+        amount: 809,
+        paymentMethod: 'QR_EWALLET',
+        case: 'RESCHEDULE',
+        daysToShift: 10,
+        splitMode: 'SPLIT',
+      } as unknown as RecordPaymentDto;
+
+      await expect(controller.recordPayment(dto, user)).rejects.toThrow(BadRequestException);
+      expect(rescheduleCollectService.executeWithCollect).not.toHaveBeenCalled();
     });
 
     it('rejects RESCHEDULE without daysToShift', async () => {
@@ -199,7 +256,7 @@ describe('PaymentsController', () => {
       } as unknown as RecordPaymentDto;
 
       await expect(controller.recordPayment(dto, user)).rejects.toThrow(BadRequestException);
-      expect(rescheduleService.execute).not.toHaveBeenCalled();
+      expect(rescheduleCollectService.executeWithCollect).not.toHaveBeenCalled();
     });
 
     it('enforces branch access before reschedule (SALES cross-branch rejected)', async () => {
@@ -216,7 +273,7 @@ describe('PaymentsController', () => {
       } as unknown as RecordPaymentDto;
 
       await expect(controller.recordPayment(dto, user)).rejects.toThrow(ForbiddenException);
-      expect(rescheduleService.execute).not.toHaveBeenCalled();
+      expect(rescheduleCollectService.executeWithCollect).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/api/src/modules/payments/payments.controller.ts
+++ b/apps/api/src/modules/payments/payments.controller.ts
@@ -17,7 +17,7 @@ import {
 import type { Request } from 'express';
 import { ApiTags, ApiBearerAuth , ApiOperation} from '@nestjs/swagger';
 import { Throttle } from '@nestjs/throttler';
-import { IsNumber, Min } from 'class-validator';
+import { IsIn, IsNumber, IsString, Min } from 'class-validator';
 import { PaymentsService } from './payments.service';
 import { RecordPaymentDto, BulkRecordPaymentDto, WaiveLateFeeDto, PreviewJournalDto } from './dto/payment.dto';
 import { ImportPaymentsCsvDto } from './dto/csv-import.dto';
@@ -30,11 +30,23 @@ import { Roles } from '../auth/decorators/roles.decorator';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
 import { PaySolutionsService } from '../paysolutions/paysolutions.service';
 import { RescheduleService } from '../installments/reschedule.service';
+import { RescheduleCollectService } from './services/reschedule-collect.service';
 
 class CreatePartialQrDto {
   @IsNumber()
   @Min(1, { message: 'ยอดต้องมากกว่า 0 บาท' })
   amount!: number;
+}
+
+class CreateRescheduleQrDto {
+  @IsNumber()
+  @Min(1, { message: 'จำนวนวันต้องมากกว่า 0' })
+  daysToShift!: number;
+
+  /** SINGLE = 6b (fee รวมงวดถัดไป — QR เก็บเฉพาะค่าปรับ) | SPLIT = 6a (fee + ค่าปรับ) */
+  @IsString()
+  @IsIn(['SINGLE', 'SPLIT'], { message: 'splitMode ต้องเป็น SINGLE หรือ SPLIT' })
+  splitMode!: 'SINGLE' | 'SPLIT';
 }
 
 @ApiTags('Payments')
@@ -47,6 +59,7 @@ export class PaymentsController {
     @Inject(forwardRef(() => PaySolutionsService))
     private paySolutionsService: PaySolutionsService,
     private rescheduleService: RescheduleService,
+    private rescheduleCollectService: RescheduleCollectService,
   ) {}
 
   @Get('pending')
@@ -190,36 +203,6 @@ export class PaymentsController {
     // Validate branch access: SALES and BRANCH_MANAGER can only record for their branch
     await this.paymentsService.validateBranchAccess(dto.contractId, user);
 
-    // ── RESCHEDULE case (Wave 3 / T3) ─────────────────────────────────────────
-    // Per CSV golden case-6a/6b: "Step 1 — UPDATE DB (ไม่มี Journal)".
-    // RescheduleService.execute() shifts due_dates + reduces last installment
-    // amountDue by fee + writes RESCHEDULE AuditLog atomically.
-    // The JP6 JE post happens later when the customer actually pays — split-pay
-    // (6a) sends a fee-advance receipt, bundled (6b) bundles fee + installment
-    // in the next normal recordPayment call. Both flows are dispatched by
-    // payments.service.previewJournal / recordPayment using `splitMode`.
-    if (dto.case === 'RESCHEDULE') {
-      if (!dto.daysToShift || dto.daysToShift < 1) {
-        throw new BadRequestException('กรุณาระบุจำนวนวันที่เลื่อน (daysToShift) มากกว่า 0');
-      }
-      const variant = dto.splitMode === 'SPLIT' ? '6a' : '6b';
-      const result = await this.rescheduleService.execute({
-        contractId: dto.contractId,
-        fromInstallmentNo: dto.installmentNo,
-        daysToShift: dto.daysToShift,
-        userId: user.id,
-        variant,
-      });
-      return {
-        success: true,
-        case: 'RESCHEDULE',
-        variant,
-        rescheduleFee: result.rescheduleFee.toFixed(2),
-        shiftedInstallmentCount: result.shiftedInstallmentIds.length,
-        shiftedInstallmentIds: result.shiftedInstallmentIds,
-      };
-    }
-
     // Wizard step 3 fields: wizardMethod/referenceNumber/slipUrl/memo map to existing recordPayment params.
     // slipUrl → evidenceUrl, referenceNumber → transactionRef, memo → notes (merged)
     const effectiveEvidenceUrl = dto.slipUrl || dto.evidenceUrl;
@@ -241,6 +224,34 @@ export class PaymentsController {
         CARD: 'CARD', // EDC — money settles into the selected bank account
       };
       effectivePaymentMethod = methodMap[dto.wizardMethod] ?? dto.paymentMethod;
+    }
+
+    // ── RESCHEDULE / ปรับดิว — collect-first (owner directive 2026-07-02) ──────
+    // เงินไม่เข้า ดิวไม่เลื่อน: RescheduleCollectService runs ONE Serializable tx —
+    // collect JE (Dr cash / Cr 21-1103 fee (6a) + Cr 42-1103 ค่าปรับ) + Payment.lateFee
+    // reset + due-date shift + audit. QR is async and must go through
+    // POST /payments/:id/reschedule-qr (reschedule executes on webhook confirm).
+    if (dto.case === 'RESCHEDULE') {
+      if (!dto.daysToShift || dto.daysToShift < 1) {
+        throw new BadRequestException('กรุณาระบุจำนวนวันที่เลื่อน (daysToShift) มากกว่า 0');
+      }
+      if (effectivePaymentMethod === 'QR_EWALLET') {
+        throw new BadRequestException(
+          'ปรับดิวผ่าน QR ต้องใช้ปุ่ม "ส่ง QR ให้ลูกค้า" — ดิวจะเลื่อนอัตโนมัติเมื่อเงินเข้า',
+        );
+      }
+      return this.rescheduleCollectService.executeWithCollect({
+        contractId: dto.contractId,
+        installmentNo: dto.installmentNo,
+        daysToShift: dto.daysToShift,
+        splitMode: dto.splitMode === 'SPLIT' ? 'SPLIT' : 'SINGLE',
+        amount: dto.amount,
+        paymentMethod: effectivePaymentMethod,
+        recordedById: user.id,
+        transactionRef: effectiveTransactionRef,
+        evidenceUrl: effectiveEvidenceUrl,
+        depositAccountCode: dto.depositAccountCode,
+      });
     }
 
     return this.paymentsService.recordPayment(
@@ -456,6 +467,57 @@ export class PaymentsController {
     return this.paySolutionsService.createPartialPaymentQR({
       paymentId: id,
       amount: dto.amount,
+    });
+  }
+
+  // ── ปรับดิว (reschedule) — server-authoritative quote + QR ─────────────────
+
+  /**
+   * Quote for the ปรับดิว overlay: fee (monthly/30×days ROUND_UP) + late fee owed
+   * for the CURRENT overdue period + collect total per 6a/6b. The overlay displays
+   * these numbers verbatim; executeWithCollect re-validates them at confirm.
+   */
+  @Get('reschedule-quote')
+  @Roles('OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'ACCOUNTANT', 'SALES')
+  @ApiOperation({ summary: 'คำนวณค่าธรรมเนียม + ค่าปรับสำหรับปรับดิว (ไม่บันทึก)' })
+  async getRescheduleQuote(
+    @Query('contractId', ParseUUIDPipe) contractId: string,
+    @Query('installmentNo') installmentNo: string,
+    @Query('daysToShift') daysToShift: string,
+    @Query('splitMode') splitMode: string,
+    @CurrentUser() user: { id: string; role: string; branchId: string | null },
+  ) {
+    await this.paymentsService.validateBranchAccess(contractId, user);
+    const instNo = parseInt(installmentNo, 10);
+    const days = parseInt(daysToShift, 10);
+    if (isNaN(instNo) || instNo < 1) throw new BadRequestException('installmentNo ไม่ถูกต้อง');
+    if (isNaN(days) || days < 1) throw new BadRequestException('กรุณาระบุจำนวนวันที่เลื่อนมากกว่า 0');
+    return this.rescheduleCollectService.quote({
+      contractId,
+      installmentNo: instNo,
+      daysToShift: days,
+      splitMode: splitMode === 'SPLIT' ? 'SPLIT' : 'SINGLE',
+    });
+  }
+
+  /**
+   * ปรับดิวผ่าน QR — สร้าง QR สำหรับยอดเก็บ (ค่าธรรมเนียม 6a + ค่าปรับ) ส่งให้ลูกค้าใน LINE.
+   * ดิวยังไม่เลื่อนตอนนี้ — webhook PaySolutions ยืนยันเงินเข้าแล้วจึง execute reschedule
+   * (เงินไม่เข้า ดิวไม่เลื่อน). Link หมดอายุใน 24 ชม. ผ่าน cron เดิม.
+   */
+  @Post(':id/reschedule-qr')
+  @Roles('OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'ACCOUNTANT', 'SALES')
+  async createRescheduleQr(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() dto: CreateRescheduleQrDto,
+    @CurrentUser() user: { id: string; role: string; branchId: string | null },
+  ) {
+    await this.paymentsService.validateBranchAccessByPayment(id, user);
+    return this.paySolutionsService.createRescheduleQR({
+      paymentId: id,
+      daysToShift: dto.daysToShift,
+      splitMode: dto.splitMode === 'SPLIT' ? 'SPLIT' : 'SINGLE',
+      requestedById: user.id,
     });
   }
 

--- a/apps/api/src/modules/payments/payments.credit-waive-summary.spec.ts
+++ b/apps/api/src/modules/payments/payments.credit-waive-summary.spec.ts
@@ -130,6 +130,11 @@ describe('PaymentsService — credit / waive / daily-summary / partial-preview (
         createMany: jest.fn().mockResolvedValue({ count: 0 }),
         findUnique: jest.fn(),
       },
+      // PARTIAL preview mirrors the posting template: reconstructPriorCleared
+      // queries prior receipt JEs. [] → first receipt (no priors).
+      journalEntry: {
+        findMany: jest.fn().mockResolvedValue([]),
+      },
       auditLog: {
         create: jest.fn().mockResolvedValue({ id: 'al-1' }),
       },
@@ -479,9 +484,14 @@ describe('PaymentsService — credit / waive / daily-summary / partial-preview (
     const mkContractRow = () => ({
       id: 'pv-contract-1',
       totalMonths: 12,
+      // PARTIAL preview now derives installmentTotal via computeInstallmentBreakdown
+      // (same as the posting template): 17000/12 ROUND_DOWN + 1190/12 HALF_UP = 1515.83.
+      // storeCommission must be an explicit 0 — null defaults to 10% of financed.
+      financedAmount: D(17000),
+      storeCommission: D(0),
       interestTotal: D(0),
       monthlyPayment: D(1515.83),
-      vatAmount: null,
+      vatAmount: D(1190),
     });
 
     it('accrued installment, case=PARTIAL, amountReceived=1000 → Dr deposit 1000 / Cr 11-2103 1000, balanced', async () => {

--- a/apps/api/src/modules/payments/payments.module.ts
+++ b/apps/api/src/modules/payments/payments.module.ts
@@ -1,6 +1,7 @@
 import { Module, forwardRef } from '@nestjs/common';
 import { PaymentsController } from './payments.controller';
 import { PaymentsService } from './payments.service';
+import { RescheduleCollectService } from './services/reschedule-collect.service';
 import { ReceiptsModule } from '../receipts/receipts.module';
 import { JournalModule } from '../journal/journal.module';
 import { ProductsModule } from '../products/products.module';
@@ -24,7 +25,7 @@ import { AccountingModule } from '../accounting/accounting.module';
     forwardRef(() => PaySolutionsModule),
   ],
   controllers: [PaymentsController],
-  providers: [PaymentsService],
-  exports: [PaymentsService],
+  providers: [PaymentsService, RescheduleCollectService],
+  exports: [PaymentsService, RescheduleCollectService],
 })
 export class PaymentsModule {}

--- a/apps/api/src/modules/payments/payments.preview-journal-money.spec.ts
+++ b/apps/api/src/modules/payments/payments.preview-journal-money.spec.ts
@@ -311,28 +311,68 @@ describe('PaymentsService.previewJournal (characterization)', () => {
       });
     });
 
-    it('6b bundled: fee 808 (ROUND_UP whole baht) → Dr deposit 3010.41 / Cr 11-2103 2202.41 / Cr 21-1103 808.00', async () => {
+    // ปรับดิว collect-first (2026-07-02): the RESCHEDULE preview now shows the
+    // JE that posts AT CONFIRM — 6a: Dr deposit (fee+ค่าปรับ) / Cr 21-1103 fee /
+    // Cr 42-1103 ค่าปรับ; 6b: ค่าปรับ only. The old bundled-6b preview
+    // (Dr cash monthly+fee / Cr 11-2103) represented a FUTURE payment and is gone.
+    it('6b (SINGLE) with no late fee → nothing to collect, NO lines', async () => {
       const out = await service.previewJournal({
         contractId: 'c-1',
         installmentNo: 1,
-        amountReceived: 3010.41,
+        amountReceived: 0,
         depositAccountCode: '11-1101',
         case: 'RESCHEDULE',
         daysToShift: 11,
-        splitMode: 'BUNDLED',
+        splitMode: 'SINGLE',
       });
 
       // 2202.41 / 30 * 11 = 807.5503... → ROUND_UP to whole baht → 808
       expect(out.rescheduleFeeDisplay).toBe('808.00');
-      expect(lineFor(out.lines, '11-1101')?.debit).toBe('3010.41');
-      expect(lineFor(out.lines, '11-2103')?.credit).toBe('2202.41');
-      expect(lineFor(out.lines, '21-1103')?.credit).toBe('808.00');
-      expect(out.totalDebit).toBe('3010.41');
-      expect(out.totalCredit).toBe('3010.41');
+      expect(out.lines).toHaveLength(0);
       expect(out.isBalanced).toBe(true);
     });
 
-    it('6a split: only the fee advance posts (Cr 21-1103 = 808.00), no 11-2103 line', async () => {
+    it('6b (SINGLE) with late fee 100 → Dr deposit 100 / Cr 42-1103 100 only', async () => {
+      const out = await service.previewJournal({
+        contractId: 'c-1',
+        installmentNo: 1,
+        amountReceived: 100,
+        depositAccountCode: '11-1101',
+        case: 'RESCHEDULE',
+        daysToShift: 11,
+        splitMode: 'SINGLE',
+        lateFee: 100,
+      });
+
+      expect(out.rescheduleFeeDisplay).toBe('808.00');
+      expect(lineFor(out.lines, '11-1101')?.debit).toBe('100.00');
+      expect(lineFor(out.lines, '42-1103')?.credit).toBe('100.00');
+      expect(lineFor(out.lines, '21-1103')).toBeUndefined();
+      expect(lineFor(out.lines, '11-2103')).toBeUndefined();
+      expect(out.isBalanced).toBe(true);
+    });
+
+    it('6a (SPLIT) with late fee 100 → Dr deposit 908 / Cr 21-1103 808 / Cr 42-1103 100', async () => {
+      const out = await service.previewJournal({
+        contractId: 'c-1',
+        installmentNo: 1,
+        amountReceived: 908,
+        depositAccountCode: '11-1101',
+        case: 'RESCHEDULE',
+        daysToShift: 11,
+        splitMode: 'SPLIT',
+        lateFee: 100,
+      });
+
+      expect(out.rescheduleFeeDisplay).toBe('808.00');
+      expect(lineFor(out.lines, '11-1101')?.debit).toBe('908.00');
+      expect(lineFor(out.lines, '21-1103')?.credit).toBe('808.00');
+      expect(lineFor(out.lines, '42-1103')?.credit).toBe('100.00');
+      expect(lineFor(out.lines, '11-2103')).toBeUndefined();
+      expect(out.isBalanced).toBe(true);
+    });
+
+    it('6a (SPLIT) no late fee: only the fee advance posts (Cr 21-1103 = 808.00), no 11-2103 line', async () => {
       const out = await service.previewJournal({
         contractId: 'c-1',
         installmentNo: 1,
@@ -350,21 +390,19 @@ describe('PaymentsService.previewJournal (characterization)', () => {
       expect(out.isBalanced).toBe(true);
     });
 
-    it('daysToShift 0 → fee 0.00 (6b still emits a zero 21-1103 line)', async () => {
+    it('daysToShift 0 → fee 0.00, nothing to collect, NO lines', async () => {
       const out = await service.previewJournal({
         contractId: 'c-1',
         installmentNo: 1,
-        amountReceived: 2202.41,
+        amountReceived: 0,
         depositAccountCode: '11-1101',
         case: 'RESCHEDULE',
         daysToShift: 0,
-        splitMode: 'BUNDLED',
+        splitMode: 'SINGLE',
       });
 
       expect(out.rescheduleFeeDisplay).toBe('0.00');
-      expect(lineFor(out.lines, '11-1101')?.debit).toBe('2202.41');
-      expect(lineFor(out.lines, '11-2103')?.credit).toBe('2202.41');
-      expect(lineFor(out.lines, '21-1103')?.credit).toBe('0.00');
+      expect(out.lines).toHaveLength(0);
       expect(out.isBalanced).toBe(true);
     });
   });

--- a/apps/api/src/modules/payments/payments.service.spec.ts
+++ b/apps/api/src/modules/payments/payments.service.spec.ts
@@ -1164,6 +1164,80 @@ describe('PaymentsService', () => {
       expect(parseFloat(cashLine!.debit)).toBeCloseTo(installmentTotal + lateFee, 2);
     });
 
+    // Owner directive 2026-07-02 (mockup TEST-20260630-003): a PARTIAL receipt
+    // books the late fee FIRST — Cr 42-1103 = fee, Cr 11-2103 = remainder — so
+    // preview matches what PaymentReceiptTemplate posts (fee-first splitReceipt).
+    describe('PARTIAL case splits late fee to 42-1103 (fee-first)', () => {
+      it('first partial receipt: 1,500 with fee 54 → Cr 42-1103 = 54 + Cr 11-2103 = 1,446', async () => {
+        prisma.installmentSchedule.findUnique.mockResolvedValue(mockInstallmentAccrued);
+        prisma.journalEntry.findMany.mockResolvedValue([]); // no prior receipts
+
+        const result = await service.previewJournal({
+          contractId: 'contract-preview',
+          installmentNo: 2,
+          amountReceived: 1500,
+          depositAccountCode: '11-1101',
+          lateFee: 54,
+          case: 'PARTIAL',
+        });
+
+        expect(result.isBalanced).toBe(true);
+        const feeLine = result.lines.find((l) => l.accountCode === '42-1103');
+        expect(feeLine).toBeDefined();
+        expect(parseFloat(feeLine!.credit)).toBeCloseTo(54, 2);
+        const receivableLine = result.lines.find((l) => l.accountCode === '11-2103');
+        expect(parseFloat(receivableLine!.credit)).toBeCloseTo(1446, 2);
+        const cashLine = result.lines.find((l) => l.accountCode === '11-1101');
+        expect(parseFloat(cashLine!.debit)).toBeCloseTo(1500, 2);
+      });
+
+      it('follow-up partial after fee already booked: no double 42-1103, all to 11-2103', async () => {
+        prisma.installmentSchedule.findUnique.mockResolvedValue(mockInstallmentAccrued);
+        // Prior receipt JE booked Cr 11-2103 = 1,446 + Cr 42-1103 = 54.
+        prisma.journalEntry.findMany.mockResolvedValue([
+          {
+            metadata: { tag: 'receipt', installmentScheduleId: 'inst-1' },
+            lines: [
+              { accountCode: '11-1101', debit: '1500.00', credit: '0' },
+              { accountCode: '11-2103', debit: '0', credit: '1446.00' },
+              { accountCode: '42-1103', debit: '0', credit: '54.00' },
+            ],
+          },
+        ]);
+
+        const result = await service.previewJournal({
+          contractId: 'contract-preview',
+          installmentNo: 2,
+          amountReceived: 500,
+          depositAccountCode: '11-1101',
+          lateFee: 54, // wizard re-sends the stored Payment.lateFee
+          case: 'PARTIAL',
+        });
+
+        expect(result.isBalanced).toBe(true);
+        const feeLine = result.lines.find((l) => l.accountCode === '42-1103');
+        expect(feeLine).toBeUndefined();
+        const receivableLine = result.lines.find((l) => l.accountCode === '11-2103');
+        expect(parseFloat(receivableLine!.credit)).toBeCloseTo(500, 2);
+      });
+
+      it('waiver + PARTIAL → BadRequest (mirrors the recordPayment guard, no misleading preview)', async () => {
+        prisma.installmentSchedule.findUnique.mockResolvedValue(mockInstallmentAccrued);
+
+        await expect(
+          service.previewJournal({
+            contractId: 'contract-preview',
+            installmentNo: 2,
+            amountReceived: 1500,
+            depositAccountCode: '11-1101',
+            lateFee: 54,
+            lateFeeWaived: 27,
+            case: 'PARTIAL',
+          }),
+        ).rejects.toThrow('อนุโลมค่าปรับทำได้เฉพาะตอนชำระปิดงวด');
+      });
+    });
+
     it('resolves account names from CoA', async () => {
       prisma.installmentSchedule.findUnique.mockResolvedValue(mockInstallmentNotAccrued);
 
@@ -1242,19 +1316,28 @@ describe('PaymentsService', () => {
       ).rejects.toThrow(/ยังไม่ได้ทำ accrual/);
     });
 
-    it('blocks RESCHEDULE when installment is not yet accrued', async () => {
+    // ปรับดิว collect-first (2026-07-02): the RESCHEDULE preview no longer needs
+    // the 2A accrual — its collect JE touches only 21-1103 / 42-1103, never
+    // 11-2103 (the old bundled-6b preview that credited 11-2103 is gone).
+    it('RESCHEDULE previews fine WITHOUT accrual (collect JE never touches 11-2103)', async () => {
       prisma.installmentSchedule.findUnique.mockResolvedValue(mockInstallmentNotAccrued);
 
-      await expect(
-        service.previewJournal({
-          contractId: 'contract-preview',
-          installmentNo: 2,
-          amountReceived: 100,
-          depositAccountCode: '11-1101',
-          case: 'RESCHEDULE',
-          daysToShift: 5,
-        }),
-      ).rejects.toThrow(/ยังไม่ได้ทำ accrual/);
+      const result = await service.previewJournal({
+        contractId: 'contract-preview',
+        installmentNo: 2,
+        amountReceived: 100,
+        depositAccountCode: '11-1101',
+        case: 'RESCHEDULE',
+        daysToShift: 5,
+        splitMode: 'SINGLE',
+        lateFee: 100,
+      });
+
+      expect(result.isBalanced).toBe(true);
+      const receivable = result.lines.find((l) => l.accountCode === '11-2103');
+      expect(receivable).toBeUndefined();
+      const feeLine = result.lines.find((l) => l.accountCode === '42-1103');
+      expect(parseFloat(feeLine!.credit)).toBeCloseTo(100, 2);
     });
   });
 

--- a/apps/api/src/modules/payments/payments.service.ts
+++ b/apps/api/src/modules/payments/payments.service.ts
@@ -31,6 +31,7 @@ import {
 } from './services/payment-helpers';
 import { PaymentReceiptOrchestrator } from './services/payment-receipt-orchestrator';
 import { LateFeeWaiverService } from './services/late-fee-waiver.service';
+import { RescheduleCollectService, RescheduleCollectInput } from './services/reschedule-collect.service';
 import { PaymentQueryService } from './services/payment-query.service';
 import { PaymentJournalPreviewService } from './services/payment-journal-preview.service';
 import { PaymentCsvImportService } from './services/payment-csv-import.service';
@@ -111,7 +112,25 @@ export class PaymentsService {
      * which match the seed rows.
      */
     @Optional() private accountRoleService?: AccountRoleService,
+    /**
+     * ปรับดิว collect-first (2026-07-02) — DI-provided (PaymentsModule providers).
+     * Optional tail param so the 6 positional construction sites (specs/e2e
+     * harnesses) stay untouched; the PaySolutions webhook reaches it through
+     * {@link rescheduleWithCollect}.
+     */
+    @Optional() private rescheduleCollectService?: RescheduleCollectService,
   ) {}
+
+  /**
+   * ปรับดิว webhook seam: a paid RESCHEDULE QR routes here (PaySolutions
+   * confirmation service) — collect JE + lateFee reset + due-date shift in one atom.
+   */
+  async rescheduleWithCollect(input: RescheduleCollectInput) {
+    if (!this.rescheduleCollectService) {
+      throw new BadRequestException('RescheduleCollectService ไม่พร้อมใช้งาน');
+    }
+    return this.rescheduleCollectService.executeWithCollect(input);
+  }
 
   /**
    * Lazily build (once) and return the decomposed sub-services. The

--- a/apps/api/src/modules/payments/services/payment-journal-preview.service.ts
+++ b/apps/api/src/modules/payments/services/payment-journal-preview.service.ts
@@ -2,6 +2,10 @@ import { Injectable, NotFoundException, BadRequestException } from '@nestjs/comm
 import { Prisma } from '@prisma/client';
 import { PrismaService } from '../../../prisma/prisma.service';
 import { AccountRoleService } from '../../journal/account-role.service';
+import { computeInstallmentBreakdown } from '../../journal/compute-installment-breakdown';
+import { splitReceipt } from '../../journal/split-receipt';
+import { buildReceiptLines } from '../../journal/build-receipt-lines';
+import { reconstructPriorCleared } from '../../journal/reconstruct-prior';
 import {
   buildPreviewBlocks,
   PreviewTaggedLine,
@@ -112,21 +116,26 @@ export class PaymentJournalPreviewService {
     // Build raw JE lines (code, dr, cr, description)
     const rawLines: { code: string; dr: Prisma.Decimal; cr: Prisma.Decimal; description: string }[] = [];
 
-    // PARTIAL and RESCHEDULE both emit Cr 11-2103 directly — they assume 2A
-    // has already accrued the installment into 11-2103. If 2A is missing
-    // (paying ahead, cron lag), the JE would credit a zero-balance account.
-    // Block here with a clear Thai message so the wizard can prompt user to
-    // wait for the next 2A tick instead of silently producing a malformed JE.
-    if (
-      !inst.accrualJournalEntryId &&
-      (input.case === 'PARTIAL' || input.case === 'RESCHEDULE')
-    ) {
+    // PARTIAL emits Cr 11-2103 directly — it assumes 2A has already accrued the
+    // installment into 11-2103. If 2A is missing (paying ahead, cron lag), the JE
+    // would credit a zero-balance account. Block here with a clear Thai message so
+    // the wizard can prompt the user to wait for the next 2A tick instead of
+    // silently producing a malformed JE.
+    // (RESCHEDULE no longer needs this guard — its collect-first JE touches only
+    //  21-1103 / 42-1103, never 11-2103; the old bundled-6b preview that credited
+    //  11-2103 was replaced by the collect semantics on 2026-07-02.)
+    if (!inst.accrualJournalEntryId && input.case === 'PARTIAL') {
       throw new BadRequestException(
-        `งวดนี้ยังไม่ได้ทำ accrual (2A) — ไม่สามารถใช้ ${input.case === 'PARTIAL' ? 'จ่ายบางส่วน' : 'เลื่อนงวด'} ได้ก่อน accrual กรุณารอรอบ 00:01 น. หรือใช้รับชำระแบบปกติ`,
+        'งวดนี้ยังไม่ได้ทำ accrual (2A) — ไม่สามารถใช้จ่ายบางส่วนได้ก่อน accrual กรุณารอรอบ 00:01 น. หรือใช้รับชำระแบบปกติ',
       );
     }
 
-    // ── RESCHEDULE case (JP6 template preview) ──────────────────────────────
+    // ── RESCHEDULE / ปรับดิว — collect-first preview (owner 2026-07-02) ────────
+    // Mirrors RescheduleCollectService.executeWithCollect: the JE that posts AT
+    // CONFIRM (เงินไม่เข้า ดิวไม่เลื่อน) —
+    //   6a (SPLIT):  Dr deposit (fee+ค่าปรับ) / Cr 21-1103 fee / Cr 42-1103 ค่าปรับ
+    //   6b (SINGLE): Dr deposit ค่าปรับ / Cr 42-1103 ค่าปรับ (fee รวมงวดถัดไป)
+    // ค่าปรับ (netLateFee) comes from the wizard/overlay quote; nothing owed → no lines.
     if (input.case === 'RESCHEDULE') {
       const days = input.daysToShift ?? 0;
       const monthlyPayment = new Prisma.Decimal(c.monthlyPayment.toString());
@@ -137,24 +146,17 @@ export class PaymentJournalPreviewService {
         : zero;
 
       const isSplit = input.splitMode === 'SPLIT';
-      const amountReceived = new Prisma.Decimal(input.amountReceived.toString());
+      const feePortion = isSplit ? rescheduleFee : zero;
+      const collectTotal = feePortion.plus(netLateFee);
 
-      if (isSplit) {
-        // 6a — fee advance only (step 1):
-        //   Dr depositAccountCode  feeAmount
-        //     Cr 21-1103           feeAmount (เงินรับล่วงหน้างวดสุดท้าย)
-        const feeAmount = rescheduleFee.gt(zero) ? rescheduleFee : amountReceived;
-        rawLines.push({ code: input.depositAccountCode, dr: feeAmount, cr: zero, description: 'รับค่าปรับดิวล่วงหน้า (6a)' });
-        rawLines.push({ code: '21-1103', dr: zero, cr: feeAmount, description: 'เงินรับล่วงหน้างวดสุดท้าย' });
-      } else {
-        // 6b — bundled (installment + fee in one transaction):
-        //   Dr depositAccountCode  installmentAmount + feeAmount
-        //     Cr 11-2103           installmentAmount
-        //     Cr 21-1103           feeAmount
-        const bundledTotal = installmentTotal.plus(rescheduleFee);
-        rawLines.push({ code: input.depositAccountCode, dr: bundledTotal, cr: zero, description: 'รับชำระงวด + ค่าปรับดิว (6b)' });
-        rawLines.push({ code: '11-2103', dr: zero, cr: installmentTotal, description: 'ล้างลูกหนี้ค้างชำระงวด' });
-        rawLines.push({ code: '21-1103', dr: zero, cr: rescheduleFee, description: 'เงินรับล่วงหน้างวดสุดท้าย' });
+      if (collectTotal.gt(zero)) {
+        rawLines.push({ code: input.depositAccountCode, dr: collectTotal, cr: zero, description: 'รับเงินปรับดิว' });
+        if (feePortion.gt(zero)) {
+          rawLines.push({ code: '21-1103', dr: zero, cr: feePortion, description: 'เงินรับล่วงหน้า — ค่าธรรมเนียมปรับดิว (6a)' });
+        }
+        if (netLateFee.gt(zero)) {
+          rawLines.push({ code: '42-1103', dr: zero, cr: netLateFee, description: 'ค่าปรับชำระล่าช้า (เก็บตอนปรับดิว)' });
+        }
       }
 
       // Resolve CoA names
@@ -192,11 +194,59 @@ export class PaymentJournalPreviewService {
       };
     }
 
-    // ── PARTIAL case: minimal partial-clear preview ─────────────────────────
+    // ── PARTIAL case: mirror PaymentReceiptTemplate exactly ─────────────────
+    // Fee-first split (owner 2026-07-02): Cr 42-1103 = late fee owed, Cr 11-2103 =
+    // remainder. Uses the SAME pure pipeline the posting runs (installmentTotal from
+    // computeInstallmentBreakdown → reconstructPriorCleared → splitReceipt →
+    // buildReceiptLines) so a follow-up receipt whose fee is already booked
+    // previews principal-only — no double 42-1103.
     if (input.case === 'PARTIAL') {
+      // Mirror recordPayment's guard (orchestrator ~line 325): waiver-on-partial is
+      // rejected at save, so the preview must not render a plausible net-fee JE
+      // (it would drop the Dr 52-1105 gross-waiver leg and mislead the cashier).
+      if (lateFeeWaivedAmount.gt(zero)) {
+        throw new BadRequestException(
+          'อนุโลมค่าปรับทำได้เฉพาะตอนชำระปิดงวด (ไม่รองรับจ่ายบางส่วน)',
+        );
+      }
       const amountReceived = new Prisma.Decimal(input.amountReceived.toString());
-      rawLines.push({ code: input.depositAccountCode, dr: amountReceived, cr: zero, description: 'รับชำระบางส่วน' });
-      rawLines.push({ code: '11-2103', dr: zero, cr: amountReceived, description: 'ล้างลูกหนี้ค้างชำระ (บางส่วน)' });
+      const { installmentTotal: instTotalForSplit } = computeInstallmentBreakdown({
+        financedAmount: c.financedAmount.toString(),
+        storeCommission: c.storeCommission != null ? c.storeCommission.toString() : null,
+        interestTotal: c.interestTotal.toString(),
+        vatAmount: c.vatAmount != null ? c.vatAmount.toString() : null,
+        totalMonths: c.totalMonths,
+      });
+      const { priorPrincipalCleared, priorLateFeeBooked } = await reconstructPriorCleared(
+        this.prisma,
+        inst.id,
+        instTotalForSplit,
+      );
+      const split = splitReceipt({
+        delta: amountReceived,
+        installmentTotal: instTotalForSplit,
+        // recordPayment rejects waiver-on-partial, so netLateFee == gross here;
+        // clamped anyway for a mid-edit preview where both fields are filled.
+        lateFee: netLateFee,
+        priorPrincipalCleared,
+        priorLateFeeBooked,
+        advanceConsume: zero, // PARTIAL never auto-consumes advance (orchestrator NORMAL-only)
+        advanceCredit: zero,
+        isFinalReceipt: false,
+      });
+      const receiptLines = buildReceiptLines({
+        split,
+        debitAccountCode: input.depositAccountCode,
+        delta: amountReceived,
+        advanceConsume: zero,
+        advanceCredit: zero,
+        lateFeeWaived: zero,
+        overpayCode: this.accountRoleService?.tryCode('adj_overpay') ?? '53-1503',
+        underpayCode: this.accountRoleService?.tryCode('adj_underpay') ?? '52-1104',
+      });
+      for (const l of receiptLines) {
+        rawLines.push({ code: l.accountCode, dr: l.dr, cr: l.cr, description: l.description ?? '' });
+      }
 
       const codes = [...new Set(rawLines.map((l) => l.code))];
       const coaRows = await this.prisma.chartOfAccount.findMany({

--- a/apps/api/src/modules/payments/services/reschedule-collect.service.spec.ts
+++ b/apps/api/src/modules/payments/services/reschedule-collect.service.spec.ts
@@ -1,0 +1,304 @@
+/**
+ * RescheduleCollectService — ปรับดิว collect-first (owner directive 2026-07-02).
+ *
+ * Locks the money semantics of "เงินไม่เข้า ดิวไม่เลื่อน":
+ *   - 6a: collect JE = Dr deposit (fee+ค่าปรับ) / Cr 21-1103 fee / Cr 42-1103 ค่าปรับ
+ *   - 6b: ค่าปรับ only; zero-collect (no fee, no late fee) → NO JE, reschedule still runs
+ *   - Payment.lateFee resets to 0 AFTER collecting (new overdue period starts clean)
+ *   - amount mismatch vs the server quote → BadRequest, nothing posted
+ *   - โอน requires ref/slip; QR-webhook path (fixedQuote) books the frozen quote
+ *   - reschedule + JE + audit share ONE $transaction; e-Receipt fires post-commit
+ *
+ * Hand-mocked Prisma ($transaction(cb) → cb(tx), tx === root) mirroring the
+ * orchestrator spec pattern. Late-fee config keys resolve to null → PER_DAY
+ * defaults (20฿/day, max 500, cap 5%).
+ */
+import { BadRequestException } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import { RescheduleCollectService } from './reschedule-collect.service';
+
+const D = (v: string | number) => new Prisma.Decimal(v);
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyObj = any;
+
+describe('RescheduleCollectService (ปรับดิว collect-first)', () => {
+  let prisma: AnyObj;
+  let journalAuto: AnyObj;
+  let rescheduleService: AnyObj;
+  let receiptsService: AnyObj;
+  let service: RescheduleCollectService;
+
+  // Mockup TEST-20260630-003: monthly 4,472; overdue 5 days → lateFee 100 (5×20).
+  const NOW = new Date('2026-07-02T05:00:00Z');
+  const DUE_5D_AGO = new Date('2026-06-27T05:00:00Z');
+
+  const contractRow = {
+    id: 'ct-1',
+    contractNumber: 'TEST-20260630-003',
+    status: 'OVERDUE',
+    deletedAt: null,
+    monthlyPayment: D('4472.00'),
+  };
+  const paymentRow = {
+    id: 'pay-1',
+    contractId: 'ct-1',
+    installmentNo: 1,
+    status: 'OVERDUE',
+    deletedAt: null,
+    dueDate: DUE_5D_AGO,
+    amountDue: D('4472.00'),
+    lateFee: D('100.00'),
+    lateFeeWaived: false,
+    notes: null,
+  };
+
+  beforeEach(() => {
+    jest.useFakeTimers({ now: NOW });
+
+    prisma = {
+      contract: {
+        findUnique: jest.fn().mockResolvedValue(contractRow),
+        update: jest.fn().mockResolvedValue({}),
+      },
+      payment: {
+        findFirst: jest.fn().mockResolvedValue(paymentRow),
+        update: jest.fn().mockResolvedValue({}),
+      },
+      installmentSchedule: {
+        findUnique: jest.fn().mockResolvedValue({ id: 'sched-1' }),
+      },
+      auditLog: { create: jest.fn().mockResolvedValue({ id: 'al-1' }) },
+      // Late-fee + period-lock config keys → null (defaults / open period).
+      systemConfig: { findUnique: jest.fn().mockResolvedValue(null) },
+      companyInfo: { findFirst: jest.fn().mockResolvedValue({ id: 'co-FINANCE' }) },
+      accountingPeriod: { findUnique: jest.fn().mockResolvedValue(null) },
+      user: { findUnique: jest.fn().mockResolvedValue({ defaultCashAccountCode: '11-1101' }) },
+      $transaction: jest.fn((cb: (tx: AnyObj) => unknown) => cb(prisma)),
+    };
+    journalAuto = { createAndPost: jest.fn().mockResolvedValue({ entryNumber: 'JE-RD-1' }) };
+    rescheduleService = {
+      execute: jest.fn().mockResolvedValue({
+        rescheduleFee: D('1044'), // 4472/30×7 = 1043.47 → ROUND_UP 1044
+        shiftedInstallmentIds: ['i-1', 'i-2'],
+        oldDueDates: {},
+        newDueDates: {},
+      }),
+    };
+    receiptsService = { generateReceipt: jest.fn().mockResolvedValue({ id: 'rt-1' }) };
+
+    service = new RescheduleCollectService(
+      prisma,
+      journalAuto,
+      rescheduleService,
+      receiptsService,
+    );
+  });
+
+  afterEach(() => jest.useRealTimers());
+
+  it('quote(): 6a = fee 1044 + lateFee 100 → collect 1144', async () => {
+    const q = await service.quote({
+      contractId: 'ct-1',
+      installmentNo: 1,
+      daysToShift: 7,
+      splitMode: 'SPLIT',
+    });
+    expect(q.rescheduleFee).toBe('1044.00');
+    expect(q.lateFee).toBe('100.00');
+    expect(q.collectAmount).toBe('1144.00');
+    expect(q.variant).toBe('6a');
+  });
+
+  it('6a happy path: JE (Dr 11-1101 1144 / Cr 21-1103 1044 / Cr 42-1103 100) + lateFee reset + reschedule on SAME tx + receipt', async () => {
+    const result = await service.executeWithCollect({
+      contractId: 'ct-1',
+      installmentNo: 1,
+      daysToShift: 7,
+      splitMode: 'SPLIT',
+      amount: 1144,
+      paymentMethod: 'CASH',
+      recordedById: 'user-1',
+    });
+
+    // JE lines — fee to advance (21-1103), late fee to income (42-1103).
+    const je = journalAuto.createAndPost.mock.calls[0][0];
+    const line = (code: string) => je.lines.find((l: AnyObj) => l.accountCode === code);
+    expect(line('11-1101').dr.toFixed(2)).toBe('1144.00');
+    expect(line('21-1103').cr.toFixed(2)).toBe('1044.00');
+    expect(line('42-1103').cr.toFixed(2)).toBe('100.00');
+    expect(je.metadata.tag).toBe('reschedule-collect'); // NOT 'receipt' — reconstructPrior must ignore
+    // JE posts on the shared tx (2nd arg).
+    expect(journalAuto.createAndPost.mock.calls[0][1]).toBe(prisma);
+
+    // Late fee ของช่วงเกินเดิม reset เป็น 0 (เก็บแล้ว).
+    const upd = prisma.payment.update.mock.calls[0][0];
+    expect(upd.where).toEqual({ id: 'pay-1' });
+    expect(upd.data.lateFee).toBe(0);
+    expect(upd.data.notes).toContain('เก็บแล้วตอนปรับดิว');
+
+    // Reschedule runs on the SAME tx (atomic with the JE).
+    expect(rescheduleService.execute).toHaveBeenCalledWith(
+      expect.objectContaining({ contractId: 'ct-1', fromInstallmentNo: 1, daysToShift: 7, variant: '6a' }),
+      prisma,
+    );
+
+    // 6a fee = PREPAYMENT (CPA case 6a): must land on the REAL advance ledger
+    // pair — Cr 21-1103 (JE above) + Contract.advanceBalance — so the existing
+    // advance machinery relieves it against upcoming installments (review C1).
+    expect(prisma.contract.update).toHaveBeenCalledWith({
+      where: { id: 'ct-1' },
+      data: { advanceBalance: { increment: expect.anything() } },
+    });
+    const advAudit = prisma.auditLog.create.mock.calls
+      .map((c: AnyObj) => c[0].data)
+      .find((d2: AnyObj) => d2.action === 'OVERPAY_ADVANCE_RECORDED');
+    expect(advAudit.newValue.advanceCredit).toBe('1044');
+    expect(advAudit.newValue.source).toBe('RESCHEDULE_COLLECT_6A_FEE');
+
+    // Money-detail audit + post-commit receipt.
+    expect(prisma.auditLog.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ action: 'RESCHEDULE_COLLECT', entityId: 'pay-1' }),
+      }),
+    );
+    expect(receiptsService.generateReceipt).toHaveBeenCalledWith(
+      'ct-1', 'pay-1', 'RESCHEDULE_FEE', 1144, 1, 'CASH', null, 'user-1',
+    );
+
+    expect(result).toMatchObject({
+      success: true,
+      variant: '6a',
+      rescheduleFee: '1044.00',
+      lateFeeCollected: '100.00',
+      collectAmount: '1144.00',
+      journalEntryNo: 'JE-RD-1',
+      shiftedInstallmentCount: 2,
+    });
+  });
+
+  it('6b: collects ONLY the late fee (Dr 100 / Cr 42-1103 100, no 21-1103 line)', async () => {
+    await service.executeWithCollect({
+      contractId: 'ct-1',
+      installmentNo: 1,
+      daysToShift: 7,
+      splitMode: 'SINGLE',
+      amount: 100,
+      paymentMethod: 'CASH',
+      recordedById: 'user-1',
+    });
+
+    const je = journalAuto.createAndPost.mock.calls[0][0];
+    const codes = je.lines.map((l: AnyObj) => l.accountCode);
+    expect(codes).toEqual(['11-1101', '42-1103']);
+    expect(je.lines[0].dr.toFixed(2)).toBe('100.00');
+    expect(je.lines[1].cr.toFixed(2)).toBe('100.00');
+  });
+
+  it('6b + no late fee (not overdue): NO JE, NO lateFee reset, NO receipt, NO advance — reschedule still runs + fee note stamped', async () => {
+    prisma.payment.findFirst.mockResolvedValue({
+      ...paymentRow,
+      dueDate: new Date('2026-07-20T05:00:00Z'),
+      lateFee: D(0),
+    });
+
+    const result = await service.executeWithCollect({
+      contractId: 'ct-1',
+      installmentNo: 1,
+      daysToShift: 7,
+      splitMode: 'SINGLE',
+      amount: 0.01, // DTO placeholder — ignored when quote collect = 0
+      paymentMethod: 'CASH',
+      recordedById: 'user-1',
+    });
+
+    expect(journalAuto.createAndPost).not.toHaveBeenCalled();
+    expect(receiptsService.generateReceipt).not.toHaveBeenCalled();
+    expect(prisma.contract.update).not.toHaveBeenCalled(); // 6b — no advance now
+    // 6b: the deferred fee is stamped on the installment note (collected with the
+    // installment; the orchestrator's D1 auto-route parks the overage as advance).
+    const upd = prisma.payment.update.mock.calls[0][0];
+    expect(upd.data.lateFee).toBeUndefined(); // no fee to reset
+    expect(upd.data.notes).toContain('ค่าธรรมเนียมปรับดิว');
+    expect(upd.data.notes).toContain('(6b)');
+    expect(rescheduleService.execute).toHaveBeenCalled();
+    expect(result.collectAmount).toBe('0.00');
+  });
+
+  it('amount mismatch vs server quote → BadRequest, nothing posted, no reschedule', async () => {
+    await expect(
+      service.executeWithCollect({
+        contractId: 'ct-1',
+        installmentNo: 1,
+        daysToShift: 7,
+        splitMode: 'SPLIT',
+        amount: 1044, // stale UI — forgot late fee 100
+        paymentMethod: 'CASH',
+        recordedById: 'user-1',
+      }),
+    ).rejects.toThrow(/ยอดเรียกเก็บเปลี่ยน/);
+
+    expect(journalAuto.createAndPost).not.toHaveBeenCalled();
+    expect(rescheduleService.execute).not.toHaveBeenCalled();
+  });
+
+  it('โอน (BANK_TRANSFER) without ref/slip → BadRequest', async () => {
+    await expect(
+      service.executeWithCollect({
+        contractId: 'ct-1',
+        installmentNo: 1,
+        daysToShift: 7,
+        splitMode: 'SPLIT',
+        amount: 1144,
+        paymentMethod: 'BANK_TRANSFER',
+        recordedById: 'user-1',
+      }),
+    ).rejects.toThrow(/หลักฐานการชำระเงิน/);
+    expect(rescheduleService.execute).not.toHaveBeenCalled();
+  });
+
+  it('QR-webhook path (fixedQuote): books the frozen quote, skips the mismatch check', async () => {
+    await service.executeWithCollect({
+      contractId: 'ct-1',
+      installmentNo: 1,
+      daysToShift: 7,
+      splitMode: 'SPLIT',
+      amount: 1144,
+      paymentMethod: 'ONLINE_GATEWAY',
+      recordedById: 'system-owner',
+      transactionRef: 'REF-QR-1',
+      depositAccountCode: '11-1201',
+      fixedQuote: { rescheduleFee: '1044', lateFee: '100', collectAmount: '1144' },
+    });
+
+    const je = journalAuto.createAndPost.mock.calls[0][0];
+    const line = (code: string) => je.lines.find((l: AnyObj) => l.accountCode === code);
+    expect(line('11-1201').dr.toFixed(2)).toBe('1144.00');
+    expect(line('21-1103').cr.toFixed(2)).toBe('1044.00');
+    expect(line('42-1103').cr.toFixed(2)).toBe('100.00');
+    // 6a via QR: advance ledger pair still maintained.
+    expect(prisma.contract.update).toHaveBeenCalledWith({
+      where: { id: 'ct-1' },
+      data: { advanceBalance: { increment: expect.anything() } },
+    });
+    const audit = prisma.auditLog.create.mock.calls
+      .map((c: AnyObj) => c[0].data)
+      .find((d2: AnyObj) => d2.action === 'RESCHEDULE_COLLECT');
+    expect(audit.newValue.source).toBe('QR_WEBHOOK');
+  });
+
+  it('PAID installment → BadRequest (ไม่ต้องปรับดิว)', async () => {
+    prisma.payment.findFirst.mockResolvedValue({ ...paymentRow, status: 'PAID' });
+    await expect(
+      service.executeWithCollect({
+        contractId: 'ct-1',
+        installmentNo: 1,
+        daysToShift: 7,
+        splitMode: 'SINGLE',
+        amount: 100,
+        paymentMethod: 'CASH',
+        recordedById: 'user-1',
+      }),
+    ).rejects.toThrow(/ชำระแล้ว/);
+  });
+});

--- a/apps/api/src/modules/payments/services/reschedule-collect.service.ts
+++ b/apps/api/src/modules/payments/services/reschedule-collect.service.ts
@@ -1,0 +1,424 @@
+import { Injectable, Logger, NotFoundException, BadRequestException } from '@nestjs/common';
+import { randomUUID } from 'crypto';
+import { Prisma } from '@prisma/client';
+import { PrismaService } from '../../../prisma/prisma.service';
+import { JournalAutoService } from '../../journal/journal-auto.service';
+import { RescheduleService } from '../../installments/reschedule.service';
+import { ReceiptsService } from '../../receipts/receipts.service';
+import { loadLateFeeConfig } from '../../../utils/late-fee.util';
+import {
+  computeRescheduleQuote,
+  RescheduleQuote,
+  RescheduleSplitMode,
+} from '../../../utils/reschedule-quote.util';
+import { validatePeriodOpen } from '../../../utils/period-lock.util';
+import { d } from '../../../utils/decimal.util';
+import {
+  resolveUserDefaultCashAccount,
+  resolveFinanceCompanyId,
+} from './payment-helpers';
+
+export interface RescheduleCollectInput {
+  contractId: string;
+  installmentNo: number;
+  daysToShift: number;
+  splitMode: RescheduleSplitMode;
+  /**
+   * Cash the cashier says they collected. Cross-checked against the server-side
+   * quote (±0.01) — a mismatch means the fee/late fee changed since the UI quoted
+   * (e.g. crossed midnight) and the cashier must re-open the dialog. Ignored when
+   * the quote's collectAmount is 0 (6b, no late fee → nothing to collect).
+   */
+  amount: number;
+  /** CASH | BANK_TRANSFER | ONLINE_GATEWAY (QR webhook path). */
+  paymentMethod: string;
+  recordedById: string;
+  transactionRef?: string;
+  evidenceUrl?: string;
+  depositAccountCode?: string;
+  /**
+   * QR-webhook path only: the quote frozen at QR creation (link.metadata). The
+   * customer already paid link.amount — we book THESE amounts instead of
+   * recomputing (a fee that grew between QR creation and payment is forgiven;
+   * the 24h link expiry bounds the drift to one day of per-day late fee).
+   */
+  fixedQuote?: { rescheduleFee: string; lateFee: string; collectAmount: string };
+}
+
+export interface RescheduleCollectResult {
+  success: true;
+  case: 'RESCHEDULE';
+  variant: '6a' | '6b';
+  rescheduleFee: string;
+  lateFeeCollected: string;
+  collectAmount: string;
+  journalEntryNo: string | null;
+  shiftedInstallmentCount: number;
+  shiftedInstallmentIds: string[];
+}
+
+/**
+ * ปรับดิว collect-first (owner directive 2026-07-02) — "เงินไม่เข้า ดิวไม่เลื่อน".
+ *
+ * Replaces the old fire-and-forget RESCHEDULE branch (which shifted due dates
+ * with ZERO cash collected, letting the late fee evaporate when the cron
+ * recomputed against the new due date). Now ONE Serializable transaction:
+ *
+ *   1. Recompute the quote server-side (fee = monthly/30×days ROUND_UP;
+ *      lateFee = mode-aware resolveLivePaymentLateFee vs the CURRENT due date).
+ *   2. Validate the collected amount matches the quote (cashier paths).
+ *   3. Post the collect JE (skipped when nothing to collect):
+ *        Dr  deposit (cash/bank)        [collectAmount]
+ *           Cr 21-1103 เงินรับล่วงหน้า     [rescheduleFee]   (6a only)
+ *           Cr 42-1103 ค่าปรับชำระล่าช้า    [lateFee]         (if > 0)
+ *      metadata.tag = 'reschedule-collect' — intentionally NOT 'receipt', so
+ *      reconstructPriorCleared ignores it (the fee belongs to the OLD overdue
+ *      period which this collect settles; a NEW overdue period vs the new due
+ *      date accrues its own fee from zero).
+ *   4. Reset Payment.lateFee → 0 (collected) + append an audit note.
+ *   5. RescheduleService.execute(..., tx) — shift due dates + reduce last
+ *      installment + RESCHEDULE AuditLog, all on the same tx.
+ *   6. AuditLog RESCHEDULE_COLLECT (money detail, hash-chained via audit table).
+ *
+ * After commit (I3 ordering — never roll back committed money): e-Receipt
+ * type 'RESCHEDULE_FEE' via ReceiptsService, failures logged not thrown.
+ */
+@Injectable()
+export class RescheduleCollectService {
+  private readonly logger = new Logger(RescheduleCollectService.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly journalAutoService: JournalAutoService,
+    private readonly rescheduleService: RescheduleService,
+    private readonly receiptsService: ReceiptsService,
+  ) {}
+
+  /** Server-authoritative quote for the overlay (display + amount prefill). */
+  async quote(input: {
+    contractId: string;
+    installmentNo: number;
+    daysToShift: number;
+    splitMode: RescheduleSplitMode;
+  }): Promise<{
+    rescheduleFee: string;
+    lateFee: string;
+    collectAmount: string;
+    variant: '6a' | '6b';
+    newDueDate: string;
+    currentDueDate: string;
+  }> {
+    const { contract, payment } = await this.loadRow(this.prisma, input.contractId, input.installmentNo);
+    const q = await this.buildQuote(this.prisma, contract, payment, input.daysToShift, input.splitMode);
+    const newDue = new Date(payment.dueDate);
+    newDue.setDate(newDue.getDate() + input.daysToShift);
+    return {
+      rescheduleFee: q.rescheduleFee.toFixed(2),
+      lateFee: q.lateFee.toFixed(2),
+      collectAmount: q.collectAmount.toFixed(2),
+      variant: q.variant,
+      newDueDate: newDue.toISOString(),
+      currentDueDate: payment.dueDate.toISOString(),
+    };
+  }
+
+  async executeWithCollect(input: RescheduleCollectInput): Promise<RescheduleCollectResult> {
+    if (!input.daysToShift || input.daysToShift < 1) {
+      throw new BadRequestException('กรุณาระบุจำนวนวันที่เลื่อน (daysToShift) มากกว่า 0');
+    }
+
+    // CR-7 parity with recordPayment: the collect JE posts today — period must be open.
+    await validatePeriodOpen(this.prisma, new Date(), await resolveFinanceCompanyId(this.prisma));
+
+    const resolvedDepositAccountCode =
+      input.depositAccountCode ??
+      (await resolveUserDefaultCashAccount(this.prisma, input.recordedById));
+
+    const txResult = await this.prisma.$transaction(
+      async (tx) => {
+        const { contract, payment } = await this.loadRow(tx, input.contractId, input.installmentNo);
+
+        // Quote: recompute (cashier) or honour the frozen QR quote (webhook).
+        const q: RescheduleQuote = input.fixedQuote
+          ? {
+              rescheduleFee: d(input.fixedQuote.rescheduleFee),
+              lateFee: d(input.fixedQuote.lateFee),
+              collectAmount: d(input.fixedQuote.collectAmount),
+              variant: input.splitMode === 'SPLIT' ? '6a' : '6b',
+            }
+          : await this.buildQuote(tx, contract, payment, input.daysToShift, input.splitMode);
+
+        // Cashier cross-check: the UI quoted a number; if the server disagrees
+        // (fee config changed / crossed midnight) refuse — never book silently.
+        if (!input.fixedQuote && q.collectAmount.gt(0)) {
+          const diff = d(input.amount).minus(q.collectAmount).abs();
+          if (diff.gt(d('0.01'))) {
+            throw new BadRequestException(
+              `ยอดเรียกเก็บเปลี่ยนเป็น ${q.collectAmount.toFixed(2)} บาท (ค่าธรรมเนียม ${q.rescheduleFee.toFixed(2)} + ค่าปรับ ${q.lateFee.toFixed(2)}) — กรุณาเปิดหน้าต่างปรับดิวใหม่`,
+            );
+          }
+        }
+
+        // Evidence rule mirrors recordPayment: โอน requires slip or ref.
+        if (
+          q.collectAmount.gt(0) &&
+          input.paymentMethod === 'BANK_TRANSFER' &&
+          !input.evidenceUrl &&
+          !input.transactionRef
+        ) {
+          throw new BadRequestException(
+            'ต้อง upload หลักฐานการชำระเงิน (สลิปโอนเงิน) หรือระบุเลขอ้างอิงธุรกรรม',
+          );
+        }
+
+        const instSched = await tx.installmentSchedule.findUnique({
+          where: {
+            contractId_installmentNo: {
+              contractId: input.contractId,
+              installmentNo: input.installmentNo,
+            },
+          },
+          select: { id: true },
+        });
+
+        // 3. Collect JE — only when there is money to collect.
+        let journalEntryNo: string | null = null;
+        if (q.collectAmount.gt(0)) {
+          const zero = new Prisma.Decimal(0);
+          const lines: { accountCode: string; dr: Prisma.Decimal; cr: Prisma.Decimal; description: string }[] = [
+            {
+              accountCode: resolvedDepositAccountCode,
+              dr: q.collectAmount,
+              cr: zero,
+              description: 'รับเงินปรับดิว',
+            },
+          ];
+          if (q.variant === '6a' && q.rescheduleFee.gt(0)) {
+            lines.push({
+              accountCode: '21-1103',
+              dr: zero,
+              cr: q.rescheduleFee,
+              // "เงินรับล่วงหน้า" (not "งวดสุดท้าย") — the 2A auto-consume relieves it
+              // FIFO against whichever installment accrues next, not the literal last.
+              description: 'เงินรับล่วงหน้า — ค่าธรรมเนียมปรับดิว (6a)',
+            });
+          }
+          if (q.lateFee.gt(0)) {
+            lines.push({
+              accountCode: '42-1103',
+              dr: zero,
+              cr: q.lateFee,
+              description: 'ค่าปรับชำระล่าช้า (เก็บตอนปรับดิว)',
+            });
+          }
+          const je = await this.journalAutoService.createAndPost(
+            {
+              description: `ปรับดิวงวด #${input.installmentNo} — สัญญา ${contract.contractNumber} (เลื่อน ${input.daysToShift} วัน, ${q.variant})`,
+              reference: randomUUID(),
+              metadata: {
+                tag: 'reschedule-collect',
+                flow: 'reschedule-collect',
+                contractId: contract.id,
+                installmentScheduleId: instSched?.id ?? null,
+                paymentId: payment.id,
+                variant: q.variant,
+                daysToShift: input.daysToShift,
+                rescheduleFee: q.rescheduleFee.toString(),
+                lateFeeCollected: q.lateFee.toString(),
+              },
+              lines,
+            },
+            tx,
+          );
+          journalEntryNo = je.entryNumber;
+        }
+
+        // 4. Payment-row bookkeeping (one update, both concerns):
+        //    - Late fee ของช่วงเกินเดิม "เก็บแล้ว" — reset to 0 so the new overdue
+        //      period (vs the new due date) accrues its own fee from a clean slate.
+        //    - 6b: stamp the deferred fee as a note on THIS installment so the
+        //      cashier collects (ค่างวด + fee) at the next receipt — the orchestrator's
+        //      D1 auto-route then parks the overage as 21-1103 advance (CPA case 6b).
+        const noteTags: string[] = [];
+        if (q.lateFee.gt(0)) {
+          noteTags.push(
+            `ค่าปรับ ${q.lateFee.toFixed(2)} บาท เก็บแล้วตอนปรับดิว (${new Date().toISOString().slice(0, 10)})`,
+          );
+        }
+        if (q.variant === '6b' && q.rescheduleFee.gt(0)) {
+          noteTags.push(
+            `ค่าธรรมเนียมปรับดิว ${q.rescheduleFee.toFixed(2)} บาท เก็บเพิ่มพร้อมงวดนี้ (6b)`,
+          );
+        }
+        if (noteTags.length > 0) {
+          const noteTag = noteTags.join(' | ');
+          await tx.payment.update({
+            where: { id: payment.id },
+            data: {
+              ...(q.lateFee.gt(0) ? { lateFee: 0 } : {}),
+              notes: payment.notes ? `${payment.notes} | ${noteTag}` : noteTag,
+            },
+          });
+        }
+
+        // 4b. 6a: the fee is a PREPAYMENT under the CPA model (CSV case 6a — the
+        // contract total never changes; the customer just pays part of it early).
+        // Credit it to the REAL advance ledger pair the rest of the system uses:
+        // Cr 21-1103 (JE above) + Contract.advanceBalance — the existing machinery
+        // (wizard AdvanceBalanceBanner, computeNetReceiptDue netting, orchestrator /
+        // 2A auto-consume) then relieves it against upcoming installments.
+        // (Review C1 2026-07-02: the old InstallmentSchedule.amountDue reduction was
+        // write-only — no billing path read it — so the 21-1103 credit was never
+        // relieved and the fee was effectively double-billed.)
+        if (q.variant === '6a' && q.rescheduleFee.gt(0)) {
+          const beforeAdvance = new Prisma.Decimal((contract.advanceBalance ?? 0).toString());
+          await tx.contract.update({
+            where: { id: contract.id },
+            data: { advanceBalance: { increment: q.rescheduleFee } },
+          });
+          // Same forensic trail the orchestrator writes for every advance delta.
+          await tx.auditLog.create({
+            data: {
+              action: 'OVERPAY_ADVANCE_RECORDED',
+              entity: 'contract',
+              entityId: contract.id,
+              userId: input.recordedById,
+              newValue: {
+                paymentId: payment.id,
+                installmentNo: input.installmentNo,
+                advanceCredit: q.rescheduleFee.toString(),
+                advanceConsume: '0',
+                delta: q.rescheduleFee.toString(),
+                beforeBalance: beforeAdvance.toString(),
+                afterBalance: beforeAdvance.plus(q.rescheduleFee).toString(),
+                source: 'RESCHEDULE_COLLECT_6A_FEE',
+              },
+            },
+          });
+        }
+
+        // 5. Shift due dates + reduce last installment + RESCHEDULE audit — same tx.
+        const reschedule = await this.rescheduleService.execute(
+          {
+            contractId: input.contractId,
+            fromInstallmentNo: input.installmentNo,
+            daysToShift: input.daysToShift,
+            userId: input.recordedById,
+            variant: q.variant,
+          },
+          tx,
+        );
+
+        // Anti-drift assert: quote fee must equal the fee RescheduleService applied.
+        if (!input.fixedQuote && !reschedule.rescheduleFee.eq(q.rescheduleFee)) {
+          throw new BadRequestException(
+            `ค่าธรรมเนียมไม่ตรงกัน (quote ${q.rescheduleFee.toFixed(2)} ≠ execute ${reschedule.rescheduleFee.toFixed(2)}) — กรุณาลองใหม่`,
+          );
+        }
+
+        // 6. Money-detail audit row (RESCHEDULE row itself is written by RescheduleService).
+        await tx.auditLog.create({
+          data: {
+            action: 'RESCHEDULE_COLLECT',
+            entity: 'payment',
+            entityId: payment.id,
+            userId: input.recordedById,
+            newValue: {
+              contractId: contract.id,
+              installmentNo: input.installmentNo,
+              variant: q.variant,
+              daysToShift: input.daysToShift,
+              rescheduleFee: q.rescheduleFee.toString(),
+              lateFeeCollected: q.lateFee.toString(),
+              collectAmount: q.collectAmount.toString(),
+              paymentMethod: input.paymentMethod,
+              transactionRef: input.transactionRef ?? null,
+              depositAccountCode: q.collectAmount.gt(0) ? resolvedDepositAccountCode : null,
+              journalEntryNo,
+              source: input.fixedQuote ? 'QR_WEBHOOK' : 'CASHIER',
+            },
+          },
+        });
+
+        return {
+          paymentId: payment.id,
+          quote: q,
+          journalEntryNo,
+          shiftedInstallmentIds: reschedule.shiftedInstallmentIds,
+        };
+      },
+      { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
+    );
+
+    // Post-commit (I3): e-Receipt for the collected money — never rolls back the tx.
+    if (d(txResult.quote.collectAmount).gt(0)) {
+      try {
+        await this.receiptsService.generateReceipt(
+          input.contractId,
+          txResult.paymentId,
+          'RESCHEDULE_FEE',
+          d(txResult.quote.collectAmount).toNumber(),
+          input.installmentNo,
+          input.paymentMethod,
+          input.transactionRef || null,
+          input.recordedById,
+        );
+      } catch (error) {
+        this.logger.error(
+          `Failed to generate reschedule-collect receipt (contract: ${input.contractId}, installment: ${input.installmentNo})`,
+          error instanceof Error ? error.stack : String(error),
+        );
+      }
+    }
+
+    return {
+      success: true,
+      case: 'RESCHEDULE',
+      variant: txResult.quote.variant,
+      rescheduleFee: txResult.quote.rescheduleFee.toFixed(2),
+      lateFeeCollected: txResult.quote.lateFee.toFixed(2),
+      collectAmount: txResult.quote.collectAmount.toFixed(2),
+      journalEntryNo: txResult.journalEntryNo,
+      shiftedInstallmentCount: txResult.shiftedInstallmentIds.length,
+      shiftedInstallmentIds: txResult.shiftedInstallmentIds,
+    };
+  }
+
+  // ── internals ──────────────────────────────────────────────────────────────
+
+  private async loadRow(
+    client: Prisma.TransactionClient | PrismaService,
+    contractId: string,
+    installmentNo: number,
+  ) {
+    const contract = await client.contract.findUnique({ where: { id: contractId } });
+    if (!contract || contract.deletedAt) throw new NotFoundException('ไม่พบสัญญา');
+    if (!['ACTIVE', 'OVERDUE', 'DEFAULT'].includes(contract.status)) {
+      throw new BadRequestException('ไม่สามารถปรับดิวได้ สัญญาต้องอยู่ในสถานะ ACTIVE, OVERDUE หรือ DEFAULT');
+    }
+    const payment = await client.payment.findFirst({
+      where: { contractId, installmentNo, deletedAt: null },
+    });
+    if (!payment) throw new NotFoundException('ไม่พบงวดที่ต้องการ');
+    if (payment.status === 'PAID') throw new BadRequestException('งวดนี้ชำระแล้ว — ไม่ต้องปรับดิว');
+    return { contract, payment };
+  }
+
+  private async buildQuote(
+    client: Prisma.TransactionClient | PrismaService,
+    contract: { monthlyPayment: Prisma.Decimal },
+    payment: { dueDate: Date; amountDue: Prisma.Decimal; lateFeeWaived: boolean },
+    daysToShift: number,
+    splitMode: RescheduleSplitMode,
+  ): Promise<RescheduleQuote> {
+    const lateFeeCfg = await loadLateFeeConfig(client as PrismaService);
+    return computeRescheduleQuote({
+      monthlyPayment: contract.monthlyPayment,
+      daysToShift,
+      splitMode,
+      payment,
+      lateFeeCfg,
+      now: new Date(),
+    });
+  }
+}

--- a/apps/api/src/modules/paysolutions/paysolutions.callbacks.spec.ts
+++ b/apps/api/src/modules/paysolutions/paysolutions.callbacks.spec.ts
@@ -37,14 +37,18 @@ describe('PaySolutionsService — secondary webhook callbacks (characterization)
   let prisma: any;
   let lineOa: { sendFlexMessage: jest.Mock };
   let saleAdapter: { createForOnlineOrder: jest.Mock };
-  let payments: { recordPayment: jest.Mock };
+  let payments: { recordPayment: jest.Mock; rescheduleWithCollect: jest.Mock };
 
   // Helper: build a fresh service with a given prisma mock surface, re-wiring
   // the shared collaborator mocks each time so per-test overrides are isolated.
   async function buildService(): Promise<void> {
     lineOa = { sendFlexMessage: jest.fn().mockResolvedValue(undefined) };
     saleAdapter = { createForOnlineOrder: jest.fn().mockResolvedValue(undefined) };
-    payments = { recordPayment: jest.fn().mockResolvedValue(undefined) };
+    payments = {
+      recordPayment: jest.fn().mockResolvedValue(undefined),
+      // ปรับดิว QR (2026-07-02): purpose=RESCHEDULE links route here on paid webhook.
+      rescheduleWithCollect: jest.fn().mockResolvedValue({ success: true }),
+    };
 
     const integrationConfig = {
       getValue: jest.fn().mockResolvedValue(''),
@@ -155,6 +159,65 @@ describe('PaySolutionsService — secondary webhook callbacks (characterization)
       expect(arg.data.cancelledAt).toBeInstanceOf(Date);
       // No money moves on a gateway failure.
       expect(payments.recordPayment).not.toHaveBeenCalled();
+    });
+
+    it('ปรับดิว: purpose=RESCHEDULE link routes to rescheduleWithCollect with the frozen quote — recordPayment NOT called', async () => {
+      const link = makeLink({
+        purpose: 'RESCHEDULE',
+        amount: new Prisma.Decimal(1144),
+        metadata: {
+          daysToShift: 7,
+          splitMode: 'SPLIT',
+          rescheduleFee: '1044',
+          lateFee: '100',
+          collectAmount: '1144',
+          requestedById: 'cashier-1',
+        },
+      });
+
+      await service.handlePartialPaymentCallback(link, {
+        refno,
+        result_code: '00',
+        transaction_id: 'tx-resched',
+      });
+
+      // Link flipped PAID first (same as the partial path).
+      expect(prisma.partialPaymentLink.update).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { id: linkId }, data: expect.objectContaining({ status: 'PAID' }) }),
+      );
+      expect(payments.rescheduleWithCollect).toHaveBeenCalledWith(
+        expect.objectContaining({
+          contractId: 'ct-partial-1',
+          installmentNo: 3,
+          daysToShift: 7,
+          splitMode: 'SPLIT',
+          amount: 1144,
+          paymentMethod: 'ONLINE_GATEWAY',
+          recordedById: 'owner-1',
+          transactionRef: refno,
+          fixedQuote: { rescheduleFee: '1044', lateFee: '100', collectAmount: '1144' },
+        }),
+      );
+      expect(payments.recordPayment).not.toHaveBeenCalled();
+    });
+
+    it('ปรับดิว: rescheduleWithCollect failure → Sentry fatal, no throw (PaySolutions gets 200)', async () => {
+      payments.rescheduleWithCollect.mockRejectedValueOnce(new Error('period closed'));
+      const link = makeLink({
+        purpose: 'RESCHEDULE',
+        metadata: { daysToShift: 7, splitMode: 'SINGLE', rescheduleFee: '1044', lateFee: '100', collectAmount: '100' },
+      });
+
+      await expect(
+        service.handlePartialPaymentCallback(link, { refno, result_code: '00', transaction_id: 'tx-r2' }),
+      ).resolves.toBeUndefined();
+
+      expect(Sentry.captureException).toHaveBeenCalledWith(
+        expect.any(Error),
+        expect.objectContaining({
+          tags: expect.objectContaining({ critical: 'paysolutions-reschedule-exec-fail' }),
+        }),
+      );
     });
 
     it('success: marks link PAID first, then recordPayment credits Number(amount) with the right keys', async () => {

--- a/apps/api/src/modules/paysolutions/paysolutions.service.ts
+++ b/apps/api/src/modules/paysolutions/paysolutions.service.ts
@@ -169,6 +169,24 @@ export class PaySolutionsService {
     return this.services().intent.createPartialPaymentQR(input);
   }
 
+  /** ปรับดิว QR — collect-first; reschedule executes on webhook confirm (เงินไม่เข้า ดิวไม่เลื่อน). */
+  createRescheduleQR(input: {
+    paymentId: string;
+    daysToShift: number;
+    splitMode: 'SINGLE' | 'SPLIT';
+    requestedById: string;
+  }): Promise<{
+    partialPaymentLinkId: string;
+    paymentUrl: string;
+    orderRef: string;
+    sentToLine: boolean;
+    collectAmount: string;
+    rescheduleFee: string;
+    lateFee: string;
+  }> {
+    return this.services().intent.createRescheduleQR(input);
+  }
+
   createSavingPlanIntent(input: {
     savingPlanId: string;
     amount: number;

--- a/apps/api/src/modules/paysolutions/services/paysolutions-confirmation.service.ts
+++ b/apps/api/src/modules/paysolutions/services/paysolutions-confirmation.service.ts
@@ -110,6 +110,18 @@ export class PaySolutionsConfirmationService {
     // Idempotent: PaySolutions retries up to 3x. After the first successful
     // callback link.status flips to PAID — subsequent invocations no-op.
     if (link.status !== 'ACTIVE') {
+      // Review W2 (2026-07-02): a SUCCESS callback landing on an EXPIRED link means
+      // the customer's money reached the gateway but nothing was recorded (the
+      // hourly cron expired the link first). Alarm — ops must reconcile manually.
+      if (link.status === 'EXPIRED' && result_code === '00') {
+        // fatal — same class as the sibling partial-orphan/reschedule-exec-fail
+        // alarms: customer's money reached the gateway but nothing was recorded.
+        Sentry.captureMessage('PaySolutions success webhook on EXPIRED link — money captured but unrecorded', {
+          level: 'fatal',
+          tags: { critical: 'paysolutions-expired-paid', refno },
+          extra: { linkId: link.id, paymentId: link.paymentId, purpose: link.purpose, amount: link.amount.toString() },
+        });
+      }
       this.logger.log(
         `Duplicate partial-payment webhook for refno=${refno} (status=${link.status}, idempotent skip)`,
       );
@@ -167,6 +179,56 @@ export class PaySolutionsConfirmationService {
         tags: { critical: 'paysolutions-partial-orphan', refno },
         extra: { paymentId: link.paymentId },
       });
+      return;
+    }
+
+    // ── ปรับดิว QR (purpose=RESCHEDULE) — เงินเข้าแล้ว ค่อยเลื่อนดิว ─────────────
+    // Books the quote frozen at QR creation (link.metadata) and shifts the due
+    // dates in ONE atom via rescheduleWithCollect. A fee that grew between QR
+    // creation and payment is forgiven (the 24h link expiry bounds the drift).
+    if (link.purpose === 'RESCHEDULE') {
+      const meta = (link.metadata ?? {}) as {
+        daysToShift?: number;
+        splitMode?: 'SINGLE' | 'SPLIT';
+        rescheduleFee?: string;
+        lateFee?: string;
+        collectAmount?: string;
+      };
+      try {
+        if (!meta.daysToShift || !meta.splitMode) {
+          throw new Error(`RESCHEDULE link ${refno} missing metadata (daysToShift/splitMode)`);
+        }
+        await this.paymentsService.rescheduleWithCollect({
+          contractId: payment.contractId,
+          installmentNo: payment.installmentNo,
+          daysToShift: meta.daysToShift,
+          splitMode: meta.splitMode,
+          amount: Number(link.amount),
+          paymentMethod: 'ONLINE_GATEWAY',
+          recordedById: systemUser.id,
+          transactionRef: refno,
+          depositAccountCode,
+          fixedQuote: {
+            rescheduleFee: meta.rescheduleFee ?? '0',
+            lateFee: meta.lateFee ?? '0',
+            collectAmount: meta.collectAmount ?? link.amount.toString(),
+          },
+        });
+        this.logger.log(
+          `Reschedule auto-executed after QR paid: refno=${refno}, payment=${link.paymentId}, +${meta.daysToShift}d (${meta.splitMode})`,
+        );
+      } catch (err) {
+        this.logger.error(
+          `Reschedule-after-QR FAILED: refno=${refno}, payment=${link.paymentId}, err=${err}`,
+        );
+        Sentry.captureException(err, {
+          level: 'fatal',
+          tags: { critical: 'paysolutions-reschedule-exec-fail', refno },
+          extra: { paymentId: link.paymentId, metadata: meta, amount: Number(link.amount) },
+        });
+        // Return 200 to PaySolutions (no infinite retry) — ops reconciles from
+        // Sentry: the money IS at the gateway, the reschedule needs a manual replay.
+      }
       return;
     }
 

--- a/apps/api/src/modules/paysolutions/services/paysolutions-intent.service.ts
+++ b/apps/api/src/modules/paysolutions/services/paysolutions-intent.service.ts
@@ -12,7 +12,10 @@ import { PrismaService } from '../../../prisma/prisma.service';
 import { LineOaService } from '../../line-oa/line-oa.service';
 import { buildEarlyPayoffQRFlex } from '../../line-oa/flex-messages/early-payoff-qr.flex';
 import { buildPartialPaymentQRFlex } from '../../line-oa/flex-messages/partial-payment-qr.flex';
+import { buildRescheduleQRFlex } from '../../line-oa/flex-messages/reschedule-qr.flex';
 import { dAdd, dSub, dClose } from '../../../utils/decimal.util';
+import { loadLateFeeConfig } from '../../../utils/late-fee.util';
+import { computeRescheduleQuote } from '../../../utils/reschedule-quote.util';
 import { PaySolutionsGatewayClient, PAYSOLUTIONS_TIMEOUT_MS } from './paysolutions-gateway.client';
 
 export interface PaymentIntentResult {
@@ -541,6 +544,187 @@ export class PaySolutionsIntentService {
       Sentry.captureException(dbError, {
         level: 'fatal',
         tags: { critical: 'paysolutions-partial-orphan', orderRef },
+        extra: { paymentId: input.paymentId },
+      });
+      throw new InternalServerErrorException('ระบบบันทึกข้อมูลชำระเงินไม่สำเร็จ');
+    }
+  }
+
+  /**
+   * ปรับดิว (reschedule) QR — เงินไม่เข้า ดิวไม่เลื่อน (owner directive 2026-07-02).
+   *
+   * Mints a PromptPay QR for the collect amount (6a: ค่าธรรมเนียม + ค่าปรับ;
+   * 6b: ค่าปรับเท่านั้น) and stores a PartialPaymentLink with purpose='RESCHEDULE'
+   * carrying the frozen quote in metadata. The reschedule itself is NOT executed
+   * here — the PaySolutions webhook routes a paid RESCHEDULE link through
+   * PaymentsService.rescheduleWithCollect, which posts the collect JE + resets the
+   * late fee + shifts due dates in one atom. Link expires in 24h via the existing
+   * partial-payment-expire cron (expired → no money → no reschedule).
+   *
+   * Zero-collect (6b, no late fee) is rejected — the cashier should confirm
+   * directly in the overlay; a 0-baht QR is meaningless.
+   */
+  async createRescheduleQR(input: {
+    paymentId: string;
+    daysToShift: number;
+    splitMode: 'SINGLE' | 'SPLIT';
+    requestedById: string;
+  }): Promise<{
+    partialPaymentLinkId: string;
+    paymentUrl: string;
+    orderRef: string;
+    sentToLine: boolean;
+    collectAmount: string;
+    rescheduleFee: string;
+    lateFee: string;
+  }> {
+    const payment = await this.prisma.payment.findUnique({
+      where: { id: input.paymentId },
+      include: {
+        contract: {
+          include: { customer: { select: { id: true, email: true, name: true, lineIdFinance: true } } },
+        },
+      },
+    });
+    if (!payment || payment.deletedAt) {
+      throw new NotFoundException('ไม่พบรายการชำระ');
+    }
+    if (payment.status === 'PAID') {
+      throw new BadRequestException('งวดนี้ชำระครบแล้ว — ไม่ต้องปรับดิว');
+    }
+    if (!input.daysToShift || input.daysToShift < 1) {
+      throw new BadRequestException('กรุณาระบุจำนวนวันที่เลื่อนมากกว่า 0');
+    }
+
+    // Server-authoritative quote — the SAME pure util the collect service uses.
+    const lateFeeCfg = await loadLateFeeConfig(this.prisma);
+    const quote = computeRescheduleQuote({
+      monthlyPayment: payment.contract.monthlyPayment,
+      daysToShift: input.daysToShift,
+      splitMode: input.splitMode,
+      payment,
+      lateFeeCfg,
+      now: new Date(),
+    });
+    if (quote.collectAmount.lte(0)) {
+      throw new BadRequestException(
+        'ไม่มียอดต้องเก็บ (6b + ไม่มีค่าปรับ) — ยืนยันปรับดิวได้โดยตรง ไม่ต้องส่ง QR',
+      );
+    }
+    const collectNumber = quote.collectAmount.toDecimalPlaces(2).toNumber();
+
+    // Single outstanding QR per installment — cancel any earlier active link
+    // (both purposes: a stale partial-QR racing a reschedule-QR would double-charge).
+    await this.prisma.partialPaymentLink.updateMany({
+      where: { paymentId: input.paymentId, status: 'ACTIVE' },
+      data: { status: 'CANCELLED', cancelledAt: new Date() },
+    });
+
+    const orderRef = String(Date.now()).slice(-12);
+    const returnUrlBase =
+      this.returnUrl || `${this.config.get('FRONTEND_URL', 'http://localhost:5173')}/payments`;
+    const returnUrl = `${returnUrlBase}?reschedule=${payment.contract.contractNumber}`;
+
+    const paymentPayload: Record<string, unknown> = {
+      merchantId: await this.gateway.getMerchantId(),
+      customerEmail: payment.contract.customer.email || 'noreply@bestchoice.com',
+      referenceNo: orderRef,
+      description: `ปรับดิวงวด ${payment.installmentNo} สัญญา ${payment.contract.contractNumber} (+${input.daysToShift} วัน)`,
+      amount: collectNumber,
+      paymentChannel: 'Qrcode',
+      paymentGateway: 'Promptpay',
+      currencyCode: '00',
+      lang: 'TH',
+      returnUrl,
+      postbackUrl: `${this.apiBaseUrl}/api/paysolutions/webhook`,
+      terminalId: await this.gateway.getTerminalId(),
+      keyVersion: 1,
+    };
+
+    const { gatewayResponse, paymentUrl } = await this.gateway.createUiPayment(paymentPayload, {
+      orderRef,
+      buildErrorLog: (response, gr) =>
+        `Pay Solutions reschedule-QR API error: ${response.status} ${JSON.stringify(gr)}`,
+      errorMessagePrefix: 'ไม่สามารถสร้าง QR ได้',
+      missingUrlMessage: 'ไม่ได้รับลิงก์ชำระเงิน',
+      timeoutSentryKey: 'paysolutions-reschedule-timeout',
+      timeoutSentryExtra: { paymentId: input.paymentId, amount: collectNumber },
+      timeoutMessage: 'ระบบชำระเงินใช้เวลานานเกินไป',
+      genericErrorMessage: 'ไม่สามารถเชื่อมต่อระบบชำระเงินได้',
+    });
+
+    try {
+      const link = await this.prisma.partialPaymentLink.create({
+        data: {
+          paymentId: input.paymentId,
+          contractId: payment.contractId,
+          customerId: payment.contract.customer.id,
+          token: orderRef,
+          amount: collectNumber,
+          gatewayRef: (gatewayResponse.refNo as string | undefined) ?? null,
+          paymentUrl,
+          status: 'ACTIVE',
+          purpose: 'RESCHEDULE',
+          metadata: {
+            daysToShift: input.daysToShift,
+            splitMode: input.splitMode,
+            rescheduleFee: quote.rescheduleFee.toString(),
+            lateFee: quote.lateFee.toString(),
+            collectAmount: quote.collectAmount.toString(),
+            requestedById: input.requestedById,
+          },
+          expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000),
+        },
+      });
+      this.logger.log(
+        `Reschedule QR created: ${orderRef} for payment ${input.paymentId}, collect ${collectNumber} (+${input.daysToShift}d, ${quote.variant})`,
+      );
+
+      let sentToLine = false;
+      const lineId = payment.contract.customer.lineIdFinance;
+      if (lineId) {
+        try {
+          const newDue = new Date(payment.dueDate);
+          newDue.setDate(newDue.getDate() + input.daysToShift);
+          const newDueDateText = newDue.toLocaleDateString('th-TH', {
+            day: 'numeric', month: 'short', year: 'numeric', timeZone: 'Asia/Bangkok',
+          });
+          const flex = buildRescheduleQRFlex({
+            customerName: payment.contract.customer.name,
+            contractNumber: payment.contract.contractNumber,
+            installmentNo: payment.installmentNo,
+            daysToShift: input.daysToShift,
+            newDueDateText,
+            rescheduleFee: quote.variant === '6a' ? quote.rescheduleFee.toNumber() : 0,
+            lateFee: quote.lateFee.toNumber(),
+            collectAmount: collectNumber,
+            paymentUrl,
+            orderRef,
+          });
+          await this.lineOaService.pushMessage(lineId, [flex], 'line-finance');
+          sentToLine = true;
+          this.logger.log(
+            `Reschedule Flex pushed to LINE: payment=${input.paymentId} lineId=${lineId.slice(0, 8)}...`,
+          );
+        } catch (pushErr) {
+          this.logger.error(`Reschedule Flex push failed: ${pushErr}`);
+          // swallow — cashier can resend or collect cash/transfer instead
+        }
+      }
+
+      return {
+        partialPaymentLinkId: link.id,
+        paymentUrl,
+        orderRef,
+        sentToLine,
+        collectAmount: quote.collectAmount.toFixed(2),
+        rescheduleFee: quote.rescheduleFee.toFixed(2),
+        lateFee: quote.lateFee.toFixed(2),
+      };
+    } catch (dbError) {
+      Sentry.captureException(dbError, {
+        level: 'fatal',
+        tags: { critical: 'paysolutions-reschedule-orphan', orderRef },
         extra: { paymentId: input.paymentId },
       });
       throw new InternalServerErrorException('ระบบบันทึกข้อมูลชำระเงินไม่สำเร็จ');

--- a/apps/api/src/utils/reschedule-quote.util.spec.ts
+++ b/apps/api/src/utils/reschedule-quote.util.spec.ts
@@ -1,0 +1,104 @@
+import { Prisma } from '@prisma/client';
+import { computeRescheduleQuote } from './reschedule-quote.util';
+import { LateFeeConfig } from './late-fee.util';
+
+const D = (v: string | number) => new Prisma.Decimal(v);
+
+// PER_DAY defaults (config.util BUSINESS_RULES): 20฿/day, max 500, cap 5%.
+const cfg: LateFeeConfig = {
+  mode: 'PER_DAY',
+  tier1Amount: 50,
+  tier2Amount: 100,
+  tier2MinDays: 3,
+  perDayRate: 20,
+  maxAmount: 500,
+  capPct: 5,
+};
+
+// Mockup case TEST-20260630-003: monthly 4,472; due 5 days ago → fee 100 (5×20).
+const now = new Date('2026-07-02T05:00:00Z');
+const overdue5d = new Date('2026-06-27T05:00:00Z');
+
+const basePayment = {
+  dueDate: overdue5d,
+  amountDue: D('4472.00'),
+  lateFeeWaived: false,
+};
+
+describe('computeRescheduleQuote — ปรับดิว collect-first quote (owner 2026-07-02)', () => {
+  it('fee = monthly/30×days ROUND_UP whole baht (4472/30×7 = 1043.47 → 1044)', () => {
+    const q = computeRescheduleQuote({
+      monthlyPayment: D('4472.00'),
+      daysToShift: 7,
+      splitMode: 'SPLIT',
+      payment: basePayment,
+      lateFeeCfg: cfg,
+      now,
+    });
+    expect(q.rescheduleFee.toFixed(2)).toBe('1044.00');
+  });
+
+  it('6a (SPLIT): collect = fee + late fee (1044 + 100 = 1144)', () => {
+    const q = computeRescheduleQuote({
+      monthlyPayment: D('4472.00'),
+      daysToShift: 7,
+      splitMode: 'SPLIT',
+      payment: basePayment,
+      lateFeeCfg: cfg,
+      now,
+    });
+    expect(q.variant).toBe('6a');
+    expect(q.lateFee.toFixed(2)).toBe('100.00'); // 5 days × 20฿
+    expect(q.collectAmount.toFixed(2)).toBe('1144.00');
+  });
+
+  it('6b (SINGLE): collect = late fee only (fee rides the next installment)', () => {
+    const q = computeRescheduleQuote({
+      monthlyPayment: D('4472.00'),
+      daysToShift: 7,
+      splitMode: 'SINGLE',
+      payment: basePayment,
+      lateFeeCfg: cfg,
+      now,
+    });
+    expect(q.variant).toBe('6b');
+    expect(q.collectAmount.toFixed(2)).toBe('100.00');
+  });
+
+  it('6b + not overdue → collect 0 (ยืนยันได้เลย ไม่ต้องเก็บเงิน)', () => {
+    const q = computeRescheduleQuote({
+      monthlyPayment: D('4472.00'),
+      daysToShift: 7,
+      splitMode: 'SINGLE',
+      payment: { ...basePayment, dueDate: new Date('2026-07-10T05:00:00Z') },
+      lateFeeCfg: cfg,
+      now,
+    });
+    expect(q.lateFee.toFixed(2)).toBe('0.00');
+    expect(q.collectAmount.toFixed(2)).toBe('0.00');
+  });
+
+  it('waived late fee → 0 even when overdue', () => {
+    const q = computeRescheduleQuote({
+      monthlyPayment: D('4472.00'),
+      daysToShift: 7,
+      splitMode: 'SINGLE',
+      payment: { ...basePayment, lateFeeWaived: true },
+      lateFeeCfg: cfg,
+      now,
+    });
+    expect(q.lateFee.toFixed(2)).toBe('0.00');
+  });
+
+  it('late fee honours the per-day caps (60 days × 20 = 1200 → capped at 5% × 4472 = 223.60)', () => {
+    const q = computeRescheduleQuote({
+      monthlyPayment: D('4472.00'),
+      daysToShift: 7,
+      splitMode: 'SINGLE',
+      payment: { ...basePayment, dueDate: new Date('2026-05-03T05:00:00Z') },
+      lateFeeCfg: cfg,
+      now,
+    });
+    expect(q.lateFee.toFixed(2)).toBe('223.60');
+  });
+});

--- a/apps/api/src/utils/reschedule-quote.util.ts
+++ b/apps/api/src/utils/reschedule-quote.util.ts
@@ -1,0 +1,54 @@
+import { Prisma } from '@prisma/client';
+import { LateFeeConfig, resolveLivePaymentLateFee } from './late-fee.util';
+
+export type RescheduleSplitMode = 'SINGLE' | 'SPLIT';
+
+export interface RescheduleQuoteInput {
+  /** Contract.monthlyPayment — per-installment total incl. commission + VAT. */
+  monthlyPayment: Prisma.Decimal | number | string;
+  daysToShift: number;
+  /** SINGLE = 6b (fee rides next installment) | SPLIT = 6a (fee collected now). */
+  splitMode: RescheduleSplitMode;
+  /** The Payment row being rescheduled (late fee owed for the CURRENT overdue period). */
+  payment: {
+    dueDate: Date;
+    amountDue: Prisma.Decimal | number | string;
+    lateFeeWaived: boolean;
+  };
+  lateFeeCfg: LateFeeConfig;
+  now: Date;
+}
+
+export interface RescheduleQuote {
+  /** monthlyPayment / 30 × daysToShift, ROUND_UP whole baht (owner policy 2026-06). */
+  rescheduleFee: Prisma.Decimal;
+  /** Late fee owed for days ALREADY overdue vs the CURRENT (pre-shift) due date. */
+  lateFee: Prisma.Decimal;
+  /** Cash to collect at confirm: 6a → fee + lateFee; 6b → lateFee only. */
+  collectAmount: Prisma.Decimal;
+  variant: '6a' | '6b';
+}
+
+/**
+ * Single source of truth for the ปรับดิว (reschedule) money quote — used by the
+ * quote endpoint, the atomic collect+reschedule execution, AND the reschedule-QR
+ * intent so all three always agree (owner directive 2026-07-02: เงินไม่เข้า ดิวไม่เลื่อน,
+ * ค่าปรับของช่วงที่เกินมาแล้วต้องถูกเก็บตอนปรับดิว ไม่ใช่ระเหยไปกับ due date ใหม่).
+ *
+ * Fee formula mirrors RescheduleService.execute exactly (anti-drift assert at the
+ * execution site). Late fee mirrors the wizard display / recordPayment recompute
+ * via resolveLivePaymentLateFee (mode-aware PER_DAY/BRACKET, waived → 0).
+ */
+export function computeRescheduleQuote(input: RescheduleQuoteInput): RescheduleQuote {
+  const fee = new Prisma.Decimal(input.monthlyPayment.toString())
+    .div(30)
+    .times(input.daysToShift)
+    .toDecimalPlaces(0, Prisma.Decimal.ROUND_UP);
+
+  const lateFee = resolveLivePaymentLateFee(input.payment, input.lateFeeCfg, input.now);
+
+  const variant = input.splitMode === 'SPLIT' ? '6a' : '6b';
+  const collectAmount = variant === '6a' ? fee.plus(lateFee) : lateFee;
+
+  return { rescheduleFee: fee, lateFee, collectAmount, variant };
+}

--- a/apps/web/src/components/payment/MobileReceipt.tsx
+++ b/apps/web/src/components/payment/MobileReceipt.tsx
@@ -11,6 +11,7 @@ const typeLabels: Record<string, string> = {
   DOWN_PAYMENT: 'ใบเสร็จเงินดาวน์',
   EARLY_PAYOFF: 'ใบเสร็จปิดยอด',
   CREDIT_NOTE: 'ใบลดหนี้',
+  RESCHEDULE_FEE: 'ใบเสร็จปรับดิว',
 };
 
 const methodLabels: Record<string, string> = {

--- a/apps/web/src/components/payment/PaymentHistorySheet.tsx
+++ b/apps/web/src/components/payment/PaymentHistorySheet.tsx
@@ -87,6 +87,7 @@ function caseFor(r: ReceiptItem, p: PaymentItem | undefined): { label: string; c
   if (r.receiptType === 'EARLY_PAYOFF') return { label: 'ปิดยอด', cls: 'text-warning' };
   if (r.receiptType === 'DOWN_PAYMENT') return { label: 'ดาวน์', cls: 'text-warning' };
   if (r.receiptType === 'CREDIT_NOTE') return { label: 'ใบลดหนี้', cls: 'text-warning' };
+  if (r.receiptType === 'RESCHEDULE_FEE') return { label: 'ปรับดิว', cls: 'text-warning' };
   if (r.paymentStatus === 'PARTIAL') return { label: 'PARTIAL', cls: 'text-info' };
   if (p && Number(r.amount) > Number(p.amountDue)) return { label: 'OVER', cls: 'text-primary' };
   return { label: 'NORMAL', cls: 'text-success' };

--- a/apps/web/src/components/payment/computeReceiptFeeDisplay.ts
+++ b/apps/web/src/components/payment/computeReceiptFeeDisplay.ts
@@ -25,7 +25,9 @@ export interface FeeInfo {
   waived: number;
 }
 
-const EXCLUDED_TYPES = new Set(['CREDIT_NOTE', 'EARLY_PAYOFF', 'DOWN_PAYMENT']);
+// RESCHEDULE_FEE: ปรับดิว collect receipt — carries its own fee/late-fee breakdown
+// in the collect JE; must not absorb the installment-level lateFee display.
+const EXCLUDED_TYPES = new Set(['CREDIT_NOTE', 'EARLY_PAYOFF', 'DOWN_PAYMENT', 'RESCHEDULE_FEE']);
 
 export function computeReceiptFeeDisplay(
   receipts: ReceiptFeeRow[],

--- a/apps/web/src/pages/PaymentsPage/components/QrSentBadge.tsx
+++ b/apps/web/src/pages/PaymentsPage/components/QrSentBadge.tsx
@@ -21,6 +21,8 @@ interface PartialPaymentLink {
   paymentUrl: string | null;
   token: string;
   status: 'ACTIVE' | 'PAID' | 'EXPIRED' | 'CANCELLED';
+  /** 'INSTALLMENT' (แบ่งชำระ) | 'RESCHEDULE' (ปรับดิว — ดิวเลื่อนเมื่อเงินเข้า) */
+  purpose?: 'INSTALLMENT' | 'RESCHEDULE';
   expiresAt: string;
   createdAt: string;
 }
@@ -97,8 +99,11 @@ export function QrSentBadge({ paymentId }: { paymentId: string }) {
     <div className="flex flex-col gap-1.5 mt-1">
       <Badge variant={badgeVariant} appearance="default" size="sm" className="gap-1.5">
         <Send className="size-3" />
-        QR ส่งแล้ว · ฿{amountThb}
+        {data.purpose === 'RESCHEDULE' ? 'QR ปรับดิว' : 'QR ส่งแล้ว'} · ฿{amountThb}
       </Badge>
+      {data.purpose === 'RESCHEDULE' && (
+        <div className="text-[10px] text-warning leading-tight">ดิวจะเลื่อนเมื่อเงินเข้า</div>
+      )}
       <div className="text-[10px] text-muted-foreground font-mono leading-tight">
         {tier === 'expired' ? 'หมดอายุ · กดส่งใหม่' : display}
       </div>

--- a/apps/web/src/pages/PaymentsPage/components/ReceiptsTab.tsx
+++ b/apps/web/src/pages/PaymentsPage/components/ReceiptsTab.tsx
@@ -72,6 +72,7 @@ const receiptTypeLabels: Record<string, string> = {
   DOWN_PAYMENT: 'เงินดาวน์',
   EARLY_PAYOFF: 'ปิดก่อนกำหนด',
   CREDIT_NOTE: 'ใบลดหนี้',
+  RESCHEDULE_FEE: 'ปรับดิว',
 };
 
 const methodLabels: Record<string, string> = {

--- a/apps/web/src/pages/PaymentsPage/components/RecordPaymentWizard.tsx
+++ b/apps/web/src/pages/PaymentsPage/components/RecordPaymentWizard.tsx
@@ -1108,7 +1108,7 @@ export function RecordPaymentWizard({
                     { key: 'PARTIAL', label: 'แบ่งชำระ', toggle: true, onClick: () => setCaseOverride('PARTIAL'), active: apiCase === 'PARTIAL' },
                     { key: 'OVERPAY_ADVANCE', label: 'ล่วงหน้า', toggle: true, onClick: () => setCaseOverride('OVERPAY_ADVANCE'), active: apiCase === 'OVERPAY_ADVANCE' },
                     { key: 'PAYOFF', label: 'ปิดยอด', toggle: false, onClick: () => setShowPayoffOverlay(true), active: false },
-                    { key: 'RESCHEDULE', label: 'ปรับงวด', toggle: false, onClick: () => setShowRescheduleOverlay(true), active: false },
+                    { key: 'RESCHEDULE', label: 'ปรับดิว', toggle: false, onClick: () => setShowRescheduleOverlay(true), active: false },
                     { key: 'REPO', label: 'คืนเครื่อง', toggle: false, onClick: () => setShowRepoOverlay(true), active: false },
                   ].map((t) => (
                     <button
@@ -1650,17 +1650,20 @@ export function RecordPaymentWizard({
         document.body,
       )}
 
-      {/* Reschedule overlay (ปรับงวด) — self-portals to document.body. Reschedule
-          posts no JE now; the JP6 JE posts at the next payment. */}
+      {/* Reschedule overlay (ปรับดิว) — self-portals to document.body. Collect-first
+          (2026-07-02): the overlay collects ค่าธรรมเนียม (6a) + ค่าปรับ BEFORE the
+          due-date shift; the collect JE posts atomically at confirm (QR → on webhook). */}
       {showRescheduleOverlay && (
         <RescheduleOverlay
           contractId={payment.contract.id}
           contractNumber={payment.contract.contractNumber}
           customerName={payment.contract.customer.name}
           branchName={payment.contract.branch.name}
+          paymentId={payment.id}
           installmentNo={payment.installmentNo}
           currentDueDate={payment.dueDate}
           monthlyPayment={payment.contract.monthlyPayment}
+          defaultDepositAccountCode={depositAccountCode}
           onClose={() => setShowRescheduleOverlay(false)}
           onSuccess={() => {
             setShowRescheduleOverlay(false);

--- a/apps/web/src/pages/PaymentsPage/components/RescheduleOverlay.tsx
+++ b/apps/web/src/pages/PaymentsPage/components/RescheduleOverlay.tsx
@@ -1,101 +1,206 @@
 import { useMemo, useState } from 'react';
 import { createPortal } from 'react-dom';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import Decimal from 'decimal.js';
-import { CalendarClock, CalendarDays, Layers, Check, AlertTriangle } from 'lucide-react';
+import {
+  CalendarClock,
+  CalendarDays,
+  Layers,
+  Check,
+  AlertTriangle,
+  Wallet,
+  Banknote,
+  Landmark,
+  QrCode,
+} from 'lucide-react';
 import api, { getErrorMessage } from '@/lib/api';
 import { formatThaiDate } from '@/lib/date';
+import { CashAccountSelect } from '@/components/CashAccountSelect';
+import { useDebounce } from '@/hooks/useDebounce';
 
 interface Props {
   contractId: string;
   contractNumber: string;
   customerName: string;
   branchName?: string;
+  /** Payment row id — needed for the reschedule-QR endpoint. */
+  paymentId: string;
   installmentNo: number;
   currentDueDate: string;
   /** serialized Decimal — the per-installment total (incl. commission + VAT). */
   monthlyPayment: string;
+  defaultDepositAccountCode?: string;
   onClose: () => void;
   onSuccess: () => void;
 }
 
 const QUICK_DAYS = [7, 14, 30];
 
+interface RescheduleQuote {
+  rescheduleFee: string;
+  lateFee: string;
+  collectAmount: string;
+  variant: '6a' | '6b';
+  newDueDate: string;
+  currentDueDate: string;
+}
+
+interface JePreviewLine {
+  accountCode: string;
+  accountName: string;
+  debit: string;
+  credit: string;
+  description: string;
+}
+
+type CollectMethod = 'CASH' | 'TRANSFER' | 'QR';
+
 /**
- * In-modal "ปรับงวด" (reschedule) overlay — mirrors EarlyPayoffOverlay's portal pattern.
- * Reschedule is a DB-only operation (shift due dates from `installmentNo` onward by
- * `daysToShift`, then set the last installment's amountDue = monthlyPayment − fee). NO
- * journal posts at reschedule time — the JP6 JE posts later when the customer pays
- * (6b bundled / 6a fee-advance). So this overlay has no live JE preview by design.
+ * In-modal "ปรับดิว" (reschedule) overlay — collect-first (owner directive
+ * 2026-07-02): เงินไม่เข้า ดิวไม่เลื่อน.
+ *
+ * Flow: เลือกจำนวนวัน → วิธีเก็บค่าธรรมเนียม (6a/6b) → ชำระเงิน (ค่าธรรมเนียม 6a +
+ * ค่าปรับค้าง ถ้ามี) → ยืนยัน. The server quotes fee + late fee authoritatively
+ * (GET /payments/reschedule-quote); confirm posts the collect JE + resets the
+ * late fee + shifts due dates in ONE transaction. QR is async: the due date
+ * shifts only when the PaySolutions webhook confirms payment.
  */
 export function RescheduleOverlay({
   contractId,
   contractNumber,
   customerName,
   branchName,
+  paymentId,
   installmentNo,
   currentDueDate,
   monthlyPayment,
+  defaultDepositAccountCode = '11-1101',
   onClose,
   onSuccess,
 }: Props) {
   const queryClient = useQueryClient();
   const [daysToShift, setDaysToShift] = useState(7);
   const [splitMode, setSplitMode] = useState<'SINGLE' | 'SPLIT'>('SINGLE');
+  const [method, setMethod] = useState<CollectMethod>('CASH');
+  const [depositAccountCode, setDepositAccountCode] = useState(defaultDepositAccountCode);
+  const [referenceNumber, setReferenceNumber] = useState('');
 
   const days = Math.max(0, Math.floor(daysToShift) || 0);
+  const debouncedDays = useDebounce(days, 300);
 
-  // Fee = monthlyPayment / 30 × days, rounded UP to a whole baht (owner policy 2026-06 —
-  // ปัดเศษขึ้นเต็มบาท). Identical to RescheduleService.execute + the preview service.
-  // Display-only estimate; the server recomputes authoritatively.
-  const fee = useMemo(() => {
-    if (days <= 0) return new Decimal(0);
-    return new Decimal(monthlyPayment || 0).div(30).times(days).toDecimalPlaces(0, Decimal.ROUND_UP);
-  }, [monthlyPayment, days]);
+  // Server-authoritative quote — fee (monthly/30×days ปัดขึ้นเต็มบาท) + ค่าปรับค้าง.
+  const { data: quote, isFetching: quoteLoading, error: quoteError } = useQuery<RescheduleQuote>({
+    queryKey: ['reschedule-quote', contractId, installmentNo, debouncedDays, splitMode],
+    queryFn: async () => {
+      const { data } = await api.get<RescheduleQuote>('/payments/reschedule-quote', {
+        params: { contractId, installmentNo, daysToShift: debouncedDays, splitMode },
+      });
+      return data;
+    },
+    enabled: debouncedDays >= 1,
+    staleTime: 0,
+    retry: false,
+  });
 
-  const lastInstallmentNewAmount = useMemo(() => {
-    return new Decimal(monthlyPayment || 0).minus(fee).toDecimalPlaces(2);
-  }, [monthlyPayment, fee]);
+  const fee = useMemo(() => new Decimal(quote?.rescheduleFee ?? 0), [quote]);
+  const lateFee = useMemo(() => new Decimal(quote?.lateFee ?? 0), [quote]);
+  const collect = useMemo(() => new Decimal(quote?.collectAmount ?? 0), [quote]);
+  const hasCollect = collect.gt(0);
 
-  const newDueDate = useMemo(() => {
-    const dt = new Date(currentDueDate);
-    if (Number.isNaN(dt.getTime())) return null;
-    dt.setDate(dt.getDate() + days);
-    return dt.toISOString().slice(0, 10);
-  }, [currentDueDate, days]);
-
-  const mutation = useMutation({
-    mutationFn: async () => {
-      // Reschedule posts NO JE now (DB-only). `amount`/`paymentMethod` are RecordPaymentDto
-      // validation placeholders — the controller's RESCHEDULE branch returns before using them.
-      // amount=0.01 is the @Min(0.01) threshold (unambiguously "required but unused").
-      const { data } = await api.post('/payments/record', {
+  // JE preview — the exact lines the confirm will post (collect-first semantics).
+  const { data: jePreview } = useQuery<{ lines: JePreviewLine[]; isBalanced: boolean }>({
+    queryKey: ['reschedule-je-preview', contractId, installmentNo, debouncedDays, splitMode, depositAccountCode, quote?.lateFee],
+    queryFn: async () => {
+      const { data } = await api.post('/payments/preview-journal', {
         contractId,
         installmentNo,
-        amount: 0.01,
-        paymentMethod: 'CASH',
+        amountReceived: collect.toNumber(),
+        depositAccountCode,
+        lateFee: lateFee.toNumber(),
         case: 'RESCHEDULE',
-        daysToShift: days,
+        daysToShift: debouncedDays,
         splitMode,
       });
       return data;
     },
+    enabled: !!quote && hasCollect && debouncedDays >= 1,
+    staleTime: 0,
+    retry: false,
+  });
+
+  const newDueDate = quote?.newDueDate ?? null;
+
+  // ── Confirm (เงินสด/โอน — synchronous atomic collect + reschedule) ──────────
+  const confirmMutation = useMutation({
+    mutationFn: async () => {
+      const { data } = await api.post('/payments/record', {
+        contractId,
+        installmentNo,
+        // Server re-validates against its own quote (±0.01). Zero-collect (6b,
+        // no late fee) still needs the DTO's @Min(0.01) — server ignores it then.
+        amount: hasCollect ? collect.toNumber() : 0.01,
+        paymentMethod: method === 'TRANSFER' ? 'BANK_TRANSFER' : 'CASH',
+        case: 'RESCHEDULE',
+        daysToShift: days,
+        splitMode,
+        depositAccountCode,
+        ...(referenceNumber ? { transactionRef: referenceNumber } : {}),
+      });
+      return data;
+    },
     onSuccess: () => {
-      toast.success('ปรับงวด (เลื่อนวันครบกำหนด) สำเร็จ');
-      // Match the parent PaymentsPage query keys so the list refreshes immediately.
-      queryClient.invalidateQueries({ queryKey: ['contract', contractId] });
-      queryClient.invalidateQueries({ queryKey: ['contracts'] });
-      queryClient.invalidateQueries({ queryKey: ['pending-payments'] });
-      queryClient.invalidateQueries({ queryKey: ['pending-summary'] });
-      queryClient.invalidateQueries({ queryKey: ['daily-summary'] });
+      toast.success(
+        hasCollect
+          ? `ปรับดิวสำเร็จ — เก็บเงิน ${collect.toNumber().toLocaleString('th-TH', { minimumFractionDigits: 2 })} บาท ลงบัญชีแล้ว`
+          : 'ปรับดิวสำเร็จ',
+      );
+      invalidateAll();
       onSuccess();
       onClose();
     },
     onError: (err) => toast.error(getErrorMessage(err)),
   });
 
-  const canSubmit = days >= 1 && !mutation.isPending;
+  // ── ส่ง QR (async — ดิวเลื่อนเมื่อ webhook ยืนยันเงินเข้า) ─────────────────────
+  const qrMutation = useMutation({
+    mutationFn: async () => {
+      const { data } = await api.post(`/payments/${paymentId}/reschedule-qr`, {
+        daysToShift: days,
+        splitMode,
+      });
+      return data as { sentToLine: boolean; collectAmount: string };
+    },
+    onSuccess: (data) => {
+      toast.success(
+        data.sentToLine
+          ? 'ส่ง QR ปรับดิวให้ลูกค้าใน LINE แล้ว — ดิวจะเลื่อนอัตโนมัติเมื่อเงินเข้า'
+          : 'สร้าง QR แล้ว (ลูกค้าไม่มี LINE — เปิดลิงก์ชำระจากรายการ QR) — ดิวจะเลื่อนเมื่อเงินเข้า',
+      );
+      invalidateAll();
+      onSuccess();
+      onClose();
+    },
+    onError: (err) => toast.error(getErrorMessage(err)),
+  });
+
+  const invalidateAll = () => {
+    queryClient.invalidateQueries({ queryKey: ['contract', contractId] });
+    queryClient.invalidateQueries({ queryKey: ['contracts'] });
+    queryClient.invalidateQueries({ queryKey: ['pending-payments'] });
+    queryClient.invalidateQueries({ queryKey: ['pending-summary'] });
+    queryClient.invalidateQueries({ queryKey: ['daily-summary'] });
+  };
+
+  const isPending = confirmMutation.isPending || qrMutation.isPending;
+  const needRef = hasCollect && method === 'TRANSFER' && !referenceNumber.trim();
+  const canSubmit =
+    days >= 1 && !isPending && !quoteLoading && !!quote && !needRef;
+
+  const submit = () => {
+    if (method === 'QR' && hasCollect) qrMutation.mutate();
+    else confirmMutation.mutate();
+  };
 
   return createPortal(
     <div className="fixed inset-0 z-50 pointer-events-auto bg-black/50 backdrop-blur-xs flex items-start justify-center pt-8 pb-8">
@@ -108,7 +213,7 @@ export function RescheduleOverlay({
           >
             ← กลับ
           </button>
-          <h2 className="text-lg font-semibold text-foreground leading-snug">ปรับงวด — เลื่อนวันครบกำหนด</h2>
+          <h2 className="text-lg font-semibold text-foreground leading-snug">ปรับดิว — เลื่อนวันครบกำหนด</h2>
           <div className="w-16" />
         </div>
 
@@ -159,38 +264,153 @@ export function RescheduleOverlay({
               {newDueDate && (
                 <Row label="ครบกำหนดใหม่ (งวดนี้)" value={formatThaiDate(newDueDate)} bold />
               )}
-              <Row label="ค่าธรรมเนียมเลื่อนงวด" value={`${fee.toFixed(2)} บาท`} />
+              <Row
+                label="ค่าธรรมเนียมเลื่อนดิว"
+                value={quoteLoading ? 'กำลังคำนวณ…' : `${fee.toFixed(2)} บาท`}
+              />
               <p className="text-xs text-muted-foreground leading-snug">
-                คำนวณจาก ค่างวด ({new Decimal(monthlyPayment || 0).toFixed(2)}) ÷ 30 × {days} วัน (ปัดขึ้นเต็มบาท) — ระบบคำนวณจริงตอนยืนยัน
+                คำนวณจาก ค่างวด ({new Decimal(monthlyPayment || 0).toFixed(2)}) ÷ 30 × {days} วัน (ปัดขึ้นเต็มบาท)
               </p>
             </div>
           </Section>
 
           {/* Section 3: รูปแบบค่าธรรมเนียม (6a/6b) */}
-          <Section icon={<Layers className="size-4" />} title="วิธีเก็บค่าธรรมเนียม" subtitle="เลือกรูปแบบการเก็บค่าธรรมเนียมเลื่อนงวด">
+          <Section icon={<Layers className="size-4" />} title="วิธีเก็บค่าธรรมเนียม" subtitle="เลือกรูปแบบการเก็บค่าธรรมเนียมเลื่อนดิว">
             <div className="space-y-2">
               <ModeOption
                 active={splitMode === 'SINGLE'}
                 onClick={() => setSplitMode('SINGLE')}
                 title="รวมกับงวดถัดไป (6b)"
-                desc="ลูกค้าจ่ายค่าธรรมเนียมพร้อมค่างวดถัดไปทีเดียว"
+                desc="ค่าธรรมเนียมรวมไปกับค่างวดถัดไป — วันนี้เก็บเฉพาะค่าปรับ (ถ้ามี)"
               />
               <ModeOption
                 active={splitMode === 'SPLIT'}
                 onClick={() => setSplitMode('SPLIT')}
-                title="เก็บค่าธรรมเนียมแยกก่อน (6a)"
-                desc="เก็บค่าธรรมเนียมเลื่อนงวดเป็นเงินรับล่วงหน้าตอนนี้ แล้วจ่ายค่างวดตามปกติ"
+                title="เก็บค่าธรรมเนียมตอนนี้ (6a)"
+                desc="เก็บค่าธรรมเนียมเลื่อนดิว + ค่าปรับ (ถ้ามี) เป็นเงินสด/โอน/QR ก่อนเลื่อนดิว"
               />
             </div>
           </Section>
 
-          {/* Section 4: สิ่งที่จะเกิดขึ้น */}
-          <Section icon={<Check className="size-4" />} title="สิ่งที่จะเกิดขึ้นเมื่อยืนยัน" subtitle="ตรวจสอบก่อนปรับงวด" tone="success">
+          {/* Section 4: ชำระเงิน (collect-first — เงินไม่เข้า ดิวไม่เลื่อน) */}
+          <Section icon={<Wallet className="size-4" />} title="ชำระเงิน" subtitle="ยอดที่ต้องเก็บก่อนเลื่อนดิว">
+            {quoteError ? (
+              <p className="text-sm text-destructive leading-snug">{getErrorMessage(quoteError)}</p>
+            ) : (
+              <>
+                <div className="space-y-1.5 text-sm mb-3">
+                  {splitMode === 'SPLIT' && (
+                    <Row label="ค่าธรรมเนียมเลื่อนดิว (6a)" value={`${fee.toFixed(2)} บาท`} />
+                  )}
+                  <Row
+                    label="ค่าปรับค้างชำระ"
+                    value={lateFee.gt(0) ? `${lateFee.toFixed(2)} บาท` : 'ไม่มี'}
+                  />
+                  <div className="border-t border-border pt-1.5">
+                    <Row label="รวมต้องเก็บวันนี้" value={`${collect.toFixed(2)} บาท`} bold />
+                  </div>
+                </div>
+
+                {hasCollect ? (
+                  <>
+                    {/* ช่องทางรับชำระ */}
+                    <div className="grid grid-cols-3 gap-2 mb-3">
+                      <MethodButton
+                        active={method === 'CASH'}
+                        onClick={() => setMethod('CASH')}
+                        icon={<Banknote className="size-4" />}
+                        label="เงินสด"
+                      />
+                      <MethodButton
+                        active={method === 'TRANSFER'}
+                        onClick={() => setMethod('TRANSFER')}
+                        icon={<Landmark className="size-4" />}
+                        label="โอนธนาคาร"
+                      />
+                      <MethodButton
+                        active={method === 'QR'}
+                        onClick={() => setMethod('QR')}
+                        icon={<QrCode className="size-4" />}
+                        label="QR ใน LINE"
+                      />
+                    </div>
+
+                    {method !== 'QR' && (
+                      <div className="space-y-2.5">
+                        <div>
+                          <label className="block text-xs font-medium text-foreground mb-1 leading-snug">บัญชีรับเงิน</label>
+                          <CashAccountSelect value={depositAccountCode} onChange={setDepositAccountCode} />
+                        </div>
+                        {method === 'TRANSFER' && (
+                          <div>
+                            <label className="block text-xs font-medium text-foreground mb-1 leading-snug">
+                              เลขอ้างอิงการโอน <span className="text-destructive">*</span>
+                            </label>
+                            <input
+                              type="text"
+                              value={referenceNumber}
+                              onChange={(e) => setReferenceNumber(e.target.value)}
+                              placeholder="เลขอ้างอิงจากสลิปโอนเงิน"
+                              className="w-full px-3 py-2 border border-input rounded-lg text-sm"
+                            />
+                          </div>
+                        )}
+                      </div>
+                    )}
+
+                    {method === 'QR' && (
+                      <div className="rounded-lg border border-warning/40 bg-warning/10 px-3 py-2.5 text-xs text-warning leading-snug">
+                        ระบบจะส่ง QR ยอด {collect.toFixed(2)} บาท ให้ลูกค้าใน LINE —
+                        <strong> ดิวจะเลื่อนอัตโนมัติเมื่อเงินเข้าเท่านั้น</strong> (QR หมดอายุใน 24 ชม.
+                        ถ้าลูกค้าไม่จ่าย ดิวไม่เลื่อน)
+                      </div>
+                    )}
+
+                    {/* JE preview — บรรทัดบัญชีที่จะลงจริงตอนยืนยัน */}
+                    {method !== 'QR' && jePreview && jePreview.lines.length > 0 && (
+                      <div className="mt-3 rounded-lg border border-border bg-muted/40 px-3 py-2.5">
+                        <div className="text-xs font-semibold text-muted-foreground mb-1.5 leading-snug">รายการบัญชี (ลงทันทีตอนยืนยัน)</div>
+                        <div className="space-y-1">
+                          {jePreview.lines.map((l, i) => (
+                            <div key={i} className="flex justify-between text-xs font-mono leading-snug">
+                              <span className="text-muted-foreground">{l.accountCode} {l.accountName}</span>
+                              <span>{Number(l.debit) > 0 ? `Dr ${l.debit}` : `Cr ${l.credit}`}</span>
+                            </div>
+                          ))}
+                        </div>
+                      </div>
+                    )}
+                  </>
+                ) : (
+                  <div className="rounded-lg border border-success/40 bg-success/10 px-3 py-2.5 text-xs text-success leading-snug">
+                    ไม่มียอดต้องเก็บวันนี้ (6b + ไม่มีค่าปรับ) — ยืนยันปรับดิวได้เลย
+                  </div>
+                )}
+              </>
+            )}
+          </Section>
+
+          {/* Section 5: สิ่งที่จะเกิดขึ้น */}
+          <Section icon={<Check className="size-4" />} title="สิ่งที่จะเกิดขึ้นเมื่อยืนยัน" subtitle="ตรวจสอบก่อนปรับดิว" tone="success">
             <ul className="space-y-1.5 text-sm">
+              {hasCollect && method === 'QR' ? (
+                <Effect text={`ส่ง QR ยอด ${collect.toFixed(2)} บาท ให้ลูกค้า — ดิวเลื่อนเมื่อเงินเข้า`} warning />
+              ) : (
+                <>
+                  {hasCollect && (
+                    <Effect text={`เก็บเงิน ${collect.toFixed(2)} บาท${lateFee.gt(0) ? ` (รวมค่าปรับ ${lateFee.toFixed(2)} บาท → ลงบัญชี 42-1103)` : ''} + ลงบัญชีทันที`} />
+                  )}
+                  {lateFee.gt(0) && <Effect text="ค่าปรับช่วงที่เกินมาแล้วถูกเก็บและปิดยอด — เริ่มนับใหม่จากดิวใหม่" />}
+                </>
+              )}
               <Effect text={`เลื่อนวันครบกำหนดงวดที่ ${installmentNo} เป็นต้นไป +${days} วัน`} />
-              <Effect text={`ปรับยอดงวดสุดท้าย = ค่างวด − ค่าธรรมเนียม (${lastInstallmentNewAmount.toFixed(2)} บาท)`} />
-              <Effect text={`บันทึก AuditLog (RESCHEDULE ${splitMode === 'SPLIT' ? '6a' : '6b'})`} />
-              <Effect text="ยังไม่ลงบัญชีตอนนี้ — JE (JP6) จะลงตอนลูกค้าจ่ายงวดถัดไป" warning />
+              {splitMode === 'SPLIT' && fee.gt(0) && (
+                <Effect text={`ค่าธรรมเนียม ${fee.toFixed(2)} บาท บันทึกเป็นเงินรับล่วงหน้า (นำไปหักค่างวดถัดไปอัตโนมัติ)`} />
+              )}
+              {splitMode === 'SINGLE' && fee.gt(0) && (
+                <Effect text={`ค่าธรรมเนียม ${fee.toFixed(2)} บาท จดไว้ในโน้ตงวดนี้ — เก็บเพิ่มพร้อมค่างวดตอนรับชำระ`} warning />
+              )}
+              <Effect text={`บันทึก AuditLog (RESCHEDULE ${splitMode === 'SPLIT' ? '6a' : '6b'} + RESCHEDULE_COLLECT)`} />
             </ul>
           </Section>
         </div>
@@ -201,11 +421,17 @@ export function RescheduleOverlay({
             ยกเลิก
           </button>
           <button
-            onClick={() => mutation.mutate()}
+            onClick={submit}
             disabled={!canSubmit}
             className="px-6 py-2.5 text-sm leading-snug bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 disabled:opacity-50 font-semibold transition-colors shadow-sm"
           >
-            {mutation.isPending ? 'กำลังปรับงวด...' : 'ยืนยันปรับงวด'}
+            {isPending
+              ? 'กำลังดำเนินการ...'
+              : method === 'QR' && hasCollect
+                ? 'ส่ง QR ให้ลูกค้า'
+                : hasCollect
+                  ? `เก็บเงิน ${collect.toFixed(2)} + ยืนยันปรับดิว`
+                  : 'ยืนยันปรับดิว'}
           </button>
         </div>
       </div>
@@ -276,6 +502,34 @@ function ModeOption({
     >
       <div className="text-sm font-semibold text-foreground leading-snug">{title}</div>
       <div className="text-xs text-muted-foreground leading-snug">{desc}</div>
+    </button>
+  );
+}
+
+function MethodButton({
+  active,
+  onClick,
+  icon,
+  label,
+}: {
+  active: boolean;
+  onClick: () => void;
+  icon: React.ReactNode;
+  label: string;
+}) {
+  return (
+    <button
+      type="button"
+      aria-pressed={active}
+      onClick={onClick}
+      className={`flex items-center justify-center gap-1.5 rounded-xl border-2 px-2 py-2 text-sm font-medium leading-snug transition-colors ${
+        active
+          ? 'bg-primary border-primary text-primary-foreground'
+          : 'bg-card border-border text-foreground hover:border-primary/40 hover:bg-accent'
+      }`}
+    >
+      {icon}
+      {label}
     </button>
   );
 }

--- a/apps/web/src/pages/liff/LiffReceipts.tsx
+++ b/apps/web/src/pages/liff/LiffReceipts.tsx
@@ -26,6 +26,7 @@ const typeLabels: Record<string, { label: string; variant: 'success' | 'info' | 
   DOWN_PAYMENT: { label: 'เงินดาวน์', variant: 'info' },
   EARLY_PAYOFF: { label: 'ปิดยอด', variant: 'info' },
   CREDIT_NOTE: { label: 'ใบลดหนี้', variant: 'secondary' },
+  RESCHEDULE_FEE: { label: 'ปรับดิว', variant: 'info' },
 };
 
 export default function LiffReceipts() {


### PR DESCRIPTION
## สรุป

2 owner directives (2026-07-02) บน payment money paths:

### 1. แบ่งชำระ: ค่าปรับ book ก่อนเงินต้น (fee-first)
- `splitReceipt` เครดิต **42-1103 ก่อน 11-2103** — ledger ตรงกับใบเสร็จ (ค่าปรับโชว์ใบแรก)
- เคส mockup: จ่ายบางส่วน 2,572 บน 4,472+100 → `Cr 42-1103 100 + Cr 11-2103 2,472`
- PARTIAL preview ใช้ pipeline เดียวกับ posting เป๊ะ (shared `reconstructPriorCleared` ใหม่) — ใบที่ 2 ไม่โชว์ค่าปรับซ้ำ, waiver+PARTIAL โดน reject ตั้งแต่ preview
- Bonus fix: ใบปิดงวดขาด ≤1฿ ไม่ short ค่าปรับเงียบๆ อีกต่อไป (ส่วนขาดไปลง 52-1104 ฝั่งเงินต้น)

### 2. ปรับดิว (rename จาก "ปรับงวด"): collect-first — เงินไม่เข้า ดิวไม่เลื่อน
- เดิม: ยืนยัน = เลื่อนดิวฟรี + ค่าปรับระเหย (dueDate shift ลบหลักฐานช่วงเกินกำหนด)
- ใหม่: `RescheduleCollectService` — 1 Serializable tx = collect JE (`Dr เงินสด / Cr 21-1103 fee (6a) + Cr 42-1103 ค่าปรับ`) + reset `Payment.lateFee` (เก็บแล้ว) + เลื่อนวัน + audit `RESCHEDULE_COLLECT`; ใบเสร็จ `RESCHEDULE_FEE` post-commit
- Quote จาก server (`GET /payments/reschedule-quote`) + mismatch guard ±0.01
- **6a fee = เงินรับล่วงหน้าตาม CPA case** → เข้า `Contract.advanceBalance` ให้กลไกเครดิตเดิมหักคืนจริง (review C1: การลด `InstallmentSchedule.amountDue` เดิมเป็น write-only — ถอดออก)
- 6b เก็บเฉพาะค่าปรับ; fee จดใน note งวด เก็บเพิ่มผ่าน D1 overage auto-route
- **QR**: `PartialPaymentLink.purpose='RESCHEDULE'` + frozen quote ใน metadata → webhook PaySolutions ยืนยันเงินเข้าแล้วจึง execute; หมดอายุ 24 ชม. = ดิวไม่เลื่อน; Flex "ใบแจ้งชำระปรับดิว" ใหม่
- Sentry fatal เมื่อ success webhook มาหลัง link EXPIRED (เงินถึง gateway แต่ไม่มีบันทึก)

## Testing
- **73 suites / 753 tests ผ่าน** (payments + paysolutions + journal + utils + installments), มี test ใหม่ ~30 ตัว
- `tsc --noEmit` clean ทั้ง API + Web
- `code-reviewer` 2 รอบ: PASS (Critical C1 + Warnings W1-W3 แก้ครบ, verified)
- Migration 1 ตัว: `20260979000000_partial_link_purpose_metadata` (additive, `IF NOT EXISTS`)

## Follow-ups (Info-level, ไม่ block)
- 6b fee เป็น note ให้พนักงานเก็บเพิ่ม — enforce เป็น field จริงภายหลัง
- Early-payoff ไม่ reconcile `advanceBalance` ค้าง (bug เก่าก่อน PR นี้)
- Reconciliation cron สำหรับ QR paid-but-exec-failed + ลบ JP6 template ที่ไม่มี caller

🤖 Generated with [Claude Code](https://claude.com/claude-code)