### PR TITLE
fix(web): เดือนนี้ date preset covers the full calendar month

### DIFF
--- a/apps/web/src/components/ui/DateRangeChips.tsx
+++ b/apps/web/src/components/ui/DateRangeChips.tsx
@@ -17,8 +17,12 @@ function toIsoDate(d: Date): string {
 }
 
 function thisMonthRange(today: Date): { startDate: string; endDate: string } {
+  // Full calendar month (1st → last day), NOT [1st → today] — owner 2026-07-02:
+  // "เดือนนี้" must cover the whole month (e.g. installments due later this month
+  // belong in the queue), and it mirrors lastMonthRange which was already full-month.
   const first = new Date(today.getFullYear(), today.getMonth(), 1);
-  return { startDate: toIsoDate(first), endDate: toIsoDate(today) };
+  const last = new Date(today.getFullYear(), today.getMonth() + 1, 0);
+  return { startDate: toIsoDate(first), endDate: toIsoDate(last) };
 }
 
 function lastMonthRange(today: Date): { startDate: string; endDate: string } {

--- a/apps/web/src/lib/date.test.ts
+++ b/apps/web/src/lib/date.test.ts
@@ -10,9 +10,9 @@ describe('lib/date — computeDefaultTimeRange', () => {
     expect(r).toEqual({ startDate: '', endDate: '' });
   });
 
-  it("'this_month' returns first-of-current-month → today (BKK)", () => {
+  it("'this_month' returns the FULL current month (owner 2026-07-02: เดือนนี้ = ทั้งเดือน)", () => {
     const r = computeDefaultTimeRange('this_month', fixedMidApril);
-    expect(r).toEqual({ startDate: '2026-04-01', endDate: '2026-04-15' });
+    expect(r).toEqual({ startDate: '2026-04-01', endDate: '2026-04-30' });
   });
 
   it("'last_month' returns first → last day of previous month", () => {

--- a/apps/web/src/lib/date.ts
+++ b/apps/web/src/lib/date.ts
@@ -126,7 +126,8 @@ export function adToBe(yearAD: number): number {
  *
  * - `'today'`      → today → today (D1.3.5.1)
  * - `'this_week'`  → Monday-of-this-week → today (D1.3.5.1, ISO week start)
- * - `'this_month'` → first-of-month → today (Asia/Bangkok)
+ * - `'this_month'` → first-of-month → last-of-month (Asia/Bangkok; full month
+ *                    per owner 2026-07-02 — matches the "เดือนนี้" chip preset)
  * - `'last_month'` → first-of-last-month → last-of-last-month
  * - `'all'`        → empty strings (the page query treats empty as "no filter")
  *
@@ -146,7 +147,14 @@ export function computeDefaultTimeRange(
     return { startDate: bkkToday, endDate: bkkToday };
   }
   if (preset === 'this_month') {
-    return { startDate: `${bkkToday.slice(0, 7)}-01`, endDate: bkkToday };
+    // Full month — last-day via the UTC "day = 0" idiom (month lengths are
+    // timezone-invariant, so UTC math on the BKK-local year/month is safe).
+    const [yStr, mStr] = bkkToday.split('-');
+    const lastDayOfMonth = new Date(Date.UTC(Number(yStr), Number(mStr), 0)).getUTCDate();
+    return {
+      startDate: `${bkkToday.slice(0, 7)}-01`,
+      endDate: `${bkkToday.slice(0, 7)}-${String(lastDayOfMonth).padStart(2, '0')}`,
+    };
   }
   if (preset === 'this_week') {
     // ISO week start (Monday). Compute day-of-week relative to UTC-indexed

--- a/apps/web/src/pages/GeneralLedgerPage.tsx
+++ b/apps/web/src/pages/GeneralLedgerPage.tsx
@@ -82,10 +82,14 @@ function NormalBalanceBadge({ value }: { value: 'Dr' | 'Cr' | 'Dr/Cr' }) {
 }
 
 export function GeneralLedgerPage() {
+  // Local-date formatting (NOT toISOString — that shifts a BKK local-midnight
+  // date back one UTC day). Default = full current month, matching the
+  // DateRangeChips "เดือนนี้" preset (owner 2026-07-02).
+  const toLocalIso = (d: Date) =>
+    `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
   const now = new Date();
-  const firstOfMonth = new Date(now.getFullYear(), now.getMonth(), 1);
-  const [startDate, setStartDate] = useState(firstOfMonth.toISOString().split('T')[0]);
-  const [endDate, setEndDate] = useState(now.toISOString().split('T')[0]);
+  const [startDate, setStartDate] = useState(toLocalIso(new Date(now.getFullYear(), now.getMonth(), 1)));
+  const [endDate, setEndDate] = useState(toLocalIso(new Date(now.getFullYear(), now.getMonth() + 1, 0)));
   const [companyId, setCompanyId] = useState('');
   const [accountCode, setAccountCode] = useState('');
   const [pickerOpen, setPickerOpen] = useState(false);

--- a/apps/web/src/pages/PaymentsPage/index.tsx
+++ b/apps/web/src/pages/PaymentsPage/index.tsx
@@ -53,7 +53,8 @@ export default function PaymentsPage() {
 
   // Period filter for the pending queue (KPI cards + list) — scopes everything
   // by installment dueDate. Default is "เดือนนี้" (matches DateRangeChips'
-  // thisMonth preset: [1st of month, today]) so that chip reads active on load.
+  // thisMonth preset: the FULL calendar month, owner 2026-07-02) so that chip
+  // reads active on load AND installments due later this month stay visible.
   // NOTE: a month default hides installments due in earlier months from the
   // queue — switch to "ทั้งหมด" to chase back-dated overdue.
   const [startDate, setStartDate] = useState(() => {
@@ -62,7 +63,8 @@ export default function PaymentsPage() {
   });
   const [endDate, setEndDate] = useState(() => {
     const now = new Date();
-    return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
+    const last = new Date(now.getFullYear(), now.getMonth() + 1, 0);
+    return `${last.getFullYear()}-${String(last.getMonth() + 1).padStart(2, '0')}-${String(last.getDate()).padStart(2, '0')}`;
   });
   const dueFrom = startDate || undefined;
   const dueTo = endDate || undefined;
@@ -73,11 +75,12 @@ export default function PaymentsPage() {
       `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
     const today = new Date();
     const thisFirst = toIso(new Date(today.getFullYear(), today.getMonth(), 1));
-    const thisToday = toIso(today);
+    // Full-month end — matches the DateRangeChips thisMonth preset (owner 2026-07-02).
+    const thisEnd = toIso(new Date(today.getFullYear(), today.getMonth() + 1, 0));
     const lastFirst = toIso(new Date(today.getFullYear(), today.getMonth() - 1, 1));
     const lastEnd = toIso(new Date(today.getFullYear(), today.getMonth(), 0));
     if (!startDate && !endDate) return 'รับชำระทั้งหมด';
-    if (startDate === thisFirst && endDate === thisToday) return 'รับชำระเดือนนี้';
+    if (startDate === thisFirst && endDate === thisEnd) return 'รับชำระเดือนนี้';
     if (startDate === lastFirst && endDate === lastEnd) return 'รับชำระเดือนที่แล้ว';
     return 'รับชำระช่วงนี้';
   }, [startDate, endDate]);

--- a/apps/web/src/pages/ReportsPage.tsx
+++ b/apps/web/src/pages/ReportsPage.tsx
@@ -458,9 +458,14 @@ function StockReport() {
 }
 
 function EntityProfitReport() {
+  // Local-date formatting (NOT toISOString — that shifts a BKK local-midnight
+  // date back one UTC day). Default = full current month, matching the
+  // DateRangeChips "เดือนนี้" preset (owner 2026-07-02).
+  const toLocalIso = (d: Date) =>
+    `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
   const today = new Date();
-  const firstDay = new Date(today.getFullYear(), today.getMonth(), 1).toISOString().slice(0, 10);
-  const lastDay = today.toISOString().slice(0, 10);
+  const firstDay = toLocalIso(new Date(today.getFullYear(), today.getMonth(), 1));
+  const lastDay = toLocalIso(new Date(today.getFullYear(), today.getMonth() + 1, 0));
   const [startDate, setStartDate] = useState(firstDay);
   const [endDate, setEndDate] = useState(lastDay);
   const [entity, setEntity] = useState<string>('ALL');

--- a/apps/web/src/pages/other-income/components/__tests__/DateRangeChips.test.tsx
+++ b/apps/web/src/pages/other-income/components/__tests__/DateRangeChips.test.tsx
@@ -24,10 +24,10 @@ describe('DateRangeChips', () => {
     expect(screen.getByRole('radio', { name: /ช่วงวันที่/ })).toBeInTheDocument();
   });
 
-  it('clicking "เดือนนี้" emits 1st of current month → today', () => {
+  it('clicking "เดือนนี้" emits the FULL current month (owner 2026-07-02)', () => {
     render(<DateRangeChips startDate="" endDate="" onChange={onChange} />);
     fireEvent.click(screen.getByRole('radio', { name: 'เดือนนี้' }));
-    expect(onChange).toHaveBeenCalledWith({ startDate: '2026-05-01', endDate: '2026-05-14' });
+    expect(onChange).toHaveBeenCalledWith({ startDate: '2026-05-01', endDate: '2026-05-31' });
   });
 
   it('clicking "เดือนที่แล้ว" emits 1st → last day of last month', () => {
@@ -71,8 +71,8 @@ describe('DateRangeChips', () => {
     );
   });
 
-  it('"เดือนนี้" chip has aria-checked=true when current month is selected', () => {
-    render(<DateRangeChips startDate="2026-05-01" endDate="2026-05-14" onChange={onChange} />);
+  it('"เดือนนี้" chip has aria-checked=true when the full current month is selected', () => {
+    render(<DateRangeChips startDate="2026-05-01" endDate="2026-05-31" onChange={onChange} />);
     expect(screen.getByRole('radio', { name: 'เดือนนี้' })).toHaveAttribute(
       'aria-checked',
       'true',


### PR DESCRIPTION
## ปัญหา (owner report 2026-07-02)
กดปุ่ม "เดือนนี้" ในหน้าชำระเงิน → ช่วงวันที่ขึ้น 01/07/2569 - **02/07/2569** (วันที่ 1 ถึง "วันนี้") แทนที่จะเป็น 01/07 - **31/07** ทั้งเดือน:
- งวดที่ครบกำหนดปลายเดือนหายจากคิว
- Label โชว์ "กรกฎาคม 2569 (01/07 - 02/07)" แทน "กรกฎาคม 2569"
- ไม่สม่ำเสมอ: "เดือนที่แล้ว" เป็นทั้งเดือนอยู่แล้ว

## แก้
- `DateRangeChips` preset thisMonth → [วันที่ 1, วันสุดท้ายของเดือน]
- `computeDefaultTimeRange('this_month')` (settings-driven default ของ other-income/expense pages) → ทั้งเดือน ให้ chip ยัง active ตอนโหลด
- Default state ของ PaymentsPage / GeneralLedgerPage / ReportsPage ปรับตาม + `collectedLabel` เทียบช่วงใหม่
- **Bonus fix**: GL/Reports เดิมใช้ `toISOString()` กับ Date เที่ยงคืนเวลาไทย → "วันที่ 1" ถอยเป็นวันสุดท้ายของเดือนก่อน (UTC shift) — เปลี่ยนเป็น local formatter

## Testing
- date.test.ts + DateRangeChips.test.tsx goldens อัปเดต
- Web suite เต็ม: **133 files / 851 tests ผ่าน**, `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)