### PR TITLE
test+fix(web): ปิด coverage gaps จาก QA #1326/#1327 + แก้ latent toISOString UTC-shift 5 จุด

### DIFF
--- a/apps/api/src/modules/journal/cpa-templates/reschedule-collect-lifecycle.integration.spec.ts
+++ b/apps/api/src/modules/journal/cpa-templates/reschedule-collect-lifecycle.integration.spec.ts
@@ -1,0 +1,382 @@
+/**
+ * P0 golden — ปรับดิว 6a collect-first → 2A accrual auto-consume → final receipt.
+ *
+ * Runner: vitest (DB-backed; cpa-templates + *.integration.spec.ts are jest-ignored
+ * per package.json testPathIgnorePatterns — same gating as
+ * payment-receipt.waiver.integration.spec.ts).
+ * Run:    cd apps/api && npx vitest run --no-file-parallelism \
+ *           src/modules/journal/cpa-templates/reschedule-collect-lifecycle.integration.spec.ts
+ *
+ * Lifecycle under test (owner directive 2026-07-02 "เงินไม่เข้า ดิวไม่เลื่อน"):
+ *   1. Overdue installment #1 (due 2025-02-01, live late fee capped 5% = 75.79).
+ *   2. RescheduleCollectService.executeWithCollect 6a (SPLIT, 7 days):
+ *        fee = 1,515.84/30×7 ROUND_UP = 354; collect = 354 + 75.79 = 429.79
+ *        JE: Dr 11-1101 429.79 / Cr 21-1103 354.00 / Cr 42-1103 75.79
+ *        + advanceBalance +354 + lateFee reset 0 + dates +7d
+ *        + AuditLog OVERPAY_ADVANCE_RECORDED (source RESCHEDULE_COLLECT_6A_FEE).
+ *   3. 2A accrual auto-consumes the 354 advance: Dr 21-1103 / Cr 11-2103 = 354.
+ *   4. Final receipt for the remainder 1,161.83 (= 1,515.83 − 354).
+ *
+ * Money-critical invariant (what reconstructPriorCleared guards):
+ *   Σ(Cr 11-2103) for the installment across ALL JEs == 1,515.83 EXACTLY once
+ *   (354.00 advance-consume + 1,161.83 receipt — no double principal credit),
+ *   Σ(Cr 42-1103) == 75.79 exactly once (fee not re-billed at the receipt),
+ *   and Contract.advanceBalance is drawn down 354 → 0 by the consume.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { PrismaClient } from '@prisma/client';
+import { Decimal } from '@prisma/client/runtime/library';
+import { seedFinanceCoa } from '../../../../prisma/seed-coa-finance';
+import { seedStandard17k12m, StandardContract } from '../__tests__/scenario-helpers';
+import { JournalAutoService } from '../journal-auto.service';
+import { ContractActivation1ATemplate } from './contract-activation-1a.template';
+import { InstallmentAccrual2ATemplate } from './installment-accrual-2a.template';
+import { PaymentReceiptTemplate } from './payment-receipt.template';
+import { ReceiptVoidReversalTemplate } from './receipt-void-reversal.template';
+import { RescheduleCollectService } from '../../payments/services/reschedule-collect.service';
+import { RescheduleService } from '../../installments/reschedule.service';
+import { ReceiptsService } from '../../receipts/receipts.service';
+
+const prisma = new PrismaClient();
+const D = (n: string) => new Decimal(n);
+
+/** Pin the late-fee config so the live quote is deterministic (PER_DAY defaults). */
+const LATE_FEE_KEYS = [
+  ['late_fee_mode', 'PER_DAY'],
+  ['late_fee_per_day_rate', '20'],
+  ['late_fee_max_amount', '500'],
+  ['late_fee_cap_pct', '5'],
+] as const;
+
+async function ensureFinanceCompany(): Promise<void> {
+  const existing = await prisma.companyInfo.findFirst({ where: { companyCode: 'FINANCE' } });
+  if (!existing) {
+    await prisma.companyInfo.create({
+      data: {
+        nameTh: 'BESTCHOICE FINANCE',
+        taxId: '0000000000002',
+        companyCode: 'FINANCE',
+        address: '1 Finance Rd.',
+        directorName: 'Test Director',
+        vatRegistered: true,
+        vatRate: new Decimal('0.0700'),
+      },
+    });
+  }
+}
+
+/** JournalAutoService.resolveSystemUserId requires admin@bestchoice.com. */
+async function ensureSystemAdminUser(): Promise<void> {
+  const existing = await prisma.user.findFirst({ where: { email: 'admin@bestchoice.com' } });
+  if (!existing) {
+    await prisma.user.create({
+      data: {
+        email: 'admin@bestchoice.com',
+        password: 'hashed_placeholder',
+        name: 'System Admin',
+        role: 'OWNER',
+      },
+    });
+  }
+}
+
+describe('reschedule-collect 6a → 2A accrual → advance consume lifecycle (integration)', () => {
+  let c: StandardContract;
+  let sched1Id: string;
+  let paymentId: string;
+  let recordedById: string;
+  let originalDue1: Date;
+  let originalDue12: Date;
+  let service: RescheduleCollectService;
+
+  type DecimalLike = { toString(): string };
+  const jeLine = (je: { lines: { accountCode: string; debit: DecimalLike; credit: DecimalLike }[] }) => ({
+    dr: (code: string) =>
+      new Decimal(je.lines.find((l) => l.accountCode === code)!.debit.toString()).toFixed(2),
+    cr: (code: string) =>
+      new Decimal(je.lines.find((l) => l.accountCode === code)!.credit.toString()).toFixed(2),
+  });
+
+  beforeAll(async () => {
+    await prisma.journalLine.deleteMany({});
+    await prisma.journalEntry.deleteMany({});
+    await prisma.receipt.deleteMany({});
+    await prisma.payment.deleteMany({});
+    await prisma.installmentSchedule.deleteMany({});
+    await prisma.contract.deleteMany({});
+
+    await seedFinanceCoa(prisma);
+    await ensureFinanceCompany();
+    await ensureSystemAdminUser();
+    for (const [key, value] of LATE_FEE_KEYS) {
+      await prisma.systemConfig.upsert({ where: { key }, update: { value }, create: { key, value } });
+    }
+
+    const journal = new JournalAutoService(prisma as any);
+    c = await seedStandard17k12m(prisma);
+    await new ContractActivation1ATemplate(journal, prisma as any).execute(c.id);
+
+    const sched1 = await prisma.installmentSchedule.findUniqueOrThrow({
+      where: { contractId_installmentNo: { contractId: c.id, installmentNo: 1 } },
+    });
+    const sched12 = await prisma.installmentSchedule.findUniqueOrThrow({
+      where: { contractId_installmentNo: { contractId: c.id, installmentNo: 12 } },
+    });
+    sched1Id = sched1.id;
+    originalDue1 = sched1.dueDate;
+    originalDue12 = sched12.dueDate;
+
+    recordedById = (
+      await prisma.user.findFirstOrThrow({
+        where: { email: 'test-salesperson@bestchoice-test.internal' },
+      })
+    ).id;
+
+    // Overdue Payment row for installment #1 — Payment IS the installment. Due
+    // 2025-02-01 (seed), so any run date ≥ 25 days later caps the per-day fee at
+    // 5% × 1,515.84 = 75.79 (deterministic). lateFee 75.79 = overdue-cron stamp.
+    const payment = await prisma.payment.create({
+      data: {
+        contractId: c.id,
+        installmentNo: 1,
+        dueDate: sched1.dueDate,
+        amountDue: D('1515.84'), // contract.monthlyPayment (incl. commission + VAT)
+        status: 'OVERDUE',
+        lateFee: D('75.79'),
+      },
+    });
+    paymentId = payment.id;
+
+    service = new RescheduleCollectService(
+      prisma as any,
+      journal,
+      new RescheduleService(prisma as any),
+      new ReceiptsService(
+        prisma as any,
+        journal,
+        new ReceiptVoidReversalTemplate(journal, prisma as any),
+        undefined,
+      ),
+    );
+  });
+
+  afterAll(async () => {
+    await prisma.journalLine.deleteMany({});
+    await prisma.journalEntry.deleteMany({});
+    await prisma.receipt.deleteMany({});
+    await prisma.payment.deleteMany({});
+    await prisma.installmentSchedule.deleteMany({});
+    await prisma.contract.deleteMany({});
+    await prisma.systemConfig.deleteMany({
+      where: { key: { in: LATE_FEE_KEYS.map(([key]) => key) } },
+    });
+    await prisma.$disconnect();
+  });
+
+  it('6a executeWithCollect: Dr 11-1101 429.79 / Cr 21-1103 354 / Cr 42-1103 75.79, advance +354, lateFee reset, dates +7d, audit written', async () => {
+    const result = await service.executeWithCollect({
+      contractId: c.id,
+      installmentNo: 1,
+      daysToShift: 7,
+      splitMode: 'SPLIT',
+      amount: 429.79, // fee 354 (1,515.84/30×7 ROUND_UP) + late fee 75.79
+      paymentMethod: 'CASH',
+      recordedById,
+    });
+
+    expect(result.variant).toBe('6a');
+    expect(result.rescheduleFee).toBe('354.00');
+    expect(result.lateFeeCollected).toBe('75.79');
+    expect(result.collectAmount).toBe('429.79');
+    expect(result.shiftedInstallmentCount).toBe(12);
+
+    // Collect JE — fee to 21-1103 advance, late fee to 42-1103 income, balanced.
+    const je = await prisma.journalEntry.findFirst({
+      where: {
+        AND: [
+          { metadata: { path: ['tag'], equals: 'reschedule-collect' } } as any,
+          { metadata: { path: ['contractId'], equals: c.id } } as any,
+        ],
+        deletedAt: null,
+      },
+      include: { lines: true },
+    });
+    expect(je, 'expected a reschedule-collect JE').not.toBeNull();
+    expect(je!.entryNumber).toBe(result.journalEntryNo);
+    const { dr, cr } = jeLine(je!);
+    expect(dr('11-1101')).toBe('429.79'); // user default cash account
+    expect(cr('21-1103')).toBe('354.00');
+    expect(cr('42-1103')).toBe('75.79');
+    const totalDr = je!.lines.reduce((s, l) => s.plus(new Decimal(l.debit.toString())), new Decimal(0));
+    const totalCr = je!.lines.reduce((s, l) => s.plus(new Decimal(l.credit.toString())), new Decimal(0));
+    expect(totalDr.toFixed(2)).toBe('429.79');
+    expect(totalCr.toFixed(2)).toBe('429.79');
+
+    // 6a fee = PREPAYMENT — Contract.advanceBalance incremented by the fee.
+    const contractAfter = await prisma.contract.findUniqueOrThrow({ where: { id: c.id } });
+    expect(new Decimal(contractAfter.advanceBalance.toString()).toFixed(2)).toBe('354.00');
+
+    // Payment.lateFee reset to 0 (collected) + collected note; dueDate shifted +7d.
+    const pay = await prisma.payment.findUniqueOrThrow({ where: { id: paymentId } });
+    expect(new Decimal(pay.lateFee.toString()).toFixed(2)).toBe('0.00');
+    expect(pay.notes).toContain('เก็บแล้วตอนปรับดิว');
+    const expectedDue1 = new Date(originalDue1);
+    expectedDue1.setDate(expectedDue1.getDate() + 7);
+    expect(pay.dueDate.getTime()).toBe(expectedDue1.getTime());
+
+    // ALL schedules from #1 shifted by daysToShift (check first + last).
+    const s1 = await prisma.installmentSchedule.findUniqueOrThrow({
+      where: { contractId_installmentNo: { contractId: c.id, installmentNo: 1 } },
+    });
+    expect(s1.dueDate.getTime()).toBe(expectedDue1.getTime());
+    expect(s1.rescheduledFromDate?.getTime()).toBe(originalDue1.getTime());
+    expect(s1.rescheduleCount).toBe(1);
+    const expectedDue12 = new Date(originalDue12);
+    expectedDue12.setDate(expectedDue12.getDate() + 7);
+    const s12 = await prisma.installmentSchedule.findUniqueOrThrow({
+      where: { contractId_installmentNo: { contractId: c.id, installmentNo: 12 } },
+    });
+    expect(s12.dueDate.getTime()).toBe(expectedDue12.getTime());
+
+    // Forensic advance trail — same shape the orchestrator writes.
+    const advAudit = await prisma.auditLog.findFirst({
+      where: { action: 'OVERPAY_ADVANCE_RECORDED', entity: 'contract', entityId: c.id },
+      orderBy: { createdAt: 'desc' },
+    });
+    expect(advAudit, 'expected OVERPAY_ADVANCE_RECORDED audit').not.toBeNull();
+    const nv = advAudit!.newValue as Record<string, unknown>;
+    expect(nv.advanceCredit).toBe('354');
+    expect(nv.source).toBe('RESCHEDULE_COLLECT_6A_FEE');
+    expect(nv.afterBalance).toBe('354');
+
+    // Money-detail audit row + post-commit e-Receipt for the collected cash.
+    const collectAudit = await prisma.auditLog.findFirst({
+      where: { action: 'RESCHEDULE_COLLECT', entity: 'payment', entityId: paymentId },
+    });
+    expect(collectAudit).not.toBeNull();
+    const receipt = await prisma.receipt.findFirst({
+      where: { contractId: c.id, receiptType: 'RESCHEDULE_FEE', deletedAt: null },
+    });
+    expect(receipt, 'expected RESCHEDULE_FEE e-Receipt').not.toBeNull();
+    expect(new Decimal(receipt!.amount.toString()).toFixed(2)).toBe('429.79');
+  });
+
+  it('2A accrual on the shifted due date auto-consumes the 354 advance (Dr 21-1103 / Cr 11-2103)', async () => {
+    const journal = new JournalAutoService(prisma as any);
+    const accrued = await new InstallmentAccrual2ATemplate(journal, prisma as any).execute(sched1Id);
+    expect(accrued).not.toBeNull();
+
+    // Accrual JE — full installmentTotal receivable.
+    const accrualJe = await prisma.journalEntry.findFirst({
+      where: {
+        AND: [
+          { metadata: { path: ['tag'], equals: '2A' } } as any,
+          { metadata: { path: ['installmentScheduleId'], equals: sched1Id } } as any,
+        ],
+        deletedAt: null,
+      },
+      include: { lines: true },
+    });
+    expect(accrualJe, 'expected a 2A accrual JE').not.toBeNull();
+    expect(jeLine(accrualJe!).dr('11-2103')).toBe('1515.83');
+
+    // Advance-consume JE (CPA Policy A) posted in the same accrual tx.
+    const consumeJe = await prisma.journalEntry.findFirst({
+      where: {
+        AND: [
+          { metadata: { path: ['flow'], equals: 'advance-consume-on-accrual' } } as any,
+          { metadata: { path: ['installmentScheduleId'], equals: sched1Id } } as any,
+        ],
+        deletedAt: null,
+      },
+      include: { lines: true },
+    });
+    expect(consumeJe, 'expected an advance-consume JE').not.toBeNull();
+    const { dr, cr } = jeLine(consumeJe!);
+    expect(dr('21-1103')).toBe('354.00');
+    expect(cr('11-2103')).toBe('354.00');
+
+    // advanceBalance drawn down by the consumed amount: 354 → 0.
+    const contractAfter = await prisma.contract.findUniqueOrThrow({ where: { id: c.id } });
+    expect(new Decimal(contractAfter.advanceBalance.toString()).toFixed(2)).toBe('0.00');
+
+    // Payment row reflects the consume (partial cover).
+    const pay = await prisma.payment.findUniqueOrThrow({ where: { id: paymentId } });
+    expect(new Decimal(pay.amountPaid.toString()).toFixed(2)).toBe('354.00');
+    expect(pay.status).toBe('PARTIALLY_PAID');
+  });
+
+  it('final receipt clears ONLY the remainder — Σ(Cr 11-2103) == 1,515.83 exactly once, Σ(Cr 42-1103) == 75.79 exactly once', async () => {
+    const journal = new JournalAutoService(prisma as any);
+    const tpl = new PaymentReceiptTemplate(journal, prisma as any);
+
+    // reconstructPriorCleared must count the 354 advance-consume (tag 2B,
+    // flow advance-consume-on-accrual) and IGNORE the reschedule-collect JE
+    // (tag intentionally NOT 'receipt') — so the final receipt clears exactly
+    // 1,515.83 − 354 = 1,161.83. Were the consume invisible, isFinalReceipt
+    // would reject (residual 354 > 1฿) — and counting the collect JE would
+    // under-clear. Either failure mode breaks this test.
+    const { split } = await tpl.execute({
+      installmentScheduleId: sched1Id,
+      delta: D('1161.83'),
+      debitAccountCode: '11-1201',
+      isFinalReceipt: true,
+      paymentId,
+    });
+    expect(split.principalCleared.toFixed(2)).toBe('1161.83');
+    expect(split.principalRemainingAfter.toFixed(2)).toBe('0.00');
+
+    const receiptJe = await prisma.journalEntry.findFirst({
+      where: {
+        AND: [
+          { metadata: { path: ['tag'], equals: 'receipt' } } as any,
+          { metadata: { path: ['installmentScheduleId'], equals: sched1Id } } as any,
+        ],
+        deletedAt: null,
+      },
+      include: { lines: true },
+    });
+    expect(receiptJe, 'expected a receipt JE').not.toBeNull();
+    const { dr, cr } = jeLine(receiptJe!);
+    expect(dr('11-1201')).toBe('1161.83');
+    expect(cr('11-2103')).toBe('1161.83');
+    // The 75.79 late fee was already booked at reschedule-collect — never again here.
+    expect(receiptJe!.lines.find((l) => l.accountCode === '42-1103')).toBeUndefined();
+
+    // ── Money-critical invariant ────────────────────────────────────────────
+    // Across ALL JEs of this installment: 11-2103 credited installmentTotal
+    // exactly ONCE (354.00 consume + 1,161.83 receipt) and fully cleared.
+    const instEntries = await prisma.journalEntry.findMany({
+      where: {
+        metadata: { path: ['installmentScheduleId'], equals: sched1Id } as any,
+        deletedAt: null,
+      },
+      include: { lines: true },
+    });
+    const sum = (code: string, side: 'debit' | 'credit') =>
+      instEntries
+        .flatMap((e) => e.lines)
+        .filter((l) => l.accountCode === code)
+        .reduce((s, l) => s.plus(new Decimal(l[side].toString())), new Decimal(0));
+    expect(sum('11-2103', 'credit').toFixed(2)).toBe('1515.83');
+    expect(sum('11-2103', 'debit').toFixed(2)).toBe('1515.83'); // accrual Dr — net 0
+
+    // Late fee income booked exactly once for the whole contract (the collect JE).
+    const contractEntries = await prisma.journalEntry.findMany({
+      where: {
+        metadata: { path: ['contractId'], equals: c.id } as any,
+        deletedAt: null,
+      },
+      include: { lines: true },
+    });
+    const lateFeeCr = contractEntries
+      .flatMap((e) => e.lines)
+      .filter((l) => l.accountCode === '42-1103')
+      .reduce((s, l) => s.plus(new Decimal(l.credit.toString())), new Decimal(0));
+    expect(lateFeeCr.toFixed(2)).toBe('75.79');
+
+    // advanceBalance stays fully drawn down after the receipt.
+    const contractAfter = await prisma.contract.findUniqueOrThrow({ where: { id: c.id } });
+    expect(new Decimal(contractAfter.advanceBalance.toString()).toFixed(2)).toBe('0.00');
+  });
+});

--- a/apps/api/src/modules/payments/payments.controller.spec.ts
+++ b/apps/api/src/modules/payments/payments.controller.spec.ts
@@ -1,5 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { BadRequestException, ForbiddenException } from '@nestjs/common';
+import { validate } from 'class-validator';
+import { plainToInstance } from 'class-transformer';
 import { Decimal } from '@prisma/client/runtime/library';
 import { PaymentsController } from './payments.controller';
 import { PaymentsService } from './payments.service';
@@ -14,6 +16,7 @@ describe('PaymentsController', () => {
   let controller: PaymentsController;
   let _prisma: unknown;
   let paymentsService: PaymentsService;
+  let paySolutionsService: PaySolutionsService;
   let rescheduleService: RescheduleService;
   let rescheduleCollectService: RescheduleCollectService;
 
@@ -31,6 +34,14 @@ describe('PaymentsController', () => {
 
     const mockPaymentsService = {
       validateBranchAccess: jest.fn().mockImplementation(async (contractId: string, user: { role: string; branchId: string | null }) => {
+        if (user.role === 'OWNER' || user.role === 'FINANCE_MANAGER' || user.role === 'ACCOUNTANT') return;
+        if (mockContract.branchId !== user.branchId) {
+          throw new ForbiddenException('ไม่สามารถบันทึกชำระเงินข้ามสาขาได้');
+        }
+      }),
+      // Payment-keyed routes (partial-qr / reschedule-qr) resolve the contract from
+      // the payment — same branch rule as validateBranchAccess.
+      validateBranchAccessByPayment: jest.fn().mockImplementation(async (paymentId: string, user: { role: string; branchId: string | null }) => {
         if (user.role === 'OWNER' || user.role === 'FINANCE_MANAGER' || user.role === 'ACCOUNTANT') return;
         if (mockContract.branchId !== user.branchId) {
           throw new ForbiddenException('ไม่สามารถบันทึกชำระเงินข้ามสาขาได้');
@@ -82,7 +93,21 @@ describe('PaymentsController', () => {
       providers: [
         { provide: PaymentsService, useValue: mockPaymentsService },
         { provide: PrismaService, useValue: mockPrisma },
-        { provide: PaySolutionsService, useValue: { createPartialPaymentQR: jest.fn(), createRescheduleQR: jest.fn() } },
+        {
+          provide: PaySolutionsService,
+          useValue: {
+            createPartialPaymentQR: jest.fn(),
+            createRescheduleQR: jest.fn().mockResolvedValue({
+              partialPaymentLinkId: 'pplink-1',
+              paymentUrl: 'https://payment.example/qr',
+              orderRef: 'RSQ-1',
+              sentToLine: true,
+              collectAmount: '1144.00',
+              rescheduleFee: '1044.00',
+              lateFee: '100.00',
+            }),
+          },
+        },
         { provide: RescheduleService, useValue: mockRescheduleService },
         { provide: RescheduleCollectService, useValue: mockRescheduleCollectService },
       ],
@@ -94,6 +119,7 @@ describe('PaymentsController', () => {
     controller = module.get<PaymentsController>(PaymentsController);
     _prisma = module.get<PrismaService>(PrismaService);
     paymentsService = module.get<PaymentsService>(PaymentsService);
+    paySolutionsService = module.get<PaySolutionsService>(PaySolutionsService);
     rescheduleService = module.get<RescheduleService>(RescheduleService);
     rescheduleCollectService = module.get<RescheduleCollectService>(RescheduleCollectService);
   });
@@ -336,6 +362,148 @@ describe('PaymentsController', () => {
         ForbiddenException,
       );
       expect(paymentsService.getContractJournalEntries).not.toHaveBeenCalled();
+    });
+  });
+
+  // PR #1326 — GET /payments/reschedule-quote (server-authoritative ปรับดิว quote).
+  // Query params arrive as strings; the controller must reject NaN / <1 values
+  // BEFORE delegating to RescheduleCollectService.quote with parsed ints.
+  describe('getRescheduleQuote param parsing + delegation', () => {
+    const owner = { id: 'user-1', role: 'OWNER', branchId: 'branch-1' };
+
+    it.each([
+      ['NaN installmentNo', 'abc', '16'],
+      ['installmentNo < 1', '0', '16'],
+      ['negative installmentNo', '-3', '16'],
+      ['NaN daysToShift', '5', 'xyz'],
+      ['daysToShift < 1', '5', '0'],
+    ])('rejects %s with BadRequestException before quoting', async (_label, installmentNo, daysToShift) => {
+      await expect(
+        controller.getRescheduleQuote('contract-1', installmentNo, daysToShift, 'SPLIT', owner),
+      ).rejects.toThrow(BadRequestException);
+      expect(rescheduleCollectService.quote).not.toHaveBeenCalled();
+    });
+
+    it('delegates to rescheduleCollectService.quote with parsed integer args (SPLIT/6a)', async () => {
+      const res = await controller.getRescheduleQuote('contract-1', '5', '16', 'SPLIT', owner);
+
+      expect(paymentsService.validateBranchAccess).toHaveBeenCalledWith('contract-1', owner);
+      expect(rescheduleCollectService.quote).toHaveBeenCalledWith({
+        contractId: 'contract-1',
+        installmentNo: 5,
+        daysToShift: 16,
+        splitMode: 'SPLIT',
+      });
+      expect(res).toMatchObject({
+        rescheduleFee: '809.00',
+        collectAmount: '809.00',
+        variant: '6a',
+      });
+    });
+
+    it('maps any non-SPLIT splitMode to SINGLE (6b default)', async () => {
+      await controller.getRescheduleQuote('contract-1', '5', '16', 'weird', owner);
+      expect(rescheduleCollectService.quote).toHaveBeenCalledWith(
+        expect.objectContaining({ splitMode: 'SINGLE' }),
+      );
+    });
+
+    it('enforces branch access BEFORE quoting (SALES cross-branch rejected)', async () => {
+      const sales = { id: 'user-1', role: 'SALES', branchId: 'branch-2' }; // contract is on branch-1
+      await expect(
+        controller.getRescheduleQuote('contract-1', '5', '16', 'SPLIT', sales),
+      ).rejects.toThrow(ForbiddenException);
+      expect(rescheduleCollectService.quote).not.toHaveBeenCalled();
+    });
+  });
+
+  // PR #1326 — POST /payments/:id/reschedule-qr (async ปรับดิว: QR collects first,
+  // the reschedule executes on webhook confirm — เงินไม่เข้า ดิวไม่เลื่อน).
+  describe('createRescheduleQr branch access + delegation', () => {
+    it('validates branch access by payment FIRST, then delegates with mapped splitMode (SPLIT)', async () => {
+      const user = { id: 'user-1', role: 'OWNER', branchId: 'branch-1' };
+      const res = await controller.createRescheduleQr(
+        'payment-1',
+        { daysToShift: 10, splitMode: 'SPLIT' as const },
+        user,
+      );
+
+      expect(paymentsService.validateBranchAccessByPayment).toHaveBeenCalledWith('payment-1', user);
+      expect(paySolutionsService.createRescheduleQR).toHaveBeenCalledWith({
+        paymentId: 'payment-1',
+        daysToShift: 10,
+        splitMode: 'SPLIT',
+        requestedById: 'user-1',
+      });
+      // The branch check must run BEFORE the gateway call.
+      const accessOrder = (paymentsService.validateBranchAccessByPayment as jest.Mock).mock
+        .invocationCallOrder[0];
+      const qrOrder = (paySolutionsService.createRescheduleQR as jest.Mock).mock
+        .invocationCallOrder[0];
+      expect(accessOrder).toBeLessThan(qrOrder);
+      expect(res).toMatchObject({ orderRef: 'RSQ-1', collectAmount: '1144.00' });
+    });
+
+    it('maps splitMode=SINGLE through unchanged (6b — QR เก็บเฉพาะค่าปรับ)', async () => {
+      const user = { id: 'user-1', role: 'OWNER', branchId: 'branch-1' };
+      await controller.createRescheduleQr(
+        'payment-1',
+        { daysToShift: 7, splitMode: 'SINGLE' as const },
+        user,
+      );
+      expect(paySolutionsService.createRescheduleQR).toHaveBeenCalledWith(
+        expect.objectContaining({ daysToShift: 7, splitMode: 'SINGLE' }),
+      );
+    });
+
+    it('rejects SALES cross-branch BEFORE creating the QR', async () => {
+      const user = { id: 'user-1', role: 'SALES', branchId: 'branch-2' }; // contract is on branch-1
+      await expect(
+        controller.createRescheduleQr('payment-1', { daysToShift: 10, splitMode: 'SPLIT' as const }, user),
+      ).rejects.toThrow(ForbiddenException);
+      expect(paySolutionsService.createRescheduleQR).not.toHaveBeenCalled();
+    });
+  });
+
+  // DTO validation for the reschedule-qr body. CreateRescheduleQrDto is declared
+  // (unexported) inside the controller file — recover the class from the
+  // design:paramtypes metadata Nest emits for the @Body() parameter, then run
+  // class-validator directly (same validate + plainToInstance convention as
+  // update-letter-evidence.dto.spec.ts).
+  describe('CreateRescheduleQrDto validation (class-validator)', () => {
+    const CreateRescheduleQrDto = (
+      Reflect.getMetadata(
+        'design:paramtypes',
+        PaymentsController.prototype,
+        'createRescheduleQr',
+      ) as Array<new () => object>
+    )[1];
+
+    async function validateDto(payload: Record<string, unknown>) {
+      return validate(plainToInstance(CreateRescheduleQrDto, payload));
+    }
+
+    it.each(['SINGLE', 'SPLIT'])('accepts splitMode=%s with daysToShift >= 1', async (splitMode) => {
+      const errors = await validateDto({ daysToShift: 10, splitMode });
+      expect(errors).toHaveLength(0);
+    });
+
+    it.each(['BOTH', 'split', '', 42])(
+      'rejects splitMode outside [SINGLE, SPLIT] (%p)',
+      async (splitMode) => {
+        const errors = await validateDto({ daysToShift: 10, splitMode });
+        expect(errors.some((e) => e.property === 'splitMode')).toBe(true);
+      },
+    );
+
+    it('rejects daysToShift < 1', async () => {
+      const errors = await validateDto({ daysToShift: 0, splitMode: 'SPLIT' });
+      expect(errors.some((e) => e.property === 'daysToShift')).toBe(true);
+    });
+
+    it('rejects non-numeric daysToShift', async () => {
+      const errors = await validateDto({ daysToShift: 'ten', splitMode: 'SPLIT' });
+      expect(errors.some((e) => e.property === 'daysToShift')).toBe(true);
     });
   });
 });

--- a/apps/api/src/modules/payments/services/reschedule-collect.service.spec.ts
+++ b/apps/api/src/modules/payments/services/reschedule-collect.service.spec.ts
@@ -301,4 +301,73 @@ describe('RescheduleCollectService (ปรับดิว collect-first)', () =>
       }),
     ).rejects.toThrow(/ชำระแล้ว/);
   });
+
+  it('closed accounting period (past grace) → BadRequest BEFORE any write (no tx, no JE, no reschedule)', async () => {
+    // Period-lock (CR-7): the collect JE posts TODAY, so validatePeriodOpen checks
+    // the CURRENT month. A CLOSED period only rejects past the grace window
+    // (last calendar day + period_grace_days) — park "today" at noon LOCAL on the
+    // last day of July with grace 0 so graceEnd (Jul 31 00:00) is already behind us.
+    jest.setSystemTime(new Date(2026, 6, 31, 12, 0, 0));
+    prisma.accountingPeriod.findUnique.mockResolvedValue({ status: 'CLOSED' });
+    prisma.systemConfig.findUnique.mockImplementation(({ where }: AnyObj) =>
+      Promise.resolve(where.key === 'period_grace_days' ? { value: '0' } : null),
+    );
+
+    const attempt = service.executeWithCollect({
+      contractId: 'ct-1',
+      installmentNo: 1,
+      daysToShift: 7,
+      splitMode: 'SPLIT',
+      amount: 1144,
+      paymentMethod: 'CASH',
+      recordedById: 'user-1',
+    });
+    await expect(attempt).rejects.toThrow(BadRequestException);
+    await expect(attempt).rejects.toThrow(/งวดที่ปิดแล้ว/);
+
+    // Guard looked up TODAY's FINANCE period (parity with recordPayment).
+    expect(prisma.accountingPeriod.findUnique).toHaveBeenCalledWith({
+      where: { companyId_year_month: { companyId: 'co-FINANCE', year: 2026, month: 7 } },
+      select: { status: true },
+    });
+    // Rejected BEFORE the money tx opened — nothing written anywhere.
+    expect(prisma.$transaction).not.toHaveBeenCalled();
+    expect(journalAuto.createAndPost).not.toHaveBeenCalled();
+    expect(prisma.payment.update).not.toHaveBeenCalled();
+    expect(prisma.contract.update).not.toHaveBeenCalled();
+    expect(prisma.auditLog.create).not.toHaveBeenCalled();
+    expect(rescheduleService.execute).not.toHaveBeenCalled();
+    expect(receiptsService.generateReceipt).not.toHaveBeenCalled();
+  });
+
+  it('post-commit receipt failure: generateReceipt rejects → still success:true (เงิน commit แล้ว), error logged not thrown', async () => {
+    receiptsService.generateReceipt.mockRejectedValue(new Error('receipt service down'));
+    const errorSpy = jest.spyOn(service['logger'], 'error').mockImplementation(() => {});
+
+    const result = await service.executeWithCollect({
+      contractId: 'ct-1',
+      installmentNo: 1,
+      daysToShift: 7,
+      splitMode: 'SPLIT',
+      amount: 1144,
+      paymentMethod: 'CASH',
+      recordedById: 'user-1',
+    });
+
+    // I3 ordering: money committed before the receipt attempt — result unaffected.
+    expect(result).toMatchObject({
+      success: true,
+      variant: '6a',
+      collectAmount: '1144.00',
+      journalEntryNo: 'JE-RD-1',
+    });
+    expect(journalAuto.createAndPost).toHaveBeenCalledTimes(1);
+    expect(rescheduleService.execute).toHaveBeenCalledTimes(1);
+    expect(receiptsService.generateReceipt).toHaveBeenCalledTimes(1);
+    // Failure surfaced to the log (message + stack), never rethrown.
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to generate reschedule-collect receipt'),
+      expect.any(String),
+    );
+  });
 });

--- a/apps/api/src/modules/paysolutions/paysolutions.callbacks.spec.ts
+++ b/apps/api/src/modules/paysolutions/paysolutions.callbacks.spec.ts
@@ -143,6 +143,72 @@ describe('PaySolutionsService — secondary webhook callbacks (characterization)
       expect(prisma.payment.findUnique).not.toHaveBeenCalled();
     });
 
+    // Review W2 (2026-07-02): SUCCESS webhook landing on an EXPIRED link = the
+    // customer's money reached the gateway but the hourly cron expired the link
+    // first — nothing was recorded. Must alarm fatal; ops reconciles manually.
+    it('EXPIRED link + SUCCESS webhook: fatal Sentry alarm, no link mutation, no recordPayment', async () => {
+      const link = makeLink({ status: 'EXPIRED' });
+
+      await service.handlePartialPaymentCallback(link, {
+        refno,
+        result_code: '00',
+        transaction_id: 'tx-expired-paid',
+      });
+
+      expect(Sentry.captureMessage as jest.Mock).toHaveBeenCalledWith(
+        expect.stringContaining('EXPIRED'),
+        expect.objectContaining({
+          level: 'fatal',
+          tags: expect.objectContaining({ critical: 'paysolutions-expired-paid', refno }),
+        }),
+      );
+      // Still the idempotent skip path — nothing is written or credited.
+      expect(prisma.partialPaymentLink.update).not.toHaveBeenCalled();
+      expect(payments.recordPayment).not.toHaveBeenCalled();
+      expect(payments.rescheduleWithCollect).not.toHaveBeenCalled();
+    });
+
+    it('EXPIRED + SUCCESS on a purpose=RESCHEDULE link: alarms and does NOT execute the reschedule', async () => {
+      const link = makeLink({
+        status: 'EXPIRED',
+        purpose: 'RESCHEDULE',
+        metadata: { daysToShift: 7, splitMode: 'SPLIT', rescheduleFee: '1044', lateFee: '100', collectAmount: '1144' },
+      });
+
+      await service.handlePartialPaymentCallback(link, {
+        refno,
+        result_code: '00',
+        transaction_id: 'tx-expired-resched',
+      });
+
+      expect(Sentry.captureMessage as jest.Mock).toHaveBeenCalledWith(
+        expect.stringContaining('EXPIRED'),
+        expect.objectContaining({
+          level: 'fatal',
+          tags: expect.objectContaining({ critical: 'paysolutions-expired-paid' }),
+        }),
+      );
+      // ดิวไม่เลื่อน — the due-date shift must never run off an expired link.
+      expect(payments.rescheduleWithCollect).not.toHaveBeenCalled();
+      expect(payments.recordPayment).not.toHaveBeenCalled();
+      expect(prisma.partialPaymentLink.update).not.toHaveBeenCalled();
+    });
+
+    it('EXPIRED link + FAILURE webhook (result_code != 00): silent idempotent skip — no alarm', async () => {
+      const link = makeLink({ status: 'EXPIRED' });
+
+      await service.handlePartialPaymentCallback(link, {
+        refno,
+        result_code: '99',
+        transaction_id: 'tx-expired-fail',
+      });
+
+      // No money was captured → no alarm, and nothing else happens either.
+      expect(Sentry.captureMessage).not.toHaveBeenCalled();
+      expect(prisma.partialPaymentLink.update).not.toHaveBeenCalled();
+      expect(payments.recordPayment).not.toHaveBeenCalled();
+    });
+
     it('failure (result_code != 00): flips link to CANCELLED and does NOT record a payment', async () => {
       const link = makeLink();
 

--- a/apps/api/src/modules/paysolutions/paysolutions.reschedule-qr.spec.ts
+++ b/apps/api/src/modules/paysolutions/paysolutions.reschedule-qr.spec.ts
@@ -1,0 +1,366 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { Prisma } from '@prisma/client';
+import { BadRequestException, InternalServerErrorException } from '@nestjs/common';
+import * as Sentry from '@sentry/nestjs';
+import { PaySolutionsService } from './paysolutions.service';
+import { PrismaService } from '../../prisma/prisma.service';
+import { ConfigService } from '@nestjs/config';
+import { LineOaService } from '../line-oa/line-oa.service';
+import { IntegrationConfigService } from '../integrations/integration-config.service';
+import { OnlineOrderSaleAdapter } from '../shop-orders/online-order-sale.adapter';
+import { ProductsService } from '../products/products.service';
+import { JournalAutoService } from '../journal/journal-auto.service';
+import { PaymentReceiptTemplate } from '../journal/cpa-templates/payment-receipt.template';
+import { Vat60dayReversalTemplate } from '../journal/cpa-templates/vat-60day-reversal.template';
+import { PaymentsService } from '../payments/payments.service';
+
+// Same Sentry-transport stub the sibling specs use — captureException is
+// asserted directly in the orphan test.
+jest.mock('@sentry/nestjs', () => ({
+  captureException: jest.fn(),
+  captureMessage: jest.fn(),
+}));
+
+/**
+ * Unit spec for createRescheduleQR — the ปรับดิว collect-first intent (PR #1326,
+ * owner directive 2026-07-02: เงินไม่เข้า ดิวไม่เลื่อน).
+ *
+ * Pins: the zero-collect guard (6b + no late fee → confirm directly, no QR),
+ * the already-PAID guard, the single-outstanding-QR cancel (updateMany →
+ * CANCELLED before create), the PartialPaymentLink row with purpose='RESCHEDULE'
+ * + the frozen quote metadata the webhook later replays, the orphan-Sentry path
+ * (gateway OK then DB create throws), and the best-effort LINE push (failure
+ * swallowed → sentToLine=false, never aborts the QR).
+ *
+ * Late-fee config is pinned to BRACKET (tier1=50 / tier2=100 @ 3 days) via the
+ * systemConfig mock so the server-authoritative quote is deterministic:
+ *   monthlyPayment 1500, daysToShift 10 → fee = 1500/30×10 = 500 (ROUND_UP)
+ *   dueDate 5.5 days ago → 5 whole days overdue → tier2 lateFee = 100
+ *   6a (SPLIT)  → collect 600  |  6b (SINGLE) → collect 100
+ */
+describe('PaySolutionsService — createRescheduleQR (ปรับดิว collect-first)', () => {
+  let service: PaySolutionsService;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+  let lineOa: { pushMessage: jest.Mock; sendFlexMessage: jest.Mock };
+  let fetchSpy: jest.SpyInstance;
+
+  const paymentId = 'pay-rs-1';
+  const requestedById = 'user-owner-1';
+
+  // A canonical Pay Solutions v2 success body.
+  function gatewayOk(redirectUrl = 'https://pay.example/redirect') {
+    return {
+      ok: true,
+      status: 200,
+      json: jest.fn().mockResolvedValue({
+        redirectUrl,
+        transactionId: 'GW-TX-1',
+        refNo: 'GW-REF-1',
+        status: 'success',
+      }),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+  }
+
+  function buildPrisma(paymentOverrides: Record<string, unknown> = {}): void {
+    prisma = {
+      payment: {
+        findUnique: jest.fn().mockResolvedValue({
+          id: paymentId,
+          deletedAt: null,
+          status: 'PENDING',
+          installmentNo: 5,
+          contractId: 'ct-rs-1',
+          // 5.5 days ago → 5 whole days overdue → BRACKET tier2 (100฿).
+          dueDate: new Date(Date.now() - 5.5 * 86_400_000),
+          amountDue: new Prisma.Decimal(1500),
+          lateFeeWaived: false,
+          contract: {
+            contractNumber: 'CT-2026-0009',
+            monthlyPayment: new Prisma.Decimal(1500),
+            customer: { id: 'cust-rs-1', email: 'c@example.com', name: 'ลูกค้า', lineIdFinance: null },
+          },
+          ...paymentOverrides,
+        }),
+      },
+      // loadLateFeeConfig reads 7 keys — pin BRACKET so the quote is deterministic.
+      systemConfig: {
+        findUnique: jest.fn().mockImplementation(({ where: { key } }: { where: { key: string } }) => {
+          const map: Record<string, string> = {
+            late_fee_mode: 'BRACKET',
+            late_fee_tier1_amount: '50',
+            late_fee_tier2_amount: '100',
+            late_fee_tier2_min_days: '3',
+          };
+          return Promise.resolve(map[key] ? { value: map[key] } : null);
+        }),
+      },
+      partialPaymentLink: {
+        updateMany: jest.fn().mockResolvedValue({ count: 0 }),
+        create: jest.fn().mockResolvedValue({ id: 'ppl-rs-1' }),
+      },
+    };
+  }
+
+  async function buildService(): Promise<void> {
+    lineOa = {
+      sendFlexMessage: jest.fn().mockResolvedValue(undefined),
+      pushMessage: jest.fn().mockResolvedValue(undefined),
+    };
+    const integrationConfig = {
+      getValue: jest.fn().mockImplementation((_ns: string, key: string) => {
+        const map: Record<string, string> = {
+          merchantId: 'MID-123',
+          secretKey: 'SK-123',
+          apiKey: 'AK-123',
+          apiUrl: 'https://apis.paysolutions.test',
+          terminalId: 'TID-XYZ',
+        };
+        return Promise.resolve(map[key] ?? '');
+      }),
+    } as Partial<IntegrationConfigService>;
+    const config = {
+      get: jest.fn().mockImplementation((_k: string, def?: string) => def ?? ''),
+    } as Partial<ConfigService>;
+
+    const mod: TestingModule = await Test.createTestingModule({
+      providers: [
+        PaySolutionsService,
+        { provide: PrismaService, useValue: prisma },
+        { provide: ConfigService, useValue: config },
+        { provide: LineOaService, useValue: lineOa },
+        { provide: IntegrationConfigService, useValue: integrationConfig },
+        { provide: OnlineOrderSaleAdapter, useValue: {} },
+        { provide: ProductsService, useValue: {} },
+        { provide: JournalAutoService, useValue: {} },
+        { provide: PaymentReceiptTemplate, useValue: { execute: jest.fn() } },
+        { provide: Vat60dayReversalTemplate, useValue: { execute: jest.fn() } },
+        { provide: PaymentsService, useValue: { recordPayment: jest.fn() } },
+      ],
+    }).compile();
+
+    service = mod.get<PaySolutionsService>(PaySolutionsService);
+  }
+
+  /** Parse the JSON body the service POSTed to the gateway in the latest fetch. */
+  function lastGatewayPayload(): Record<string, unknown> {
+    const body = fetchSpy.mock.calls[0][1].body as string;
+    return JSON.parse(body) as Record<string, unknown>;
+  }
+
+  beforeEach(() => {
+    (Sentry.captureException as jest.Mock).mockClear();
+    (Sentry.captureMessage as jest.Mock).mockClear();
+  });
+
+  afterEach(() => {
+    fetchSpy?.mockRestore();
+  });
+
+  it('zero-collect (6b + waived late fee) → BadRequest "ยืนยันปรับดิวได้โดยตรง", no gateway call, no link cancel', async () => {
+    buildPrisma({ lateFeeWaived: true }); // 6b collects lateFee only → 0
+    await buildService();
+    fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue(gatewayOk());
+
+    const err = await service
+      .createRescheduleQR({ paymentId, daysToShift: 10, splitMode: 'SINGLE', requestedById })
+      .then(() => null)
+      .catch((e: Error) => e);
+
+    expect(err).toBeInstanceOf(BadRequestException);
+    expect((err as Error).message).toContain('ยืนยันปรับดิวได้โดยตรง');
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(prisma.partialPaymentLink.updateMany).not.toHaveBeenCalled();
+    expect(prisma.partialPaymentLink.create).not.toHaveBeenCalled();
+  });
+
+  it('payment already PAID → BadRequest, no gateway call', async () => {
+    buildPrisma({ status: 'PAID' });
+    await buildService();
+    fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue(gatewayOk());
+
+    const err = await service
+      .createRescheduleQR({ paymentId, daysToShift: 10, splitMode: 'SPLIT', requestedById })
+      .then(() => null)
+      .catch((e: Error) => e);
+
+    expect(err).toBeInstanceOf(BadRequestException);
+    expect((err as Error).message).toContain('ชำระครบแล้ว');
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(prisma.partialPaymentLink.create).not.toHaveBeenCalled();
+  });
+
+  it('cancels prior ACTIVE PartialPaymentLink rows (→ CANCELLED) BEFORE creating the new link', async () => {
+    buildPrisma();
+    await buildService();
+    fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue(gatewayOk());
+
+    await service.createRescheduleQR({ paymentId, daysToShift: 10, splitMode: 'SPLIT', requestedById });
+
+    // Single-outstanding-QR rule — BOTH purposes cancelled (stale partial QR
+    // racing a reschedule QR would double-charge).
+    expect(prisma.partialPaymentLink.updateMany).toHaveBeenCalledWith({
+      where: { paymentId, status: 'ACTIVE' },
+      data: expect.objectContaining({ status: 'CANCELLED', cancelledAt: expect.any(Date) }),
+    });
+    expect(prisma.partialPaymentLink.create).toHaveBeenCalledTimes(1);
+    expect(prisma.partialPaymentLink.updateMany.mock.invocationCallOrder[0]).toBeLessThan(
+      prisma.partialPaymentLink.create.mock.invocationCallOrder[0],
+    );
+  });
+
+  it('6a (SPLIT): gateway amount = fee+lateFee, link has purpose=RESCHEDULE + frozen quote metadata', async () => {
+    buildPrisma();
+    await buildService();
+    fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue(gatewayOk());
+
+    const res = await service.createRescheduleQR({
+      paymentId,
+      daysToShift: 10,
+      splitMode: 'SPLIT',
+      requestedById,
+    });
+
+    // Server-authoritative quote: fee 500 + lateFee 100 = collect 600.
+    const payload = lastGatewayPayload();
+    expect(payload.amount).toBe(600);
+    expect(payload.paymentChannel).toBe('Qrcode');
+    expect(payload.paymentGateway).toBe('Promptpay');
+    expect(payload.description).toContain('ปรับดิวงวด 5');
+    expect(payload.postbackUrl).toContain('/api/paysolutions/webhook');
+
+    // The link row the webhook later routes through rescheduleWithCollect.
+    expect(prisma.partialPaymentLink.create).toHaveBeenCalledTimes(1);
+    const linkData = prisma.partialPaymentLink.create.mock.calls[0][0].data;
+    expect(linkData.paymentId).toBe(paymentId);
+    expect(linkData.contractId).toBe('ct-rs-1');
+    expect(linkData.customerId).toBe('cust-rs-1');
+    expect(linkData.amount).toBe(600);
+    expect(linkData.gatewayRef).toBe('GW-REF-1');
+    expect(linkData.status).toBe('ACTIVE');
+    expect(linkData.purpose).toBe('RESCHEDULE');
+    // Frozen quote — the webhook must execute EXACTLY what the cashier quoted.
+    expect(linkData.metadata).toEqual({
+      daysToShift: 10,
+      splitMode: 'SPLIT',
+      rescheduleFee: '500',
+      lateFee: '100',
+      collectAmount: '600',
+      requestedById,
+    });
+
+    expect(res.partialPaymentLinkId).toBe('ppl-rs-1');
+    expect(res.paymentUrl).toBe('https://pay.example/redirect');
+    expect(typeof res.orderRef).toBe('string');
+    expect(res.sentToLine).toBe(false); // no lineIdFinance
+    expect(res.collectAmount).toBe('600.00');
+    expect(res.rescheduleFee).toBe('500.00');
+    expect(res.lateFee).toBe('100.00');
+  });
+
+  it('6b (SINGLE): collects the late fee ONLY (fee rides the next installment) but still freezes the fee in metadata', async () => {
+    buildPrisma();
+    await buildService();
+    fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue(gatewayOk());
+
+    const res = await service.createRescheduleQR({
+      paymentId,
+      daysToShift: 10,
+      splitMode: 'SINGLE',
+      requestedById,
+    });
+
+    expect(lastGatewayPayload().amount).toBe(100);
+    const linkData = prisma.partialPaymentLink.create.mock.calls[0][0].data;
+    expect(linkData.amount).toBe(100);
+    expect(linkData.metadata).toEqual({
+      daysToShift: 10,
+      splitMode: 'SINGLE',
+      rescheduleFee: '500',
+      lateFee: '100',
+      collectAmount: '100',
+      requestedById,
+    });
+    expect(res.collectAmount).toBe('100.00');
+    expect(res.rescheduleFee).toBe('500.00');
+    expect(res.lateFee).toBe('100.00');
+  });
+
+  it('orphan path: gateway OK then PartialPaymentLink.create throws → Sentry critical=paysolutions-reschedule-orphan + InternalServerError', async () => {
+    buildPrisma();
+    prisma.partialPaymentLink.create.mockRejectedValueOnce(new Error('DB down'));
+    await buildService();
+    fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue(gatewayOk());
+
+    await expect(
+      service.createRescheduleQR({ paymentId, daysToShift: 10, splitMode: 'SPLIT', requestedById }),
+    ).rejects.toBeInstanceOf(InternalServerErrorException);
+
+    expect(Sentry.captureException as jest.Mock).toHaveBeenCalledTimes(1);
+    const opts = (Sentry.captureException as jest.Mock).mock.calls[0][1];
+    expect(opts.level).toBe('fatal');
+    expect(opts.tags.critical).toBe('paysolutions-reschedule-orphan');
+  });
+
+  it('LINE push failure is swallowed: resolves with sentToLine=false, link still created, no Sentry', async () => {
+    buildPrisma({
+      contract: {
+        contractNumber: 'CT-2026-0009',
+        monthlyPayment: new Prisma.Decimal(1500),
+        customer: {
+          id: 'cust-rs-1',
+          email: 'c@example.com',
+          name: 'ลูกค้า',
+          lineIdFinance: 'U1234567890abcdef',
+        },
+      },
+    });
+    await buildService();
+    lineOa.pushMessage.mockRejectedValue(new Error('LINE OA down'));
+    fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue(gatewayOk());
+
+    const res = await service.createRescheduleQR({
+      paymentId,
+      daysToShift: 10,
+      splitMode: 'SPLIT',
+      requestedById,
+    });
+
+    expect(lineOa.pushMessage).toHaveBeenCalledTimes(1);
+    expect(res.sentToLine).toBe(false);
+    expect(res.partialPaymentLinkId).toBe('ppl-rs-1');
+    expect(Sentry.captureException as jest.Mock).not.toHaveBeenCalled();
+  });
+
+  it('LINE push success: sentToLine=true, Flex pushed via the FINANCE channel', async () => {
+    buildPrisma({
+      contract: {
+        contractNumber: 'CT-2026-0009',
+        monthlyPayment: new Prisma.Decimal(1500),
+        customer: {
+          id: 'cust-rs-1',
+          email: 'c@example.com',
+          name: 'ลูกค้า',
+          lineIdFinance: 'U1234567890abcdef',
+        },
+      },
+    });
+    await buildService();
+    fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue(gatewayOk());
+
+    const res = await service.createRescheduleQR({
+      paymentId,
+      daysToShift: 10,
+      splitMode: 'SPLIT',
+      requestedById,
+    });
+
+    expect(lineOa.pushMessage).toHaveBeenCalledWith(
+      'U1234567890abcdef',
+      [expect.objectContaining({ type: 'flex' })],
+      'line-finance',
+    );
+    expect(res.sentToLine).toBe(true);
+  });
+});

--- a/apps/web/src/components/payment/__tests__/computeReceiptFeeDisplay.test.ts
+++ b/apps/web/src/components/payment/__tests__/computeReceiptFeeDisplay.test.ts
@@ -66,6 +66,17 @@ describe('computeReceiptFeeDisplay', () => {
     expect(out.get('good')?.lateFee).toBe(100);
   });
 
+  it('never attributes the fee to a RESCHEDULE_FEE (ปรับดิว) receipt', () => {
+    const receipts = [
+      receipt({ id: 'rf', receiptNumber: 'RT-202607-00003', receiptType: 'RESCHEDULE_FEE' }),
+      receipt({ id: 'good', receiptNumber: 'RT-202607-00004', paidDate: '2026-07-01T05:00:00.000Z' }),
+    ];
+    const fees = new Map<string, FeeInfo>([['pay-1', { lateFee: 100, waived: 0 }]]);
+    const out = computeReceiptFeeDisplay(receipts, fees);
+    expect(out.get('rf')?.lateFee).toBe(0);
+    expect(out.get('good')?.lateFee).toBe(100);
+  });
+
   it('attributes each installment its own first-receipt fee', () => {
     const receipts = [
       receipt({ id: 'a1', paymentId: 'pay-1', receiptNumber: 'RT-202607-00001' }),

--- a/apps/web/src/lib/date.test.ts
+++ b/apps/web/src/lib/date.test.ts
@@ -1,5 +1,28 @@
-import { describe, it, expect } from 'vitest';
-import { computeDefaultTimeRange } from './date';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { computeDefaultTimeRange, toLocalDateString } from './date';
+
+describe('lib/date — toLocalDateString', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('formats the LOCAL calendar day as YYYY-MM-DD (local constructor → local getters, TZ-safe)', () => {
+    // Local-time constructor + local getters round-trip in ANY machine TZ, so
+    // this assertion is deterministic. toISOString() would give 2026-07-02 on
+    // an Asia/Bangkok machine (2026-07-03 01:30 BKK = 2026-07-02T18:30:00Z).
+    expect(toLocalDateString(new Date(2026, 6, 3, 1, 30, 0))).toBe('2026-07-03');
+  });
+
+  it('zero-pads single-digit month and day', () => {
+    expect(toLocalDateString(new Date(2026, 0, 5))).toBe('2026-01-05');
+  });
+
+  it('defaults to now when called without an argument', () => {
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(new Date(2026, 6, 3, 1, 30, 0));
+    expect(toLocalDateString()).toBe('2026-07-03');
+  });
+});
 
 describe('lib/date — computeDefaultTimeRange', () => {
   // Anchor: 2026-04-15 12:00 UTC = 2026-04-15 19:00 Asia/Bangkok (same calendar day).
@@ -13,6 +36,44 @@ describe('lib/date — computeDefaultTimeRange', () => {
   it("'this_month' returns the FULL current month (owner 2026-07-02: เดือนนี้ = ทั้งเดือน)", () => {
     const r = computeDefaultTimeRange('this_month', fixedMidApril);
     expect(r).toEqual({ startDate: '2026-04-01', endDate: '2026-04-30' });
+  });
+
+  it("BKK boundary — 17:30 UTC Jun 30 is Jul 1 00:30 in Bangkok, so 'this_month' = full July", () => {
+    // 2026-06-30 17:30 UTC = 2026-07-01 00:30 BKK (BKK is UTC+7).
+    const lateJune = new Date('2026-06-30T17:30:00Z');
+    const r = computeDefaultTimeRange('this_month', lateJune);
+    expect(r).toEqual({ startDate: '2026-07-01', endDate: '2026-07-31' });
+  });
+
+  it("BKK boundary — 17:00 UTC Jul 31 is Aug 1 00:00 in Bangkok, so 'this_month' = full August", () => {
+    // 2026-07-31 17:00 UTC = 2026-08-01 00:00 BKK exactly (midnight boundary).
+    const bkkMidnight = new Date('2026-07-31T17:00:00Z');
+    const r = computeDefaultTimeRange('this_month', bkkMidnight);
+    expect(r).toEqual({ startDate: '2026-08-01', endDate: '2026-08-31' });
+  });
+
+  it("'this_month' in December returns Dec 1 → Dec 31 (year-end month wrap)", () => {
+    const dec15 = new Date('2026-12-15T12:00:00Z');
+    const r = computeDefaultTimeRange('this_month', dec15);
+    expect(r).toEqual({ startDate: '2026-12-01', endDate: '2026-12-31' });
+  });
+
+  it("'this_month' returns 29 days for leap-year February (2028)", () => {
+    const feb15Leap = new Date('2028-02-15T12:00:00Z');
+    const r = computeDefaultTimeRange('this_month', feb15Leap);
+    expect(r).toEqual({ startDate: '2028-02-01', endDate: '2028-02-29' });
+  });
+
+  it("'this_month' returns 28 days for non-leap February (2026)", () => {
+    const feb15NonLeap = new Date('2026-02-15T12:00:00Z');
+    const r = computeDefaultTimeRange('this_month', feb15NonLeap);
+    expect(r).toEqual({ startDate: '2026-02-01', endDate: '2026-02-28' });
+  });
+
+  it("'this_month' handles 30-day months (September → Sep 30)", () => {
+    const sep15 = new Date('2026-09-15T12:00:00Z');
+    const r = computeDefaultTimeRange('this_month', sep15);
+    expect(r).toEqual({ startDate: '2026-09-01', endDate: '2026-09-30' });
   });
 
   it("'last_month' returns first → last day of previous month", () => {

--- a/apps/web/src/lib/date.ts
+++ b/apps/web/src/lib/date.ts
@@ -49,6 +49,17 @@ function toDate(input: DateInput): Date | null {
 const pad = (n: number) => n.toString().padStart(2, '0');
 
 /**
+ * YYYY-MM-DD of the given moment in LOCAL time — e.g. "2026-07-03".
+ *
+ * Use this (never `new Date().toISOString().split('T')[0]`) for date-input
+ * defaults: toISOString() returns the UTC calendar day, which before
+ * 07:00 Asia/Bangkok is still YESTERDAY (the PR #1327 bug class).
+ */
+export function toLocalDateString(d: Date = new Date()): string {
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+}
+
+/**
  * DD/MM/YYYY (พ.ศ.) — e.g. "08/04/2569"
  */
 export function formatThaiDate(input: DateInput): string {

--- a/apps/web/src/pages/GeneralLedgerPage.test.tsx
+++ b/apps/web/src/pages/GeneralLedgerPage.test.tsx
@@ -1,5 +1,6 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach, beforeAll } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter } from 'react-router';
 import React from 'react';
@@ -145,5 +146,98 @@ describe('GeneralLedgerPage', () => {
     });
     // Then directly verify the table layout is reachable via DOM — title only.
     expect(screen.getByText('บัญชีแยกประเภท')).toBeInTheDocument();
+  });
+});
+
+describe('GeneralLedgerPage — default date range (PR #1327)', () => {
+  beforeAll(() => {
+    // jsdom does not implement scrollIntoView; cmdk calls it on CommandItem mount.
+    if (!window.HTMLElement.prototype.scrollIntoView) {
+      window.HTMLElement.prototype.scrollIntoView = () => {};
+    }
+  });
+
+  beforeEach(() => {
+    apiGet.mockReset();
+    // Freeze ONLY Date (timers stay real so waitFor/userEvent keep working).
+    // The page computes its default range from LOCAL time, so anchor the clock
+    // with a local-time constructor: 2026-07-01 00:30 local. On an Asia/Bangkok
+    // machine this instant is 2026-06-30T17:30:00Z — the exact month-boundary
+    // where the pre-fix toISOString() code shifted periodStart back to
+    // 2026-06-30 (last day of the PREVIOUS month).
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(new Date(2026, 6, 1, 0, 30, 0));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('defaults to the FULL current month and fires the GL query with periodStart = 1st, periodEnd = last day', async () => {
+    apiGet.mockImplementation(async (url: string) => {
+      if (url.startsWith('/chart-of-accounts/grouped')) {
+        return {
+          data: {
+            groups: [
+              {
+                category: 'Assets',
+                accounts: [
+                  {
+                    code: '11-2101',
+                    name: 'ลูกหนี้ผ่อนชำระ',
+                    normalBalance: 'Dr',
+                    vatApplicable: false,
+                    notes: null,
+                  },
+                ],
+              },
+            ],
+          },
+        };
+      }
+      if (url.startsWith('/expenses/ledger/general-ledger')) {
+        return {
+          data: {
+            accountCode: '11-2101',
+            accountName: 'ลูกหนี้ผ่อนชำระ',
+            normalBalance: 'Dr',
+            periodStart: '2026-07-01T00:00:00.000Z',
+            periodEnd: '2026-07-31T23:59:59.999Z',
+            opening: 0,
+            closing: 0,
+            totalDebit: 0,
+            totalCredit: 0,
+            lines: [],
+          },
+        };
+      }
+      throw new Error(`unexpected url ${url}`);
+    });
+
+    renderPage();
+
+    // Default = full current month → the "เดือนนี้" chip reads active and the
+    // label renders as the bare month name (pre-fix code produced a partial
+    // range, so the chip was inactive and the label showed "(30/06 - 01/07)").
+    await waitFor(() => {
+      expect(screen.getByRole('radio', { name: 'เดือนนี้' })).toHaveAttribute(
+        'aria-checked',
+        'true',
+      );
+    });
+    expect(screen.getByTestId('date-range-label')).toHaveTextContent(/^กรกฎาคม 2569$/);
+
+    // Select an account — the GL query is gated on accountCode.
+    await userEvent.click(screen.getByRole('combobox', { name: 'เลือกบัญชี' }));
+    await userEvent.click(await screen.findByText('ลูกหนี้ผ่อนชำระ'));
+
+    // The GL API call must use the local-month boundaries — NOT the UTC-shifted
+    // 2026-06-30 start the old toISOString() code produced, and NOT "today" as
+    // the end.
+    await waitFor(() => {
+      expect(apiGet).toHaveBeenCalledWith(
+        '/expenses/ledger/general-ledger?accountCode=11-2101&periodStart=2026-07-01&periodEnd=2026-07-31',
+      );
+    });
   });
 });

--- a/apps/web/src/pages/PaymentsPage/__tests__/PaymentsPage.default-range.test.tsx
+++ b/apps/web/src/pages/PaymentsPage/__tests__/PaymentsPage.default-range.test.tsx
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router';
+
+const apiGet = vi.fn();
+vi.mock('@/lib/api', () => ({
+  __esModule: true,
+  default: {
+    get: (...args: unknown[]) => apiGet(...args),
+  },
+  getErrorMessage: (e: unknown) => String(e),
+}));
+
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => ({
+    user: { id: 'u1', role: 'SALES', defaultCashAccountCode: '11-1101' },
+  }),
+}));
+
+// Heavy children stubbed out — this spec asserts ONLY the default period range
+// (PR #1327: "เดือนนี้" default = the FULL calendar month, owner 2026-07-02).
+vi.mock('@/components/payment/SlipReviewTab', () => ({ __esModule: true, default: () => null }));
+vi.mock('@/components/payment/PaymentHistorySheet', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+vi.mock('@/components/ToleranceApprovalDialog', () => ({
+  ToleranceApprovalDialog: () => null,
+}));
+vi.mock('../components/ReceiptsTab', () => ({ __esModule: true, default: () => null }));
+vi.mock('../components/PaymentFilters', () => ({ __esModule: true, default: () => null }));
+vi.mock('../components/PaymentTable', () => ({ __esModule: true, default: () => null }));
+vi.mock('../components/PaymentSummary', () => ({ __esModule: true, default: () => null }));
+vi.mock('../components/PaymentModals', () => ({
+  RecordPaymentModal: () => null,
+  BatchPaymentModal: () => null,
+}));
+vi.mock('../components/RecordPaymentWizard', () => ({ RecordPaymentWizard: () => null }));
+// Render the page's period + KPI-label state as plain text so the default
+// range is directly observable.
+vi.mock('../components/PaymentPeriodBar', () => ({
+  __esModule: true,
+  default: ({ startDate, endDate }: { startDate: string; endDate: string }) => (
+    <div data-testid="period-bar">{`${startDate}|${endDate}`}</div>
+  ),
+}));
+vi.mock('../components/PaymentKpiCards', () => ({
+  __esModule: true,
+  default: ({ collectedLabel }: { collectedLabel: string }) => (
+    <div data-testid="collected-label">{collectedLabel}</div>
+  ),
+}));
+
+import PaymentsPage from '../index';
+
+function renderPage() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>
+        <PaymentsPage />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe('PaymentsPage — default period range (PR #1327)', () => {
+  beforeEach(() => {
+    apiGet.mockReset();
+    apiGet.mockImplementation(async (url: string) => {
+      if (url.startsWith('/payments/pending-summary')) return { data: {} };
+      if (url.startsWith('/payments/pending')) return { data: { data: [] } };
+      throw new Error(`unexpected url ${url}`);
+    });
+    // Freeze ONLY Date (timers stay real so waitFor keeps working). The page
+    // computes its default range from LOCAL time, so anchor the clock with a
+    // local-time constructor: 2026-07-01 00:30 local. On an Asia/Bangkok
+    // machine this instant is 2026-06-30T17:30:00Z — the month boundary where
+    // any toISOString()-based date math would shift back to 2026-06-30.
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(new Date(2026, 6, 1, 0, 30, 0));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('defaults dueFrom/dueTo to the FULL current month and queries the queue + KPI with that window', async () => {
+    renderPage();
+
+    // Default state = 1st → LAST day of the current month (not "today").
+    expect(screen.getByTestId('period-bar')).toHaveTextContent('2026-07-01|2026-07-31');
+
+    // Both dueDate-scoped queries fire with the full-month window.
+    await waitFor(() => {
+      expect(apiGet).toHaveBeenCalledWith('/payments/pending?dueFrom=2026-07-01&dueTo=2026-07-31');
+    });
+    await waitFor(() => {
+      expect(apiGet).toHaveBeenCalledWith(
+        '/payments/pending-summary?dueFrom=2026-07-01&dueTo=2026-07-31',
+      );
+    });
+  });
+
+  it("labels the collected KPI 'รับชำระเดือนนี้' for the default range", () => {
+    renderPage();
+
+    // The label compares state against the full-month "เดือนนี้" preset — if the
+    // default were [1st, today] the comparison would fall through to
+    // 'รับชำระช่วงนี้' (the pre-#1327 regression).
+    expect(screen.getByTestId('collected-label')).toHaveTextContent(/^รับชำระเดือนนี้$/);
+  });
+});

--- a/apps/web/src/pages/PaymentsPage/__tests__/PaymentsPage.local-date.test.tsx
+++ b/apps/web/src/pages/PaymentsPage/__tests__/PaymentsPage.local-date.test.tsx
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router';
+
+const apiGet = vi.fn();
+vi.mock('@/lib/api', () => ({
+  __esModule: true,
+  default: {
+    get: (...args: unknown[]) => apiGet(...args),
+  },
+  getErrorMessage: (e: unknown) => String(e),
+}));
+
+const exportToExcel = vi.fn();
+vi.mock('@/utils/excel.util', () => ({
+  __esModule: true,
+  exportToExcel: (...args: unknown[]) => exportToExcel(...args),
+}));
+
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => ({
+    user: { id: 'u1', role: 'SALES', defaultCashAccountCode: '11-1101' },
+  }),
+}));
+
+// Heavy children stubbed out — this spec asserts ONLY the LOCAL-date defaults
+// (same toISOString-before-07:00-BKK bug class PR #1327 fixed for date ranges).
+vi.mock('@/components/payment/SlipReviewTab', () => ({ __esModule: true, default: () => null }));
+vi.mock('@/components/payment/PaymentHistorySheet', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+vi.mock('@/components/ToleranceApprovalDialog', () => ({
+  ToleranceApprovalDialog: () => null,
+}));
+vi.mock('../components/ReceiptsTab', () => ({ __esModule: true, default: () => null }));
+// Expose the export trigger so the Excel filename date is observable.
+vi.mock('../components/PaymentFilters', () => ({
+  __esModule: true,
+  default: ({ onExport }: { onExport: () => void }) => (
+    <button data-testid="export-excel" onClick={onExport}>
+      export
+    </button>
+  ),
+}));
+// Expose the pay trigger so openPayModal's payForm re-seed is observable.
+vi.mock('../components/PaymentTable', () => ({
+  __esModule: true,
+  default: ({ onOpenPayModal }: { onOpenPayModal: (p: unknown) => void }) => (
+    <button
+      data-testid="open-pay-modal"
+      onClick={() => onOpenPayModal({ amountDue: '1515.83', lateFee: '0', amountPaid: '0' })}
+    >
+      pay
+    </button>
+  ),
+}));
+vi.mock('../components/PaymentPeriodBar', () => ({ __esModule: true, default: () => null }));
+vi.mock('../components/PaymentKpiCards', () => ({ __esModule: true, default: () => null }));
+vi.mock('../components/RecordPaymentWizard', () => ({ RecordPaymentWizard: () => null }));
+// Render the page's summaryDate state as plain text so the daily-summary tab
+// default is directly observable.
+vi.mock('../components/PaymentSummary', () => ({
+  __esModule: true,
+  default: ({ summaryDate }: { summaryDate: string }) => (
+    <div data-testid="summary-date">{summaryDate}</div>
+  ),
+}));
+// Render payForm.paidDate (the RECORDED PAYMENT DATE default — money-impacting)
+// plus a close trigger so the onClose reset path is observable too.
+vi.mock('../components/PaymentModals', () => ({
+  RecordPaymentModal: ({ payForm, onClose }: { payForm: { paidDate: string }; onClose: () => void }) => (
+    <div>
+      <div data-testid="paid-date">{payForm.paidDate}</div>
+      <button data-testid="close-pay-modal" onClick={onClose}>
+        close
+      </button>
+    </div>
+  ),
+  BatchPaymentModal: () => null,
+}));
+
+import PaymentsPage from '../index';
+
+function renderPage(initialEntry = '/payments') {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={[initialEntry]}>
+        <PaymentsPage />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe('PaymentsPage — LOCAL-date defaults (toISOString bug class, PR #1327)', () => {
+  beforeEach(() => {
+    apiGet.mockReset();
+    apiGet.mockImplementation(async (url: string) => {
+      if (url.startsWith('/payments/daily-summary')) return { data: {} };
+      if (url.startsWith('/payments/pending-summary')) return { data: {} };
+      if (url.startsWith('/payments/pending')) return { data: { data: [] } };
+      throw new Error(`unexpected url ${url}`);
+    });
+    // Freeze ONLY Date (timers stay real so waitFor keeps working). The page
+    // must compute its date defaults from LOCAL time, so anchor the clock with
+    // a local-time constructor: 2026-07-03 01:30 local. On an Asia/Bangkok
+    // machine this instant is 2026-07-02T18:30:00Z — before 07:00 BKK, where
+    // any toISOString()-based default yields YESTERDAY (2026-07-02).
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(new Date(2026, 6, 3, 1, 30, 0));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('defaults the daily-summary date to the LOCAL date and queries with it', async () => {
+    renderPage('/payments?tab=summary');
+
+    // Before 07:00 BKK the UTC date is still yesterday — the default must be
+    // the LOCAL calendar day, not toISOString()'s UTC day.
+    expect(screen.getByTestId('summary-date')).toHaveTextContent(/^2026-07-03$/);
+
+    await waitFor(() => {
+      expect(apiGet).toHaveBeenCalledWith('/payments/daily-summary?date=2026-07-03');
+    });
+  });
+
+  it('defaults payForm.paidDate (recorded payment date) to the LOCAL date', () => {
+    renderPage();
+
+    expect(screen.getByTestId('paid-date')).toHaveTextContent(/^2026-07-03$/);
+  });
+
+  it('keeps payForm.paidDate on the LOCAL date after the pay modal resets on close', () => {
+    renderPage();
+
+    // onClose re-seeds payForm with a fresh default — that reset must use the
+    // LOCAL date too, or reopening the modal brings the UTC-yesterday bug back.
+    fireEvent.click(screen.getByTestId('close-pay-modal'));
+
+    expect(screen.getByTestId('paid-date')).toHaveTextContent(/^2026-07-03$/);
+  });
+
+  it('re-seeds payForm.paidDate with the LOCAL date when opening the pay flow', async () => {
+    renderPage();
+
+    // openPayModal re-seeds payForm from scratch — the symmetric path to the
+    // onClose reset; it must not reintroduce the toISOString UTC-yesterday bug.
+    await waitFor(() => screen.getByTestId('open-pay-modal'));
+    fireEvent.click(screen.getByTestId('open-pay-modal'));
+
+    expect(screen.getByTestId('paid-date')).toHaveTextContent(/^2026-07-03$/);
+  });
+
+  it('stamps the Excel export filename with the LOCAL date', async () => {
+    renderPage();
+
+    await waitFor(() => screen.getByTestId('export-excel'));
+    fireEvent.click(screen.getByTestId('export-excel'));
+
+    await waitFor(() => expect(exportToExcel).toHaveBeenCalled());
+    expect(exportToExcel).toHaveBeenCalledWith(
+      expect.objectContaining({ filename: 'pending-payments-2026-07-03.xlsx' }),
+    );
+  });
+});

--- a/apps/web/src/pages/PaymentsPage/components/QrSentBadge.test.tsx
+++ b/apps/web/src/pages/PaymentsPage/components/QrSentBadge.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QrSentBadge } from './QrSentBadge';
+import api from '@/lib/api';
+
+vi.mock('@/lib/api', () => ({
+  default: {
+    get: vi.fn(),
+    delete: vi.fn(),
+  },
+  getErrorMessage: vi.fn(() => 'error'),
+}));
+
+function wrap(ui: React.ReactElement) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={qc}>{ui}</QueryClientProvider>;
+}
+
+const activeLink = (purpose: 'INSTALLMENT' | 'RESCHEDULE') => ({
+  id: 'pp-1',
+  paymentId: 'pay-1',
+  amount: '500',
+  paymentUrl: 'https://pay.example/x',
+  token: 'TOK123',
+  status: 'ACTIVE' as const,
+  purpose,
+  expiresAt: new Date(Date.now() + 2 * 60 * 60 * 1000).toISOString(),
+  createdAt: new Date().toISOString(),
+});
+
+describe('QrSentBadge — purpose labels', () => {
+  beforeEach(() => {
+    vi.mocked(api.get).mockReset();
+  });
+
+  it("purpose RESCHEDULE renders 'QR ปรับดิว' + the pending hint ดิวจะเลื่อนเมื่อเงินเข้า", async () => {
+    vi.mocked(api.get).mockResolvedValue({ data: activeLink('RESCHEDULE') });
+    render(wrap(<QrSentBadge paymentId="pay-1" />));
+    expect(await screen.findByText(/QR ปรับดิว/)).toBeInTheDocument();
+    expect(screen.getByText('ดิวจะเลื่อนเมื่อเงินเข้า')).toBeInTheDocument();
+  });
+
+  it("purpose INSTALLMENT renders the default 'QR ส่งแล้ว' without the reschedule hint", async () => {
+    vi.mocked(api.get).mockResolvedValue({ data: activeLink('INSTALLMENT') });
+    render(wrap(<QrSentBadge paymentId="pay-1" />));
+    expect(await screen.findByText(/QR ส่งแล้ว/)).toBeInTheDocument();
+    expect(screen.queryByText('ดิวจะเลื่อนเมื่อเงินเข้า')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/pages/PaymentsPage/components/__tests__/RescheduleOverlay.test.tsx
+++ b/apps/web/src/pages/PaymentsPage/components/__tests__/RescheduleOverlay.test.tsx
@@ -1,0 +1,313 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { RescheduleOverlay } from '../RescheduleOverlay';
+
+// ── Mock @/lib/api ─────────────────────────────────────────────────────────
+
+const apiGetMock = vi.fn();
+const apiPostMock = vi.fn();
+
+vi.mock('@/lib/api', () => ({
+  default: {
+    get: (...args: unknown[]) => apiGetMock(...args),
+    post: (...args: unknown[]) => apiPostMock(...args),
+  },
+  getErrorMessage: (e: unknown) =>
+    (e as { response?: { data?: { message?: string } } })?.response?.data?.message ??
+    'เกิดข้อผิดพลาด',
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+// Radix Select needs pointer-capture APIs jsdom lacks — stub with a native select.
+vi.mock('@/components/CashAccountSelect', () => ({
+  CashAccountSelect: ({
+    value,
+    onChange,
+  }: {
+    value?: string;
+    onChange: (code: string) => void;
+  }) => (
+    <select aria-label="บัญชีรับเงิน" value={value ?? ''} onChange={(e) => onChange(e.target.value)}>
+      <option value="11-1101">11-1101 เงินสด</option>
+      <option value="11-1201">11-1201 ธนาคาร KBank</option>
+    </select>
+  ),
+}));
+
+// ── Fixtures ───────────────────────────────────────────────────────────────
+
+// monthlyPayment 1515.83 ÷ 30 × 7 วัน = 353.69 → ปัดขึ้นเต็มบาท = 354.00
+const QUOTE_NO_COLLECT = {
+  rescheduleFee: '354.00',
+  lateFee: '0.00',
+  collectAmount: '0.00',
+  variant: '6b' as const,
+  newDueDate: '2026-07-17',
+  currentDueDate: '2026-07-10',
+};
+
+// 6b (SINGLE) + ค่าปรับค้าง → เก็บเฉพาะค่าปรับวันนี้
+const QUOTE_LATE_FEE_ONLY = {
+  rescheduleFee: '354.00',
+  lateFee: '75.79',
+  collectAmount: '75.79',
+  variant: '6b' as const,
+  newDueDate: '2026-07-17',
+  currentDueDate: '2026-07-10',
+};
+
+// 6a (SPLIT) + ค่าปรับค้าง → เก็บค่าธรรมเนียม + ค่าปรับ
+const QUOTE_SPLIT = {
+  rescheduleFee: '354.00',
+  lateFee: '75.79',
+  collectAmount: '429.79',
+  variant: '6a' as const,
+  newDueDate: '2026-07-17',
+  currentDueDate: '2026-07-10',
+};
+
+function mockHappyApi({
+  singleQuote = QUOTE_LATE_FEE_ONLY,
+  splitQuote = QUOTE_SPLIT,
+  qrResponse = { sentToLine: true, collectAmount: '75.79' },
+} = {}) {
+  apiGetMock.mockImplementation((url: string, config?: { params?: { splitMode?: string } }) => {
+    if (url === '/payments/reschedule-quote') {
+      const quote = config?.params?.splitMode === 'SPLIT' ? splitQuote : singleQuote;
+      return Promise.resolve({ data: quote });
+    }
+    return Promise.resolve({ data: [] });
+  });
+  apiPostMock.mockImplementation((url: string) => {
+    if (url === '/payments/preview-journal') {
+      return Promise.resolve({
+        data: {
+          lines: [
+            { accountCode: '11-1101', accountName: 'เงินสด', debit: '75.79', credit: '0.00', description: '' },
+            { accountCode: '42-1103', accountName: 'ค่าปรับชำระล่าช้า', debit: '0.00', credit: '75.79', description: '' },
+          ],
+          isBalanced: true,
+        },
+      });
+    }
+    if (url.endsWith('/reschedule-qr')) {
+      return Promise.resolve({ data: qrResponse });
+    }
+    return Promise.resolve({ data: { id: 'payment-1' } });
+  });
+}
+
+/** api.post calls to a specific endpoint (JE preview fires in parallel — filter it out). */
+function postCallsTo(url: string) {
+  return apiPostMock.mock.calls.filter(([calledUrl]) => calledUrl === url);
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function renderOverlay(props: Partial<React.ComponentProps<typeof RescheduleOverlay>> = {}) {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const onClose = props.onClose ?? vi.fn();
+  const onSuccess = props.onSuccess ?? vi.fn();
+
+  render(
+    <QueryClientProvider client={qc}>
+      <RescheduleOverlay
+        contractId="contract-1"
+        contractNumber="CT-2026-0001"
+        customerName="สมชาย ใจดี"
+        branchName="สาขาลาดพร้าว"
+        paymentId="pay-1"
+        installmentNo={3}
+        currentDueDate="2026-07-10"
+        monthlyPayment="1515.83"
+        {...props}
+        onClose={onClose}
+        onSuccess={onSuccess}
+      />
+    </QueryClientProvider>,
+  );
+
+  return { onClose, onSuccess };
+}
+
+beforeEach(() => {
+  apiGetMock.mockReset();
+  apiPostMock.mockReset();
+  vi.mocked(toast.success).mockClear();
+  vi.mocked(toast.error).mockClear();
+});
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe('RescheduleOverlay', () => {
+  it('renders the "ปรับดิว" title with contract info', async () => {
+    mockHappyApi();
+    renderOverlay();
+
+    expect(screen.getByText('ปรับดิว — เลื่อนวันครบกำหนด')).toBeInTheDocument();
+    expect(screen.getByText('CT-2026-0001')).toBeInTheDocument();
+    expect(screen.getByText('สมชาย ใจดี')).toBeInTheDocument();
+  });
+
+  it('drives fee / late-fee / collect rows from the server quote (6a split)', async () => {
+    mockHappyApi();
+    const user = userEvent.setup();
+    renderOverlay();
+
+    // Switch to 6a (เก็บค่าธรรมเนียมตอนนี้) — quote refetches with splitMode=SPLIT
+    await user.click(screen.getByRole('button', { name: /เก็บค่าธรรมเนียมตอนนี้ \(6a\)/ }));
+
+    // รวมต้องเก็บวันนี้ = collectAmount from the quote
+    expect(await screen.findByText('429.79 บาท')).toBeInTheDocument();
+    expect(screen.getByText('รวมต้องเก็บวันนี้')).toBeInTheDocument();
+
+    // ค่าปรับค้างชำระ row
+    expect(screen.getByText('ค่าปรับค้างชำระ')).toBeInTheDocument();
+    expect(screen.getByText('75.79 บาท')).toBeInTheDocument();
+
+    // ค่าธรรมเนียม appears in Section 2 AND as the 6a row in the payment section
+    expect(screen.getByText('ค่าธรรมเนียมเลื่อนดิว (6a)')).toBeInTheDocument();
+    expect(screen.getAllByText('354.00 บาท')).toHaveLength(2);
+  });
+
+  it('hasCollect=false (6b + no late fee): label "ยืนยันปรับดิว" and POST /payments/record with amount 0.01', async () => {
+    mockHappyApi({ singleQuote: QUOTE_NO_COLLECT });
+    const user = userEvent.setup();
+    const { onClose, onSuccess } = renderOverlay();
+
+    // Zero-collect banner shows
+    expect(await screen.findByText(/ไม่มียอดต้องเก็บวันนี้/)).toBeInTheDocument();
+
+    const submitBtn = screen.getByRole('button', { name: 'ยืนยันปรับดิว' });
+    await waitFor(() => expect(submitBtn).toBeEnabled());
+    await user.click(submitBtn);
+
+    await waitFor(() => expect(postCallsTo('/payments/record')).toHaveLength(1));
+    const [, payload] = postCallsTo('/payments/record')[0];
+    expect(payload).toMatchObject({
+      contractId: 'contract-1',
+      installmentNo: 3,
+      amount: 0.01, // zero-collect still needs the DTO's @Min(0.01)
+      paymentMethod: 'CASH',
+      case: 'RESCHEDULE',
+      daysToShift: 7,
+      splitMode: 'SINGLE',
+    });
+    expect(payload.transactionRef).toBeUndefined();
+
+    await waitFor(() => expect(vi.mocked(toast.success)).toHaveBeenCalledWith('ปรับดิวสำเร็จ'));
+    expect(onSuccess).toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('hasCollect=true + CASH: button label includes เก็บเงิน + amount, POST amount=collectAmount with depositAccountCode', async () => {
+    mockHappyApi({ singleQuote: QUOTE_LATE_FEE_ONLY });
+    const user = userEvent.setup();
+    const { onSuccess } = renderOverlay();
+
+    // Button label carries the collect amount
+    const submitBtn = await screen.findByRole('button', {
+      name: 'เก็บเงิน 75.79 + ยืนยันปรับดิว',
+    });
+
+    // JE preview box renders the lines the confirm will post
+    expect(await screen.findByText('รายการบัญชี (ลงทันทีตอนยืนยัน)')).toBeInTheDocument();
+
+    await waitFor(() => expect(submitBtn).toBeEnabled());
+    await user.click(submitBtn);
+
+    await waitFor(() => expect(postCallsTo('/payments/record')).toHaveLength(1));
+    const [, payload] = postCallsTo('/payments/record')[0];
+    expect(payload).toMatchObject({
+      contractId: 'contract-1',
+      installmentNo: 3,
+      amount: 75.79,
+      paymentMethod: 'CASH',
+      case: 'RESCHEDULE',
+      daysToShift: 7,
+      splitMode: 'SINGLE',
+      depositAccountCode: '11-1101',
+    });
+
+    await waitFor(() => expect(onSuccess).toHaveBeenCalled());
+    expect(vi.mocked(toast.success)).toHaveBeenCalledWith(
+      expect.stringContaining('เก็บเงิน 75.79'),
+    );
+  });
+
+  it('TRANSFER with empty ref: submit disabled until เลขอ้างอิง is filled, then posts BANK_TRANSFER + transactionRef', async () => {
+    mockHappyApi({ singleQuote: QUOTE_LATE_FEE_ONLY });
+    const user = userEvent.setup();
+    renderOverlay();
+
+    await user.click(await screen.findByRole('button', { name: 'โอนธนาคาร' }));
+
+    const submitBtn = screen.getByRole('button', { name: 'เก็บเงิน 75.79 + ยืนยันปรับดิว' });
+    // needRef gating — เลขอ้างอิงการโอน is required for TRANSFER
+    expect(submitBtn).toBeDisabled();
+
+    await user.type(screen.getByPlaceholderText('เลขอ้างอิงจากสลิปโอนเงิน'), 'TX-12345');
+    await waitFor(() => expect(submitBtn).toBeEnabled());
+    await user.click(submitBtn);
+
+    await waitFor(() => expect(postCallsTo('/payments/record')).toHaveLength(1));
+    const [, payload] = postCallsTo('/payments/record')[0];
+    expect(payload).toMatchObject({
+      paymentMethod: 'BANK_TRANSFER',
+      transactionRef: 'TX-12345',
+      amount: 75.79,
+    });
+  });
+
+  it('QR method + collect: POSTs /payments/{paymentId}/reschedule-qr and shows ส่ง QR success toast', async () => {
+    mockHappyApi({ singleQuote: QUOTE_LATE_FEE_ONLY });
+    const user = userEvent.setup();
+    const { onClose, onSuccess } = renderOverlay();
+
+    await user.click(await screen.findByRole('button', { name: 'QR ใน LINE' }));
+
+    const submitBtn = screen.getByRole('button', { name: 'ส่ง QR ให้ลูกค้า' });
+    await waitFor(() => expect(submitBtn).toBeEnabled());
+    await user.click(submitBtn);
+
+    await waitFor(() => expect(postCallsTo('/payments/pay-1/reschedule-qr')).toHaveLength(1));
+    const [, payload] = postCallsTo('/payments/pay-1/reschedule-qr')[0];
+    expect(payload).toEqual({ daysToShift: 7, splitMode: 'SINGLE' });
+
+    // QR is async — must NOT hit the synchronous record endpoint
+    expect(postCallsTo('/payments/record')).toHaveLength(0);
+
+    await waitFor(() =>
+      expect(vi.mocked(toast.success)).toHaveBeenCalledWith(
+        expect.stringContaining('ส่ง QR ปรับดิวให้ลูกค้าใน LINE แล้ว'),
+      ),
+    );
+    expect(onSuccess).toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('quote fetch error: shows the error message and keeps submit disabled', async () => {
+    apiGetMock.mockRejectedValue({
+      response: { data: { message: 'ไม่พบงวดที่ต้องการเลื่อน' } },
+    });
+    apiPostMock.mockResolvedValue({ data: {} });
+    renderOverlay();
+
+    expect(await screen.findByText('ไม่พบงวดที่ต้องการเลื่อน')).toBeInTheDocument();
+
+    // No quote → canSubmit=false (hasCollect=false → label is ยืนยันปรับดิว)
+    expect(screen.getByRole('button', { name: 'ยืนยันปรับดิว' })).toBeDisabled();
+    expect(postCallsTo('/payments/record')).toHaveLength(0);
+  });
+});

--- a/apps/web/src/pages/PaymentsPage/index.tsx
+++ b/apps/web/src/pages/PaymentsPage/index.tsx
@@ -6,6 +6,7 @@ import { useDocumentTitle } from '@/hooks/useDocumentTitle';
 import { useSearchParams } from 'react-router';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import api, { getErrorMessage } from '@/lib/api';
+import { toLocalDateString } from '@/lib/date';
 import { useAuth } from '@/contexts/AuthContext';
 import SlipReviewTab from '@/components/payment/SlipReviewTab';
 import ReceiptsTab from './components/ReceiptsTab';
@@ -49,7 +50,8 @@ export default function PaymentsPage() {
   const [branchFilter, setBranchFilter] = useState('');
   const [searchTerm, setSearchTerm] = useState('');
   const debouncedSearch = useDebounce(searchTerm, 400);
-  const [summaryDate, setSummaryDate] = useState(new Date().toISOString().split('T')[0]);
+  // LOCAL date, not toISOString() — the UTC day is still yesterday before 07:00 BKK (PR #1327 bug class).
+  const [summaryDate, setSummaryDate] = useState(toLocalDateString());
 
   // Period filter for the pending queue (KPI cards + list) — scopes everything
   // by installment dueDate. Default is "เดือนนี้" (matches DateRangeChips'
@@ -90,7 +92,8 @@ export default function PaymentsPage() {
   const [showPayModal, setShowPayModal] = useState(false);
   const [showPayWizard, setShowPayWizard] = useState(false);
   const [selectedPayment, setSelectedPayment] = useState<PendingPayment | null>(null);
-  const [payForm, setPayForm] = useState({ amount: 0, paymentMethod: 'CASH', notes: '', paidDate: new Date().toISOString().split('T')[0] });
+  // paidDate = LOCAL date (money-impacting: toISOString() records YESTERDAY before 07:00 BKK).
+  const [payForm, setPayForm] = useState({ amount: 0, paymentMethod: 'CASH', notes: '', paidDate: toLocalDateString() });
   // T15: deposit account code for the payment journal Dr leg; defaults to user preference or system default
   const [depositAccountCode, setDepositAccountCode] = useState<string>(
     user?.defaultCashAccountCode ?? '11-1101',
@@ -298,7 +301,7 @@ export default function PaymentsPage() {
         };
       }),
       sheetName: 'รายการรอชำระ',
-      filename: `pending-payments-${new Date().toISOString().split('T')[0]}.xlsx`,
+      filename: `pending-payments-${toLocalDateString()}.xlsx`,
     });
     toast.success('ส่งออก Excel สำเร็จ');
   };
@@ -357,7 +360,7 @@ export default function PaymentsPage() {
   const openPayModal = useCallback((payment: PendingPayment) => {
     setSelectedPayment(payment);
     const remaining = parseFloat(payment.amountDue) + parseFloat(payment.lateFee) - parseFloat(payment.amountPaid);
-    setPayForm({ amount: Math.round(remaining * 100) / 100, paymentMethod: 'CASH', notes: '', paidDate: new Date().toISOString().split('T')[0] });
+    setPayForm({ amount: Math.round(remaining * 100) / 100, paymentMethod: 'CASH', notes: '', paidDate: toLocalDateString() });
     setDepositAccountCode(user?.defaultCashAccountCode ?? '11-1101');
     setSlipResult(null);
     // Open the new wizard UI
@@ -736,7 +739,7 @@ export default function PaymentsPage() {
         payment={selectedPayment}
         payForm={payForm}
         onPayFormChange={setPayForm}
-        onClose={() => { setShowPayModal(false); setSelectedPayment(null); setSlipResult(null); setPayForm({ amount: 0, paymentMethod: 'CASH', notes: '', paidDate: new Date().toISOString().split('T')[0] }); }}
+        onClose={() => { setShowPayModal(false); setSelectedPayment(null); setSlipResult(null); setPayForm({ amount: 0, paymentMethod: 'CASH', notes: '', paidDate: toLocalDateString() }); }}
         onSubmit={handlePay}
         isPending={recordMutation.isPending}
         slipFileRef={slipFileRef}

--- a/apps/web/src/pages/ReportsPage.test.tsx
+++ b/apps/web/src/pages/ReportsPage.test.tsx
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router';
+import React from 'react';
+
+const apiGet = vi.fn();
+vi.mock('@/lib/api', () => ({
+  __esModule: true,
+  default: {
+    get: (...args: unknown[]) => apiGet(...args),
+  },
+}));
+
+import ReportsPage from './ReportsPage';
+
+function renderPage() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    React.createElement(
+      QueryClientProvider,
+      { client: qc },
+      React.createElement(MemoryRouter, null, React.createElement(ReportsPage)),
+    ),
+  );
+}
+
+describe('ReportsPage — EntityProfitReport default date range (PR #1327)', () => {
+  beforeEach(() => {
+    apiGet.mockReset();
+    apiGet.mockImplementation(async (url: string) => {
+      if (url.startsWith('/reports/aging')) return { data: {} };
+      if (url.startsWith('/reports/entity-profit')) return { data: {} };
+      throw new Error(`unexpected url ${url}`);
+    });
+    // Freeze ONLY Date (timers stay real so waitFor keeps working). The report
+    // computes its default range from LOCAL time, so anchor the clock with a
+    // local-time constructor: 2026-07-01 00:30 local. On an Asia/Bangkok
+    // machine this instant is 2026-06-30T17:30:00Z — the exact month-boundary
+    // where the pre-fix toISOString() code shifted firstDay back to 2026-06-30
+    // (last day of the PREVIOUS month).
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(new Date(2026, 6, 1, 0, 30, 0));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('defaults to the FULL current local month — no UTC shift on firstDay/lastDay', async () => {
+    renderPage();
+
+    // Switch to the กำไร Shop/Finance tab (EntityProfitReport).
+    fireEvent.click(screen.getByRole('button', { name: 'กำไร Shop/Finance' }));
+
+    // The report query must use the local-month boundaries — NOT the
+    // UTC-shifted 2026-06-30 start the old toISOString() code produced, and
+    // NOT "today" as the end.
+    await waitFor(() => {
+      expect(apiGet).toHaveBeenCalledWith(
+        '/reports/entity-profit?startDate=2026-07-01&endDate=2026-07-31',
+      );
+    });
+
+    // Default = full current month → the "เดือนนี้" chip reads active and the
+    // label renders as the bare month name.
+    expect(screen.getByRole('radio', { name: 'เดือนนี้' })).toHaveAttribute(
+      'aria-checked',
+      'true',
+    );
+    expect(screen.getByTestId('date-range-label')).toHaveTextContent(/^กรกฎาคม 2569$/);
+  });
+});
+
+describe('ReportsPage — toISOString UTC-shift bug (dateFilter default + CSV filename)', () => {
+  beforeEach(() => {
+    apiGet.mockReset();
+    apiGet.mockImplementation(async (url: string) => {
+      if (url.startsWith('/reports/aging')) return { data: {} };
+      if (url.startsWith('/reports/daily-payments')) return { data: {} };
+      if (url.startsWith('/reports/export/contracts')) return { data: new Blob(['csv']) };
+      throw new Error(`unexpected url ${url}`);
+    });
+    // Freeze ONLY Date (timers stay real so waitFor keeps working). Anchor the
+    // clock with a LOCAL-time constructor: 2026-07-03 01:30 local. On an
+    // Asia/Bangkok machine this instant is 2026-07-02T18:30:00Z — before
+    // 07:00 BKK, where new Date().toISOString().slice(0, 10) returns
+    // YESTERDAY (2026-07-02) while the local calendar date is 2026-07-03.
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(new Date(2026, 6, 3, 1, 30, 0));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('daily-payment tab defaults its date filter to the LOCAL date, not the UTC date', async () => {
+    renderPage();
+
+    fireEvent.click(screen.getByRole('button', { name: 'ชำระรายวัน' }));
+
+    // The report query must use the local calendar day — NOT the UTC-shifted
+    // 2026-07-02 the old toISOString() default produced.
+    await waitFor(() => {
+      expect(apiGet).toHaveBeenCalledWith('/reports/daily-payments?date=2026-07-03');
+    });
+  });
+
+  it('stamps the CSV export filename with the LOCAL date, not the UTC date', async () => {
+    renderPage();
+
+    // jsdom has no URL.createObjectURL — stub it, and capture the anchor the
+    // export mutation creates so its download filename is observable. Spies
+    // go in AFTER render so React's own element creation is not captured.
+    window.URL.createObjectURL = vi.fn(() => 'blob:mock') as typeof URL.createObjectURL;
+    window.URL.revokeObjectURL = vi.fn() as typeof URL.revokeObjectURL;
+    vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
+    const anchors: HTMLAnchorElement[] = [];
+    const realCreateElement = document.createElement.bind(document);
+    vi.spyOn(document, 'createElement').mockImplementation(((
+      tagName: string,
+      options?: ElementCreationOptions,
+    ) => {
+      const el = realCreateElement(tagName, options);
+      if (tagName === 'a') anchors.push(el as HTMLAnchorElement);
+      return el;
+    }) as typeof document.createElement);
+
+    fireEvent.click(screen.getByRole('button', { name: 'ส่งออก CSV' }));
+
+    await waitFor(() => expect(anchors).toHaveLength(1));
+    expect(anchors[0].download).toBe('contracts-export-2026-07-03.csv');
+  });
+});

--- a/apps/web/src/pages/ReportsPage.tsx
+++ b/apps/web/src/pages/ReportsPage.tsx
@@ -10,6 +10,7 @@ import { toast } from 'sonner';
 import { Download } from 'lucide-react';
 import ThaiDateInput from '@/components/ui/ThaiDateInput';
 import { DateRangeChips } from '@/components/ui/DateRangeChips';
+import { toLocalDateString } from '@/lib/date';
 import {
   BarChart,
   Bar,
@@ -42,7 +43,7 @@ const reportTabs: { key: ReportType; label: string }[] = [
 export default function ReportsPage() {
   useDocumentTitle('รายงาน');
   const [activeTab, setActiveTab] = useState<ReportType>('aging');
-  const [dateFilter, setDateFilter] = useState(new Date().toISOString().slice(0, 10));
+  const [dateFilter, setDateFilter] = useState(toLocalDateString());
 
   const exportMutation = useMutation({
     mutationFn: async () => {
@@ -50,7 +51,7 @@ export default function ReportsPage() {
       const url = window.URL.createObjectURL(new Blob([data]));
       const a = document.createElement('a');
       a.href = url;
-      a.download = `contracts-export-${new Date().toISOString().slice(0, 10)}.csv`;
+      a.download = `contracts-export-${toLocalDateString()}.csv`;
       a.click();
       window.URL.revokeObjectURL(url);
     },
@@ -458,14 +459,11 @@ function StockReport() {
 }
 
 function EntityProfitReport() {
-  // Local-date formatting (NOT toISOString — that shifts a BKK local-midnight
-  // date back one UTC day). Default = full current month, matching the
-  // DateRangeChips "เดือนนี้" preset (owner 2026-07-02).
-  const toLocalIso = (d: Date) =>
-    `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+  // Default = full current month, matching the DateRangeChips "เดือนนี้"
+  // preset (owner 2026-07-02). Uses the shared local-date helper (@/lib/date).
   const today = new Date();
-  const firstDay = toLocalIso(new Date(today.getFullYear(), today.getMonth(), 1));
-  const lastDay = toLocalIso(new Date(today.getFullYear(), today.getMonth() + 1, 0));
+  const firstDay = toLocalDateString(new Date(today.getFullYear(), today.getMonth(), 1));
+  const lastDay = toLocalDateString(new Date(today.getFullYear(), today.getMonth() + 1, 0));
   const [startDate, setStartDate] = useState(firstDay);
   const [endDate, setEndDate] = useState(lastDay);
   const [entity, setEntity] = useState<string>('ALL');

--- a/apps/web/src/pages/other-income/components/__tests__/DateRangeChips.test.tsx
+++ b/apps/web/src/pages/other-income/components/__tests__/DateRangeChips.test.tsx
@@ -30,6 +30,34 @@ describe('DateRangeChips', () => {
     expect(onChange).toHaveBeenCalledWith({ startDate: '2026-05-01', endDate: '2026-05-31' });
   });
 
+  it('clicking "เดือนนี้" in December emits Dec 1 → Dec 31 (year-end month wrap)', () => {
+    vi.setSystemTime(new Date('2026-12-10T05:00:00.000Z')); // 12:00 BKK
+    render(<DateRangeChips startDate="" endDate="" onChange={onChange} />);
+    fireEvent.click(screen.getByRole('radio', { name: 'เดือนนี้' }));
+    expect(onChange).toHaveBeenCalledWith({ startDate: '2026-12-01', endDate: '2026-12-31' });
+  });
+
+  it('clicking "เดือนนี้" in leap-year February emits end 2028-02-29', () => {
+    vi.setSystemTime(new Date('2028-02-10T05:00:00.000Z')); // 12:00 BKK
+    render(<DateRangeChips startDate="" endDate="" onChange={onChange} />);
+    fireEvent.click(screen.getByRole('radio', { name: 'เดือนนี้' }));
+    expect(onChange).toHaveBeenCalledWith({ startDate: '2028-02-01', endDate: '2028-02-29' });
+  });
+
+  it('clicking "เดือนนี้" in non-leap February emits end 2026-02-28', () => {
+    vi.setSystemTime(new Date('2026-02-10T05:00:00.000Z')); // 12:00 BKK
+    render(<DateRangeChips startDate="" endDate="" onChange={onChange} />);
+    fireEvent.click(screen.getByRole('radio', { name: 'เดือนนี้' }));
+    expect(onChange).toHaveBeenCalledWith({ startDate: '2026-02-01', endDate: '2026-02-28' });
+  });
+
+  it('clicking "เดือนนี้" in a 30-day month emits end 2026-04-30', () => {
+    vi.setSystemTime(new Date('2026-04-10T05:00:00.000Z')); // 12:00 BKK
+    render(<DateRangeChips startDate="" endDate="" onChange={onChange} />);
+    fireEvent.click(screen.getByRole('radio', { name: 'เดือนนี้' }));
+    expect(onChange).toHaveBeenCalledWith({ startDate: '2026-04-01', endDate: '2026-04-30' });
+  });
+
   it('clicking "เดือนที่แล้ว" emits 1st → last day of last month', () => {
     render(<DateRangeChips startDate="" endDate="" onChange={onChange} />);
     fireEvent.click(screen.getByRole('radio', { name: 'เดือนที่แล้ว' }));
@@ -73,6 +101,15 @@ describe('DateRangeChips', () => {
 
   it('"เดือนนี้" chip has aria-checked=true when the full current month is selected', () => {
     render(<DateRangeChips startDate="2026-05-01" endDate="2026-05-31" onChange={onChange} />);
+    expect(screen.getByRole('radio', { name: 'เดือนนี้' })).toHaveAttribute(
+      'aria-checked',
+      'true',
+    );
+  });
+
+  it('"เดือนนี้" chip has aria-checked=true when the full non-31-day month is selected', () => {
+    vi.setSystemTime(new Date('2026-04-10T05:00:00.000Z')); // 12:00 BKK — April has 30 days
+    render(<DateRangeChips startDate="2026-04-01" endDate="2026-04-30" onChange={onChange} />);
     expect(screen.getByRole('radio', { name: 'เดือนนี้' })).toHaveAttribute(
       'aria-checked',
       'true',


### PR DESCRIPTION
## สรุป

ผลจาก QA pass ของ PR #1326 (ปรับดิว) + #1327 (เดือนนี้ preset) — 2 commits:

### 1️⃣ `test:` ปิด coverage gaps (~60 tests / 11 ไฟล์, ไม่แตะ production)

**API:**
- `paysolutions.reschedule-qr.spec.ts` (ใหม่, 8 tests) — `createRescheduleQR`: collect≤0/PAID reject, cancel ACTIVE links, frozen metadata, orphan Sentry, LINE fail swallowed
- `payments.controller.spec.ts` (+22 tests รวม callbacks) — endpoints `reschedule-quote`/`reschedule-qr` + DTO validation
- `paysolutions.callbacks.spec.ts` — EXPIRED-link-paid → Sentry fatal, ไม่ record/ไม่ reschedule
- `reschedule-collect.service.spec.ts` (+2) — closed period reject ก่อน write, receipt-failure post-commit swallowed
- `reschedule-collect-lifecycle.integration.spec.ts` (ใหม่, DB-gated) — **6a → 2A accrual → advance consume**: Σ(Cr 11-2103) exactly once, advanceBalance drawdown ⚠️ รันได้เฉพาะกับ Postgres — ดู #1328

**Web:**
- `RescheduleOverlay.test.tsx` (ใหม่, 7 scenarios) — quote rows, 6b amount 0.01, CASH collect, TRANSFER ref gating, QR submit, error disable
- `date.test.ts` + `DateRangeChips.test.tsx` — this_month: BKK เที่ยงคืนคร่อมวัน, ธันวา wrap, ก.พ. leap 2028/non-leap, เดือน 30 วัน
- `GeneralLedgerPage.test.tsx` + `PaymentsPage.default-range.test.tsx` — lock default range เต็มเดือน (fail กับโค้ดก่อน #1327 — พิสูจน์ด้วย transient revert)
- `computeReceiptFeeDisplay` RESCHEDULE_FEE exclusion + `QrSentBadge` labels

### 2️⃣ `fix(web):` latent toISOString bugs 5 จุด (bug class เดียวกับที่ #1327 แก้)

ก่อน 07:00 น. BKK ค่า `toISOString()` ยังเป็น**เมื่อวาน** (UTC) — เจอ latent 5 จุดระหว่าง QA:

| จุด | ผลกระทบ |
|---|---|
| PaymentsPage `summaryDate` | daily-summary tab เปิดมาเป็นเมื่อวาน |
| PaymentsPage `payForm.paidDate` (init + close-reset + `openPayModal` re-seed) | วันที่บันทึกรับชำระ default ผิดวัน |
| PaymentsPage Excel filename | `pending-payments-<เมื่อวาน>.xlsx` |
| ReportsPage `dateFilter` | ชำระรายวัน filter ผิดวัน |
| ReportsPage CSV filename | `contracts-export-<เมื่อวาน>.csv` |

เพิ่ม `toLocalDateString()` ใน `lib/date.ts` (consolidate inline helper ของ ReportsPage เข้าไปด้วย) — **ทุกจุด TDD**: เห็น test fail ด้วยค่า UTC-yesterday ก่อนแก้ทุกตัว

## Test plan

- ✅ Web vitest เต็มชุด: **140 files / 907 tests pass** + `tsc --noEmit` clean
- ✅ API targeted jest (payments/paysolutions/journal/utils/installments): **74 suites / 789 tests pass** + tsc clean
- ✅ ทุก test ใหม่ผ่าน adversarial review (assertion จริง ไม่ vacuous)
- ⚠️ `reschedule-collect-lifecycle.integration.spec.ts` = compile-verified เท่านั้น (ไม่มี Postgres local) — ต้องการ CI job จาก #1328

Related: #1328

🤖 Generated with [Claude Code](https://claude.com/claude-code)
