### PR TITLE
ci: รัน DB-backed money-invariant specs ใน CI (non-blocking รอบแรก) — #1328

### DIFF
--- a/.github/workflows/deploy-gcp.yml
+++ b/.github/workflows/deploy-gcp.yml
@@ -131,6 +131,27 @@ jobs:
           JWT_REFRESH_EXPIRATION: 7d
           NODE_ENV: test
 
+      # DB-backed money-invariant specs (vitest) — jest ignores these via
+      # testPathIgnorePatterns (/cpa-templates/, installments/reschedule.service.spec.ts)
+      # and test:e2e only matches e2e/*.e2e-spec.ts, so before this step they NEVER
+      # ran in any pipeline (#1328). Non-blocking (continue-on-error) for the first
+      # runs — flip to blocking once green.
+      # contract-cancellation.template.spec.ts is excluded: it is a jest-format
+      # mocked unit spec (uses jest.* globals) that crashes vitest's collector.
+      - name: Run DB-backed money-invariant specs (vitest, non-blocking — #1328)
+        continue-on-error: true
+        timeout-minutes: 10
+        working-directory: apps/api
+        run: |
+          FILES=$(ls src/modules/journal/cpa-templates/*.spec.ts | grep -v contract-cancellation.template.spec.ts)
+          npx vitest run --no-file-parallelism $FILES \
+            src/modules/installments/reschedule.service.spec.ts
+        env:
+          DATABASE_URL: postgresql://test:test@localhost:5432/test_db?schema=public
+          DATABASE_URL_FINANCE: postgresql://test:test@localhost:5433/test_finance_db?schema=public
+          JWT_SECRET: test-secret
+          NODE_ENV: test
+
       - name: Build API
         run: npm run build --workspace=apps/api
 


### PR DESCRIPTION
## สรุป

Implement #1328 เฟสแรก: เพิ่ม step ใน `lint-and-test` job รัน DB-backed vitest suite ที่**ไม่เคยถูกรันใน pipeline ไหนเลย** (jest ignore ผ่าน `testPathIgnorePatterns`, `test:e2e` จับแค่ `e2e/*.e2e-spec.ts`)

## ครอบคลุม

- **25 specs ใน `cpa-templates/`** — payment-receipt.waiver, reschedule-collect-lifecycle (ใหม่จาก PR #1329), shop-collect-coa, installment-accrual-2a, reschedule-jp6 ฯลฯ
- **`installments/reschedule.service.spec.ts`** — golden ที่ PR #1326 เปลี่ยน (งวดสุดท้ายไม่ลดยอด) ⚠️ merge ไปโดยไม่มี pipeline พิสูจน์
- รวม **26 files / 121 tests** (verify การ collect แล้ว local: 26 files / 121 tests, 0 error)

## การตัดสินใจใน design

- **`continue-on-error: true`** — suite นี้ไม่เคยรันใน CI มาก่อน รอบแรกอาจเจอ env issues; job นี้ gate การ deploy จึงเปิด non-blocking ก่อน → **flip เป็น blocking หลังเขียว 1-2 รอบ** (ค่อยปิด #1328)
- **`timeout-minutes: 10`** ระดับ step — กัน hang ไม่ให้กิน job budget (25 นาที)
- **exclude `contract-cancellation.template.spec.ts`** — เป็น jest-format (ใช้ `jest.*` globals) ทำ vitest collector crash ทั้ง dir-scan; หมายเหตุ: ไฟล์นี้เองก็ orphaned (jest ignore ด้วย) — ควรย้าย/แปลงในงานแยก
- ใช้ DB services + migrations ที่ job มีอยู่แล้ว — ไม่เพิ่ม infra

## Test plan

- ✅ YAML valid (ruby yaml parse)
- ✅ `npx vitest list` explicit list local: 26 files / 121 tests, 0 collection error
- 🔄 **PR นี้เองจะรัน step ใหม่เป็นครั้งแรก** (lint-and-test รันบน pull_request) — ดูผลได้ใน checks ของ PR นี้เลย

Refs #1328

🤖 Generated with [Claude Code](https://claude.com/claude-code)