### PR TITLE
test(installments): แก้ golden ของ reschedule spec — assert amountDue ไม่เปลี่ยน แทน constant ที่ผิด

### DIFF
--- a/apps/api/src/modules/installments/reschedule.service.spec.ts
+++ b/apps/api/src/modules/installments/reschedule.service.spec.ts
@@ -40,6 +40,14 @@ describe('RescheduleService', () => {
 
   it('shifts due_date for installments >= fromInstallmentNo (amountDue untouched — fee is an advance)', async () => {
     const c = await seedStandard17k12m(prisma);
+    // Capture the seeded amountDue BEFORE the reschedule — the invariant under
+    // test is "unchanged", not a specific constant. (The seed writes
+    // principal + interest + VAT = 833.33 + 500.00 + 99.17 = 1,432.50, which is
+    // NOT monthlyPayment 1,515.84 — commission is not part of amountDue.)
+    const inst12Before = await prisma.installmentSchedule.findFirstOrThrow({
+      where: { contractId: c.id, installmentNo: 12 },
+    });
+    const amountDueBefore = new Decimal((inst12Before.amountDue as any).toString());
     const svc = new RescheduleService(prisma as any);
     const result = await svc.execute({
       contractId: c.id,
@@ -71,9 +79,11 @@ describe('RescheduleService', () => {
     // the old write was to a field no billing path reads, so the fee's 21-1103 credit
     // was never relieved. The CPA case-6a prepayment now flows through
     // Contract.advanceBalance (RescheduleCollectService) instead; the schedule row
-    // stays at the full per-installment amount.
+    // stays at whatever it was seeded with. (2026-07-03: was a hardcoded '1515.84'
+    // golden written without a DB run — first-ever CI execution, PR #1330, showed the
+    // seed actually writes 1,432.50. Assert the true invariant: before == after.)
     const inst12AmountDue = new Decimal((inst12.amountDue as any).toString());
-    expect(inst12AmountDue.toFixed(2)).toBe('1515.84');
+    expect(inst12AmountDue.toFixed(2)).toBe(amountDueBefore.toFixed(2));
 
     // Installments 5-12 should all be shifted
     const allShifted = await prisma.installmentSchedule.findMany({


### PR DESCRIPTION
## สรุป

CI รอบแรกของ DB-backed suite (จาก #1330, refs #1328) จับได้ว่า golden ของ PR #1326 **ผิด**:

- Spec assert `inst12.amountDue === '1515.84'` (= monthlyPayment **รวม commission**)
- แต่ `seedStandard17k12m` เขียน `amountDue = principal + interest + VAT = 833.33 + 500.00 + 99.17 = 1,432.50` (**ไม่รวม commission**)
- Golden ตัวนี้ถูกแก้ใน #1326 โดย**ไม่เคยได้รันกับ DB เลย** (ไม่มี Postgres local + ไม่มี CI ตอนนั้น — คือ gap #1328 เป๊ะๆ)

**Production ถูกต้อง ไม่มี regression**: ค่า `1432.50` ที่ CI ได้คือค่า seed **ที่ไม่ถูกแตะ** — ตรงตาม intent ของ C1 (fee ไหลผ่าน `Contract.advanceBalance` ไม่ลดงวดสุดท้าย)

## การแก้

Assert invariant ที่แท้จริง: **`amountDue` before === after** แทน constant ที่ผูกกับ seed — ทนต่อการเปลี่ยน seed ในอนาคตด้วย

## Test plan

- ✅ `tsc --noEmit` clean
- 🔄 CI ของ PR นี้จะรัน spec นี้กับ Postgres จริง (step จาก #1330 อยู่บน main แล้ว) — ดูผลใน checks

## ไม่เกี่ยวกับ PR นี้

failure ที่ 2 จาก CI run เดียวกัน (`repossession-jp5` — golden EIR 3,012.50 vs production straight-line 4,000.00) เป็น divergence เก่าที่ไม่เคยถูกจับ ต้องให้ CPA/เจ้าของตัดสิน accounting treatment — จะเปิด issue แยก

Refs #1328

🤖 Generated with [Claude Code](https://claude.com/claude-code)