### PR TITLE
fix(payments): overlay focus/scroll escapes (WizardStackedOverlay) + ปรับดิว slip attach

### DIFF
--- a/apps/api/src/modules/payments/services/reschedule-collect.service.ts
+++ b/apps/api/src/modules/payments/services/reschedule-collect.service.ts
@@ -333,6 +333,7 @@ export class RescheduleCollectService {
               collectAmount: q.collectAmount.toString(),
               paymentMethod: input.paymentMethod,
               transactionRef: input.transactionRef ?? null,
+              evidenceUrl: input.evidenceUrl ?? null,
               depositAccountCode: q.collectAmount.gt(0) ? resolvedDepositAccountCode : null,
               journalEntryNo,
               source: input.fixedQuote ? 'QR_WEBHOOK' : 'CASHIER',

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -32,6 +32,7 @@
     "@radix-ui/react-context-menu": "^2.2.16",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
+    "@radix-ui/react-focus-scope": "^1.1.7",
     "@radix-ui/react-hover-card": "^1.1.15",
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-navigation-menu": "^1.2.14",

--- a/apps/web/src/components/WizardStackedOverlay.tsx
+++ b/apps/web/src/components/WizardStackedOverlay.tsx
@@ -1,0 +1,53 @@
+import { createPortal } from 'react-dom';
+import { FocusScope } from '@radix-ui/react-focus-scope';
+
+interface Props {
+  /** Tailwind max-width class for the panel — pass a literal so the scanner sees it. */
+  maxWidthClass?: 'max-w-xl' | 'max-w-2xl';
+  children: React.ReactNode;
+}
+
+/**
+ * Full-screen overlay stacked ABOVE the RecordPaymentWizard's modal Radix
+ * Dialog, portaled to document.body (the DialogContent has a CSS transform,
+ * which would otherwise become the containing block for position:fixed).
+ *
+ * An open modal Dialog actively fights outside content on three fronts; each
+ * needs an explicit escape here:
+ *
+ * - body gets `pointer-events: none` → `pointer-events-auto` on the backdrop
+ *   re-enables clicks (commit 82f84065).
+ * - react-remove-scroll preventDefault()s wheel/touchmove that bubble to
+ *   document from outside the DialogContent → stopPropagation at the panel
+ *   lets it scroll.
+ * - the Dialog's FocusScope yanks focus back into the DialogContent on any
+ *   focus change outside it → mounting our own trapped FocusScope pauses the
+ *   wizard's via Radix's scope stack, so text inputs here are typable. Radix
+ *   portalled widgets inside (Select, etc.) mount their own scope and compose
+ *   the same way.
+ *
+ * Also used standalone (no wizard open, e.g. ContractDetailPage) — the trap
+ * and escapes are correct modal-overlay behavior there too.
+ */
+export function WizardStackedOverlay({ maxWidthClass = 'max-w-xl', children }: Props) {
+  const stopScrollLock = (e: React.SyntheticEvent) => e.stopPropagation();
+
+  // NOTE: backdrop-blur (backdrop-filter) makes this div the containing block
+  // for position:fixed DESCENDANTS — children using `fixed inset-0` (e.g. a
+  // nested confirm dialog) only fill the viewport because this div is itself
+  // fixed inset-0 with no padding/border. Don't add padding here.
+  return createPortal(
+    <div className="fixed inset-0 z-50 pointer-events-auto bg-black/50 backdrop-blur-xs flex items-start justify-center pt-8 pb-8">
+      <FocusScope asChild loop trapped>
+        <div
+          className={`w-full ${maxWidthClass} bg-background rounded-xl shadow-2xl overflow-y-auto max-h-[calc(100vh-4rem)]`}
+          onWheel={stopScrollLock}
+          onTouchMove={stopScrollLock}
+        >
+          {children}
+        </div>
+      </FocusScope>
+    </div>,
+    document.body,
+  );
+}

--- a/apps/web/src/components/contract/ContractEarlyPayoff.tsx
+++ b/apps/web/src/components/contract/ContractEarlyPayoff.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
-import { createPortal } from 'react-dom';
+import { FocusScope } from '@radix-ui/react-focus-scope';
+import { WizardStackedOverlay } from '@/components/WizardStackedOverlay';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { AlertTriangle, Check, Store } from 'lucide-react';
@@ -72,7 +73,9 @@ export function ContractEarlyPayoffQuote({
         </div>
         <div>
           <div className="text-xs text-primary font-semibold">ยอดปิดสัญญา (ส่วนลด 50%)</div>
-          <div className="text-xl font-bold text-primary">{formatNumber(payoffQuote.totalPayoff)} บาท</div>
+          <div className="text-xl font-bold text-primary">
+            {formatNumber(payoffQuote.totalPayoff)} บาท
+          </div>
         </div>
       </div>
     </div>
@@ -173,384 +176,516 @@ export function EarlyPayoffOverlay({
     'w-full px-3 py-2 border border-input rounded-lg text-sm focus-visible:ring-2 focus-visible:ring-ring/30 outline-hidden';
 
   const needsReference = paymentMethod !== 'CASH';
-  const canSubmit = !!quote && !mutation.isPending && (!needsReference || referenceNo.trim().length > 0);
+  const canSubmit =
+    !!quote && !mutation.isPending && (!needsReference || referenceNo.trim().length > 0);
 
-  // Render via createPortal to document.body so the fixed-position overlay
-  // is never trapped inside a parent stacking context (transformed ancestor,
-  // Radix Dialog portal, etc.) — previous bug: buttons appeared but click
-  // events did not reach handlers when mounted inside transformed parent.
-  return createPortal(
-    <div className="fixed inset-0 z-50 pointer-events-auto bg-black/50 backdrop-blur-xs flex items-start justify-center pt-8 pb-8">
-      <div className="w-full max-w-2xl bg-background rounded-xl shadow-2xl overflow-y-auto max-h-[calc(100vh-4rem)]">
-        {/* Header */}
-        <div className="sticky top-0 z-10 bg-background/95 backdrop-blur-xs border-b px-6 py-4 flex items-center justify-between">
-          <button
-            onClick={onClose}
-            className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
-          >
-            ← กลับ
-          </button>
-          <h2 className="text-lg font-semibold text-foreground">ปิดสัญญาก่อนกำหนด</h2>
-          <div className="w-16" />
-        </div>
+  return (
+    <WizardStackedOverlay maxWidthClass="max-w-2xl">
+      {/* Header */}
+      <div className="sticky top-0 z-10 bg-background/95 backdrop-blur-xs border-b px-6 py-4 flex items-center justify-between">
+        <button
+          onClick={onClose}
+          className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
+        >
+          ← กลับ
+        </button>
+        <h2 className="text-lg font-semibold text-foreground">ปิดสัญญาก่อนกำหนด</h2>
+        <div className="w-16" />
+      </div>
 
-        <div className="p-6 space-y-5">
-          {/* Section 1: ข้อมูลสัญญา */}
-          <div className="rounded-xl border border-border bg-card p-5">
-            <div className="flex items-center gap-2.5 mb-4">
-              <div className="flex items-center justify-center size-8 rounded-lg bg-primary/10 text-primary">
-                <svg xmlns="http://www.w3.org/2000/svg" className="size-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M9 12h3.75M9 15h3.75M9 18h3.75m3 .75H18a2.25 2.25 0 002.25-2.25V6.108c0-1.135-.845-2.098-1.976-2.192a48.424 48.424 0 00-1.123-.08m-5.801 0c-.065.21-.1.433-.1.664 0 .414.336.75.75.75h4.5a.75.75 0 00.75-.75 2.25 2.25 0 00-.1-.664m-5.8 0A2.251 2.251 0 0113.5 2.25H15" />
-                </svg>
-              </div>
-              <div>
-                <h3 className="text-sm font-semibold text-foreground">ข้อมูลสัญญา</h3>
-                <p className="text-xs text-muted-foreground">เลขที่, ลูกค้า, สินค้า</p>
-              </div>
+      <div className="p-6 space-y-5">
+        {/* Section 1: ข้อมูลสัญญา */}
+        <div className="rounded-xl border border-border bg-card p-5">
+          <div className="flex items-center gap-2.5 mb-4">
+            <div className="flex items-center justify-center size-8 rounded-lg bg-primary/10 text-primary">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                className="size-4"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={1.5}
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M9 12h3.75M9 15h3.75M9 18h3.75m3 .75H18a2.25 2.25 0 002.25-2.25V6.108c0-1.135-.845-2.098-1.976-2.192a48.424 48.424 0 00-1.123-.08m-5.801 0c-.065.21-.1.433-.1.664 0 .414.336.75.75.75h4.5a.75.75 0 00.75-.75 2.25 2.25 0 00-.1-.664m-5.8 0A2.251 2.251 0 0113.5 2.25H15"
+                />
+              </svg>
             </div>
-            <div className="grid grid-cols-2 gap-x-6 gap-y-2 text-sm">
-              <div><span className="text-muted-foreground">สัญญา: </span><span className="font-mono font-semibold">{contractNumber}</span></div>
-              <div><span className="text-muted-foreground">ลูกค้า: </span><span className="font-medium">{customerName}</span></div>
-              {productName && <div><span className="text-muted-foreground">สินค้า: </span><span className="font-medium">{productName}</span></div>}
-              {branchName && <div><span className="text-muted-foreground">สาขา: </span><span className="font-medium">{branchName}</span></div>}
+            <div>
+              <h3 className="text-sm font-semibold text-foreground">ข้อมูลสัญญา</h3>
+              <p className="text-xs text-muted-foreground">เลขที่, ลูกค้า, สินค้า</p>
             </div>
           </div>
-
-          {/* Section 2: คำนวณยอดปิดสัญญา */}
-          <div className="rounded-xl border border-border bg-card p-5">
-            <div className="flex items-center gap-2.5 mb-4">
-              <div className="flex items-center justify-center size-8 rounded-lg bg-primary/10 text-primary">
-                <svg xmlns="http://www.w3.org/2000/svg" className="size-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M2.25 18.75a60.07 60.07 0 0115.797 2.101c.727.198 1.453-.342 1.453-1.096V18.75M3.75 4.5v.75A.75.75 0 013 6h-.75m0 0v-.375c0-.621.504-1.125 1.125-1.125H20.25" />
-                </svg>
-              </div>
+          <div className="grid grid-cols-2 gap-x-6 gap-y-2 text-sm">
+            <div>
+              <span className="text-muted-foreground">สัญญา: </span>
+              <span className="font-mono font-semibold">{contractNumber}</span>
+            </div>
+            <div>
+              <span className="text-muted-foreground">ลูกค้า: </span>
+              <span className="font-medium">{customerName}</span>
+            </div>
+            {productName && (
               <div>
-                <h3 className="text-sm font-semibold text-foreground">คำนวณยอดปิดสัญญา</h3>
-                <p className="text-xs text-muted-foreground">เลือก % ส่วนลดเพื่อ recalc</p>
+                <span className="text-muted-foreground">สินค้า: </span>
+                <span className="font-medium">{productName}</span>
               </div>
-            </div>
-
-            {/* Discount selector */}
-            <div className="mb-4">
-              <label className="block text-xs font-medium text-foreground mb-1.5">ส่วนลดบนกำไรขั้นต้น</label>
-              <div className="flex flex-wrap gap-2">
-                {DISCOUNT_PRESETS.map((p) => (
-                  <button
-                    key={p}
-                    type="button"
-                    onClick={() => setDiscountPct(p)}
-                    className={`px-3 py-1.5 text-sm rounded-lg border transition-colors ${
-                      discountPct === p
-                        ? 'bg-primary text-primary-foreground border-primary'
-                        : 'bg-background border-input hover:bg-muted'
-                    }`}
-                  >
-                    {p}%
-                  </button>
-                ))}
-                <input
-                  type="number"
-                  min={0}
-                  max={MAX_DISCOUNT}
-                  value={discountPct}
-                  onChange={(e) => setDiscountPct(Math.max(0, Math.min(MAX_DISCOUNT, Number(e.target.value))))}
-                  className="w-20 px-2 py-1.5 border border-input rounded-lg text-sm"
-                />
-                <span className="text-sm text-muted-foreground self-center">%</span>
-              </div>
-            </div>
-
-            {/* Breakdown table */}
-            {isLoading || !quote ? (
-              <div className="py-8 text-center text-sm text-muted-foreground">กำลังคำนวณ...</div>
-            ) : (
-              <div className="space-y-1.5 text-sm">
-                <Row label="ค่างวด" value={`${formatNumber(quote.monthlyPayment)} บาท`} />
-                <Row label="จำนวนงวด" value={`${quote.remainingMonths} งวด`} />
-                <Row label="รวมค้างชำระ" value={`${formatNumber(quote.totalRemaining)} บาท`} bold />
-                {quote.advancePayment > 0 && (
-                  <Row label="ยอดชำระล่วงหน้า" value={`-${formatNumber(quote.advancePayment)} บาท`} muted />
-                )}
-                <Row label="คงเหลือยอดค้าง" value={`${formatNumber(quote.remainingBalance)} บาท`} bold />
-                <div className="border-t border-border my-2" />
-                <Row label="ค่างวดไม่รวม VAT (1)" value={`${formatNumber(quote.remainingExVat)} บาท`} />
-                <Row label="ต้นทุนยอดค้างชำระ (2)" value={`${formatNumber(quote.remainingCost)} บาท`} />
-                <Row label="(1) − (2)" value={`${formatNumber(quote.grossProfit)} บาท`} />
-                <Row label={`ส่วนลดลูกค้า ${discountPct}%`} value={`-${formatNumber(quote.discountAmount)} บาท`} success />
-                {quote.unpaidLateFees > 0 && (
-                  <Row label="ค่าปรับค้างชำระ" value={`+${formatNumber(quote.unpaidLateFees)} บาท`} destructive />
-                )}
-                <div className="border-t border-primary/30 my-2" />
-                <div className="flex justify-between items-center bg-primary/5 rounded-lg px-3 py-3">
-                  <span className="text-base font-semibold text-primary">ยอดชำระปิดยอด</span>
-                  <span className="text-2xl font-bold text-primary">{formatNumber(quote.totalPayoff)} บาท</span>
-                </div>
+            )}
+            {branchName && (
+              <div>
+                <span className="text-muted-foreground">สาขา: </span>
+                <span className="font-medium">{branchName}</span>
               </div>
             )}
           </div>
+        </div>
 
-          {/* Section 3: รับชำระ */}
-          <div className="rounded-xl border border-border bg-card p-5">
-            <div className="flex items-center gap-2.5 mb-4">
-              <div className="flex items-center justify-center size-8 rounded-lg bg-warning/10 text-warning">
-                <svg xmlns="http://www.w3.org/2000/svg" className="size-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M2.25 8.25h19.5M2.25 9h19.5m-16.5 5.25h6m-6 2.25h3m-3.75 3h15a2.25 2.25 0 002.25-2.25V6.75A2.25 2.25 0 0019.5 4.5h-15a2.25 2.25 0 00-2.25 2.25v10.5A2.25 2.25 0 004.5 19.5z" />
-                </svg>
-              </div>
-              <div>
-                <h3 className="text-sm font-semibold text-foreground">รับชำระ</h3>
-                <p className="text-xs text-muted-foreground">วิธีชำระ, วันที่, อ้างอิง</p>
-              </div>
+        {/* Section 2: คำนวณยอดปิดสัญญา */}
+        <div className="rounded-xl border border-border bg-card p-5">
+          <div className="flex items-center gap-2.5 mb-4">
+            <div className="flex items-center justify-center size-8 rounded-lg bg-primary/10 text-primary">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                className="size-4"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={1.5}
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M2.25 18.75a60.07 60.07 0 0115.797 2.101c.727.198 1.453-.342 1.453-1.096V18.75M3.75 4.5v.75A.75.75 0 013 6h-.75m0 0v-.375c0-.621.504-1.125 1.125-1.125H20.25"
+                />
+              </svg>
             </div>
-            <div className="space-y-4">
-              <div className="grid grid-cols-2 gap-4">
-                <div>
-                  <label className="block text-xs font-medium text-foreground mb-1.5">วิธีชำระ <span className="text-destructive">*</span></label>
-                  <select value={paymentMethod} onChange={(e) => setPaymentMethod(e.target.value)} className={inputClass}>
-                    <option value="CASH">เงินสด</option>
-                    <option value="BANK_TRANSFER">โอนเงิน</option>
-                    <option value="QR_EWALLET">QR/E-Wallet</option>
-                  </select>
-                </div>
-                <div>
-                  <label className="block text-xs font-medium text-foreground mb-1.5">วันที่ชำระ</label>
-                  <input type="date" value={paymentDate} onChange={(e) => setPaymentDate(e.target.value)} className={inputClass} />
-                </div>
-              </div>
-              {/* Shop-collect toggle */}
-              <div className="flex items-start gap-3 rounded-lg border border-border bg-muted/40 px-3 py-3">
-                <input
-                  id="collected-by-shop"
-                  type="checkbox"
-                  checked={collectedByShop}
-                  onChange={(e) => setCollectedByShop(e.target.checked)}
-                  className="mt-0.5 size-4 accent-primary cursor-pointer"
-                />
-                <label htmlFor="collected-by-shop" className="cursor-pointer select-none">
-                  <span className="flex items-center gap-1.5 text-sm font-medium text-foreground leading-snug">
-                    <Store className="size-3.5 shrink-0 text-primary" />
-                    เก็บที่หน้าร้าน
-                  </span>
-                  <span className="text-xs text-muted-foreground leading-snug">
-                    หน้าร้านรับเงินแล้วโอนเข้า FINANCE ภายหลัง (บันทึก Dr 11-2107 ลูกหนี้-หน้าร้าน)
-                  </span>
-                </label>
-              </div>
-
-              <div>
-                <label className="block text-xs font-medium text-foreground mb-1.5">
-                  บัญชีรับเงิน <span className="text-destructive">*</span>
-                </label>
-                <CashAccountSelect
-                  value={depositAccountCode}
-                  onChange={setDepositAccountCode}
-                  disabled={collectedByShop}
-                />
-                {collectedByShop && (
-                  <p className="mt-1 text-xs text-muted-foreground leading-snug">
-                    บัญชีถูกกำหนดเป็น 11-2107 อัตโนมัติโดยระบบ — กรอกบัญชีรับโอนจากหน้าร้านตอน settlement
-                  </p>
-                )}
-              </div>
-              {needsReference && (
-                <div>
-                  <label className="block text-xs font-medium text-foreground mb-1.5">
-                    เลขที่อ้างอิง / Ref <span className="text-destructive">*</span>
-                  </label>
-                  <input
-                    type="text"
-                    value={referenceNo}
-                    onChange={(e) => setReferenceNo(e.target.value)}
-                    className={inputClass}
-                    placeholder="เลขที่อ้างอิงจากสลิป"
-                  />
-                </div>
-              )}
-              <div>
-                <label className="block text-xs font-medium text-foreground mb-1.5">หมายเหตุ</label>
-                <input type="text" value={notes} onChange={(e) => setNotes(e.target.value)} className={inputClass} placeholder="หมายเหตุเพิ่มเติม (ถ้ามี)" />
-              </div>
+            <div>
+              <h3 className="text-sm font-semibold text-foreground">คำนวณยอดปิดสัญญา</h3>
+              <p className="text-xs text-muted-foreground">เลือก % ส่วนลดเพื่อ recalc</p>
             </div>
           </div>
 
-          {/* Section JOURNAL AUTO */}
-          {quote?.journalPreview && (
-            <div className="rounded-xl border border-border bg-card p-5">
-              <div className="flex items-center justify-between mb-4">
-                <div className="flex items-center gap-2.5">
-                  <div className="flex items-center justify-center size-8 rounded-lg bg-primary/10 text-primary">
-                    <svg xmlns="http://www.w3.org/2000/svg" className="size-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-                      <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 12h16.5m-16.5 3.75h16.5M3.75 19.5h16.5M5.625 4.5h12.75a1.875 1.875 0 010 3.75H5.625a1.875 1.875 0 010-3.75z" />
-                    </svg>
-                  </div>
-                  <div>
-                    <h3 className="text-sm font-semibold text-foreground">JOURNAL AUTO — บันทึกทางบัญชี</h3>
-                    <p className="text-xs text-muted-foreground">JP4 — ปิดยอดก่อนกำหนด (Policy A)</p>
-                  </div>
-                </div>
-                <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-primary/10 text-primary text-xs font-medium leading-snug">
-                  AUTO
-                </span>
-              </div>
-              <div className="space-y-1">
-                <div className="grid grid-cols-[80px_1fr_90px_90px] gap-1 text-xs text-muted-foreground font-medium pb-1 border-b border-border">
-                  <span>รหัส</span>
-                  <span>บัญชี</span>
-                  <span className="text-right">Dr</span>
-                  <span className="text-right">Cr</span>
-                </div>
-                {quote.journalPreview.lines.map((line, idx) => (
-                  <div key={idx} className="grid grid-cols-[80px_1fr_90px_90px] gap-1 text-xs leading-snug">
-                    <span className="font-mono text-muted-foreground">{line.accountCode}</span>
-                    <div className="min-w-0">
-                      <span className="text-foreground truncate block">{line.accountName}</span>
-                      <span className="text-muted-foreground/70 text-[10px]">{line.description}</span>
-                    </div>
-                    <span className="text-right font-mono text-foreground">
-                      {parseFloat(line.debit) > 0 ? formatNumberDecimal(line.debit) : ''}
-                    </span>
-                    <span className="text-right font-mono text-foreground">
-                      {parseFloat(line.credit) > 0 ? formatNumberDecimal(line.credit) : ''}
-                    </span>
-                  </div>
-                ))}
-              </div>
-              <div
-                className={`flex items-center justify-between mt-3 pt-2 border-t text-xs font-medium ${
-                  quote.journalPreview.isBalanced
-                    ? 'border-success/30 text-success'
-                    : 'border-destructive/30 text-destructive'
-                }`}
-              >
-                <span>Dr รวม = Cr รวม</span>
-                <span className="font-mono">
-                  {formatNumberDecimal(quote.journalPreview.totalDebit)} ={' '}
-                  {formatNumberDecimal(quote.journalPreview.totalCredit)}{' '}
-                  {quote.journalPreview.isBalanced ? 'BALANCED' : 'UNBALANCED'}
+          {/* Discount selector */}
+          <div className="mb-4">
+            <label className="block text-xs font-medium text-foreground mb-1.5">
+              ส่วนลดบนกำไรขั้นต้น
+            </label>
+            <div className="flex flex-wrap gap-2">
+              {DISCOUNT_PRESETS.map((p) => (
+                <button
+                  key={p}
+                  type="button"
+                  onClick={() => setDiscountPct(p)}
+                  className={`px-3 py-1.5 text-sm rounded-lg border transition-colors ${
+                    discountPct === p
+                      ? 'bg-primary text-primary-foreground border-primary'
+                      : 'bg-background border-input hover:bg-muted'
+                  }`}
+                >
+                  {p}%
+                </button>
+              ))}
+              <input
+                type="number"
+                min={0}
+                max={MAX_DISCOUNT}
+                value={discountPct}
+                onChange={(e) =>
+                  setDiscountPct(Math.max(0, Math.min(MAX_DISCOUNT, Number(e.target.value))))
+                }
+                className="w-20 px-2 py-1.5 border border-input rounded-lg text-sm"
+              />
+              <span className="text-sm text-muted-foreground self-center">%</span>
+            </div>
+          </div>
+
+          {/* Breakdown table */}
+          {isLoading || !quote ? (
+            <div className="py-8 text-center text-sm text-muted-foreground">กำลังคำนวณ...</div>
+          ) : (
+            <div className="space-y-1.5 text-sm">
+              <Row label="ค่างวด" value={`${formatNumber(quote.monthlyPayment)} บาท`} />
+              <Row label="จำนวนงวด" value={`${quote.remainingMonths} งวด`} />
+              <Row label="รวมค้างชำระ" value={`${formatNumber(quote.totalRemaining)} บาท`} bold />
+              {quote.advancePayment > 0 && (
+                <Row
+                  label="ยอดชำระล่วงหน้า"
+                  value={`-${formatNumber(quote.advancePayment)} บาท`}
+                  muted
+                />
+              )}
+              <Row
+                label="คงเหลือยอดค้าง"
+                value={`${formatNumber(quote.remainingBalance)} บาท`}
+                bold
+              />
+              <div className="border-t border-border my-2" />
+              <Row
+                label="ค่างวดไม่รวม VAT (1)"
+                value={`${formatNumber(quote.remainingExVat)} บาท`}
+              />
+              <Row
+                label="ต้นทุนยอดค้างชำระ (2)"
+                value={`${formatNumber(quote.remainingCost)} บาท`}
+              />
+              <Row label="(1) − (2)" value={`${formatNumber(quote.grossProfit)} บาท`} />
+              <Row
+                label={`ส่วนลดลูกค้า ${discountPct}%`}
+                value={`-${formatNumber(quote.discountAmount)} บาท`}
+                success
+              />
+              {quote.unpaidLateFees > 0 && (
+                <Row
+                  label="ค่าปรับค้างชำระ"
+                  value={`+${formatNumber(quote.unpaidLateFees)} บาท`}
+                  destructive
+                />
+              )}
+              <div className="border-t border-primary/30 my-2" />
+              <div className="flex justify-between items-center bg-primary/5 rounded-lg px-3 py-3">
+                <span className="text-base font-semibold text-primary">ยอดชำระปิดยอด</span>
+                <span className="text-2xl font-bold text-primary">
+                  {formatNumber(quote.totalPayoff)} บาท
                 </span>
               </div>
             </div>
           )}
+        </div>
 
-          {/* Section 4: สิ่งที่จะเกิดขึ้น */}
-          <div className="rounded-xl border border-border bg-card p-5">
-            <div className="flex items-center gap-2.5 mb-4">
-              <div className="flex items-center justify-center size-8 rounded-lg bg-success/10 text-success">
-                <svg xmlns="http://www.w3.org/2000/svg" className="size-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-                </svg>
+        {/* Section 3: รับชำระ */}
+        <div className="rounded-xl border border-border bg-card p-5">
+          <div className="flex items-center gap-2.5 mb-4">
+            <div className="flex items-center justify-center size-8 rounded-lg bg-warning/10 text-warning">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                className="size-4"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={1.5}
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M2.25 8.25h19.5M2.25 9h19.5m-16.5 5.25h6m-6 2.25h3m-3.75 3h15a2.25 2.25 0 002.25-2.25V6.75A2.25 2.25 0 0019.5 4.5h-15a2.25 2.25 0 00-2.25 2.25v10.5A2.25 2.25 0 004.5 19.5z"
+                />
+              </svg>
+            </div>
+            <div>
+              <h3 className="text-sm font-semibold text-foreground">รับชำระ</h3>
+              <p className="text-xs text-muted-foreground">วิธีชำระ, วันที่, อ้างอิง</p>
+            </div>
+          </div>
+          <div className="space-y-4">
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <label className="block text-xs font-medium text-foreground mb-1.5">
+                  วิธีชำระ <span className="text-destructive">*</span>
+                </label>
+                <select
+                  value={paymentMethod}
+                  onChange={(e) => setPaymentMethod(e.target.value)}
+                  className={inputClass}
+                >
+                  <option value="CASH">เงินสด</option>
+                  <option value="BANK_TRANSFER">โอนเงิน</option>
+                  <option value="QR_EWALLET">QR/E-Wallet</option>
+                </select>
               </div>
               <div>
-                <h3 className="text-sm font-semibold text-foreground">สิ่งที่จะเกิดขึ้นเมื่อยืนยัน</h3>
-                <p className="text-xs text-muted-foreground">ตรวจสอบก่อนปิดสัญญา</p>
+                <label className="block text-xs font-medium text-foreground mb-1.5">
+                  วันที่ชำระ
+                </label>
+                <input
+                  type="date"
+                  value={paymentDate}
+                  onChange={(e) => setPaymentDate(e.target.value)}
+                  className={inputClass}
+                />
               </div>
             </div>
-            <ul className="space-y-1.5 text-sm">
-              <Effect text="โอนกรรมสิทธิ์สินค้าจาก FINANCE → ลูกค้า" />
-              <Effect text="ออกใบเสร็จและหนังสือปิดสัญญา" />
-              <Effect text="บันทึก JournalEntry (ตัด HP Receivable, รับรู้ดอกเบี้ย, VAT)" />
-              <Effect text="แจ้งลูกค้าผ่าน LINE OA (ถ้าอนุญาต PDPA)" />
-              <Effect text="ปลดล็อค MDM (PJ-Soft) — ต้องทำ manual" warning />
-            </ul>
+            {/* Shop-collect toggle */}
+            <div className="flex items-start gap-3 rounded-lg border border-border bg-muted/40 px-3 py-3">
+              <input
+                id="collected-by-shop"
+                type="checkbox"
+                checked={collectedByShop}
+                onChange={(e) => setCollectedByShop(e.target.checked)}
+                className="mt-0.5 size-4 accent-primary cursor-pointer"
+              />
+              <label htmlFor="collected-by-shop" className="cursor-pointer select-none">
+                <span className="flex items-center gap-1.5 text-sm font-medium text-foreground leading-snug">
+                  <Store className="size-3.5 shrink-0 text-primary" />
+                  เก็บที่หน้าร้าน
+                </span>
+                <span className="text-xs text-muted-foreground leading-snug">
+                  หน้าร้านรับเงินแล้วโอนเข้า FINANCE ภายหลัง (บันทึก Dr 11-2107 ลูกหนี้-หน้าร้าน)
+                </span>
+              </label>
+            </div>
+
+            <div>
+              <label className="block text-xs font-medium text-foreground mb-1.5">
+                บัญชีรับเงิน <span className="text-destructive">*</span>
+              </label>
+              <CashAccountSelect
+                value={depositAccountCode}
+                onChange={setDepositAccountCode}
+                disabled={collectedByShop}
+              />
+              {collectedByShop && (
+                <p className="mt-1 text-xs text-muted-foreground leading-snug">
+                  บัญชีถูกกำหนดเป็น 11-2107 อัตโนมัติโดยระบบ — กรอกบัญชีรับโอนจากหน้าร้านตอน
+                  settlement
+                </p>
+              )}
+            </div>
+            {needsReference && (
+              <div>
+                <label className="block text-xs font-medium text-foreground mb-1.5">
+                  เลขที่อ้างอิง / Ref <span className="text-destructive">*</span>
+                </label>
+                <input
+                  type="text"
+                  value={referenceNo}
+                  onChange={(e) => setReferenceNo(e.target.value)}
+                  className={inputClass}
+                  placeholder="เลขที่อ้างอิงจากสลิป"
+                />
+              </div>
+            )}
+            <div>
+              <label className="block text-xs font-medium text-foreground mb-1.5">หมายเหตุ</label>
+              <input
+                type="text"
+                value={notes}
+                onChange={(e) => setNotes(e.target.value)}
+                className={inputClass}
+                placeholder="หมายเหตุเพิ่มเติม (ถ้ามี)"
+              />
+            </div>
           </div>
         </div>
 
-        {/* Footer */}
-        <div className="sticky bottom-0 bg-background/95 backdrop-blur-xs border-t px-6 py-4 flex items-center justify-between gap-3">
-          {/* Settlement button — visible to OWNER / FINANCE_MANAGER / ACCOUNTANT */}
-          {canSettlement ? (
-            <button
-              type="button"
-              onClick={() => setSettlementOpen(true)}
-              className="flex items-center gap-1.5 px-4 py-2.5 text-sm border border-input rounded-lg hover:bg-muted transition-colors text-muted-foreground"
+        {/* Section JOURNAL AUTO */}
+        {quote?.journalPreview && (
+          <div className="rounded-xl border border-border bg-card p-5">
+            <div className="flex items-center justify-between mb-4">
+              <div className="flex items-center gap-2.5">
+                <div className="flex items-center justify-center size-8 rounded-lg bg-primary/10 text-primary">
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    className="size-4"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={1.5}
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M3.75 12h16.5m-16.5 3.75h16.5M3.75 19.5h16.5M5.625 4.5h12.75a1.875 1.875 0 010 3.75H5.625a1.875 1.875 0 010-3.75z"
+                    />
+                  </svg>
+                </div>
+                <div>
+                  <h3 className="text-sm font-semibold text-foreground">
+                    JOURNAL AUTO — บันทึกทางบัญชี
+                  </h3>
+                  <p className="text-xs text-muted-foreground">JP4 — ปิดยอดก่อนกำหนด (Policy A)</p>
+                </div>
+              </div>
+              <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-primary/10 text-primary text-xs font-medium leading-snug">
+                AUTO
+              </span>
+            </div>
+            <div className="space-y-1">
+              <div className="grid grid-cols-[80px_1fr_90px_90px] gap-1 text-xs text-muted-foreground font-medium pb-1 border-b border-border">
+                <span>รหัส</span>
+                <span>บัญชี</span>
+                <span className="text-right">Dr</span>
+                <span className="text-right">Cr</span>
+              </div>
+              {quote.journalPreview.lines.map((line, idx) => (
+                <div
+                  key={idx}
+                  className="grid grid-cols-[80px_1fr_90px_90px] gap-1 text-xs leading-snug"
+                >
+                  <span className="font-mono text-muted-foreground">{line.accountCode}</span>
+                  <div className="min-w-0">
+                    <span className="text-foreground truncate block">{line.accountName}</span>
+                    <span className="text-muted-foreground/70 text-[10px]">{line.description}</span>
+                  </div>
+                  <span className="text-right font-mono text-foreground">
+                    {parseFloat(line.debit) > 0 ? formatNumberDecimal(line.debit) : ''}
+                  </span>
+                  <span className="text-right font-mono text-foreground">
+                    {parseFloat(line.credit) > 0 ? formatNumberDecimal(line.credit) : ''}
+                  </span>
+                </div>
+              ))}
+            </div>
+            <div
+              className={`flex items-center justify-between mt-3 pt-2 border-t text-xs font-medium ${
+                quote.journalPreview.isBalanced
+                  ? 'border-success/30 text-success'
+                  : 'border-destructive/30 text-destructive'
+              }`}
             >
-              <Store className="size-4" />
-              บันทึกรับโอนจากหน้าร้าน
-            </button>
-          ) : (
-            <div />
-          )}
-          <div className="flex gap-3">
-            <button onClick={onClose} className="px-6 py-2.5 text-sm border border-input rounded-lg hover:bg-muted transition-colors">
-              ยกเลิก
-            </button>
-            <button
-              onClick={() => mutation.mutate()}
-              disabled={!canSubmit}
-              className="px-6 py-2.5 text-sm bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 disabled:opacity-50 font-semibold transition-colors shadow-sm"
-            >
-              {mutation.isPending ? 'กำลังปิด...' : 'ยืนยันปิดสัญญา'}
-            </button>
+              <span>Dr รวม = Cr รวม</span>
+              <span className="font-mono">
+                {formatNumberDecimal(quote.journalPreview.totalDebit)} ={' '}
+                {formatNumberDecimal(quote.journalPreview.totalCredit)}{' '}
+                {quote.journalPreview.isBalanced ? 'BALANCED' : 'UNBALANCED'}
+              </span>
+            </div>
           </div>
+        )}
+
+        {/* Section 4: สิ่งที่จะเกิดขึ้น */}
+        <div className="rounded-xl border border-border bg-card p-5">
+          <div className="flex items-center gap-2.5 mb-4">
+            <div className="flex items-center justify-center size-8 rounded-lg bg-success/10 text-success">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                className="size-4"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={1.5}
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+                />
+              </svg>
+            </div>
+            <div>
+              <h3 className="text-sm font-semibold text-foreground">
+                สิ่งที่จะเกิดขึ้นเมื่อยืนยัน
+              </h3>
+              <p className="text-xs text-muted-foreground">ตรวจสอบก่อนปิดสัญญา</p>
+            </div>
+          </div>
+          <ul className="space-y-1.5 text-sm">
+            <Effect text="โอนกรรมสิทธิ์สินค้าจาก FINANCE → ลูกค้า" />
+            <Effect text="ออกใบเสร็จและหนังสือปิดสัญญา" />
+            <Effect text="บันทึก JournalEntry (ตัด HP Receivable, รับรู้ดอกเบี้ย, VAT)" />
+            <Effect text="แจ้งลูกค้าผ่าน LINE OA (ถ้าอนุญาต PDPA)" />
+            <Effect text="ปลดล็อค MDM (PJ-Soft) — ต้องทำ manual" warning />
+          </ul>
         </div>
       </div>
 
-      {/* Settlement dialog — Dr cash / Cr 11-2107 when shop remits to FINANCE */}
+      {/* Footer */}
+      <div className="sticky bottom-0 bg-background/95 backdrop-blur-xs border-t px-6 py-4 flex items-center justify-between gap-3">
+        {/* Settlement button — visible to OWNER / FINANCE_MANAGER / ACCOUNTANT */}
+        {canSettlement ? (
+          <button
+            type="button"
+            onClick={() => setSettlementOpen(true)}
+            className="flex items-center gap-1.5 px-4 py-2.5 text-sm border border-input rounded-lg hover:bg-muted transition-colors text-muted-foreground"
+          >
+            <Store className="size-4" />
+            บันทึกรับโอนจากหน้าร้าน
+          </button>
+        ) : (
+          <div />
+        )}
+        <div className="flex gap-3">
+          <button
+            onClick={onClose}
+            className="px-6 py-2.5 text-sm border border-input rounded-lg hover:bg-muted transition-colors"
+          >
+            ยกเลิก
+          </button>
+          <button
+            onClick={() => mutation.mutate()}
+            disabled={!canSubmit}
+            className="px-6 py-2.5 text-sm bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 disabled:opacity-50 font-semibold transition-colors shadow-sm"
+          >
+            {mutation.isPending ? 'กำลังปิด...' : 'ยืนยันปิดสัญญา'}
+          </button>
+        </div>
+      </div>
+
+      {/* Settlement dialog — Dr cash / Cr 11-2107 when shop remits to FINANCE.
+          Own trapped FocusScope: keeps Tab inside the popup (the payoff panel
+          underneath stays mounted and tabbable otherwise); nested scopes pause
+          the outer overlay's via Radix's scope stack. */}
       {settlementOpen && (
         <div className="fixed inset-0 z-60 bg-black/50 backdrop-blur-xs flex items-center justify-center">
-          <div className="w-full max-w-sm bg-background rounded-xl shadow-2xl p-6 space-y-4">
-            <div className="flex items-center gap-2.5">
-              <div className="flex items-center justify-center size-8 rounded-lg bg-primary/10 text-primary">
-                <Store className="size-4" />
+          <FocusScope asChild loop trapped>
+            <div className="w-full max-w-sm bg-background rounded-xl shadow-2xl p-6 space-y-4">
+              <div className="flex items-center gap-2.5">
+                <div className="flex items-center justify-center size-8 rounded-lg bg-primary/10 text-primary">
+                  <Store className="size-4" />
+                </div>
+                <div>
+                  <h3 className="text-sm font-semibold text-foreground leading-snug">
+                    บันทึกรับโอนจากหน้าร้าน
+                  </h3>
+                  <p className="text-xs text-muted-foreground leading-snug">
+                    Dr บัญชีรับเงิน / Cr 11-2107 ลูกหนี้-หน้าร้าน
+                  </p>
+                </div>
               </div>
-              <div>
-                <h3 className="text-sm font-semibold text-foreground leading-snug">บันทึกรับโอนจากหน้าร้าน</h3>
-                <p className="text-xs text-muted-foreground leading-snug">Dr บัญชีรับเงิน / Cr 11-2107 ลูกหนี้-หน้าร้าน</p>
+              <div className="space-y-3">
+                <div>
+                  <label className="block text-xs font-medium text-foreground mb-1.5">
+                    บัญชีรับเงิน (FINANCE) <span className="text-destructive">*</span>
+                  </label>
+                  <CashAccountSelect
+                    value={settlementAccountCode}
+                    onChange={setSettlementAccountCode}
+                  />
+                </div>
+                <div>
+                  <label className="block text-xs font-medium text-foreground mb-1.5">
+                    จำนวนเงินที่รับโอน <span className="text-destructive">*</span>
+                  </label>
+                  <input
+                    type="number"
+                    min={0.01}
+                    step={0.01}
+                    value={settlementAmount}
+                    onChange={(e) => setSettlementAmount(e.target.value)}
+                    className="w-full px-3 py-2 border border-input rounded-lg text-sm focus-visible:ring-2 focus-visible:ring-ring/30 outline-hidden"
+                    placeholder="0.00"
+                  />
+                </div>
+              </div>
+              <div className="flex justify-end gap-3 pt-2">
+                <button
+                  type="button"
+                  onClick={() => setSettlementOpen(false)}
+                  disabled={settlementMutation.isPending}
+                  className="px-4 py-2 text-sm border border-input rounded-lg hover:bg-muted transition-colors"
+                >
+                  ยกเลิก
+                </button>
+                <button
+                  type="button"
+                  onClick={() => settlementMutation.mutate()}
+                  disabled={
+                    settlementMutation.isPending ||
+                    !settlementAccountCode ||
+                    !settlementAmount ||
+                    Number(settlementAmount) <= 0
+                  }
+                  className="px-5 py-2 text-sm bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 disabled:opacity-50 font-semibold transition-colors"
+                >
+                  {settlementMutation.isPending ? 'กำลังบันทึก...' : 'ยืนยัน'}
+                </button>
               </div>
             </div>
-            <div className="space-y-3">
-              <div>
-                <label className="block text-xs font-medium text-foreground mb-1.5">
-                  บัญชีรับเงิน (FINANCE) <span className="text-destructive">*</span>
-                </label>
-                <CashAccountSelect
-                  value={settlementAccountCode}
-                  onChange={setSettlementAccountCode}
-                />
-              </div>
-              <div>
-                <label className="block text-xs font-medium text-foreground mb-1.5">
-                  จำนวนเงินที่รับโอน <span className="text-destructive">*</span>
-                </label>
-                <input
-                  type="number"
-                  min={0.01}
-                  step={0.01}
-                  value={settlementAmount}
-                  onChange={(e) => setSettlementAmount(e.target.value)}
-                  className="w-full px-3 py-2 border border-input rounded-lg text-sm focus-visible:ring-2 focus-visible:ring-ring/30 outline-hidden"
-                  placeholder="0.00"
-                />
-              </div>
-            </div>
-            <div className="flex justify-end gap-3 pt-2">
-              <button
-                type="button"
-                onClick={() => setSettlementOpen(false)}
-                disabled={settlementMutation.isPending}
-                className="px-4 py-2 text-sm border border-input rounded-lg hover:bg-muted transition-colors"
-              >
-                ยกเลิก
-              </button>
-              <button
-                type="button"
-                onClick={() => settlementMutation.mutate()}
-                disabled={
-                  settlementMutation.isPending ||
-                  !settlementAccountCode ||
-                  !settlementAmount ||
-                  Number(settlementAmount) <= 0
-                }
-                className="px-5 py-2 text-sm bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 disabled:opacity-50 font-semibold transition-colors"
-              >
-                {settlementMutation.isPending ? 'กำลังบันทึก...' : 'ยืนยัน'}
-              </button>
-            </div>
-          </div>
+          </FocusScope>
         </div>
       )}
-    </div>,
-    document.body,
+    </WizardStackedOverlay>
   );
 }
 
@@ -589,7 +724,13 @@ function Row({
 function Effect({ text, warning }: { text: string; warning?: boolean }) {
   return (
     <li className="flex items-start gap-2">
-      <span className={warning ? 'text-warning' : 'text-success'}>{warning ? <AlertTriangle className="size-4 inline" /> : <Check className="size-4 inline" />}</span>
+      <span className={warning ? 'text-warning' : 'text-success'}>
+        {warning ? (
+          <AlertTriangle className="size-4 inline" />
+        ) : (
+          <Check className="size-4 inline" />
+        )}
+      </span>
       <span className={warning ? 'text-warning' : 'text-foreground'}>{text}</span>
     </li>
   );

--- a/apps/web/src/hooks/useSlipUpload.ts
+++ b/apps/web/src/hooks/useSlipUpload.ts
@@ -1,0 +1,38 @@
+import { useMutation } from '@tanstack/react-query';
+import api from '@/lib/api';
+
+export const MAX_SLIP_BYTES = 10 * 1024 * 1024; // 10 MB
+export const SLIP_MIME_TYPES = ['image/jpeg', 'image/png', 'image/webp', 'application/pdf'];
+
+/**
+ * Bank-slip upload via presigned S3 URL (kind BANK_SLIP) — resolves to the
+ * public URL to send as `slipUrl` on payment endpoints.
+ */
+export function useSlipUpload() {
+  return useMutation({
+    mutationFn: async (file: File) => {
+      if (file.size > MAX_SLIP_BYTES) throw new Error('ไฟล์ใหญ่เกิน 10MB');
+      if (!SLIP_MIME_TYPES.includes(file.type)) {
+        throw new Error('รองรับ JPG, PNG, WebP, PDF เท่านั้น');
+      }
+      const { data: presign } = await api.post<{
+        uploadUrl: string;
+        method: string;
+        key: string;
+        publicUrl: string;
+      }>('/shop/upload/signed-url', {
+        kind: 'BANK_SLIP',
+        contentType: file.type,
+      });
+
+      const putRes = await fetch(presign.uploadUrl, {
+        method: presign.method,
+        body: file,
+        headers: { 'Content-Type': file.type },
+      });
+      if (!putRes.ok) throw new Error('อัปโหลดสลิปไม่สำเร็จ');
+
+      return presign.publicUrl;
+    },
+  });
+}

--- a/apps/web/src/pages/PaymentsPage/components/RecordPaymentWizard.tsx
+++ b/apps/web/src/pages/PaymentsPage/components/RecordPaymentWizard.tsx
@@ -36,6 +36,7 @@ import { AccrualModeChip } from './AccrualModeChip';
 import { CASH_ACCOUNT_CODES } from '@/components/CashAccountSelect';
 import { formatThaiDate } from '@/lib/date';
 import { useDebounce } from '@/hooks/useDebounce';
+import { useSlipUpload, SLIP_MIME_TYPES } from '@/hooks/useSlipUpload';
 import { toast } from 'sonner';
 import type { PendingPayment } from '../types';
 import { computeNetReceiptDue } from '../computeNetReceiptDue';
@@ -266,41 +267,6 @@ function CaseBadge({
       </span>
     </div>
   );
-}
-
-// ─── Slip upload helper ────────────────────────────────────────────────────────
-
-const MAX_SLIP_BYTES = 10 * 1024 * 1024; // 10 MB
-const SLIP_MIME_TYPES = ['image/jpeg', 'image/png', 'image/webp', 'application/pdf'];
-
-function useSlipUpload() {
-  const mutation = useMutation({
-    mutationFn: async (file: File) => {
-      if (file.size > MAX_SLIP_BYTES) throw new Error('ไฟล์ใหญ่เกิน 10MB');
-      if (!SLIP_MIME_TYPES.includes(file.type)) {
-        throw new Error('รองรับ JPG, PNG, WebP, PDF เท่านั้น');
-      }
-      const { data: presign } = await api.post<{
-        uploadUrl: string;
-        method: string;
-        key: string;
-        publicUrl: string;
-      }>('/shop/upload/signed-url', {
-        kind: 'BANK_SLIP',
-        contentType: file.type,
-      });
-
-      const putRes = await fetch(presign.uploadUrl, {
-        method: presign.method,
-        body: file,
-        headers: { 'Content-Type': file.type },
-      });
-      if (!putRes.ok) throw new Error('อัปโหลดสลิปไม่สำเร็จ');
-
-      return presign.publicUrl;
-    },
-  });
-  return mutation;
 }
 
 // ─── Method options ───────────────────────────────────────────────────────────

--- a/apps/web/src/pages/PaymentsPage/components/RepossessionOverlay.tsx
+++ b/apps/web/src/pages/PaymentsPage/components/RepossessionOverlay.tsx
@@ -1,8 +1,18 @@
 import { useMemo, useState } from 'react';
-import { createPortal } from 'react-dom';
+import { WizardStackedOverlay } from '@/components/WizardStackedOverlay';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
-import { PackageX, Gauge, Calculator, Banknote, FileText, Check, X, AlertTriangle, Lock } from 'lucide-react';
+import {
+  PackageX,
+  Gauge,
+  Calculator,
+  Banknote,
+  FileText,
+  Check,
+  X,
+  AlertTriangle,
+  Lock,
+} from 'lucide-react';
 import api, { getErrorMessage } from '@/lib/api';
 import { CashAccountSelect } from '@/components/CashAccountSelect';
 import { useAuth } from '@/contexts/AuthContext';
@@ -76,7 +86,9 @@ export function RepossessionOverlay({
   const [marketValue, setMarketValue] = useState('');
   const [discountPct, setDiscountPct] = useState('50');
   const [customerRefundEnabled, setCustomerRefundEnabled] = useState(false);
-  const [depositAccountCode, setDepositAccountCode] = useState(user?.defaultCashAccountCode || '11-1101');
+  const [depositAccountCode, setDepositAccountCode] = useState(
+    user?.defaultCashAccountCode || '11-1101',
+  );
   const [notes, setNotes] = useState('');
 
   const { data: preview, isLoading: previewLoading } = useQuery<RepoPreview>({
@@ -125,198 +137,365 @@ export function RepossessionOverlay({
 
   const appraisalNum = Number(appraisalPrice);
   const canSubmit = useMemo(
-    () => canCreate && repossessedDate.length > 0 && !!conditionGrade && appraisalNum > 0 && !mutation.isPending,
+    () =>
+      canCreate &&
+      repossessedDate.length > 0 &&
+      !!conditionGrade &&
+      appraisalNum > 0 &&
+      !mutation.isPending,
     [canCreate, repossessedDate, conditionGrade, appraisalNum, mutation.isPending],
   );
 
   const inputClass =
     'w-full px-3 py-2 border border-input rounded-lg text-sm focus-visible:ring-2 focus-visible:ring-ring/30 outline-hidden';
 
-  return createPortal(
-    <div className="fixed inset-0 z-50 pointer-events-auto bg-black/50 backdrop-blur-xs flex items-start justify-center pt-8 pb-8">
-      <div className="w-full max-w-2xl bg-background rounded-xl shadow-2xl overflow-y-auto max-h-[calc(100vh-4rem)]">
-        {/* Header */}
-        <div className="sticky top-0 z-10 bg-background/95 backdrop-blur-xs border-b px-6 py-4 flex items-center justify-between">
-          <button
-            onClick={onClose}
-            className="flex items-center gap-1.5 text-sm leading-snug text-muted-foreground hover:text-foreground transition-colors"
-          >
-            ← กลับ
-          </button>
-          <h2 className="text-lg font-semibold text-foreground leading-snug">คืนเครื่อง (ยึดคืน)</h2>
-          <div className="w-16" />
-        </div>
+  return (
+    <WizardStackedOverlay maxWidthClass="max-w-2xl">
+      {/* Header */}
+      <div className="sticky top-0 z-10 bg-background/95 backdrop-blur-xs border-b px-6 py-4 flex items-center justify-between">
+        <button
+          onClick={onClose}
+          className="flex items-center gap-1.5 text-sm leading-snug text-muted-foreground hover:text-foreground transition-colors"
+        >
+          ← กลับ
+        </button>
+        <h2 className="text-lg font-semibold text-foreground leading-snug">คืนเครื่อง (ยึดคืน)</h2>
+        <div className="w-16" />
+      </div>
 
-        <div className="p-6 space-y-5">
-          {/* OWNER-only notice */}
-          {!canCreate && (
-            <div className="flex items-start gap-2.5 rounded-lg border border-warning/40 bg-warning/10 px-3 py-3">
-              <Lock className="size-4 text-warning shrink-0 mt-0.5" />
-              <div className="text-xs text-warning leading-snug">
-                <strong className="block">การยึดคืนทำได้เฉพาะเจ้าของ (OWNER)</strong>
-                {canPreview
-                  ? 'ดูตัวอย่างกำไร/ขาดทุนได้ แต่กดยึดคืนจริงไม่ได้ — ให้เจ้าของเป็นผู้ยืนยัน'
-                  : 'บทบาทนี้ดูตัวอย่าง P&L และยึดคืนไม่ได้ — ให้เจ้าของเป็นผู้ดำเนินการ'}
+      <div className="p-6 space-y-5">
+        {/* OWNER-only notice */}
+        {!canCreate && (
+          <div className="flex items-start gap-2.5 rounded-lg border border-warning/40 bg-warning/10 px-3 py-3">
+            <Lock className="size-4 text-warning shrink-0 mt-0.5" />
+            <div className="text-xs text-warning leading-snug">
+              <strong className="block">การยึดคืนทำได้เฉพาะเจ้าของ (OWNER)</strong>
+              {canPreview
+                ? 'ดูตัวอย่างกำไร/ขาดทุนได้ แต่กดยึดคืนจริงไม่ได้ — ให้เจ้าของเป็นผู้ยืนยัน'
+                : 'บทบาทนี้ดูตัวอย่าง P&L และยึดคืนไม่ได้ — ให้เจ้าของเป็นผู้ดำเนินการ'}
+            </div>
+          </div>
+        )}
+
+        {/* Section 1: ข้อมูลสัญญา */}
+        <Section
+          icon={<PackageX className="size-4" />}
+          title="ข้อมูลสัญญา"
+          subtitle="เลขที่, ลูกค้า, สินค้า"
+        >
+          <div className="grid grid-cols-2 gap-x-6 gap-y-2 text-sm">
+            <div>
+              <span className="text-muted-foreground">สัญญา: </span>
+              <span className="font-mono font-semibold">{contractNumber}</span>
+            </div>
+            <div>
+              <span className="text-muted-foreground">ลูกค้า: </span>
+              <span className="font-medium">{customerName}</span>
+            </div>
+            {preview?.contract.product && (
+              <div>
+                <span className="text-muted-foreground">สินค้า: </span>
+                <span className="font-medium">
+                  {preview.contract.product.brand} {preview.contract.product.model}
+                </span>
+              </div>
+            )}
+            {branchName && (
+              <div>
+                <span className="text-muted-foreground">สาขา: </span>
+                <span className="font-medium">{branchName}</span>
+              </div>
+            )}
+          </div>
+        </Section>
+
+        {/* Section 2: สภาพเครื่อง + ราคาประเมิน */}
+        <Section
+          icon={<Gauge className="size-4" />}
+          title="สภาพเครื่อง + ราคาประเมิน"
+          subtitle="เกรดสภาพ, ราคาตี, ค่าซ่อม"
+        >
+          <div className="space-y-4">
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <label className="block text-xs font-medium text-foreground mb-1.5 leading-snug">
+                  วันที่ยึดคืน <span className="text-destructive">*</span>
+                </label>
+                <input
+                  type="date"
+                  value={repossessedDate}
+                  max={bkkToday()}
+                  onChange={(e) => setRepossessedDate(e.target.value)}
+                  className={inputClass}
+                />
+              </div>
+              <div>
+                <label className="block text-xs font-medium text-foreground mb-1.5 leading-snug">
+                  เกรดสภาพ <span className="text-destructive">*</span>
+                </label>
+                <div className="flex gap-2">
+                  {GRADES.map((g) => (
+                    <button
+                      key={g}
+                      type="button"
+                      aria-pressed={conditionGrade === g}
+                      onClick={() => setConditionGrade(g)}
+                      className={`flex-1 px-2 py-2 text-sm rounded-lg border transition-colors ${
+                        conditionGrade === g
+                          ? 'bg-primary text-primary-foreground border-primary'
+                          : 'bg-background border-input hover:bg-muted'
+                      }`}
+                    >
+                      {g}
+                    </button>
+                  ))}
+                </div>
               </div>
             </div>
-          )}
-
-          {/* Section 1: ข้อมูลสัญญา */}
-          <Section icon={<PackageX className="size-4" />} title="ข้อมูลสัญญา" subtitle="เลขที่, ลูกค้า, สินค้า">
-            <div className="grid grid-cols-2 gap-x-6 gap-y-2 text-sm">
-              <div><span className="text-muted-foreground">สัญญา: </span><span className="font-mono font-semibold">{contractNumber}</span></div>
-              <div><span className="text-muted-foreground">ลูกค้า: </span><span className="font-medium">{customerName}</span></div>
-              {preview?.contract.product && (
-                <div><span className="text-muted-foreground">สินค้า: </span><span className="font-medium">{preview.contract.product.brand} {preview.contract.product.model}</span></div>
-              )}
-              {branchName && <div><span className="text-muted-foreground">สาขา: </span><span className="font-medium">{branchName}</span></div>}
-            </div>
-          </Section>
-
-          {/* Section 2: สภาพเครื่อง + ราคาประเมิน */}
-          <Section icon={<Gauge className="size-4" />} title="สภาพเครื่อง + ราคาประเมิน" subtitle="เกรดสภาพ, ราคาตี, ค่าซ่อม">
-            <div className="space-y-4">
-              <div className="grid grid-cols-2 gap-4">
-                <div>
-                  <label className="block text-xs font-medium text-foreground mb-1.5 leading-snug">วันที่ยึดคืน <span className="text-destructive">*</span></label>
-                  <input type="date" value={repossessedDate} max={bkkToday()} onChange={(e) => setRepossessedDate(e.target.value)} className={inputClass} />
-                </div>
-                <div>
-                  <label className="block text-xs font-medium text-foreground mb-1.5 leading-snug">เกรดสภาพ <span className="text-destructive">*</span></label>
-                  <div className="flex gap-2">
-                    {GRADES.map((g) => (
-                      <button
-                        key={g}
-                        type="button"
-                        aria-pressed={conditionGrade === g}
-                        onClick={() => setConditionGrade(g)}
-                        className={`flex-1 px-2 py-2 text-sm rounded-lg border transition-colors ${
-                          conditionGrade === g
-                            ? 'bg-primary text-primary-foreground border-primary'
-                            : 'bg-background border-input hover:bg-muted'
-                        }`}
-                      >
-                        {g}
-                      </button>
-                    ))}
-                  </div>
-                </div>
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <label className="block text-xs font-medium text-foreground mb-1.5 leading-snug">
+                  ราคาประเมิน (฿) <span className="text-destructive">*</span>
+                </label>
+                <input
+                  type="number"
+                  min={0}
+                  step="0.01"
+                  value={appraisalPrice}
+                  onChange={(e) => setAppraisalPrice(e.target.value)}
+                  className={`${inputClass} text-right font-mono`}
+                  placeholder="0.00"
+                />
               </div>
-              <div className="grid grid-cols-2 gap-4">
-                <div>
-                  <label className="block text-xs font-medium text-foreground mb-1.5 leading-snug">ราคาประเมิน (฿) <span className="text-destructive">*</span></label>
-                  <input type="number" min={0} step="0.01" value={appraisalPrice} onChange={(e) => setAppraisalPrice(e.target.value)} className={`${inputClass} text-right font-mono`} placeholder="0.00" />
-                </div>
-                <div>
-                  <label className="block text-xs font-medium text-foreground mb-1.5 leading-snug">ค่าซ่อม (฿)</label>
-                  <input type="number" min={0} step="0.01" value={repairCost} onChange={(e) => setRepairCost(e.target.value)} className={`${inputClass} text-right font-mono`} placeholder="0.00" />
-                </div>
+              <div>
+                <label className="block text-xs font-medium text-foreground mb-1.5 leading-snug">
+                  ค่าซ่อม (฿)
+                </label>
+                <input
+                  type="number"
+                  min={0}
+                  step="0.01"
+                  value={repairCost}
+                  onChange={(e) => setRepairCost(e.target.value)}
+                  className={`${inputClass} text-right font-mono`}
+                  placeholder="0.00"
+                />
               </div>
             </div>
-          </Section>
+          </div>
+        </Section>
 
-          {/* Section 3: คำนวณกำไร/ขาดทุน */}
-          <Section icon={<Calculator className="size-4" />} title="คำนวณกำไร/ขาดทุน (FINANCE)" subtitle="ราคากลาง, ส่วนลด, เงินคืนลูกค้า">
-            <div className="space-y-4">
-              <div className="grid grid-cols-2 gap-4">
-                <div>
-                  <label className="block text-xs font-medium text-foreground mb-1.5 leading-snug">ราคากลางเครื่อง (฿)</label>
-                  <input type="number" min={0} step="0.01" value={marketValue} onChange={(e) => setMarketValue(e.target.value)} className={`${inputClass} text-right font-mono`} placeholder="ใช้ราคาประเมินถ้าเว้นว่าง" />
-                </div>
-                <div>
-                  <label className="block text-xs font-medium text-foreground mb-1.5 leading-snug">ส่วนลดยอดปิด (%)</label>
-                  <input type="number" min={0} max={100} value={discountPct} onChange={(e) => setDiscountPct(e.target.value)} className={`${inputClass} text-right font-mono`} placeholder="50" />
-                </div>
+        {/* Section 3: คำนวณกำไร/ขาดทุน */}
+        <Section
+          icon={<Calculator className="size-4" />}
+          title="คำนวณกำไร/ขาดทุน (FINANCE)"
+          subtitle="ราคากลาง, ส่วนลด, เงินคืนลูกค้า"
+        >
+          <div className="space-y-4">
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <label className="block text-xs font-medium text-foreground mb-1.5 leading-snug">
+                  ราคากลางเครื่อง (฿)
+                </label>
+                <input
+                  type="number"
+                  min={0}
+                  step="0.01"
+                  value={marketValue}
+                  onChange={(e) => setMarketValue(e.target.value)}
+                  className={`${inputClass} text-right font-mono`}
+                  placeholder="ใช้ราคาประเมินถ้าเว้นว่าง"
+                />
               </div>
-              <label className="flex items-center gap-2 cursor-pointer px-3 py-2.5 rounded-lg bg-muted hover:bg-accent transition-colors">
-                <input type="checkbox" checked={customerRefundEnabled} onChange={(e) => setCustomerRefundEnabled(e.target.checked)} className="size-4 accent-primary cursor-pointer" />
-                <span className="text-sm font-medium text-foreground leading-snug">คืนเงินส่วนต่างให้ลูกค้า</span>
-                <span className="text-xs text-muted-foreground ml-auto leading-snug">(กรณีราคากลาง &gt; ยอดปิด)</span>
-              </label>
+              <div>
+                <label className="block text-xs font-medium text-foreground mb-1.5 leading-snug">
+                  ส่วนลดยอดปิด (%)
+                </label>
+                <input
+                  type="number"
+                  min={0}
+                  max={100}
+                  value={discountPct}
+                  onChange={(e) => setDiscountPct(e.target.value)}
+                  className={`${inputClass} text-right font-mono`}
+                  placeholder="50"
+                />
+              </div>
+            </div>
+            <label className="flex items-center gap-2 cursor-pointer px-3 py-2.5 rounded-lg bg-muted hover:bg-accent transition-colors">
+              <input
+                type="checkbox"
+                checked={customerRefundEnabled}
+                onChange={(e) => setCustomerRefundEnabled(e.target.checked)}
+                className="size-4 accent-primary cursor-pointer"
+              />
+              <span className="text-sm font-medium text-foreground leading-snug">
+                คืนเงินส่วนต่างให้ลูกค้า
+              </span>
+              <span className="text-xs text-muted-foreground ml-auto leading-snug">
+                (กรณีราคากลาง &gt; ยอดปิด)
+              </span>
+            </label>
 
-              {/* Live breakdown */}
-              {!canPreview ? (
-                <div className="py-6 text-center text-sm leading-snug text-muted-foreground">ดูตัวอย่าง P&L ได้เฉพาะ OWNER / ผจก.สาขา / ผจก.การเงิน</div>
-              ) : previewLoading || !preview ? (
-                <div className="py-6 text-center text-sm leading-snug text-muted-foreground">กำลังคำนวณ...</div>
-              ) : (
-                <div className="rounded-xl bg-muted/60 p-4 space-y-2">
-                  <Row label="ยอดค้าง (รวม VAT)" value={`${preview.calculation.outstandingBalance.toLocaleString('th-TH', { minimumFractionDigits: 2, maximumFractionDigits: 2 })} ฿`} />
-                  <Row label="ค่างวดไม่รวม VAT (÷ 1.07)" value={`${preview.calculation.principalExVat.toLocaleString('th-TH', { minimumFractionDigits: 2, maximumFractionDigits: 2 })} ฿`} />
-                  <Row label="ต้นทุนคงเหลือ (financedAmount + คอม)" value={`${preview.calculation.remainingCost.toLocaleString('th-TH', { minimumFractionDigits: 2, maximumFractionDigits: 2 })} ฿`} />
-                  <div className="border-t border-border pt-2">
-                    <Row label={`ส่วนลดลูกค้า (${preview.calculation.discountPct}%)`} value={`- ${preview.calculation.discountAmount.toLocaleString('th-TH', { minimumFractionDigits: 2, maximumFractionDigits: 2 })} ฿`} destructive />
-                  </div>
-                  <div className="border-t border-border pt-2">
-                    <Row label="ยอดปิดสัญญา" value={`${preview.calculation.closingAmount.toLocaleString('th-TH', { minimumFractionDigits: 2, maximumFractionDigits: 2 })} ฿`} bold />
-                  </div>
-                  <div className="border-t border-border pt-2 space-y-2">
-                    <Row label="ราคากลางเครื่อง" value={`${preview.calculation.marketValue.toLocaleString('th-TH', { minimumFractionDigits: 2, maximumFractionDigits: 2 })} ฿`} />
-                    {preview.calculation.customerRefundEnabled && (
-                      <Row label="เงินคืนลูกค้า" value={`- ${preview.calculation.customerRefund.toLocaleString('th-TH', { minimumFractionDigits: 2, maximumFractionDigits: 2 })} ฿`} destructive />
-                    )}
+            {/* Live breakdown */}
+            {!canPreview ? (
+              <div className="py-6 text-center text-sm leading-snug text-muted-foreground">
+                ดูตัวอย่าง P&L ได้เฉพาะ OWNER / ผจก.สาขา / ผจก.การเงิน
+              </div>
+            ) : previewLoading || !preview ? (
+              <div className="py-6 text-center text-sm leading-snug text-muted-foreground">
+                กำลังคำนวณ...
+              </div>
+            ) : (
+              <div className="rounded-xl bg-muted/60 p-4 space-y-2">
+                <Row
+                  label="ยอดค้าง (รวม VAT)"
+                  value={`${preview.calculation.outstandingBalance.toLocaleString('th-TH', { minimumFractionDigits: 2, maximumFractionDigits: 2 })} ฿`}
+                />
+                <Row
+                  label="ค่างวดไม่รวม VAT (÷ 1.07)"
+                  value={`${preview.calculation.principalExVat.toLocaleString('th-TH', { minimumFractionDigits: 2, maximumFractionDigits: 2 })} ฿`}
+                />
+                <Row
+                  label="ต้นทุนคงเหลือ (financedAmount + คอม)"
+                  value={`${preview.calculation.remainingCost.toLocaleString('th-TH', { minimumFractionDigits: 2, maximumFractionDigits: 2 })} ฿`}
+                />
+                <div className="border-t border-border pt-2">
+                  <Row
+                    label={`ส่วนลดลูกค้า (${preview.calculation.discountPct}%)`}
+                    value={`- ${preview.calculation.discountAmount.toLocaleString('th-TH', { minimumFractionDigits: 2, maximumFractionDigits: 2 })} ฿`}
+                    destructive
+                  />
+                </div>
+                <div className="border-t border-border pt-2">
+                  <Row
+                    label="ยอดปิดสัญญา"
+                    value={`${preview.calculation.closingAmount.toLocaleString('th-TH', { minimumFractionDigits: 2, maximumFractionDigits: 2 })} ฿`}
+                    bold
+                  />
+                </div>
+                <div className="border-t border-border pt-2 space-y-2">
+                  <Row
+                    label="ราคากลางเครื่อง"
+                    value={`${preview.calculation.marketValue.toLocaleString('th-TH', { minimumFractionDigits: 2, maximumFractionDigits: 2 })} ฿`}
+                  />
+                  {preview.calculation.customerRefundEnabled && (
+                    <Row
+                      label="เงินคืนลูกค้า"
+                      value={`- ${preview.calculation.customerRefund.toLocaleString('th-TH', { minimumFractionDigits: 2, maximumFractionDigits: 2 })} ฿`}
+                      destructive
+                    />
+                  )}
+                </div>
+                <div
+                  className={`flex justify-between items-center mt-2 p-3 rounded-lg ${
+                    preview.calculation.profitLoss >= 0
+                      ? 'bg-success/10 ring-1 ring-success/30'
+                      : 'bg-destructive/10 ring-1 ring-destructive/30'
+                  }`}
+                >
+                  <div>
+                    <div
+                      className={`text-xs font-medium leading-snug ${preview.calculation.profitLoss >= 0 ? 'text-success' : 'text-destructive'}`}
+                    >
+                      {preview.calculation.profitLoss >= 0 ? (
+                        <>
+                          <Check className="size-4 inline mr-1" />
+                          บริษัทได้กำไร
+                        </>
+                      ) : (
+                        <>
+                          <X className="size-4 inline mr-1" />
+                          บริษัทขาดทุน
+                        </>
+                      )}
+                    </div>
+                    <div className="text-xs text-muted-foreground leading-snug">
+                      ราคากลาง − ต้นทุนคงเหลือ − เงินคืน
+                    </div>
                   </div>
                   <div
-                    className={`flex justify-between items-center mt-2 p-3 rounded-lg ${
-                      preview.calculation.profitLoss >= 0
-                        ? 'bg-success/10 ring-1 ring-success/30'
-                        : 'bg-destructive/10 ring-1 ring-destructive/30'
-                    }`}
+                    className={`text-xl font-bold ${preview.calculation.profitLoss >= 0 ? 'text-success' : 'text-destructive'}`}
                   >
-                    <div>
-                      <div className={`text-xs font-medium leading-snug ${preview.calculation.profitLoss >= 0 ? 'text-success' : 'text-destructive'}`}>
-                        {preview.calculation.profitLoss >= 0 ? <><Check className="size-4 inline mr-1" />บริษัทได้กำไร</> : <><X className="size-4 inline mr-1" />บริษัทขาดทุน</>}
-                      </div>
-                      <div className="text-xs text-muted-foreground leading-snug">ราคากลาง − ต้นทุนคงเหลือ − เงินคืน</div>
-                    </div>
-                    <div className={`text-xl font-bold ${preview.calculation.profitLoss >= 0 ? 'text-success' : 'text-destructive'}`}>
-                      {preview.calculation.profitLoss >= 0 ? '+' : ''}{preview.calculation.profitLoss.toLocaleString('th-TH', { minimumFractionDigits: 2, maximumFractionDigits: 2 })} ฿
-                    </div>
+                    {preview.calculation.profitLoss >= 0 ? '+' : ''}
+                    {preview.calculation.profitLoss.toLocaleString('th-TH', {
+                      minimumFractionDigits: 2,
+                      maximumFractionDigits: 2,
+                    })}{' '}
+                    ฿
                   </div>
                 </div>
-              )}
-            </div>
-          </Section>
+              </div>
+            )}
+          </div>
+        </Section>
 
-          {/* Section 4: บัญชีรับเงิน (JP5 deposit leg) */}
-          <Section icon={<Banknote className="size-4" />} title="บัญชีรับเงิน" subtitle="บัญชีสำหรับขา deposit ของ JP5" tone="warning">
-            <CashAccountSelect value={depositAccountCode} onChange={setDepositAccountCode} />
-          </Section>
+        {/* Section 4: บัญชีรับเงิน (JP5 deposit leg) */}
+        <Section
+          icon={<Banknote className="size-4" />}
+          title="บัญชีรับเงิน"
+          subtitle="บัญชีสำหรับขา deposit ของ JP5"
+          tone="warning"
+        >
+          <CashAccountSelect value={depositAccountCode} onChange={setDepositAccountCode} />
+        </Section>
 
-          {/* Section 5: หมายเหตุ */}
-          <Section icon={<FileText className="size-4" />} title="หมายเหตุ" subtitle="บันทึกเพิ่มเติม (ถ้ามี)">
-            <textarea value={notes} onChange={(e) => setNotes(e.target.value)} rows={3} className={`${inputClass} resize-none`} placeholder="เช่น สาเหตุการยึด, สภาพเครื่อง..." />
-          </Section>
+        {/* Section 5: หมายเหตุ */}
+        <Section
+          icon={<FileText className="size-4" />}
+          title="หมายเหตุ"
+          subtitle="บันทึกเพิ่มเติม (ถ้ามี)"
+        >
+          <textarea
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+            rows={3}
+            className={`${inputClass} resize-none`}
+            placeholder="เช่น สาเหตุการยึด, สภาพเครื่อง..."
+          />
+        </Section>
 
-          {/* Section 6: สิ่งที่จะเกิดขึ้น */}
-          <Section icon={<Check className="size-4" />} title="สิ่งที่จะเกิดขึ้นเมื่อยืนยัน" subtitle="ตรวจสอบก่อนยึดคืน" tone="success">
-            <ul className="space-y-1.5 text-sm">
-              <Effect text="ปิดลูกหนี้คงค้าง + ออกใบลดหนี้ VAT (ม.82/5) — บันทึก JE (JP5)" />
-              <Effect text="บันทึกกำไร/ขาดทุนจากการยึด (41-1102 / 51-1102)" />
-              <Effect text="เปลี่ยนสถานะสัญญาเป็น ปิด-หนี้สูญ + สินค้าเป็น ยึดคืน" />
-              <Effect text="จัดการซ่อม/ตั้งราคาขายต่อ ทำต่อที่หน้า ยึดคืน & ขายต่อ" warning />
-              <Effect text="ปลดล็อค MDM (PJ-Soft) — ต้องทำ manual" warning />
-            </ul>
-          </Section>
-        </div>
-
-        {/* Footer */}
-        <div className="sticky bottom-0 bg-background/95 backdrop-blur-xs border-t px-6 py-4 flex items-center justify-end gap-3">
-          <button onClick={onClose} className="px-6 py-2.5 text-sm leading-snug border border-input rounded-lg hover:bg-muted transition-colors">
-            ยกเลิก
-          </button>
-          <button
-            onClick={() => mutation.mutate()}
-            disabled={!canSubmit}
-            title={!canCreate ? 'เฉพาะเจ้าของ (OWNER) ยึดคืนได้' : appraisalNum <= 0 ? 'กรุณาระบุราคาประเมิน' : undefined}
-            className="px-6 py-2.5 text-sm leading-snug bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 disabled:opacity-50 font-semibold transition-colors shadow-sm"
-          >
-            {mutation.isPending ? 'กำลังบันทึก...' : 'ยืนยันยึดคืน'}
-          </button>
-        </div>
+        {/* Section 6: สิ่งที่จะเกิดขึ้น */}
+        <Section
+          icon={<Check className="size-4" />}
+          title="สิ่งที่จะเกิดขึ้นเมื่อยืนยัน"
+          subtitle="ตรวจสอบก่อนยึดคืน"
+          tone="success"
+        >
+          <ul className="space-y-1.5 text-sm">
+            <Effect text="ปิดลูกหนี้คงค้าง + ออกใบลดหนี้ VAT (ม.82/5) — บันทึก JE (JP5)" />
+            <Effect text="บันทึกกำไร/ขาดทุนจากการยึด (41-1102 / 51-1102)" />
+            <Effect text="เปลี่ยนสถานะสัญญาเป็น ปิด-หนี้สูญ + สินค้าเป็น ยึดคืน" />
+            <Effect text="จัดการซ่อม/ตั้งราคาขายต่อ ทำต่อที่หน้า ยึดคืน & ขายต่อ" warning />
+            <Effect text="ปลดล็อค MDM (PJ-Soft) — ต้องทำ manual" warning />
+          </ul>
+        </Section>
       </div>
-    </div>,
-    document.body,
+
+      {/* Footer */}
+      <div className="sticky bottom-0 bg-background/95 backdrop-blur-xs border-t px-6 py-4 flex items-center justify-end gap-3">
+        <button
+          onClick={onClose}
+          className="px-6 py-2.5 text-sm leading-snug border border-input rounded-lg hover:bg-muted transition-colors"
+        >
+          ยกเลิก
+        </button>
+        <button
+          onClick={() => mutation.mutate()}
+          disabled={!canSubmit}
+          title={
+            !canCreate
+              ? 'เฉพาะเจ้าของ (OWNER) ยึดคืนได้'
+              : appraisalNum <= 0
+                ? 'กรุณาระบุราคาประเมิน'
+                : undefined
+          }
+          className="px-6 py-2.5 text-sm leading-snug bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 disabled:opacity-50 font-semibold transition-colors shadow-sm"
+        >
+          {mutation.isPending ? 'กำลังบันทึก...' : 'ยืนยันยึดคืน'}
+        </button>
+      </div>
+    </WizardStackedOverlay>
   );
 }
 
@@ -338,12 +517,14 @@ function Section({
     tone === 'success'
       ? 'bg-success/10 text-success'
       : tone === 'warning'
-      ? 'bg-warning/10 text-warning'
-      : 'bg-primary/10 text-primary';
+        ? 'bg-warning/10 text-warning'
+        : 'bg-primary/10 text-primary';
   return (
     <div className="rounded-xl border border-border bg-card p-5">
       <div className="flex items-center gap-2.5 mb-4">
-        <div className={`flex items-center justify-center size-8 rounded-lg ${iconClass}`}>{icon}</div>
+        <div className={`flex items-center justify-center size-8 rounded-lg ${iconClass}`}>
+          {icon}
+        </div>
         <div>
           <h3 className="text-sm font-semibold text-foreground leading-snug">{title}</h3>
           {subtitle && <p className="text-xs text-muted-foreground leading-snug">{subtitle}</p>}
@@ -368,8 +549,8 @@ function Row({
   const valueClass = destructive
     ? 'text-destructive font-medium'
     : bold
-    ? 'font-semibold text-foreground'
-    : 'text-foreground';
+      ? 'font-semibold text-foreground'
+      : 'text-foreground';
   return (
     <div className="flex justify-between items-baseline text-sm">
       <span className="text-muted-foreground leading-snug">{label}</span>
@@ -382,7 +563,11 @@ function Effect({ text, warning }: { text: string; warning?: boolean }) {
   return (
     <li className="flex items-start gap-2">
       <span className={warning ? 'text-warning' : 'text-success'}>
-        {warning ? <AlertTriangle className="size-4 inline" /> : <Check className="size-4 inline" />}
+        {warning ? (
+          <AlertTriangle className="size-4 inline" />
+        ) : (
+          <Check className="size-4 inline" />
+        )}
       </span>
       <span className={warning ? 'text-warning' : 'text-foreground'}>{text}</span>
     </li>

--- a/apps/web/src/pages/PaymentsPage/components/RescheduleOverlay.test.tsx
+++ b/apps/web/src/pages/PaymentsPage/components/RescheduleOverlay.test.tsx
@@ -1,0 +1,183 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
+import { RescheduleOverlay } from './RescheduleOverlay';
+
+// ── Mock @/lib/api ─────────────────────────────────────────────────────────
+
+const apiGetMock = vi.fn();
+const apiPostMock = vi.fn();
+
+vi.mock('@/lib/api', () => ({
+  default: {
+    get: (...args: unknown[]) => apiGetMock(...args),
+    post: (...args: unknown[]) => apiPostMock(...args),
+  },
+  getErrorMessage: (err: unknown) => String(err),
+}));
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+/**
+ * Mirrors production structure: RecordPaymentWizard is a MODAL Radix Dialog
+ * (react-remove-scroll + FocusScope fight everything outside its content),
+ * and the reschedule overlay self-portals to document.body — OUTSIDE the
+ * dialog's subtree.
+ *
+ * Two-step mount on purpose: Radix Portal defers DialogContent by one effect
+ * pass, so mounting wizard + overlay in one render would register the
+ * wizard's FocusScope AFTER the overlay's and pause the wrong scope. In
+ * production the overlay always opens from a user action long after the
+ * wizard mounted — the rerender reproduces that ordering.
+ */
+async function renderOverlayAboveWizardDialog() {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+
+  const harness = (withOverlay: boolean) => (
+    <QueryClientProvider client={qc}>
+      <Dialog open>
+        <DialogContent>
+          <DialogTitle>บันทึกรับชำระ</DialogTitle>
+        </DialogContent>
+      </Dialog>
+      {withOverlay && (
+        <RescheduleOverlay
+          contractId="c1"
+          contractNumber="TEST-20260630-003"
+          customerName="ทดสอบ ค้าง"
+          paymentId="p1"
+          installmentNo={1}
+          currentDueDate="2026-05-21T00:00:00.000Z"
+          monthlyPayment="4472.00"
+          onClose={vi.fn()}
+          onSuccess={vi.fn()}
+        />
+      )}
+    </QueryClientProvider>
+  );
+
+  const view = render(harness(false));
+  await screen.findByText('บันทึกรับชำระ'); // wizard's deferred portal mounted
+  view.rerender(harness(true));
+}
+
+function dispatchWheel(target: Element): WheelEvent {
+  const evt = new WheelEvent('wheel', { bubbles: true, cancelable: true, deltaY: 50 });
+  target.dispatchEvent(evt);
+  return evt;
+}
+
+// jsdom's TouchEvent constructor lacks changedTouches (react-remove-scroll's
+// getTouchXY crashes on it) — synthesize a plain event carrying the one field
+// the library reads. React's delegated onTouchMove matches by type string, so
+// this still exercises the overlay's handler.
+function dispatchTouchMove(target: Element): Event {
+  const evt = new Event('touchmove', { bubbles: true, cancelable: true });
+  Object.defineProperty(evt, 'changedTouches', { value: [{ clientX: 10, clientY: 10 }] });
+  target.dispatchEvent(evt);
+  return evt;
+}
+
+/** Route api.get by URL — the overlay fetches the quote, CashAccountSelect fetches CoA rows. */
+function mockApiGet(quote: Record<string, string>) {
+  apiGetMock.mockImplementation((url: string) =>
+    url.includes('reschedule-quote')
+      ? Promise.resolve({ data: quote })
+      : Promise.resolve({ data: [{ code: '11-1101', name: 'เงินสด' }] }),
+  );
+}
+
+beforeEach(() => {
+  apiGetMock.mockReset();
+  apiPostMock.mockReset();
+  // Zero collect keeps the JE-preview + payment-method branches out of the
+  // escape test's scope; the slip test overrides with a collectable quote.
+  mockApiGet({
+    rescheduleFee: '0.00',
+    lateFee: '0.00',
+    collectAmount: '0.00',
+    variant: '6b',
+    newDueDate: '2026-05-28T00:00:00.000Z',
+    currentDueDate: '2026-05-21T00:00:00.000Z',
+  });
+});
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+//
+// Single it() for the escape assertions on purpose: react-remove-scroll and
+// Radix FocusScope both keep module-level stacks — a second Dialog mounted in
+// a later test in the same file sees stale stack state and stops enforcing
+// entirely, making per-test assertions vacuous. All lock/trap assertions must
+// run against the SAME mounted dialog.
+
+describe('RescheduleOverlay wizard-dialog escapes (scroll lock + focus trap)', () => {
+  it('scrolls and keeps focus inside the overlay while the wizard modal Dialog is open', async () => {
+    await renderOverlayAboveWizardDialog();
+
+    // Control — proves the wizard's scroll lock is ACTIVE in this harness:
+    // events outside both dialog and overlay must be preventDefault()ed.
+    const outside = document.createElement('div');
+    document.body.appendChild(outside);
+    expect(dispatchWheel(outside).defaultPrevented).toBe(true);
+    expect(dispatchTouchMove(outside).defaultPrevented).toBe(true);
+    outside.remove();
+
+    // The overlay panel: react-remove-scroll would preventDefault() these too
+    // (target is outside the wizard DialogContent) unless the panel stops
+    // propagation before the event bubbles to document.
+    const heading = screen.getByText('ปรับดิว — เลื่อนวันครบกำหนด');
+    expect(dispatchWheel(heading).defaultPrevented).toBe(false);
+    expect(dispatchTouchMove(heading).defaultPrevented).toBe(false);
+
+    // Focus — the wizard Dialog's FocusScope used to yank focus back into the
+    // DialogContent on every focusout, making overlay inputs untypable. The
+    // overlay's own trapped FocusScope pauses the wizard's, so focus sticks.
+    const daysInput = screen.getByLabelText('จำนวนวันที่เลื่อน');
+    daysInput.focus();
+    expect(document.activeElement).toBe(daysInput);
+
+    // Control — the overlay's own trap is ACTIVE: focusing an element outside
+    // gets pulled back to the last-focused element inside the overlay.
+    const outsideButton = document.createElement('button');
+    document.body.appendChild(outsideButton);
+    outsideButton.focus();
+    expect(document.activeElement).toBe(daysInput);
+    outsideButton.remove();
+  });
+
+  it('TRANSFER requires both เลขอ้างอิง and slip before submit enables', async () => {
+    // Quote with money to collect so the payment-method buttons render.
+    mockApiGet({
+      rescheduleFee: '244.00',
+      lateFee: '75.79',
+      collectAmount: '319.79',
+      variant: '6a',
+      newDueDate: '2026-05-28T00:00:00.000Z',
+      currentDueDate: '2026-05-21T00:00:00.000Z',
+    });
+    apiPostMock.mockResolvedValue({ data: { lines: [], isBalanced: true } });
+
+    await renderOverlayAboveWizardDialog();
+
+    // fireEvent (not user-event): the wizard modal sets body pointer-events:none
+    // and aria-hidden on siblings — jsdom can't see the overlay's CSS-class
+    // escapes, so user-event would refuse the click and role queries hide it.
+    fireEvent.click(await screen.findByText('โอนธนาคาร'));
+
+    // Slip upload field appears for TRANSFER.
+    expect(screen.getByText('แนบสลิปโอนเงิน')).toBeTruthy();
+
+    // No ref + no slip → submit stays disabled.
+    const submit = screen.getByText(/ยืนยันปรับดิว/).closest('button') as HTMLButtonElement;
+    expect(submit.disabled).toBe(true);
+
+    // Ref alone is not enough — slip still required (mirrors RecordPaymentWizard).
+    fireEvent.change(screen.getByPlaceholderText('เลขอ้างอิงจากสลิปโอนเงิน'), {
+      target: { value: 'REF123' },
+    });
+    expect(submit.disabled).toBe(true);
+  });
+});

--- a/apps/web/src/pages/PaymentsPage/components/RescheduleOverlay.tsx
+++ b/apps/web/src/pages/PaymentsPage/components/RescheduleOverlay.tsx
@@ -1,5 +1,4 @@
-import { useMemo, useState } from 'react';
-import { createPortal } from 'react-dom';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import Decimal from 'decimal.js';
@@ -8,16 +7,22 @@ import {
   CalendarDays,
   Layers,
   Check,
+  CheckCircle2,
   AlertTriangle,
   Wallet,
   Banknote,
   Landmark,
+  Loader2,
   QrCode,
+  Upload,
+  X,
 } from 'lucide-react';
 import api, { getErrorMessage } from '@/lib/api';
 import { formatThaiDate } from '@/lib/date';
 import { CashAccountSelect } from '@/components/CashAccountSelect';
+import { WizardStackedOverlay } from '@/components/WizardStackedOverlay';
 import { useDebounce } from '@/hooks/useDebounce';
+import { useSlipUpload, SLIP_MIME_TYPES } from '@/hooks/useSlipUpload';
 
 interface Props {
   contractId: string;
@@ -86,11 +91,57 @@ export function RescheduleOverlay({
   const [depositAccountCode, setDepositAccountCode] = useState(defaultDepositAccountCode);
   const [referenceNumber, setReferenceNumber] = useState('');
 
+  // Slip upload (โอนธนาคาร) — mirrors RecordPaymentWizard: TRANSFER ต้องมี ref + slip
+  const [slipUrl, setSlipUrl] = useState('');
+  const [slipFileName, setSlipFileName] = useState('');
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const uploadMutation = useSlipUpload();
+
+  const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setSlipFileName(file.name);
+    try {
+      const url = await uploadMutation.mutateAsync(file);
+      setSlipUrl(url);
+      toast.success('อัปโหลดสลิปสำเร็จ');
+    } catch (err: unknown) {
+      toast.error(err instanceof Error ? err.message : 'อัปโหลดสลิปไม่สำเร็จ');
+      setSlipFileName('');
+      if (fileInputRef.current) fileInputRef.current.value = '';
+    }
+  };
+
+  const handleClearSlip = () => {
+    setSlipUrl('');
+    setSlipFileName('');
+    if (fileInputRef.current) fileInputRef.current.value = '';
+  };
+
   const days = Math.max(0, Math.floor(daysToShift) || 0);
   const debouncedDays = useDebounce(days, 300);
 
+  // Evidence is amount-specific: changing days/split recomputes collectAmount,
+  // so a slip/ref attached for the OLD quote must not survive into the new
+  // one's audit trail.
+  const isFirstQuote = useRef(true);
+  useEffect(() => {
+    if (isFirstQuote.current) {
+      isFirstQuote.current = false;
+      return;
+    }
+    setReferenceNumber('');
+    setSlipUrl('');
+    setSlipFileName('');
+    if (fileInputRef.current) fileInputRef.current.value = '';
+  }, [debouncedDays, splitMode]);
+
   // Server-authoritative quote — fee (monthly/30×days ปัดขึ้นเต็มบาท) + ค่าปรับค้าง.
-  const { data: quote, isFetching: quoteLoading, error: quoteError } = useQuery<RescheduleQuote>({
+  const {
+    data: quote,
+    isFetching: quoteLoading,
+    error: quoteError,
+  } = useQuery<RescheduleQuote>({
     queryKey: ['reschedule-quote', contractId, installmentNo, debouncedDays, splitMode],
     queryFn: async () => {
       const { data } = await api.get<RescheduleQuote>('/payments/reschedule-quote', {
@@ -110,7 +161,15 @@ export function RescheduleOverlay({
 
   // JE preview — the exact lines the confirm will post (collect-first semantics).
   const { data: jePreview } = useQuery<{ lines: JePreviewLine[]; isBalanced: boolean }>({
-    queryKey: ['reschedule-je-preview', contractId, installmentNo, debouncedDays, splitMode, depositAccountCode, quote?.lateFee],
+    queryKey: [
+      'reschedule-je-preview',
+      contractId,
+      installmentNo,
+      debouncedDays,
+      splitMode,
+      depositAccountCode,
+      quote?.lateFee,
+    ],
     queryFn: async () => {
       const { data } = await api.post('/payments/preview-journal', {
         contractId,
@@ -146,6 +205,7 @@ export function RescheduleOverlay({
         splitMode,
         depositAccountCode,
         ...(referenceNumber ? { transactionRef: referenceNumber } : {}),
+        ...(slipUrl ? { slipUrl } : {}),
       });
       return data;
     },
@@ -194,154 +254,199 @@ export function RescheduleOverlay({
 
   const isPending = confirmMutation.isPending || qrMutation.isPending;
   const needRef = hasCollect && method === 'TRANSFER' && !referenceNumber.trim();
-  const canSubmit =
-    days >= 1 && !isPending && !quoteLoading && !!quote && !needRef;
+  const needSlip = hasCollect && method === 'TRANSFER' && !slipUrl;
+  const canSubmit = days >= 1 && !isPending && !quoteLoading && !!quote && !needRef && !needSlip;
 
   const submit = () => {
     if (method === 'QR' && hasCollect) qrMutation.mutate();
     else confirmMutation.mutate();
   };
 
-  return createPortal(
-    <div className="fixed inset-0 z-50 pointer-events-auto bg-black/50 backdrop-blur-xs flex items-start justify-center pt-8 pb-8">
-      <div className="w-full max-w-xl bg-background rounded-xl shadow-2xl overflow-y-auto max-h-[calc(100vh-4rem)]">
-        {/* Header */}
-        <div className="sticky top-0 z-10 bg-background/95 backdrop-blur-xs border-b px-6 py-4 flex items-center justify-between">
-          <button
-            onClick={onClose}
-            className="flex items-center gap-1.5 text-sm leading-snug text-muted-foreground hover:text-foreground transition-colors"
-          >
-            ← กลับ
-          </button>
-          <h2 className="text-lg font-semibold text-foreground leading-snug">ปรับดิว — เลื่อนวันครบกำหนด</h2>
-          <div className="w-16" />
-        </div>
+  return (
+    <WizardStackedOverlay maxWidthClass="max-w-xl">
+      {/* Header */}
+      <div className="sticky top-0 z-10 bg-background/95 backdrop-blur-xs border-b px-6 py-4 flex items-center justify-between">
+        <button
+          onClick={onClose}
+          className="flex items-center gap-1.5 text-sm leading-snug text-muted-foreground hover:text-foreground transition-colors"
+        >
+          ← กลับ
+        </button>
+        <h2 className="text-lg font-semibold text-foreground leading-snug">
+          ปรับดิว — เลื่อนวันครบกำหนด
+        </h2>
+        <div className="w-16" />
+      </div>
 
-        <div className="p-6 space-y-5">
-          {/* Section 1: ข้อมูลสัญญา */}
-          <Section icon={<CalendarClock className="size-4" />} title="ข้อมูลสัญญา" subtitle="เลขที่, ลูกค้า, งวดปัจจุบัน">
-            <div className="grid grid-cols-2 gap-x-6 gap-y-2 text-sm">
-              <div><span className="text-muted-foreground">สัญญา: </span><span className="font-mono font-semibold">{contractNumber}</span></div>
-              <div><span className="text-muted-foreground">ลูกค้า: </span><span className="font-medium">{customerName}</span></div>
-              {branchName && <div><span className="text-muted-foreground">สาขา: </span><span className="font-medium">{branchName}</span></div>}
-              <div><span className="text-muted-foreground">เลื่อนจากงวดที่: </span><span className="font-medium">{installmentNo}</span></div>
-              <div className="col-span-2"><span className="text-muted-foreground">ครบกำหนดเดิม: </span><span className="font-medium">{formatThaiDate(currentDueDate)}</span></div>
+      <div className="p-6 space-y-5">
+        {/* Section 1: ข้อมูลสัญญา */}
+        <Section
+          icon={<CalendarClock className="size-4" />}
+          title="ข้อมูลสัญญา"
+          subtitle="เลขที่, ลูกค้า, งวดปัจจุบัน"
+        >
+          <div className="grid grid-cols-2 gap-x-6 gap-y-2 text-sm">
+            <div>
+              <span className="text-muted-foreground">สัญญา: </span>
+              <span className="font-mono font-semibold">{contractNumber}</span>
             </div>
-          </Section>
-
-          {/* Section 2: เลื่อนกี่วัน */}
-          <Section icon={<CalendarDays className="size-4" />} title="เลื่อนกี่วัน" subtitle="กำหนดจำนวนวันที่ต้องการเลื่อน">
-            <label className="block text-xs font-medium text-foreground mb-1.5 leading-snug">จำนวนวันที่เลื่อน</label>
-            <div className="flex flex-wrap gap-2 mb-3">
-              {QUICK_DAYS.map((d) => (
-                <button
-                  key={d}
-                  type="button"
-                  onClick={() => setDaysToShift(d)}
-                  className={`px-3 py-1.5 text-sm rounded-lg border transition-colors ${
-                    days === d
-                      ? 'bg-primary text-primary-foreground border-primary'
-                      : 'bg-background border-input hover:bg-muted'
-                  }`}
-                >
-                  {d} วัน
-                </button>
-              ))}
-              <div className="flex items-center gap-1.5">
-                <input
-                  type="number"
-                  min={1}
-                  max={365}
-                  value={daysToShift}
-                  onChange={(e) => setDaysToShift(Math.max(1, Math.min(365, Number(e.target.value) || 0)))}
-                  className="w-20 px-2 py-1.5 border border-input rounded-lg text-sm text-right font-mono"
-                  aria-label="จำนวนวันที่เลื่อน"
-                />
-                <span className="text-sm text-muted-foreground">วัน</span>
+            <div>
+              <span className="text-muted-foreground">ลูกค้า: </span>
+              <span className="font-medium">{customerName}</span>
+            </div>
+            {branchName && (
+              <div>
+                <span className="text-muted-foreground">สาขา: </span>
+                <span className="font-medium">{branchName}</span>
               </div>
+            )}
+            <div>
+              <span className="text-muted-foreground">เลื่อนจากงวดที่: </span>
+              <span className="font-medium">{installmentNo}</span>
             </div>
-            <div className="space-y-1.5 text-sm">
-              {newDueDate && (
-                <Row label="ครบกำหนดใหม่ (งวดนี้)" value={formatThaiDate(newDueDate)} bold />
-              )}
-              <Row
-                label="ค่าธรรมเนียมเลื่อนดิว"
-                value={quoteLoading ? 'กำลังคำนวณ…' : `${fee.toFixed(2)} บาท`}
-              />
-              <p className="text-xs text-muted-foreground leading-snug">
-                คำนวณจาก ค่างวด ({new Decimal(monthlyPayment || 0).toFixed(2)}) ÷ 30 × {days} วัน (ปัดขึ้นเต็มบาท)
-              </p>
+            <div className="col-span-2">
+              <span className="text-muted-foreground">ครบกำหนดเดิม: </span>
+              <span className="font-medium">{formatThaiDate(currentDueDate)}</span>
             </div>
-          </Section>
+          </div>
+        </Section>
 
-          {/* Section 3: รูปแบบค่าธรรมเนียม (6a/6b) */}
-          <Section icon={<Layers className="size-4" />} title="วิธีเก็บค่าธรรมเนียม" subtitle="เลือกรูปแบบการเก็บค่าธรรมเนียมเลื่อนดิว">
-            <div className="space-y-2">
-              <ModeOption
-                active={splitMode === 'SINGLE'}
-                onClick={() => setSplitMode('SINGLE')}
-                title="รวมกับงวดถัดไป (6b)"
-                desc="ค่าธรรมเนียมรวมไปกับค่างวดถัดไป — วันนี้เก็บเฉพาะค่าปรับ (ถ้ามี)"
+        {/* Section 2: เลื่อนกี่วัน */}
+        <Section
+          icon={<CalendarDays className="size-4" />}
+          title="เลื่อนกี่วัน"
+          subtitle="กำหนดจำนวนวันที่ต้องการเลื่อน"
+        >
+          <label className="block text-xs font-medium text-foreground mb-1.5 leading-snug">
+            จำนวนวันที่เลื่อน
+          </label>
+          <div className="flex flex-wrap gap-2 mb-3">
+            {QUICK_DAYS.map((d) => (
+              <button
+                key={d}
+                type="button"
+                onClick={() => setDaysToShift(d)}
+                className={`px-3 py-1.5 text-sm rounded-lg border transition-colors ${
+                  days === d
+                    ? 'bg-primary text-primary-foreground border-primary'
+                    : 'bg-background border-input hover:bg-muted'
+                }`}
+              >
+                {d} วัน
+              </button>
+            ))}
+            <div className="flex items-center gap-1.5">
+              <input
+                type="number"
+                min={1}
+                max={365}
+                value={daysToShift}
+                onChange={(e) =>
+                  setDaysToShift(Math.max(1, Math.min(365, Number(e.target.value) || 0)))
+                }
+                className="w-20 px-2 py-1.5 border border-input rounded-lg text-sm text-right font-mono"
+                aria-label="จำนวนวันที่เลื่อน"
               />
-              <ModeOption
-                active={splitMode === 'SPLIT'}
-                onClick={() => setSplitMode('SPLIT')}
-                title="เก็บค่าธรรมเนียมตอนนี้ (6a)"
-                desc="เก็บค่าธรรมเนียมเลื่อนดิว + ค่าปรับ (ถ้ามี) เป็นเงินสด/โอน/QR ก่อนเลื่อนดิว"
-              />
+              <span className="text-sm text-muted-foreground">วัน</span>
             </div>
-          </Section>
+          </div>
+          <div className="space-y-1.5 text-sm">
+            {newDueDate && (
+              <Row label="ครบกำหนดใหม่ (งวดนี้)" value={formatThaiDate(newDueDate)} bold />
+            )}
+            <Row
+              label="ค่าธรรมเนียมเลื่อนดิว"
+              value={quoteLoading ? 'กำลังคำนวณ…' : `${fee.toFixed(2)} บาท`}
+            />
+            <p className="text-xs text-muted-foreground leading-snug">
+              คำนวณจาก ค่างวด ({new Decimal(monthlyPayment || 0).toFixed(2)}) ÷ 30 × {days} วัน
+              (ปัดขึ้นเต็มบาท)
+            </p>
+          </div>
+        </Section>
 
-          {/* Section 4: ชำระเงิน (collect-first — เงินไม่เข้า ดิวไม่เลื่อน) */}
-          <Section icon={<Wallet className="size-4" />} title="ชำระเงิน" subtitle="ยอดที่ต้องเก็บก่อนเลื่อนดิว">
-            {quoteError ? (
-              <p className="text-sm text-destructive leading-snug">{getErrorMessage(quoteError)}</p>
-            ) : (
-              <>
-                <div className="space-y-1.5 text-sm mb-3">
-                  {splitMode === 'SPLIT' && (
-                    <Row label="ค่าธรรมเนียมเลื่อนดิว (6a)" value={`${fee.toFixed(2)} บาท`} />
-                  )}
-                  <Row
-                    label="ค่าปรับค้างชำระ"
-                    value={lateFee.gt(0) ? `${lateFee.toFixed(2)} บาท` : 'ไม่มี'}
-                  />
-                  <div className="border-t border-border pt-1.5">
-                    <Row label="รวมต้องเก็บวันนี้" value={`${collect.toFixed(2)} บาท`} bold />
-                  </div>
+        {/* Section 3: รูปแบบค่าธรรมเนียม (6a/6b) */}
+        <Section
+          icon={<Layers className="size-4" />}
+          title="วิธีเก็บค่าธรรมเนียม"
+          subtitle="เลือกรูปแบบการเก็บค่าธรรมเนียมเลื่อนดิว"
+        >
+          <div className="space-y-2">
+            <ModeOption
+              active={splitMode === 'SINGLE'}
+              onClick={() => setSplitMode('SINGLE')}
+              title="รวมกับงวดถัดไป (6b)"
+              desc="ค่าธรรมเนียมรวมไปกับค่างวดถัดไป — วันนี้เก็บเฉพาะค่าปรับ (ถ้ามี)"
+            />
+            <ModeOption
+              active={splitMode === 'SPLIT'}
+              onClick={() => setSplitMode('SPLIT')}
+              title="เก็บค่าธรรมเนียมตอนนี้ (6a)"
+              desc="เก็บค่าธรรมเนียมเลื่อนดิว + ค่าปรับ (ถ้ามี) เป็นเงินสด/โอน/QR ก่อนเลื่อนดิว"
+            />
+          </div>
+        </Section>
+
+        {/* Section 4: ชำระเงิน (collect-first — เงินไม่เข้า ดิวไม่เลื่อน) */}
+        <Section
+          icon={<Wallet className="size-4" />}
+          title="ชำระเงิน"
+          subtitle="ยอดที่ต้องเก็บก่อนเลื่อนดิว"
+        >
+          {quoteError ? (
+            <p className="text-sm text-destructive leading-snug">{getErrorMessage(quoteError)}</p>
+          ) : (
+            <>
+              <div className="space-y-1.5 text-sm mb-3">
+                {splitMode === 'SPLIT' && (
+                  <Row label="ค่าธรรมเนียมเลื่อนดิว (6a)" value={`${fee.toFixed(2)} บาท`} />
+                )}
+                <Row
+                  label="ค่าปรับค้างชำระ"
+                  value={lateFee.gt(0) ? `${lateFee.toFixed(2)} บาท` : 'ไม่มี'}
+                />
+                <div className="border-t border-border pt-1.5">
+                  <Row label="รวมต้องเก็บวันนี้" value={`${collect.toFixed(2)} บาท`} bold />
                 </div>
+              </div>
 
-                {hasCollect ? (
-                  <>
-                    {/* ช่องทางรับชำระ */}
-                    <div className="grid grid-cols-3 gap-2 mb-3">
-                      <MethodButton
-                        active={method === 'CASH'}
-                        onClick={() => setMethod('CASH')}
-                        icon={<Banknote className="size-4" />}
-                        label="เงินสด"
-                      />
-                      <MethodButton
-                        active={method === 'TRANSFER'}
-                        onClick={() => setMethod('TRANSFER')}
-                        icon={<Landmark className="size-4" />}
-                        label="โอนธนาคาร"
-                      />
-                      <MethodButton
-                        active={method === 'QR'}
-                        onClick={() => setMethod('QR')}
-                        icon={<QrCode className="size-4" />}
-                        label="QR ใน LINE"
-                      />
-                    </div>
+              {hasCollect ? (
+                <>
+                  {/* ช่องทางรับชำระ */}
+                  <div className="grid grid-cols-3 gap-2 mb-3">
+                    <MethodButton
+                      active={method === 'CASH'}
+                      onClick={() => setMethod('CASH')}
+                      icon={<Banknote className="size-4" />}
+                      label="เงินสด"
+                    />
+                    <MethodButton
+                      active={method === 'TRANSFER'}
+                      onClick={() => setMethod('TRANSFER')}
+                      icon={<Landmark className="size-4" />}
+                      label="โอนธนาคาร"
+                    />
+                    <MethodButton
+                      active={method === 'QR'}
+                      onClick={() => setMethod('QR')}
+                      icon={<QrCode className="size-4" />}
+                      label="QR ใน LINE"
+                    />
+                  </div>
 
-                    {method !== 'QR' && (
-                      <div className="space-y-2.5">
-                        <div>
-                          <label className="block text-xs font-medium text-foreground mb-1 leading-snug">บัญชีรับเงิน</label>
-                          <CashAccountSelect value={depositAccountCode} onChange={setDepositAccountCode} />
-                        </div>
-                        {method === 'TRANSFER' && (
+                  {method !== 'QR' && (
+                    <div className="space-y-2.5">
+                      <div>
+                        <label className="block text-xs font-medium text-foreground mb-1 leading-snug">
+                          บัญชีรับเงิน
+                        </label>
+                        <CashAccountSelect
+                          value={depositAccountCode}
+                          onChange={setDepositAccountCode}
+                        />
+                      </div>
+                      {method === 'TRANSFER' && (
+                        <>
                           <div>
                             <label className="block text-xs font-medium text-foreground mb-1 leading-snug">
                               เลขอ้างอิงการโอน <span className="text-destructive">*</span>
@@ -354,89 +459,167 @@ export function RescheduleOverlay({
                               className="w-full px-3 py-2 border border-input rounded-lg text-sm"
                             />
                           </div>
-                        )}
-                      </div>
-                    )}
+                          <div>
+                            <label className="block text-xs font-medium text-foreground mb-1 leading-snug">
+                              แนบสลิปโอนเงิน <span className="text-destructive">*</span>
+                            </label>
+                            <input
+                              ref={fileInputRef}
+                              type="file"
+                              accept={SLIP_MIME_TYPES.join(',')}
+                              className="hidden"
+                              aria-label="อัปโหลดสลิป"
+                              onChange={handleFileChange}
+                            />
+                            {slipUrl ? (
+                              <div className="flex items-center gap-2 rounded-lg border border-success/40 bg-success/5 px-3 py-2.5">
+                                <CheckCircle2 className="size-4 text-success shrink-0" />
+                                <span className="text-sm text-foreground leading-snug truncate flex-1">
+                                  {slipFileName || 'สลิปอัปโหลดแล้ว'}
+                                </span>
+                                <button
+                                  type="button"
+                                  onClick={handleClearSlip}
+                                  className="shrink-0 rounded p-0.5 text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-colors"
+                                  aria-label="ลบสลิป"
+                                >
+                                  <X className="size-3.5" />
+                                </button>
+                              </div>
+                            ) : (
+                              <button
+                                type="button"
+                                onClick={() => fileInputRef.current?.click()}
+                                disabled={uploadMutation.isPending}
+                                className="flex w-full items-center justify-center gap-2 rounded-lg border-2 border-dashed border-border px-4 py-3 text-sm text-muted-foreground hover:border-primary/40 hover:text-foreground hover:bg-accent transition-colors disabled:opacity-60 disabled:pointer-events-none"
+                              >
+                                {uploadMutation.isPending ? (
+                                  <>
+                                    <Loader2 className="size-4 animate-spin" />
+                                    <span className="leading-snug">กำลังอัปโหลด...</span>
+                                  </>
+                                ) : (
+                                  <>
+                                    <Upload className="size-4" />
+                                    <span className="leading-snug">
+                                      คลิกเพื่ออัปโหลดสลิป (JPG/PNG/PDF)
+                                    </span>
+                                  </>
+                                )}
+                              </button>
+                            )}
+                          </div>
+                        </>
+                      )}
+                    </div>
+                  )}
 
-                    {method === 'QR' && (
-                      <div className="rounded-lg border border-warning/40 bg-warning/10 px-3 py-2.5 text-xs text-warning leading-snug">
-                        ระบบจะส่ง QR ยอด {collect.toFixed(2)} บาท ให้ลูกค้าใน LINE —
-                        <strong> ดิวจะเลื่อนอัตโนมัติเมื่อเงินเข้าเท่านั้น</strong> (QR หมดอายุใน 24 ชม.
-                        ถ้าลูกค้าไม่จ่าย ดิวไม่เลื่อน)
-                      </div>
-                    )}
+                  {method === 'QR' && (
+                    <div className="rounded-lg border border-warning/40 bg-warning/10 px-3 py-2.5 text-xs text-warning leading-snug">
+                      ระบบจะส่ง QR ยอด {collect.toFixed(2)} บาท ให้ลูกค้าใน LINE —
+                      <strong> ดิวจะเลื่อนอัตโนมัติเมื่อเงินเข้าเท่านั้น</strong> (QR หมดอายุใน 24
+                      ชม. ถ้าลูกค้าไม่จ่าย ดิวไม่เลื่อน)
+                    </div>
+                  )}
 
-                    {/* JE preview — บรรทัดบัญชีที่จะลงจริงตอนยืนยัน */}
-                    {method !== 'QR' && jePreview && jePreview.lines.length > 0 && (
-                      <div className="mt-3 rounded-lg border border-border bg-muted/40 px-3 py-2.5">
-                        <div className="text-xs font-semibold text-muted-foreground mb-1.5 leading-snug">รายการบัญชี (ลงทันทีตอนยืนยัน)</div>
-                        <div className="space-y-1">
-                          {jePreview.lines.map((l, i) => (
-                            <div key={i} className="flex justify-between text-xs font-mono leading-snug">
-                              <span className="text-muted-foreground">{l.accountCode} {l.accountName}</span>
-                              <span>{Number(l.debit) > 0 ? `Dr ${l.debit}` : `Cr ${l.credit}`}</span>
-                            </div>
-                          ))}
-                        </div>
+                  {/* JE preview — บรรทัดบัญชีที่จะลงจริงตอนยืนยัน */}
+                  {method !== 'QR' && jePreview && jePreview.lines.length > 0 && (
+                    <div className="mt-3 rounded-lg border border-border bg-muted/40 px-3 py-2.5">
+                      <div className="text-xs font-semibold text-muted-foreground mb-1.5 leading-snug">
+                        รายการบัญชี (ลงทันทีตอนยืนยัน)
                       </div>
-                    )}
-                  </>
-                ) : (
-                  <div className="rounded-lg border border-success/40 bg-success/10 px-3 py-2.5 text-xs text-success leading-snug">
-                    ไม่มียอดต้องเก็บวันนี้ (6b + ไม่มีค่าปรับ) — ยืนยันปรับดิวได้เลย
-                  </div>
+                      <div className="space-y-1">
+                        {jePreview.lines.map((l, i) => (
+                          <div
+                            key={i}
+                            className="flex justify-between text-xs font-mono leading-snug"
+                          >
+                            <span className="text-muted-foreground">
+                              {l.accountCode} {l.accountName}
+                            </span>
+                            <span>{Number(l.debit) > 0 ? `Dr ${l.debit}` : `Cr ${l.credit}`}</span>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+                </>
+              ) : (
+                <div className="rounded-lg border border-success/40 bg-success/10 px-3 py-2.5 text-xs text-success leading-snug">
+                  ไม่มียอดต้องเก็บวันนี้ (6b + ไม่มีค่าปรับ) — ยืนยันปรับดิวได้เลย
+                </div>
+              )}
+            </>
+          )}
+        </Section>
+
+        {/* Section 5: สิ่งที่จะเกิดขึ้น */}
+        <Section
+          icon={<Check className="size-4" />}
+          title="สิ่งที่จะเกิดขึ้นเมื่อยืนยัน"
+          subtitle="ตรวจสอบก่อนปรับดิว"
+          tone="success"
+        >
+          <ul className="space-y-1.5 text-sm">
+            {hasCollect && method === 'QR' ? (
+              <Effect
+                text={`ส่ง QR ยอด ${collect.toFixed(2)} บาท ให้ลูกค้า — ดิวเลื่อนเมื่อเงินเข้า`}
+                warning
+              />
+            ) : (
+              <>
+                {hasCollect && (
+                  <Effect
+                    text={`เก็บเงิน ${collect.toFixed(2)} บาท${lateFee.gt(0) ? ` (รวมค่าปรับ ${lateFee.toFixed(2)} บาท → ลงบัญชี 42-1103)` : ''} + ลงบัญชีทันที`}
+                  />
+                )}
+                {lateFee.gt(0) && (
+                  <Effect text="ค่าปรับช่วงที่เกินมาแล้วถูกเก็บและปิดยอด — เริ่มนับใหม่จากดิวใหม่" />
                 )}
               </>
             )}
-          </Section>
-
-          {/* Section 5: สิ่งที่จะเกิดขึ้น */}
-          <Section icon={<Check className="size-4" />} title="สิ่งที่จะเกิดขึ้นเมื่อยืนยัน" subtitle="ตรวจสอบก่อนปรับดิว" tone="success">
-            <ul className="space-y-1.5 text-sm">
-              {hasCollect && method === 'QR' ? (
-                <Effect text={`ส่ง QR ยอด ${collect.toFixed(2)} บาท ให้ลูกค้า — ดิวเลื่อนเมื่อเงินเข้า`} warning />
-              ) : (
-                <>
-                  {hasCollect && (
-                    <Effect text={`เก็บเงิน ${collect.toFixed(2)} บาท${lateFee.gt(0) ? ` (รวมค่าปรับ ${lateFee.toFixed(2)} บาท → ลงบัญชี 42-1103)` : ''} + ลงบัญชีทันที`} />
-                  )}
-                  {lateFee.gt(0) && <Effect text="ค่าปรับช่วงที่เกินมาแล้วถูกเก็บและปิดยอด — เริ่มนับใหม่จากดิวใหม่" />}
-                </>
-              )}
-              <Effect text={`เลื่อนวันครบกำหนดงวดที่ ${installmentNo} เป็นต้นไป +${days} วัน`} />
-              {splitMode === 'SPLIT' && fee.gt(0) && (
-                <Effect text={`ค่าธรรมเนียม ${fee.toFixed(2)} บาท บันทึกเป็นเงินรับล่วงหน้า (นำไปหักค่างวดถัดไปอัตโนมัติ)`} />
-              )}
-              {splitMode === 'SINGLE' && fee.gt(0) && (
-                <Effect text={`ค่าธรรมเนียม ${fee.toFixed(2)} บาท จดไว้ในโน้ตงวดนี้ — เก็บเพิ่มพร้อมค่างวดตอนรับชำระ`} warning />
-              )}
-              <Effect text={`บันทึก AuditLog (RESCHEDULE ${splitMode === 'SPLIT' ? '6a' : '6b'} + RESCHEDULE_COLLECT)`} />
-            </ul>
-          </Section>
-        </div>
-
-        {/* Footer */}
-        <div className="sticky bottom-0 bg-background/95 backdrop-blur-xs border-t px-6 py-4 flex items-center justify-end gap-3">
-          <button onClick={onClose} className="px-6 py-2.5 text-sm leading-snug border border-input rounded-lg hover:bg-muted transition-colors">
-            ยกเลิก
-          </button>
-          <button
-            onClick={submit}
-            disabled={!canSubmit}
-            className="px-6 py-2.5 text-sm leading-snug bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 disabled:opacity-50 font-semibold transition-colors shadow-sm"
-          >
-            {isPending
-              ? 'กำลังดำเนินการ...'
-              : method === 'QR' && hasCollect
-                ? 'ส่ง QR ให้ลูกค้า'
-                : hasCollect
-                  ? `เก็บเงิน ${collect.toFixed(2)} + ยืนยันปรับดิว`
-                  : 'ยืนยันปรับดิว'}
-          </button>
-        </div>
+            <Effect text={`เลื่อนวันครบกำหนดงวดที่ ${installmentNo} เป็นต้นไป +${days} วัน`} />
+            {splitMode === 'SPLIT' && fee.gt(0) && (
+              <Effect
+                text={`ค่าธรรมเนียม ${fee.toFixed(2)} บาท บันทึกเป็นเงินรับล่วงหน้า (นำไปหักค่างวดถัดไปอัตโนมัติ)`}
+              />
+            )}
+            {splitMode === 'SINGLE' && fee.gt(0) && (
+              <Effect
+                text={`ค่าธรรมเนียม ${fee.toFixed(2)} บาท จดไว้ในโน้ตงวดนี้ — เก็บเพิ่มพร้อมค่างวดตอนรับชำระ`}
+                warning
+              />
+            )}
+            <Effect
+              text={`บันทึก AuditLog (RESCHEDULE ${splitMode === 'SPLIT' ? '6a' : '6b'} + RESCHEDULE_COLLECT)`}
+            />
+          </ul>
+        </Section>
       </div>
-    </div>,
-    document.body,
+
+      {/* Footer */}
+      <div className="sticky bottom-0 bg-background/95 backdrop-blur-xs border-t px-6 py-4 flex items-center justify-end gap-3">
+        <button
+          onClick={onClose}
+          className="px-6 py-2.5 text-sm leading-snug border border-input rounded-lg hover:bg-muted transition-colors"
+        >
+          ยกเลิก
+        </button>
+        <button
+          onClick={submit}
+          disabled={!canSubmit}
+          className="px-6 py-2.5 text-sm leading-snug bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 disabled:opacity-50 font-semibold transition-colors shadow-sm"
+        >
+          {isPending
+            ? 'กำลังดำเนินการ...'
+            : method === 'QR' && hasCollect
+              ? 'ส่ง QR ให้ลูกค้า'
+              : hasCollect
+                ? `เก็บเงิน ${collect.toFixed(2)} + ยืนยันปรับดิว`
+                : 'ยืนยันปรับดิว'}
+        </button>
+      </div>
+    </WizardStackedOverlay>
   );
 }
 
@@ -454,11 +637,14 @@ function Section({
   tone?: 'primary' | 'success';
   children: React.ReactNode;
 }) {
-  const iconClass = tone === 'success' ? 'bg-success/10 text-success' : 'bg-primary/10 text-primary';
+  const iconClass =
+    tone === 'success' ? 'bg-success/10 text-success' : 'bg-primary/10 text-primary';
   return (
     <div className="rounded-xl border border-border bg-card p-5">
       <div className="flex items-center gap-2.5 mb-4">
-        <div className={`flex items-center justify-center size-8 rounded-lg ${iconClass}`}>{icon}</div>
+        <div className={`flex items-center justify-center size-8 rounded-lg ${iconClass}`}>
+          {icon}
+        </div>
         <div>
           <h3 className="text-sm font-semibold text-foreground leading-snug">{title}</h3>
           {subtitle && <p className="text-xs text-muted-foreground leading-snug">{subtitle}</p>}
@@ -473,7 +659,11 @@ function Row({ label, value, bold }: { label: string; value: string; bold?: bool
   return (
     <div className="flex justify-between items-baseline">
       <span className="text-muted-foreground leading-snug">{label}</span>
-      <span className={`leading-snug ${bold ? 'font-semibold text-foreground' : 'text-foreground'}`}>{value}</span>
+      <span
+        className={`leading-snug ${bold ? 'font-semibold text-foreground' : 'text-foreground'}`}
+      >
+        {value}
+      </span>
     </div>
   );
 }
@@ -538,7 +728,11 @@ function Effect({ text, warning }: { text: string; warning?: boolean }) {
   return (
     <li className="flex items-start gap-2">
       <span className={warning ? 'text-warning' : 'text-success'}>
-        {warning ? <AlertTriangle className="size-4 inline" /> : <Check className="size-4 inline" />}
+        {warning ? (
+          <AlertTriangle className="size-4 inline" />
+        ) : (
+          <Check className="size-4 inline" />
+        )}
       </span>
       <span className={warning ? 'text-warning' : 'text-foreground'}>{text}</span>
     </li>

--- a/package-lock.json
+++ b/package-lock.json
@@ -172,6 +172,7 @@
         "@radix-ui/react-context-menu": "^2.2.16",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
+        "@radix-ui/react-focus-scope": "^1.1.7",
         "@radix-ui/react-hover-card": "^1.1.15",
         "@radix-ui/react-label": "^2.1.8",
         "@radix-ui/react-navigation-menu": "^1.2.14",


### PR DESCRIPTION
## ปัญหา (owner-reported ระหว่างทดสอบปรับดิว)

1. **เลื่อน dialog ปรับดิวไม่ได้** — react-remove-scroll ของ wizard (modal Radix Dialog) preventDefault wheel/touchmove ที่ document สำหรับทุก event นอก DialogContent
2. **พิมพ์เลขอ้างอิงไม่ได้** — FocusScope ของ wizard ดึง focus กลับเข้า DialogContent ทุกครั้งที่ focus ออกไปที่ overlay (handleFocusOut ยิงจากฝั่ง dialog — stopPropagation ที่ overlay ครอบไม่ถึง)
3. **ไม่มีที่แนบสลิป** ในการเก็บเงินปรับดิวแบบโอนธนาคาร ทั้งที่ backend บังคับ slip-or-ref อยู่แล้ว

ข้อ 1-2 เป็นบั๊กตระกูลเดียวกับ pointer-events ที่แก้ใน 82f84065 — ครั้งที่ 3 ของ class เดียวกัน เลยแก้เชิงโครงสร้าง

## การแก้

- **NEW `WizardStackedOverlay`** — shell กลางรวม escape ทั้ง 3 ด้าน (pointer-events / scroll / focus) ใช้โดย overlay ปรับดิว + ปิดยอด + คืนเครื่อง; FocusScope ของ overlay pause trap ของ wizard ผ่าน Radix scope stack (verified กับ source @radix-ui/react-focus-scope@1.1.7)
- **แนบสลิปปรับดิว (โอนธนาคาร)** — บังคับ ref + slip เหมือน RecordPaymentWizard, `useSlipUpload` extract เป็น shared hook, slipUrl → evidenceUrl ลง AuditLog `RESCHEDULE_COLLECT` (เดิม validate แล้วทิ้ง)
- **ล้าง slip/ref เมื่อ quote เปลี่ยน** (เปลี่ยนจำนวนวัน / 6a↔6b) — หลักฐานผูกกับยอด ไม่ให้ติดข้าม quote
- **Nested FocusScope ให้ settlement dialog** ในปิดยอด — กัน Tab หลุดไปปุ่มยืนยันปิดสัญญาข้างใต้

## Tests

- ✅ NEW `RescheduleOverlay.test.tsx` — scroll + focus escapes ทดสอบกับ Radix Dialog จริงใน jsdom (two-step mount ตาม production ordering) + slip gating
- ✅ Web vitest 874/874, API reschedule-collect spec 8/8, tsc 0 ทั้งสองฝั่ง
- ✅ Code review 2 รอบ (0 Critical; warnings แก้แล้ว 3, follow-up: aria-hidden/role=dialog สำหรับ screen reader + standalone-mount test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)