### PR TITLE
payments: ช่องผู้อนุมัติยกเลิกใบเสร็จ + แท็บชำระครบ (+reschedule QA test follow-up)

### DIFF
--- a/apps/api/src/modules/payments/payments.pending-live-fee.spec.ts
+++ b/apps/api/src/modules/payments/payments.pending-live-fee.spec.ts
@@ -53,4 +53,48 @@ describe('PaymentQueryService — getPendingPayments live late fee', () => {
     const res = await service.getPendingPayments({});
     expect(lateFeeNum(res.data[0])).toBe(0);
   });
+
+  it('PAID installment keeps the STORED fee — never recomputed from now − dueDate (ชำระครบ tab)', async () => {
+    // Paid on time (charged fee = 0), viewed 30 days after the due date: a
+    // live recompute would fabricate a 5%-cap fee that was never collected.
+    const service = makeService([
+      { id: 'p4', status: 'PAID', dueDate: daysAgo(30), amountDue: D('3671'), amountPaid: D('3671'), lateFeeWaived: false, lateFee: D('0'), contract: {} },
+    ]);
+    const res = await service.getPendingPayments({ status: 'PAID' });
+    expect(lateFeeNum(res.data[0])).toBe(0);
+  });
+
+  it('PAID installment that DID pay a fee keeps that charged amount', async () => {
+    const service = makeService([
+      { id: 'p5', status: 'PAID', dueDate: daysAgo(60), amountDue: D('3671'), amountPaid: D('3731'), lateFeeWaived: false, lateFee: D('60'), contract: {} },
+    ]);
+    const res = await service.getPendingPayments({ status: 'PAID' });
+    expect(lateFeeNum(res.data[0])).toBe(60);
+  });
+
+  it('PAID + gross-waiver (PR #1313): returns the NET fee — gross stamp minus waivedAmount', async () => {
+    // Wizard waiver keeps lateFee at GROSS (Cr 42-1103) and books the discount
+    // in waivedAmount (Dr 52-1105). Fully waived → net 0, not a fake 100฿ "underpay".
+    const service = makeService([
+      { id: 'p6', status: 'PAID', dueDate: daysAgo(20), amountDue: D('3671'), amountPaid: D('3671'), lateFeeWaived: true, lateFee: D('100'), waivedAmount: D('100'), contract: {} },
+    ]);
+    const res = await service.getPendingPayments({ status: 'PAID' });
+    expect(lateFeeNum(res.data[0])).toBe(0);
+  });
+
+  it('PAID + partial waiver: net = gross − waived', async () => {
+    const service = makeService([
+      { id: 'p7', status: 'PAID', dueDate: daysAgo(20), amountDue: D('3671'), amountPaid: D('3731'), lateFeeWaived: true, lateFee: D('100'), waivedAmount: D('40'), contract: {} },
+    ]);
+    const res = await service.getPendingPayments({ status: 'PAID' });
+    expect(lateFeeNum(res.data[0])).toBe(60);
+  });
+
+  it('PAID + standalone waiver (lateFee already zeroed, waivedAmount set): clamps at 0, never negative', async () => {
+    const service = makeService([
+      { id: 'p8', status: 'PAID', dueDate: daysAgo(20), amountDue: D('3671'), amountPaid: D('3671'), lateFeeWaived: true, lateFee: D('0'), waivedAmount: D('100'), contract: {} },
+    ]);
+    const res = await service.getPendingPayments({ status: 'PAID' });
+    expect(lateFeeNum(res.data[0])).toBe(0);
+  });
 });

--- a/apps/api/src/modules/payments/services/payment-query.service.ts
+++ b/apps/api/src/modules/payments/services/payment-query.service.ts
@@ -307,9 +307,24 @@ export class PaymentQueryService {
     // value — that is the real charged fee on PAID installments.)
     const cfg = await loadLateFeeConfig(this.prisma);
     const now = new Date();
+    // PAID rows keep the STORED fee — that is the fee actually charged at
+    // record time. Recomputing from (now − dueDate) would show a fictitious
+    // fee on installments that were paid on time but are viewed after the
+    // due date (ชำระครบ tab, status=PAID queries).
+    //
+    // Waived rows must surface the NET fee the customer actually owed: the
+    // wizard's gross-waiver convention (PR #1313) keeps Payment.lateFee at
+    // GROSS (Cr 42-1103) and records the discount in waivedAmount (Dr
+    // 52-1105) — returning the gross fee would make the row read as an
+    // underpayment. Clamped at 0 because the standalone waiver flow zeroes
+    // lateFee AND sets waivedAmount, so an unclamped subtraction goes negative.
+    const netStoredFee = (p: { lateFee: Prisma.Decimal; lateFeeWaived: boolean; waivedAmount: Prisma.Decimal | null }) =>
+      p.lateFeeWaived
+        ? Prisma.Decimal.max(0, new Prisma.Decimal(p.lateFee).sub(p.waivedAmount ?? 0))
+        : p.lateFee;
     const withLiveFee = data.map((p) => ({
       ...p,
-      lateFee: resolveLivePaymentLateFee(p, cfg, now),
+      lateFee: p.status === 'PAID' ? netStoredFee(p) : resolveLivePaymentLateFee(p, cfg, now),
     }));
 
     return paginatedResponse(withLiveFee, total, page, limit);

--- a/apps/api/src/modules/receipts/receipts.service.spec.ts
+++ b/apps/api/src/modules/receipts/receipts.service.spec.ts
@@ -1,5 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { ForbiddenException } from '@nestjs/common';
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
 import { ReceiptsService } from './receipts.service';
 import { PrismaService } from '../../prisma/prisma.service';
 import { JournalAutoService } from '../journal/journal-auto.service';
@@ -49,6 +49,16 @@ describe('ReceiptsService', () => {
       receipt: {
         findUnique: jest.fn(),
         update: jest.fn(),
+      },
+      // Approver validation (SoD hardening): voidReceipt resolves the approver
+      // before the $transaction. Default = valid active FINANCE_MANAGER.
+      user: {
+        findUnique: jest.fn().mockResolvedValue({
+          id: approverId,
+          role: 'FINANCE_MANAGER',
+          isActive: true,
+          deletedAt: null,
+        }),
       },
       companyInfo: {
         findFirst: jest.fn().mockResolvedValue({ id: 'co-FINANCE' }),
@@ -357,6 +367,121 @@ describe('ReceiptsService', () => {
       await expect(
         service.voidReceipt(receiptId, 'wrong amount', userId, approverId),
       ).resolves.toBeDefined();
+    });
+
+    it('throws ForbiddenException when requester and approver are the same user (SoD)', async () => {
+      const tx = prisma.__tx;
+      setupHappyPath(tx);
+
+      await expect(
+        service.voidReceipt(receiptId, 'wrong amount', userId, userId, 'OWNER'),
+      ).rejects.toThrow(ForbiddenException);
+      expect(tx.auditLog.create).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('voidReceipt — approver validation (SoD hardening)', () => {
+    const setupHappyPath = (tx: any) => {
+      tx.receipt.findUnique.mockResolvedValue({
+        id: receiptId,
+        receiptNumber: 'RT-202604-00001',
+        contractId: 'ct-1',
+        paymentId: 'pay-1',
+        payerName: 'Customer A',
+        receiverName: 'Cashier',
+        amount: 1000,
+        installmentNo: 1,
+        paymentMethod: 'CASH',
+        isVoided: false,
+        deletedAt: null,
+        createdAt: new Date(),
+        paidDate: new Date(),
+      });
+      tx.receipt.create.mockResolvedValue({
+        id: 'cn-1',
+        receiptNumber: 'RT-202604-00002',
+        receiptType: 'CREDIT_NOTE',
+      });
+      tx.receipt.update.mockResolvedValue({ id: receiptId, isVoided: true });
+      tx.journalEntry.findMany.mockResolvedValue([]);
+    };
+
+    it('throws NotFoundException when the approver id does not exist', async () => {
+      const tx = prisma.__tx;
+      setupHappyPath(tx);
+      prisma.user.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.voidReceipt(receiptId, 'wrong amount', userId, 'ghost-user', 'OWNER'),
+      ).rejects.toThrow(NotFoundException);
+      expect(tx.auditLog.create).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFoundException when the approver is deactivated', async () => {
+      const tx = prisma.__tx;
+      setupHappyPath(tx);
+      prisma.user.findUnique.mockResolvedValue({
+        id: approverId,
+        role: 'OWNER',
+        isActive: false,
+        deletedAt: null,
+      });
+
+      await expect(
+        service.voidReceipt(receiptId, 'wrong amount', userId, approverId, 'OWNER'),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('throws NotFoundException when the approver is soft-deleted', async () => {
+      const tx = prisma.__tx;
+      setupHappyPath(tx);
+      prisma.user.findUnique.mockResolvedValue({
+        id: approverId,
+        role: 'OWNER',
+        isActive: true,
+        deletedAt: new Date(),
+      });
+
+      await expect(
+        service.voidReceipt(receiptId, 'wrong amount', userId, approverId, 'OWNER'),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('throws ForbiddenException when the approver role is SALES (not void-capable)', async () => {
+      const tx = prisma.__tx;
+      setupHappyPath(tx);
+      prisma.user.findUnique.mockResolvedValue({
+        id: approverId,
+        role: 'SALES',
+        isActive: true,
+        deletedAt: null,
+      });
+
+      await expect(
+        service.voidReceipt(receiptId, 'wrong amount', userId, approverId, 'OWNER'),
+      ).rejects.toThrow(ForbiddenException);
+      expect(tx.auditLog.create).not.toHaveBeenCalled();
+    });
+
+    it('accepts an active ACCOUNTANT approver and records them in the void trail', async () => {
+      const tx = prisma.__tx;
+      setupHappyPath(tx);
+      prisma.user.findUnique.mockResolvedValue({
+        id: approverId,
+        role: 'ACCOUNTANT',
+        isActive: true,
+        deletedAt: null,
+      });
+
+      await expect(
+        service.voidReceipt(receiptId, 'wrong amount', userId, approverId, 'OWNER'),
+      ).resolves.toBeDefined();
+
+      // Approver recorded on both the receipt row and the forensic audit log.
+      const updateCall = tx.receipt.update.mock.calls[0][0];
+      expect(updateCall.data.voidApprovedById).toBe(approverId);
+      const auditCall = tx.auditLog.create.mock.calls[0][0];
+      expect(auditCall.data.newValue.approvedById).toBe(approverId);
     });
   });
 

--- a/apps/api/src/modules/receipts/services/receipt-void.service.ts
+++ b/apps/api/src/modules/receipts/services/receipt-void.service.ts
@@ -69,6 +69,23 @@ export class ReceiptVoidService {
       );
     }
 
+    // The approver must be a real, active user with a void-capable role —
+    // otherwise the SoD control is client-side only and the forensic audit
+    // trail could reference a non-user. Mirrors late-fee-waiver /
+    // stock-adjustments approver validation.
+    const approver = await this.prisma.user.findUnique({
+      where: { id: approvedById },
+      select: { id: true, role: true, isActive: true, deletedAt: true },
+    });
+    if (!approver || approver.deletedAt || !approver.isActive) {
+      throw new NotFoundException('ไม่พบผู้อนุมัติ หรือถูกปิดการใช้งาน');
+    }
+    if (!ALLOWED_VOID_ROLES.includes(approver.role)) {
+      throw new ForbiddenException(
+        'ผู้อนุมัติต้องเป็นเจ้าของ / ฝ่ายบัญชี / ผจก.สาขา / ผจก.การเงิน',
+      );
+    }
+
     // CR-7: Validate void date is not in a closed (FINANCE) accounting period.
     await validatePeriodOpen(this.prisma, new Date(), await this.resolveFinanceCompanyId());
     return this.prisma.$transaction(async (tx) => {

--- a/apps/api/src/modules/users/users.controller.ts
+++ b/apps/api/src/modules/users/users.controller.ts
@@ -43,6 +43,20 @@ export class UsersController {
     return this.usersService.deleteSavedSignature(userId);
   }
 
+  /**
+   * Lean approver lookup for 4-eyes pickers (receipt void, late-fee waiver,
+   * expense approval, tolerance). GET /users is OWNER-only because findAll
+   * returns PII (nationalId, birthDate, phone) — this endpoint returns only
+   * { id, name, role } of active manager-role users so every role that can
+   * initiate an approval-gated action can load the list. Declared before
+   * `:id` routes so "approvers" never parses as a UUID.
+   */
+  @Get('approvers')
+  @Roles('OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'ACCOUNTANT', 'SALES')
+  findApprovers() {
+    return this.usersService.findApprovers();
+  }
+
   // ─── Admin user management (OWNER only) ────────────
   @Get()
   @Roles('OWNER')

--- a/apps/api/src/modules/users/users.service.spec.ts
+++ b/apps/api/src/modules/users/users.service.spec.ts
@@ -72,3 +72,53 @@ describe('UsersService.update — T7-C7 deactivation revokes refresh tokens', ()
     expect(prisma.refreshToken.updateMany).not.toHaveBeenCalled();
   });
 });
+
+describe('UsersService.findApprovers — lean 4-eyes approver lookup', () => {
+  let service: UsersService;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+
+  beforeEach(async () => {
+    prisma = {
+      user: {
+        findMany: jest.fn().mockResolvedValue([]),
+      },
+    };
+
+    const mod: TestingModule = await Test.createTestingModule({
+      providers: [
+        UsersService,
+        { provide: PrismaService, useValue: prisma },
+        { provide: AuditService, useValue: { log: jest.fn() } },
+        { provide: EmployeesService, useValue: { upsertProfileTx: jest.fn() } },
+      ],
+    }).compile();
+    service = mod.get(UsersService);
+  });
+
+  it('returns only active, non-deleted manager-role users with a PII-free select', async () => {
+    await service.findApprovers();
+
+    expect(prisma.user.findMany).toHaveBeenCalledTimes(1);
+    const arg = prisma.user.findMany.mock.calls[0][0];
+
+    // Role scoping: SALES (and VIEWER) must never appear in approver dropdowns.
+    expect(arg.where.role.in).toEqual(
+      expect.arrayContaining(['OWNER', 'FINANCE_MANAGER', 'BRANCH_MANAGER', 'ACCOUNTANT']),
+    );
+    expect(arg.where.role.in).not.toContain('SALES');
+    expect(arg.where.isActive).toBe(true);
+    expect(arg.where.deletedAt).toBeNull();
+
+    // The endpoint is exposed to every role — the select is the PII guard.
+    // GET /users stays OWNER-only precisely because findAll returns PII.
+    expect(arg.select).toEqual({ id: true, name: true, role: true });
+  });
+
+  it('hides system/service accounts from the approver list', async () => {
+    await service.findApprovers();
+
+    const arg = prisma.user.findMany.mock.calls[0][0];
+    expect(arg.where.email.notIn).toEqual(expect.arrayContaining(['legacy-import@bestchoice.com']));
+  });
+});

--- a/apps/api/src/modules/users/users.service.ts
+++ b/apps/api/src/modules/users/users.service.ts
@@ -22,6 +22,25 @@ export class UsersService {
     private employees: EmployeesService,
   ) {}
 
+  /**
+   * PII-free list of users who can act as a 4-eyes approver. Server-side
+   * filters mirror what every picker re-checks client-side (active + not
+   * deleted); role scoping here keeps SALES out of approver dropdowns even
+   * if a client forgets to filter.
+   */
+  async findApprovers() {
+    return this.prisma.user.findMany({
+      where: {
+        deletedAt: null,
+        isActive: true,
+        role: { in: [UserRole.OWNER, UserRole.FINANCE_MANAGER, UserRole.BRANCH_MANAGER, UserRole.ACCOUNTANT] },
+        email: { notIn: SYSTEM_USER_EMAILS },
+      },
+      select: { id: true, name: true, role: true },
+      orderBy: { name: 'asc' },
+    });
+  }
+
   async findAll(page = 1, limit = 50) {
     page = Math.max(1, page);
     limit = Math.min(200, Math.max(1, limit));

--- a/apps/web/src/components/expense-form-v4/ApproverSection.tsx
+++ b/apps/web/src/components/expense-form-v4/ApproverSection.tsx
@@ -17,13 +17,15 @@ const APPROVER_ROLES = ['OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT'];
 
 export function ApproverSection({ approvedById, onChange }: Props) {
   const { user } = useAuth();
-  // /users returns paginated { data, total, page, limit } — not a bare array.
-  // Backend findAll doesn't filter by role, so we filter client-side.
+  // /users/approvers is the lean PII-free approver lookup (GET /users is
+  // OWNER-only, so non-OWNER recorders used to get an empty list here). It
+  // returns a bare array of active manager-role users; keep the expense role
+  // subset filter client-side.
   const { data: approvers } = useQuery<UserRow[]>({
     queryKey: ['users', 'approvers'],
     queryFn: async () => {
-      const res = await api.get('/users?limit=200');
-      const list: UserRow[] = res.data?.data ?? (Array.isArray(res.data) ? res.data : []);
+      const res = await api.get('/users/approvers');
+      const list: UserRow[] = res.data ?? [];
       return list.filter((u) => APPROVER_ROLES.includes(u.role));
     },
     staleTime: 60_000,

--- a/apps/web/src/components/payment/ReceiptVoidDialog.tsx
+++ b/apps/web/src/components/payment/ReceiptVoidDialog.tsx
@@ -1,5 +1,5 @@
-import { useState } from 'react';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useEffect, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import api, { getErrorMessage } from '@/lib/api';
 import { toast } from 'sonner';
 import {
@@ -11,6 +11,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
+import { useAuth } from '@/contexts/AuthContext';
 
 interface Props {
   receiptId: string | null;
@@ -18,13 +19,55 @@ interface Props {
   onClose: () => void;
 }
 
+interface ApproverRow {
+  id: string;
+  name: string;
+  role: string;
+}
+
 export default function ReceiptVoidDialog({ receiptId, receiptNumber, onClose }: Props) {
   const queryClient = useQueryClient();
+  const { user } = useAuth();
   const [reason, setReason] = useState('');
+  const [approvedById, setApprovedById] = useState('');
+
+  // SoD (ปพพ.386 W-3): the void needs an independent approver — a different
+  // user from the requester. /users/approvers is the lean PII-free lookup
+  // accessible to every role that can void (OWNER / ACC / BM / FM).
+  const {
+    data: approverData = [],
+    isLoading: approversLoading,
+    isError: approversError,
+    refetch: refetchApprovers,
+  } = useQuery<ApproverRow[]>({
+    queryKey: ['void-approvers'],
+    queryFn: async () => {
+      const { data } = await api.get('/users/approvers');
+      return data ?? [];
+    },
+    enabled: !!receiptId,
+    staleTime: 60_000,
+  });
+  const approvers = approverData.filter((a) => a.id !== user?.id);
+
+  const resetForm = () => {
+    setReason('');
+    setApprovedById('');
+  };
+
+  // The parents close this dialog by flipping the controlled prop
+  // (setVoidTarget(null)) — Radix fires onOpenChange only for
+  // internally-initiated closes (Esc / overlay / X), so state must also
+  // reset when the target receipt changes or the form from a previous
+  // receipt survives into the next void.
+  useEffect(() => {
+    setReason('');
+    setApprovedById('');
+  }, [receiptId]);
 
   const voidMutation = useMutation({
     mutationFn: async (id: string) => {
-      const { data } = await api.post(`/receipts/${id}/void`, { reason });
+      const { data } = await api.post(`/receipts/${id}/void`, { reason, approvedById });
       return data;
     },
     onSuccess: () => {
@@ -32,7 +75,7 @@ export default function ReceiptVoidDialog({ receiptId, receiptNumber, onClose }:
       queryClient.invalidateQueries({ queryKey: ['receipts'] });
       queryClient.invalidateQueries({ queryKey: ['contract-receipts'] });
       queryClient.invalidateQueries({ queryKey: ['contract-payments'] });
-      setReason('');
+      resetForm();
       onClose();
     },
     onError: (err: unknown) => toast.error(getErrorMessage(err)),
@@ -43,7 +86,7 @@ export default function ReceiptVoidDialog({ receiptId, receiptNumber, onClose }:
       open={!!receiptId}
       onOpenChange={(open) => {
         if (!open) {
-          setReason('');
+          resetForm();
           onClose();
         }
       }}
@@ -56,24 +99,71 @@ export default function ReceiptVoidDialog({ receiptId, receiptNumber, onClose }:
             {receiptNumber ? <span className="font-mono"> {receiptNumber}</span> : ''}
           </DialogDescription>
         </DialogHeader>
-        <div className="space-y-2">
-          <label className="text-sm font-medium text-foreground">เหตุผลที่ยกเลิก</label>
-          <textarea
-            value={reason}
-            onChange={(e) => setReason(e.target.value)}
-            placeholder="เช่น ลูกค้าโอนผิดบัญชี, บันทึกผิด..."
-            rows={3}
-            className="w-full px-3 py-2 border border-input rounded-lg text-sm bg-background"
-          />
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <label className="text-sm font-medium text-foreground leading-snug">
+              เหตุผลที่ยกเลิก <span className="text-destructive">*</span>
+            </label>
+            <textarea
+              value={reason}
+              onChange={(e) => setReason(e.target.value)}
+              placeholder="เช่น ลูกค้าโอนผิดบัญชี, บันทึกผิด..."
+              rows={3}
+              className="w-full px-3 py-2 border border-input rounded-lg text-sm bg-background"
+            />
+          </div>
+          <div className="space-y-2">
+            <label htmlFor="void-approver" className="text-sm font-medium text-foreground leading-snug">
+              ผู้อนุมัติการยกเลิก <span className="text-destructive">*</span>
+            </label>
+            <select
+              id="void-approver"
+              value={approvedById}
+              onChange={(e) => setApprovedById(e.target.value)}
+              className="w-full px-3 py-2 border border-input rounded-lg text-sm bg-background"
+            >
+              <option value="">— เลือกผู้อนุมัติ —</option>
+              {approvers.map((a) => (
+                <option key={a.id} value={a.id}>
+                  {a.name} ({a.role})
+                </option>
+              ))}
+            </select>
+            {approversLoading ? (
+              <p className="text-xs text-muted-foreground leading-snug">กำลังโหลดรายชื่อผู้อนุมัติ...</p>
+            ) : approversError ? (
+              <p className="text-xs text-destructive leading-snug">
+                โหลดรายชื่อผู้อนุมัติไม่สำเร็จ{' '}
+                <button type="button" onClick={() => refetchApprovers()} className="underline">
+                  ลองใหม่
+                </button>
+              </p>
+            ) : approvers.length === 0 ? (
+              <p className="text-xs text-destructive leading-snug">
+                ไม่มีผู้อนุมัติที่ใช้ได้ — ต้องมีเจ้าของ / ฝ่ายบัญชี / ผจก.สาขา / ผจก.การเงิน คนอื่นที่ไม่ใช่ตัวคุณเอง
+              </p>
+            ) : (
+              <p className="text-xs text-muted-foreground leading-snug">
+                ผู้อนุมัติต้องเป็นคนละคนกับผู้ทำรายการ (Segregation of Duties)
+              </p>
+            )}
+          </div>
         </div>
         <DialogFooter className="gap-2 sm:gap-0">
-          <Button variant="outline" onClick={onClose} disabled={voidMutation.isPending}>
+          <Button
+            variant="outline"
+            onClick={() => {
+              resetForm();
+              onClose();
+            }}
+            disabled={voidMutation.isPending}
+          >
             ปิด
           </Button>
           <Button
             variant="destructive"
             onClick={() => receiptId && voidMutation.mutate(receiptId)}
-            disabled={!reason.trim() || voidMutation.isPending}
+            disabled={!reason.trim() || !approvedById || voidMutation.isPending}
           >
             {voidMutation.isPending ? 'กำลังยกเลิก...' : 'ยืนยันยกเลิก'}
           </Button>

--- a/apps/web/src/components/payment/__tests__/ReceiptVoidDialog.test.tsx
+++ b/apps/web/src/components/payment/__tests__/ReceiptVoidDialog.test.tsx
@@ -1,0 +1,147 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import ReceiptVoidDialog from '../ReceiptVoidDialog';
+
+/**
+ * Regression: PR #780 (ปพพ.386 Wave 3 T2) made `approvedById` required on
+ * POST /receipts/:id/void, but this dialog kept sending only { reason } —
+ * every void 400'd with "กรุณาระบุผู้อนุมัติการยกเลิก" and there was no field
+ * to fill. The dialog must collect an independent approver (SoD) and send it.
+ */
+
+const apiGet = vi.fn();
+const apiPost = vi.fn();
+
+vi.mock('@/lib/api', () => ({
+  default: {
+    get: (...args: unknown[]) => apiGet(...args),
+    post: (...args: unknown[]) => apiPost(...args),
+  },
+  getErrorMessage: (e: unknown) => String(e),
+}));
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => ({
+    user: { id: 'u-me', name: 'ฉันเอง', role: 'ACCOUNTANT' },
+    isLoading: false,
+    isAuthenticated: true,
+  }),
+}));
+
+const APPROVERS = [
+  { id: 'u-me', name: 'ฉันเอง', role: 'ACCOUNTANT' },
+  { id: 'u-boss', name: 'เจ้าของร้าน', role: 'OWNER' },
+];
+
+function wrap(ui: React.ReactElement) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  apiGet.mockResolvedValue({ data: APPROVERS });
+  apiPost.mockResolvedValue({ data: { creditNote: { id: 'cn-1' } } });
+});
+
+describe('ReceiptVoidDialog — SoD approver field', () => {
+  it('loads approvers from /users/approvers and excludes the current user (SoD)', async () => {
+    render(wrap(<ReceiptVoidDialog receiptId="r-1" receiptNumber="RT-202607-00007" onClose={vi.fn()} />));
+
+    await waitFor(() => expect(apiGet).toHaveBeenCalledWith('/users/approvers'));
+
+    const select = await screen.findByLabelText(/ผู้อนุมัติการยกเลิก/);
+    const options = Array.from((select as HTMLSelectElement).options).map((o) => o.value);
+    expect(options).toContain('u-boss');
+    expect(options).not.toContain('u-me');
+  });
+
+  it('keeps ยืนยันยกเลิก disabled until BOTH reason and approver are filled', async () => {
+    render(wrap(<ReceiptVoidDialog receiptId="r-1" onClose={vi.fn()} />));
+
+    const submit = screen.getByRole('button', { name: 'ยืนยันยกเลิก' });
+    expect(submit).toBeDisabled();
+
+    fireEvent.change(screen.getByPlaceholderText(/ลูกค้าโอนผิดบัญชี/), {
+      target: { value: 'บันทึกผิด' },
+    });
+    expect(submit).toBeDisabled(); // reason alone is not enough
+
+    // Wait for the approver options to load — a native <select> silently
+    // ignores a change to a value that has no matching <option> yet.
+    await screen.findByRole('option', { name: /เจ้าของร้าน/ });
+    fireEvent.change(screen.getByLabelText(/ผู้อนุมัติการยกเลิก/), {
+      target: { value: 'u-boss' },
+    });
+    expect(submit).not.toBeDisabled();
+  });
+
+  it('POSTs reason + approvedById to /receipts/:id/void', async () => {
+    const onClose = vi.fn();
+    render(wrap(<ReceiptVoidDialog receiptId="r-1" onClose={onClose} />));
+
+    fireEvent.change(screen.getByPlaceholderText(/ลูกค้าโอนผิดบัญชี/), {
+      target: { value: 'บันทึกผิด' },
+    });
+    await screen.findByRole('option', { name: /เจ้าของร้าน/ });
+    fireEvent.change(screen.getByLabelText(/ผู้อนุมัติการยกเลิก/), {
+      target: { value: 'u-boss' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'ยืนยันยกเลิก' }));
+
+    await waitFor(() =>
+      expect(apiPost).toHaveBeenCalledWith('/receipts/r-1/void', {
+        reason: 'บันทึกผิด',
+        approvedById: 'u-boss',
+      }),
+    );
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+  });
+
+  it('warns when there is no eligible approver (only the current user has a manager role)', async () => {
+    apiGet.mockResolvedValue({ data: [{ id: 'u-me', name: 'ฉันเอง', role: 'ACCOUNTANT' }] });
+    render(wrap(<ReceiptVoidDialog receiptId="r-1" onClose={vi.fn()} />));
+
+    expect(await screen.findByText(/ไม่มีผู้อนุมัติที่ใช้ได้/)).toBeInTheDocument();
+  });
+
+  it('shows a loading hint (NOT the no-approver warning) while the list is fetching', async () => {
+    let resolve!: (v: { data: typeof APPROVERS }) => void;
+    apiGet.mockReturnValue(new Promise((r) => (resolve = r)));
+    render(wrap(<ReceiptVoidDialog receiptId="r-1" onClose={vi.fn()} />));
+
+    expect(screen.getByText(/กำลังโหลดรายชื่อผู้อนุมัติ/)).toBeInTheDocument();
+    expect(screen.queryByText(/ไม่มีผู้อนุมัติที่ใช้ได้/)).not.toBeInTheDocument();
+
+    resolve({ data: APPROVERS });
+    await screen.findByRole('option', { name: /เจ้าของร้าน/ });
+  });
+
+  it('resets stale reason/approver when the dialog is reopened for a different receipt', async () => {
+    // Parents close via setVoidTarget(null) — an external controlled-prop
+    // flip Radix does NOT report through onOpenChange — so the reset must
+    // happen on receiptId change, or RT-A's reason+approver survive into
+    // RT-B's void and ยืนยันยกเลิก is instantly clickable.
+    const { rerender } = render(wrap(<ReceiptVoidDialog receiptId="r-1" onClose={vi.fn()} />));
+
+    fireEvent.change(screen.getByPlaceholderText(/ลูกค้าโอนผิดบัญชี/), {
+      target: { value: 'เหตุผลของใบแรก' },
+    });
+    await screen.findByRole('option', { name: /เจ้าของร้าน/ });
+    fireEvent.change(screen.getByLabelText(/ผู้อนุมัติการยกเลิก/), {
+      target: { value: 'u-boss' },
+    });
+
+    rerender(wrap(<ReceiptVoidDialog receiptId={null} onClose={vi.fn()} />));
+    rerender(wrap(<ReceiptVoidDialog receiptId="r-2" onClose={vi.fn()} />));
+
+    expect(screen.getByPlaceholderText(/ลูกค้าโอนผิดบัญชี/)).toHaveValue('');
+    expect(screen.getByLabelText(/ผู้อนุมัติการยกเลิก/)).toHaveValue('');
+    expect(screen.getByRole('button', { name: 'ยืนยันยกเลิก' })).toBeDisabled();
+  });
+});

--- a/apps/web/src/pages/PaymentsPage/__tests__/invalidatePaymentQueries.test.ts
+++ b/apps/web/src/pages/PaymentsPage/__tests__/invalidatePaymentQueries.test.ts
@@ -17,5 +17,7 @@ describe('invalidatePaymentQueries', () => {
     // Existing invalidations preserved.
     expect(keys).toContain('pending-payments');
     expect(keys).toContain('daily-summary');
+    // ชำระครบ tab must refresh when a payment posts (PENDING → PAID moves rows).
+    expect(keys).toContain('paid-payments');
   });
 });

--- a/apps/web/src/pages/PaymentsPage/components/PaymentFilters.tsx
+++ b/apps/web/src/pages/PaymentsPage/components/PaymentFilters.tsx
@@ -9,6 +9,8 @@ interface PaymentFiltersProps {
   branches: { id: string; name: string }[];
   onExport: () => void;
   hasPendingPayments: boolean;
+  /** ชำระครบ tab pins status=PAID server-side — the pending-status dropdown is meaningless there. */
+  showStatusFilter?: boolean;
 }
 
 export default function PaymentFilters({
@@ -22,6 +24,7 @@ export default function PaymentFilters({
   branches,
   onExport,
   hasPendingPayments,
+  showStatusFilter = true,
 }: PaymentFiltersProps) {
   return (
     <div className="bg-card rounded-xl border border-border/50 p-4 mb-5 shadow-sm">
@@ -36,16 +39,18 @@ export default function PaymentFilters({
             className="w-full pl-9 pr-3 py-2 border border-input rounded-lg text-sm bg-background outline-hidden focus:ring-2 focus:ring-ring/30"
           />
         </div>
-        <select
-          value={statusFilter}
-          onChange={(e) => onStatusFilterChange(e.target.value)}
-          className="px-3 py-2 border border-input rounded-lg text-sm bg-background outline-hidden focus:ring-2 focus:ring-ring/30"
-        >
-          <option value="">ทุกสถานะ</option>
-          <option value="PENDING">รอชำระ</option>
-          <option value="OVERDUE">เกินกำหนด</option>
-          <option value="PARTIALLY_PAID">ชำระบางส่วน</option>
-        </select>
+        {showStatusFilter && (
+          <select
+            value={statusFilter}
+            onChange={(e) => onStatusFilterChange(e.target.value)}
+            className="px-3 py-2 border border-input rounded-lg text-sm bg-background outline-hidden focus:ring-2 focus:ring-ring/30"
+          >
+            <option value="">ทุกสถานะ</option>
+            <option value="PENDING">รอชำระ</option>
+            <option value="OVERDUE">เกินกำหนด</option>
+            <option value="PARTIALLY_PAID">ชำระบางส่วน</option>
+          </select>
+        )}
         {isOwner && (
           <select
             value={branchFilter}

--- a/apps/web/src/pages/PaymentsPage/components/PaymentTable.tsx
+++ b/apps/web/src/pages/PaymentsPage/components/PaymentTable.tsx
@@ -21,6 +21,8 @@ interface PaymentTableProps {
   batchTotal: number;
   onShowBatchModal: () => void;
   onClearSelection: () => void;
+  /** 'paid' = ชำระครบ tab — read-only rows: no checkbox/batch/รับชำระ, shows paidDate. */
+  mode?: 'pending' | 'paid';
 }
 
 export default function PaymentTable({
@@ -33,10 +35,13 @@ export default function PaymentTable({
   batchTotal,
   onShowBatchModal,
   onClearSelection,
+  mode = 'pending',
 }: PaymentTableProps) {
   const { copy } = useCopyToClipboard();
+  const isPaidMode = mode === 'paid';
   const pendingColumns = useMemo(() => [
-    {
+    // ชำระครบ tab is read-only — no batch selection.
+    ...(isPaidMode ? [] : [{
       key: 'select',
       label: '',
       render: (p: PendingPayment) => (
@@ -48,7 +53,7 @@ export default function PaymentTable({
           aria-label={`เลือกงวดที่ ${p.installmentNo} ของสัญญา ${p.contract.contractNumber}`}
         />
       ),
-    },
+    }]),
     {
       key: 'contract',
       label: 'สัญญา',
@@ -70,9 +75,18 @@ export default function PaymentTable({
     },
     { key: 'installmentNo', label: 'งวดที่', render: (p: PendingPayment) => <span className="font-medium">{p.installmentNo}</span> },
     { key: 'dueDate', label: 'วันครบกำหนด', render: (p: PendingPayment) => {
-      const isOverdue = new Date(p.dueDate) < new Date();
+      // A settled installment is never "overdue" — the red flag is pending-only.
+      const isOverdue = !isPaidMode && new Date(p.dueDate) < new Date();
       return <span className={`text-sm ${isOverdue ? 'text-destructive font-medium' : ''}`}>{formatDateShort(p.dueDate)}</span>;
     }},
+    ...(isPaidMode ? [{
+      key: 'paidDate',
+      label: 'วันที่ชำระ',
+      render: (p: PendingPayment) =>
+        p.paidDate
+          ? <span className="text-sm text-success font-medium">{formatDateShort(p.paidDate)}</span>
+          : <span className="text-xs text-muted-foreground">-</span>,
+    }] : []),
     { key: 'amountDue', label: 'ยอดที่ต้องชำระ', render: (p: PendingPayment) => {
       const total = parseFloat(p.amountDue) + parseFloat(p.lateFee);
       return <span className="text-sm font-medium">{total.toLocaleString()} ฿</span>;
@@ -101,9 +115,17 @@ export default function PaymentTable({
           const cfg = getStatusBadgeProps(p.status, paymentStatusMap);
           mainBadge = <Badge variant={cfg.variant} appearance={cfg.appearance} size="sm">{cfg.label}</Badge>;
         }
+        // Settlement-method stamps (paid mode): explain why ชำระแล้ว can be
+        // partial or '-' on a PAID row — the record flows stamp notes with
+        // '[ปิดก่อนกำหนด]' (early payoff, discount closes the rest) and
+        // 'ใช้เครดิต X บาท' (advance credit consumed, no new cash on this row).
+        const closedEarly = isPaidMode && p.notes?.includes('ปิดก่อนกำหนด');
+        const usedCredit = isPaidMode && p.notes?.includes('ใช้เครดิต');
         return (
-          <div>
+          <div className="flex flex-col gap-1 items-start">
             {mainBadge}
+            {closedEarly && <Badge variant="secondary" appearance="outline" size="sm">ปิดยอดก่อนกำหนด</Badge>}
+            {usedCredit && <Badge variant="secondary" appearance="outline" size="sm">หักจากเครดิตล่วงหน้า</Badge>}
             {/* Active partial-payment QR (cashier sent QR earlier, awaiting customer scan) */}
             {p.status !== 'PAID' && <QrSentBadge paymentId={p.id} />}
           </div>
@@ -116,34 +138,36 @@ export default function PaymentTable({
       label: '',
       render: (p: PendingPayment) => (
         <div className="flex gap-1">
-          <button onClick={() => onOpenPayModal(p)} className="px-2 py-1 text-xs bg-success text-success-foreground rounded hover:bg-success/90">
-            รับชำระ
-          </button>
+          {!isPaidMode && (
+            <button onClick={() => onOpenPayModal(p)} className="px-2 py-1 text-xs bg-success text-success-foreground rounded hover:bg-success/90">
+              รับชำระ
+            </button>
+          )}
           <button onClick={() => onViewHistory(p.contract.id)} className="px-2 py-1 text-xs border border-muted-foreground/30 text-muted-foreground rounded hover:bg-muted">
             ประวัติ
           </button>
         </div>
       ),
     },
-  ], [onOpenPayModal, onViewHistory, selectedIds, onToggleSelect, copy]);
+  ], [onOpenPayModal, onViewHistory, selectedIds, onToggleSelect, copy, isPaidMode]);
 
   return (
     <>
       <Card>
         <CardHeader>
-          <CardTitle>รายการรอชำระ</CardTitle>
+          <CardTitle>{isPaidMode ? 'รายการชำระครบ' : 'รายการรอชำระ'}</CardTitle>
         </CardHeader>
         <CardContent className="p-0">
           {loadingPending ? (
             <div className="flex items-center justify-center py-12"><div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div></div>
           ) : (
-            <DataTable columns={pendingColumns} data={pendingPayments} emptyMessage="ไม่มีรายการรอชำระ" />
+            <DataTable columns={pendingColumns} data={pendingPayments} emptyMessage={isPaidMode ? 'ไม่มีรายการชำระครบในช่วงที่เลือก' : 'ไม่มีรายการรอชำระ'} />
           )}
         </CardContent>
       </Card>
 
       {/* Batch action bar */}
-      {selectedIds.size > 0 && (
+      {!isPaidMode && selectedIds.size > 0 && (
         <div className="fixed bottom-4 left-1/2 -translate-x-1/2 bg-primary text-primary-foreground px-6 py-3 rounded-xl shadow-lg flex items-center gap-4 z-50">
           <span className="text-sm font-medium">เลือก {selectedIds.size} รายการ ({Math.round(batchTotal).toLocaleString()} ฿)</span>
           <button onClick={onShowBatchModal} className="px-4 py-1.5 bg-card text-primary rounded-lg text-sm font-medium hover:bg-card/90">

--- a/apps/web/src/pages/PaymentsPage/components/RecordPaymentWizard.tsx
+++ b/apps/web/src/pages/PaymentsPage/components/RecordPaymentWizard.tsx
@@ -293,8 +293,6 @@ interface ApproverRow {
   id: string;
   name: string;
   role: string;
-  isActive?: boolean;
-  deletedAt?: string | null;
 }
 
 // ─── JE Preview panel (always visible) ────────────────────────────────────────
@@ -741,12 +739,14 @@ export function RecordPaymentWizard({
   const needsApproval = approvalActions.length > 0;
 
   // 4-eyes approver list — managers other than the current user (SoD).
+  // /users/approvers is the lean PII-free lookup (GET /users is OWNER-only,
+  // so non-OWNER recorders used to get an empty list here). Server already
+  // filters to active manager roles; keep the waiver role subset + SoD here.
   const { data: approverData = [] } = useQuery<ApproverRow[]>({
     queryKey: ['waiver-approvers'],
     queryFn: async () => {
-      const { data } = await api.get('/users?limit=200');
-      const list: ApproverRow[] = data?.data ?? data ?? [];
-      return list;
+      const { data } = await api.get('/users/approvers');
+      return data ?? [];
     },
     staleTime: 60_000,
   });
@@ -755,9 +755,7 @@ export function RecordPaymentWizard({
       approverData.filter(
         (u) =>
           WAIVER_APPROVER_ROLES.includes(u.role) &&
-          u.id !== user?.id && // 4-eyes: approver ≠ recorder
-          u.isActive !== false &&
-          !u.deletedAt, // exclude inactive/soft-deleted (server rejects them anyway)
+          u.id !== user?.id, // 4-eyes: approver ≠ recorder
       ),
     [approverData, user?.id],
   );

--- a/apps/web/src/pages/PaymentsPage/components/__tests__/PaymentTable.paid-mode.test.tsx
+++ b/apps/web/src/pages/PaymentsPage/components/__tests__/PaymentTable.paid-mode.test.tsx
@@ -1,0 +1,120 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import PaymentTable from '../PaymentTable';
+import type { PendingPayment } from '../../types';
+
+// QrSentBadge (rendered on non-PAID rows) queries active partial-payment links.
+vi.mock('@/lib/api', () => ({
+  default: { get: vi.fn(() => Promise.resolve({ data: [] })) },
+  getErrorMessage: (e: unknown) => String(e),
+}));
+
+/**
+ * ชำระครบ tab renders the same table in mode="paid": read-only rows — no batch
+ * checkbox, no รับชำระ button, a วันที่ชำระ column, and no overdue-red on the
+ * due date (a settled installment is never "overdue").
+ */
+
+function makePayment(overrides: Partial<PendingPayment> = {}): PendingPayment {
+  return {
+    id: 'pay-1',
+    installmentNo: 3,
+    dueDate: '2026-06-05T00:00:00.000Z', // past date
+    amountDue: '1515.83',
+    amountPaid: '1515.83',
+    lateFee: '0',
+    status: 'PAID',
+    paidDate: '2026-06-04T10:00:00.000Z',
+    monthlyPrincipal: null,
+    monthlyInterest: null,
+    monthlyCommission: null,
+    vatAmount: null,
+    contract: {
+      id: 'ct-1',
+      contractNumber: 'CT-2026-0001',
+      totalMonths: 12,
+      monthlyPayment: '1515.83',
+      advanceBalance: '0',
+      customer: { id: 'cus-1', name: 'ลูกค้า ก', phone: '0812345678' },
+      branch: { id: 'br-1', name: 'ลาดพร้าว' },
+    },
+    ...overrides,
+  };
+}
+
+const noop = () => {};
+
+function renderTable(mode: 'pending' | 'paid', payments: PendingPayment[]) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <PaymentTable
+        mode={mode}
+        pendingPayments={payments}
+        loadingPending={false}
+        selectedIds={new Set()}
+        onToggleSelect={noop}
+        onToggleAll={noop}
+        onOpenPayModal={vi.fn()}
+        onViewHistory={vi.fn()}
+        batchTotal={0}
+        onShowBatchModal={noop}
+        onClearSelection={noop}
+      />
+    </QueryClientProvider>,
+  );
+}
+
+describe('PaymentTable — mode="paid" (ชำระครบ tab)', () => {
+  it('hides the batch checkbox and รับชำระ button; keeps ประวัติ', () => {
+    renderTable('paid', [makePayment()]);
+
+    expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'รับชำระ' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'ประวัติ' })).toBeInTheDocument();
+  });
+
+  it('shows the วันที่ชำระ column and the paid-tab title', () => {
+    renderTable('paid', [makePayment()]);
+
+    expect(screen.getByText('วันที่ชำระ')).toBeInTheDocument();
+    expect(screen.getByText('รายการชำระครบ')).toBeInTheDocument();
+  });
+
+  it('does NOT paint a past due date as overdue-red for settled rows', () => {
+    const { container } = renderTable('paid', [makePayment()]);
+
+    // In pending mode a past dueDate gets text-destructive; a PAID row must not.
+    const destructiveDates = Array.from(container.querySelectorAll('.text-destructive'));
+    expect(destructiveDates.map((el) => el.textContent)).not.toContain('5 มิ.ย. 2569');
+  });
+
+  it('pending mode still shows checkbox + รับชำระ (regression guard)', () => {
+    renderTable('pending', [makePayment({ status: 'PENDING', amountPaid: '0', paidDate: null })]);
+
+    expect(screen.getByRole('checkbox')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'รับชำระ' })).toBeInTheDocument();
+    expect(screen.queryByText('วันที่ชำระ')).not.toBeInTheDocument();
+  });
+
+  it('labels early-payoff rows (notes "[ปิดก่อนกำหนด]") so a partial ชำระแล้ว is explained', () => {
+    renderTable('paid', [makePayment({ amountPaid: '900', notes: '[ปิดก่อนกำหนด]' })]);
+
+    expect(screen.getByText('ปิดยอดก่อนกำหนด')).toBeInTheDocument();
+  });
+
+  it('labels advance-credit rows (notes "ใช้เครดิต ... บาท")', () => {
+    renderTable('paid', [makePayment({ amountPaid: '0', notes: 'ใช้เครดิต 1,515.83 บาท' })]);
+
+    expect(screen.getByText('หักจากเครดิตล่วงหน้า')).toBeInTheDocument();
+  });
+
+  it('does NOT show settlement badges in pending mode even when notes match', () => {
+    renderTable('pending', [
+      makePayment({ status: 'PENDING', amountPaid: '0', paidDate: null, notes: '[ปิดก่อนกำหนด]' }),
+    ]);
+
+    expect(screen.queryByText('ปิดยอดก่อนกำหนด')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/pages/PaymentsPage/components/__tests__/RescheduleOverlay.test.tsx
+++ b/apps/web/src/pages/PaymentsPage/components/__tests__/RescheduleOverlay.test.tsx
@@ -102,6 +102,16 @@ function mockHappyApi({
     if (url.endsWith('/reschedule-qr')) {
       return Promise.resolve({ data: qrResponse });
     }
+    if (url === '/shop/upload/signed-url') {
+      return Promise.resolve({
+        data: {
+          uploadUrl: 'https://s3.test/put',
+          method: 'PUT',
+          key: 'slips/slip-1.jpg',
+          publicUrl: 'https://cdn.test/slips/slip-1.jpg',
+        },
+      });
+    }
     return Promise.resolve({ data: { id: 'payment-1' } });
   });
 }
@@ -246,8 +256,10 @@ describe('RescheduleOverlay', () => {
     );
   });
 
-  it('TRANSFER with empty ref: submit disabled until เลขอ้างอิง is filled, then posts BANK_TRANSFER + transactionRef', async () => {
+  it('TRANSFER: submit disabled until BOTH เลขอ้างอิง and slip are provided, then posts BANK_TRANSFER + transactionRef + slipUrl', async () => {
     mockHappyApi({ singleQuote: QUOTE_LATE_FEE_ONLY });
+    // Presigned S3 PUT goes through raw fetch (not the api client).
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({ ok: true } as Response);
     const user = userEvent.setup();
     renderOverlay();
 
@@ -258,6 +270,13 @@ describe('RescheduleOverlay', () => {
     expect(submitBtn).toBeDisabled();
 
     await user.type(screen.getByPlaceholderText('เลขอ้างอิงจากสลิปโอนเงิน'), 'TX-12345');
+    // ref alone is not enough — แนบสลิป is also required (needSlip)
+    expect(submitBtn).toBeDisabled();
+
+    await user.upload(
+      screen.getByLabelText('อัปโหลดสลิป'),
+      new File(['slip'], 'slip.jpg', { type: 'image/jpeg' }),
+    );
     await waitFor(() => expect(submitBtn).toBeEnabled());
     await user.click(submitBtn);
 
@@ -266,8 +285,10 @@ describe('RescheduleOverlay', () => {
     expect(payload).toMatchObject({
       paymentMethod: 'BANK_TRANSFER',
       transactionRef: 'TX-12345',
+      slipUrl: 'https://cdn.test/slips/slip-1.jpg',
       amount: 75.79,
     });
+    fetchSpy.mockRestore();
   });
 
   it('QR method + collect: POSTs /payments/{paymentId}/reschedule-qr and shows ส่ง QR success toast', async () => {

--- a/apps/web/src/pages/PaymentsPage/index.tsx
+++ b/apps/web/src/pages/PaymentsPage/index.tsx
@@ -36,8 +36,8 @@ export default function PaymentsPage() {
   const isOwner = user?.role === 'OWNER';
   const canSeeReceipts = user && ['OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'ACCOUNTANT'].includes(user.role);
   const [searchParams, setSearchParams] = useSearchParams();
-  const tab = (searchParams.get('tab') || 'pending') as 'pending' | 'summary' | 'slip-review' | 'receipts';
-  const setTab = (value: 'pending' | 'summary' | 'slip-review' | 'receipts') => setSearchParams({ tab: value });
+  const tab = (searchParams.get('tab') || 'pending') as 'pending' | 'paid' | 'summary' | 'slip-review' | 'receipts';
+  const setTab = (value: 'pending' | 'paid' | 'summary' | 'slip-review' | 'receipts') => setSearchParams({ tab: value });
 
   // Redirect SALES users away from receipts tab (no permission)
   useEffect(() => {
@@ -154,6 +154,38 @@ export default function PaymentsPage() {
     enabled: tab === 'pending',
   });
 
+  // ชำระครบ tab — same endpoint/filters as the pending queue but pinned to
+  // status=PAID (the endpoint's status param overrides the default
+  // PENDING/OVERDUE/PARTIALLY_PAID set). Server keeps the STORED (net-of-
+  // waiver) late fee for PAID rows — the fee actually charged, not a live
+  // recompute. Unlike the shrinking pending queue, the paid set grows all
+  // month, so ask for the service max (100) and keep `total` to surface
+  // truncation instead of silently dropping rows.
+  const {
+    data: paidResult,
+    isLoading: loadingPaid,
+    isError: paidError,
+    error: paidErrorDetail,
+    refetch: refetchPaid,
+  } = useQuery<{ rows: PendingPayment[]; total: number }>({
+    queryKey: ['paid-payments', debouncedSearch, branchFilter, dueFrom, dueTo],
+    queryFn: async () => {
+      const params = new URLSearchParams();
+      params.set('status', 'PAID');
+      params.set('limit', '100');
+      if (debouncedSearch) params.set('search', debouncedSearch);
+      if (branchFilter) params.set('branchId', branchFilter);
+      if (dueFrom) params.set('dueFrom', dueFrom);
+      if (dueTo) params.set('dueTo', dueTo);
+      const { data } = await api.get(`/payments/pending?${params}`);
+      return { rows: data.data ?? [], total: data.total ?? (data.data?.length || 0) };
+    },
+    enabled: tab === 'paid',
+  });
+  const paidPayments = paidResult?.rows ?? [];
+  const paidTotal = paidResult?.total ?? 0;
+  const paidTruncated = paidTotal > paidPayments.length;
+
   // Whole-system KPI summary (6 cards) — scoped by the same dueDate window +
   // branch as the queue, but NOT page-limited.
   const { data: pendingKpi, isLoading: loadingKpi } = useQuery<PendingSummary>({
@@ -241,8 +273,10 @@ export default function PaymentsPage() {
     },
     onSuccess: (data) => {
       toast.success(`รับชำระสำเร็จ ${data.length} รายการ`);
-      queryClient.invalidateQueries({ queryKey: ['pending-payments'] });
-      queryClient.invalidateQueries({ queryKey: ['daily-summary'] });
+      // Same helper as recordMutation/postDraftMutation — batch flips rows
+      // PENDING→PAID too, so 'paid-payments' + per-contract history caches
+      // must refresh (3-min staleTime otherwise serves the old list).
+      invalidatePaymentQueries(queryClient);
       setSelectedIds(new Set());
       setShowBatchModal(false);
       setBatchSlipResult(null);
@@ -304,6 +338,49 @@ export default function PaymentsPage() {
       filename: `pending-payments-${toLocalDateString()}.xlsx`,
     });
     toast.success('ส่งออก Excel สำเร็จ');
+  };
+
+  // ชำระครบ tab export — same shape as pending plus วันที่ชำระ; ยอดชำระจริง
+  // replaces ยอดค้าง (a settled row has nothing outstanding).
+  const handleExportPaid = async () => {
+    await exportToExcel({
+      columns: [
+        { header: 'สัญญา', key: 'contractNumber', width: 15 },
+        { header: 'ลูกค้า', key: 'customer', width: 15 },
+        { header: 'เบอร์โทร', key: 'phone', width: 15 },
+        { header: 'งวดที่', key: 'installmentNo', width: 15 },
+        { header: 'ยอดงวด', key: 'amountDue', width: 15 },
+        { header: 'ค่าปรับ', key: 'lateFee', width: 15 },
+        { header: 'ชำระแล้ว', key: 'amountPaid', width: 15 },
+        { header: 'วันครบกำหนด', key: 'dueDate', width: 15 },
+        { header: 'วันที่ชำระ', key: 'paidDate', width: 15 },
+        { header: 'สาขา', key: 'branch', width: 15 },
+        { header: 'หมายเหตุ', key: 'notes', width: 25 },
+      ],
+      data: paidPayments.map((p) => ({
+        contractNumber: p.contract.contractNumber,
+        customer: p.contract.customer.name,
+        phone: p.contract.customer.phone,
+        installmentNo: p.installmentNo,
+        amountDue: parseFloat(p.amountDue).toLocaleString(),
+        lateFee: parseFloat(p.lateFee).toLocaleString(),
+        amountPaid: parseFloat(p.amountPaid).toLocaleString(),
+        dueDate: p.dueDate ? new Date(p.dueDate).toLocaleDateString('th-TH') : '-',
+        paidDate: p.paidDate ? new Date(p.paidDate).toLocaleDateString('th-TH') : '-',
+        branch: p.contract.branch.name,
+        // '[ปิดก่อนกำหนด]' / 'ใช้เครดิต X บาท' — explains rows where ชำระแล้ว ≠ ยอดงวด+ค่าปรับ.
+        notes: p.notes || '',
+      })),
+      sheetName: 'รายการชำระครบ',
+      filename: `paid-payments-${toLocalDateString()}.xlsx`,
+    });
+    if (paidTruncated) {
+      toast.warning(
+        `ส่งออกได้ ${paidPayments.length.toLocaleString('th-TH')} จาก ${paidTotal.toLocaleString('th-TH')} รายการ — ปรับช่วงวันที่ให้แคบลงเพื่อส่งออกครบ`,
+      );
+    } else {
+      toast.success('ส่งออก Excel สำเร็จ');
+    }
   };
 
   // Batch helpers
@@ -553,6 +630,12 @@ export default function PaymentsPage() {
           )}
         </button>
         <button
+          onClick={() => setTab('paid')}
+          className={`px-5 py-3 text-sm font-medium border-b-2 -mb-px transition-all ${tab === 'paid' ? 'border-primary text-primary' : 'border-transparent text-muted-foreground hover:text-foreground'}`}
+        >
+          ชำระครบ
+        </button>
+        <button
           onClick={() => setTab('summary')}
           className={`px-5 py-3 text-sm font-medium border-b-2 -mb-px transition-all ${tab === 'summary' ? 'border-primary text-primary' : 'border-transparent text-muted-foreground hover:text-foreground'}`}
         >
@@ -621,6 +704,68 @@ export default function PaymentsPage() {
               batchTotal={batchTotal}
               onShowBatchModal={() => setShowBatchModal(true)}
               onClearSelection={() => setSelectedIds(new Set())}
+            />
+          </QueryBoundary>
+        </div>
+      )}
+
+      {/* Paid Tab — ชำระครบ: same layout/filters as the pending queue, rows
+          pinned to status=PAID and read-only (history per row, no batch). */}
+      {tab === 'paid' && (
+        <div>
+          <PaymentPeriodBar
+            startDate={startDate}
+            endDate={endDate}
+            onChange={({ startDate: sd, endDate: ed }) => {
+              setStartDate(sd);
+              setEndDate(ed);
+            }}
+          />
+          <p className="mb-4 -mt-2 text-xs text-muted-foreground leading-snug">
+            ช่วงวันที่กรองตาม<span className="font-medium text-foreground">วันครบกำหนดของงวด</span> (เหมือนแท็บรอชำระ)
+            — งวดเก่าที่เพิ่งมาชำระเดือนนี้ ให้ขยายช่วงย้อนหลังจึงจะเห็น
+          </p>
+
+          <PaymentFilters
+            searchTerm={searchTerm}
+            onSearchChange={setSearchTerm}
+            statusFilter=""
+            onStatusFilterChange={() => {}}
+            showStatusFilter={false}
+            branchFilter={branchFilter}
+            onBranchFilterChange={setBranchFilter}
+            isOwner={isOwner}
+            branches={branches}
+            onExport={handleExportPaid}
+            hasPendingPayments={paidPayments.length > 0}
+          />
+
+          {paidTruncated && (
+            <div className="mb-4 rounded-lg border border-warning/40 bg-warning/10 px-4 py-2.5 text-sm text-warning leading-snug">
+              แสดง {paidPayments.length.toLocaleString('th-TH')} จาก {paidTotal.toLocaleString('th-TH')} รายการ
+              (เรียงตามวันครบกำหนด) — ปรับช่วงวันที่ให้แคบลงเพื่อดูรายการทั้งหมด
+            </div>
+          )}
+
+          <QueryBoundary
+            isLoading={loadingPaid && paidPayments.length === 0}
+            isError={paidError}
+            error={paidErrorDetail}
+            onRetry={refetchPaid}
+            errorTitle="ไม่สามารถโหลดรายการชำระครบได้"
+          >
+            <PaymentTable
+              mode="paid"
+              pendingPayments={paidPayments}
+              loadingPending={loadingPaid}
+              selectedIds={selectedIds}
+              onToggleSelect={toggleSelect}
+              onToggleAll={toggleAll}
+              onOpenPayModal={openPayModal}
+              onViewHistory={(contractId) => setHistoryContractId(contractId)}
+              batchTotal={0}
+              onShowBatchModal={() => {}}
+              onClearSelection={() => {}}
             />
           </QueryBoundary>
         </div>

--- a/apps/web/src/pages/PaymentsPage/invalidatePaymentQueries.ts
+++ b/apps/web/src/pages/PaymentsPage/invalidatePaymentQueries.ts
@@ -13,6 +13,7 @@ import type { QueryClient } from '@tanstack/react-query';
 export function invalidatePaymentQueries(qc: QueryClient): void {
   const keys = [
     'pending-payments',
+    'paid-payments',
     'daily-summary',
     'contract-payments',
     'contract-receipts',

--- a/apps/web/src/pages/PaymentsPage/types.ts
+++ b/apps/web/src/pages/PaymentsPage/types.ts
@@ -21,6 +21,11 @@ export interface PendingPayment {
   amountPaid: string;
   lateFee: string;
   status: string;
+  /** Set once the installment is PAID — used by the ชำระครบ tab. */
+  paidDate?: string | null;
+  /** Free-text stamps from record flows — '[ปิดก่อนกำหนด]', 'ใช้เครดิต X บาท' explain
+   *  why a PAID row's ชำระแล้ว can be partial or '-'. */
+  notes?: string | null;
   monthlyPrincipal: string | null;
   monthlyInterest: string | null;
   monthlyCommission: string | null;


### PR DESCRIPTION
## สรุป

PR นี้รวม 3 เรื่อง (ไฟล์ไม่ทับกัน):

### 1. fix(receipts): ยกเลิกใบเสร็จได้อีกครั้ง — ช่องผู้อนุมัติ (SoD)
- **Bug:** dialog ยกเลิกใบเสร็จส่งแค่ `reason` แต่ `VoidReceiptDto` (PR #780) บังคับ `approvedById` → กดยืนยันแล้วโดน "กรุณาระบุผู้อนุมัติการยกเลิก" โดยไม่มีช่องให้กรอก
- เพิ่ม dropdown ผู้อนุมัติ (ตัดตัวเองออกตาม Segregation of Duties), reset ฟอร์มเมื่อเปลี่ยนใบเสร็จ, สถานะโหลด/พลาด
- endpoint ใหม่ `GET /users/approvers` (PII-free: id/name/role, manager ที่ active เท่านั้น) — `GET /users` เดิมเป็น OWNER-only เพราะคืน PII เต็ม; สลับ RecordPaymentWizard + expense ApproverSection มาใช้ด้วย (แก้ latent 403 ของ non-OWNER)
- server validate ผู้อนุมัติ: มีจริง + active + role OWNER/ACC/BM/FM

### 2. feat(payments): แท็บ "ชำระครบ" ใน /payments
- tab ใหม่ read-only รายละเอียดเหมือนแท็บรอชำระ + คอลัมน์วันที่ชำระ + badge "ปิดยอดก่อนกำหนด"/"หักจากเครดิตล่วงหน้า" + หมายเหตุใน Excel
- แถว PAID คงค่าปรับที่เก็บจริงแบบ net-of-waiver (กันค่าปรับปลอมจาก live recompute + กัน gross-waiver ดูเหมือนจ่ายขาด)
- limit=100 + banner "แสดง X จาก N รายการ" กัน truncation เงียบ
- batch รับชำระรวมใช้ invalidatePaymentQueries (ปิด gap cache stale 3 นาที)

### 3. test(web): reschedule QA test follow-up (de4613ef — ค้างจาก #1343)

## Test plan
- [x] API: receipts spec 15, users spec 6, live-fee spec 8 — ผ่านหมด
- [x] Web: ทั้ง suite 922/922 (143 ไฟล์) รวม component tests ใหม่ 13 เคส
- [x] `tsc --noEmit` สะอาดทั้ง api + web
- [x] Multi-agent adversarial review 2 รอบ (26 agents) — findings ที่ยืนยันแล้วแก้ครบ

🤖 Generated with [Claude Code](https://claude.com/claude-code)